### PR TITLE
[codex] 增加 Structured Story Memory MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 这是什么
 
-这个仓库有三个主要入口/支持脚本，以及一个内部共享 runtime：
+这个仓库有几个主要入口/支持脚本，以及一个内部共享 runtime：
 
 - `gemini_translate.py`
   - Ren'Py 主翻译脚本
@@ -16,6 +16,9 @@
 - `rag_memory.py`
   - 轻量 RAG / history store 模块
   - 提供本地 JSON 历史库存储、文本哈希和相似度检索
+- `story_memory.py`
+  - 可选的结构化剧情记忆模块
+  - 从本地 `story_graph.json` 读取角色、关系、术语和场景摘要，并在启用后注入 `STORY MEMORY` prompt 块
 - `translator_runtime.py`
   - 内部共享 runtime
   - 为同步脚本和 Batch 脚本提供共用的配置、SDK、校验、响应解析和文件处理逻辑
@@ -31,6 +34,7 @@
 - 生成 Batch 请求包并执行完整的 `build / submit / status / probe / download / check / apply / split / repair` 流程
 - 使用本地 history store 做轻量 RAG 检索
 - 将历史译文注入后续请求，提升术语和语气一致性
+- 可选注入结构化剧情记忆，补充角色、关系、场景和术语上下文
 - 允许已知术语按规则保留英文，不再把这类结果一律判成失败
 
 ## 快速开始
@@ -124,6 +128,7 @@ python gemini_translate_batch.py apply
 
 - `python gemini_translate.py --help` 会显示同步脚本的最小 CLI 帮助
 - 同步 RAG 启用后，每个成功写回的小批次会更新本地 history store，后续同步批次会在请求前重新检索并注入相关历史
+- Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
 - 不带子命令直接运行 `gemini_translate_batch.py` 时，默认等价于 `submit`
 - Batch 产物默认会写到本地 `logs/` 目录
 - `probe` 会用同步请求做最小 smoke test
@@ -131,6 +136,78 @@ python gemini_translate_batch.py apply
 - `apply` 只会写回通过校验的结果
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
 - 当前不建议并行 `apply` 到同一个本地 RAG store；共享 `history.jsonl` 的写入保护还不算完整产品化
+
+### 可选：Structured Story Memory
+
+Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可选上下文层。它不会调用额外 LLM 自动抽取图谱，也不依赖 Neo4j；启用后只读取本地 JSON，并把命中的结构化信息插入到 prompt 的 `STORY MEMORY` 分区。
+
+配置示例见 `translator_config.example.json`：
+
+```json
+{
+  "batch": {
+    "story_memory": {
+      "enabled": false,
+      "graph_file": "logs/story_memory/story_graph.json",
+      "max_context_chars": 1200,
+      "top_k_relations": 6,
+      "top_k_terms": 12,
+      "include_scene_summary": true
+    }
+  },
+  "sync": {
+    "story_memory": {
+      "enabled": false,
+      "graph_file": "logs/story_memory/story_graph.json",
+      "max_context_chars": 800,
+      "top_k_relations": 4,
+      "top_k_terms": 8,
+      "include_scene_summary": true
+    }
+  }
+}
+```
+
+`story_graph.json` 可以先手写或半自动维护，初版结构类似：
+
+```json
+{
+  "characters": {
+    "eileen": {
+      "zh_name": "艾琳",
+      "speaker_ids": ["eileen", "eileen_side"],
+      "style": "语气轻快，常吐槽，但关键时刻认真。"
+    }
+  },
+  "relations": [
+    {
+      "left": "eileen",
+      "right": "noah",
+      "type": "close_friend",
+      "note": "两人关系亲近，可以使用自然熟悉的中文语气。",
+      "confidence": 0.85
+    }
+  ],
+  "terms": [
+    {
+      "source": "Void Gate",
+      "target": "虚空门",
+      "note": "世界观核心术语，必须统一。"
+    }
+  ],
+  "scenes": [
+    {
+      "file_rel_path": "chapter1.rpy",
+      "line_start": 120,
+      "line_end": 220,
+      "summary": "艾琳和诺亚在天台讨论是否进入危险区域。",
+      "characters": ["eileen", "noah"]
+    }
+  ]
+}
+```
+
+当前实现仍是 MVP：检索逻辑是轻量启发式，正式 schema 校验、`relation_analyzer` seed 导出、Neo4j 可视化导出和更完整 diagnostics 还属于后续工作。
 
 ## 角色关系 / 语义分析
 
@@ -177,6 +254,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - 面向普通用户的零配置体验
 - 完整的游戏解包 / 打包一体化发布流程
 - 面向超大项目的完整 RAG 生产工作流（例如全项目 bootstrap 建库、严格的波次式回灌编排、并发写保护）
+- 完整的结构化剧情图谱生产工作流（例如 schema 校验、自动 seed 生成、Neo4j 可视化导出）
 
 ## 项目状态
 
@@ -191,6 +269,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - 当前更推荐使用 Batch 脚本；同步脚本保留用于直接运行、补译、局部修复、smoke test，以及可选的 RAG 滚动记忆验证
 - Batch / RAG 仍是主要验证方向；同步 RAG 更适合小批量即时反馈和局部精修，不是 Batch 吞吐流程的替代品
 - 当前的 RAG 能力更适合“小包验证 + 逐步扩展”，还不应被表述为已经完成的大项目生产级方案
+- Structured Story Memory 目前是可选 MVP，适合作为人工维护剧情上下文的 prompt 增强，不是完整自动图谱系统
 
 执行任何会修改项目文件的操作前，请先备份，并优先在副本上测试。
 
@@ -202,6 +281,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - 你本地的 `api_keys.json`
 - 你本地的 `translator_config.json`
 - 你本地的 `glossary.json` / `glossary_*.json`
+- 你本地的 `story_graph.json` / `story_graph.seed.json`
 - 你本地的 `macro_setting.md`
 - 私有游戏脚本
 - 本地 batch 结果

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1184,7 +1184,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
         } if STORY_MEMORY_ENABLED else {},
         'story_memory_summary': {
             'chunks_with_story_hits': sum(
-                1 for chunk in chunks if chunk.get('story_hits')
+                1 for chunk in chunks if story_memory.has_story_hits(chunk.get('story_hits'))
             ),
         } if STORY_MEMORY_ENABLED else {},
         'summary': {

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -16,6 +16,7 @@ if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
 from rag_memory import JsonRagStore, hash_text, truncate_text
+import story_memory
 import translator_runtime as runtime
 
 try:
@@ -85,6 +86,15 @@ RAG_HISTORY_CHAR_LIMIT = 220
 _RAG_STORE = None
 _RAG_PRESERVED_TERMS_CACHE = None
 _RAG_PRESERVED_TERMS_CACHE_KEY = None
+
+STORY_MEMORY_ENABLED = False
+STORY_MEMORY_GRAPH_FILE = ''
+STORY_MEMORY_MAX_CONTEXT_CHARS = 1200
+STORY_MEMORY_TOP_K_RELATIONS = 6
+STORY_MEMORY_TOP_K_TERMS = 12
+STORY_MEMORY_INCLUDE_SCENE_SUMMARY = True
+_STORY_GRAPH = None
+_STORY_GRAPH_PATH = ''
 
 
 def load_json_file(path):
@@ -156,6 +166,9 @@ def load_batch_settings():
     global RAG_DOCUMENT_TASK_TYPE, RAG_OUTPUT_DIMENSIONALITY, RAG_TOP_K_HISTORY
     global RAG_TOP_K_TERMS, RAG_MIN_SIMILARITY, RAG_SEGMENT_LINES
     global RAG_BOOTSTRAP_ON_BUILD, RAG_HISTORY_CHAR_LIMIT, _RAG_STORE
+    global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
+    global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
+    global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
 
     config = load_json_file(legacy.CONFIG_FILE)
     translator_config = load_json_file(legacy.TRANSLATOR_CONFIG)
@@ -249,6 +262,39 @@ def load_batch_settings():
         RAG_STORE_DIR = ''
 
     _RAG_STORE = None
+
+    story_config = batch.get('story_memory')
+    if not isinstance(story_config, dict):
+        story_config = {}
+
+    STORY_MEMORY_ENABLED = coerce_bool(story_config.get('enabled'), False)
+    STORY_MEMORY_MAX_CONTEXT_CHARS = coerce_positive_int(
+        story_config.get('max_context_chars'),
+        1200,
+    )
+    STORY_MEMORY_TOP_K_RELATIONS = coerce_positive_int(
+        story_config.get('top_k_relations'),
+        6,
+    )
+    STORY_MEMORY_TOP_K_TERMS = coerce_positive_int(
+        story_config.get('top_k_terms'),
+        12,
+    )
+    STORY_MEMORY_INCLUDE_SCENE_SUMMARY = coerce_bool(
+        story_config.get('include_scene_summary'),
+        True,
+    )
+    graph_file = story_config.get('graph_file')
+    if graph_file:
+        STORY_MEMORY_GRAPH_FILE = legacy._resolve_preferred_path(
+            legacy.BASE_DIR,
+            SCRIPT_DIR,
+            graph_file,
+        )
+    else:
+        STORY_MEMORY_GRAPH_FILE = ''
+    _STORY_GRAPH = None
+    _STORY_GRAPH_PATH = ''
 
 
 load_batch_settings()
@@ -615,6 +661,32 @@ def retrieve_history_hits(target_items, context_past):
     }
 
 
+def get_story_graph():
+    global _STORY_GRAPH, _STORY_GRAPH_PATH
+    if not STORY_MEMORY_ENABLED:
+        return None
+    graph_path = os.path.abspath(STORY_MEMORY_GRAPH_FILE) if STORY_MEMORY_GRAPH_FILE else ''
+    if _STORY_GRAPH is None or _STORY_GRAPH_PATH != graph_path:
+        _STORY_GRAPH = story_memory.load_story_graph(graph_path)
+        _STORY_GRAPH_PATH = graph_path
+    return _STORY_GRAPH
+
+
+def retrieve_batch_story_hits(file_rel_path, target_items, context_past, context_future):
+    if not STORY_MEMORY_ENABLED:
+        return None
+    return story_memory.retrieve_story_hits(
+        get_story_graph(),
+        file_rel_path,
+        target_items,
+        context_past=context_past,
+        context_future=context_future,
+        top_k_relations=STORY_MEMORY_TOP_K_RELATIONS,
+        top_k_terms=STORY_MEMORY_TOP_K_TERMS,
+        include_scene_summary=STORY_MEMORY_INCLUDE_SCENE_SUMMARY,
+    )
+
+
 
 def manifest_path_for_target(target):
     if target:
@@ -864,7 +936,14 @@ def build_system_instruction():
     )
 
 
-def build_user_prompt(context_past, target_items, context_future, glossary_hits=None, history_hits=None):
+def build_user_prompt(
+    context_past,
+    target_items,
+    context_future,
+    glossary_hits=None,
+    history_hits=None,
+    story_hits=None,
+):
     target_payload = json.dumps(
         [{'id': item['id'], 'text': item['text']} for item in target_items],
         ensure_ascii=False,
@@ -872,14 +951,24 @@ def build_user_prompt(context_past, target_items, context_future, glossary_hits=
     )
     glossary_hits = glossary_hits or []
     history_hits = history_hits or []
-    return (
+    blocks = [
         f'LOCKED TERMS:\n{format_glossary_hits_block(glossary_hits, "(none)")}\n\n'
-        f'RETRIEVED MEMORY:\n{format_history_hits_block(history_hits, "(none)")}\n\n'
-        f'CONTEXT BEFORE:\n{format_context_block(context_past, "(none)")}\n\n'
-        f'TARGET:\n{target_payload}\n\n'
-        f'CONTEXT AFTER:\n{format_context_block(context_future, "(none)")}\n\n'
-        'Return the result now.'
+        f'RETRIEVED MEMORY:\n{format_history_hits_block(history_hits, "(none)")}\n\n',
+    ]
+    if story_hits is not None:
+        blocks.append(
+            'STORY MEMORY:\n'
+            f'{story_memory.format_story_hits_block(story_hits, STORY_MEMORY_MAX_CONTEXT_CHARS)}\n\n'
+        )
+    blocks.extend(
+        [
+            f'CONTEXT BEFORE:\n{format_context_block(context_past, "(none)")}\n\n',
+            f'TARGET:\n{target_payload}\n\n',
+            f'CONTEXT AFTER:\n{format_context_block(context_future, "(none)")}\n\n',
+            'Return the result now.',
+        ]
     )
+    return ''.join(blocks)
 
 
 
@@ -931,6 +1020,7 @@ def build_batch_request(chunk):
                                 chunk['context_future'],
                                 glossary_hits=chunk.get('glossary_hits') or [],
                                 history_hits=chunk.get('history_hits') or [],
+                                story_hits=chunk.get('story_hits') if 'story_hits' in chunk else None,
                             )
                         }
                     ],
@@ -954,34 +1044,41 @@ def build_chunks(file_jobs):
             context_future = [item['text'] for item in tasks[end:min(total, end + BATCH_CONTEXT_AFTER)]]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
             history_hits, rag_stats = retrieve_history_hits(target_items, context_past) if RAG_ENABLED else ([], {})
+            story_hits = retrieve_batch_story_hits(
+                job['file_rel_path'],
+                target_items,
+                context_past,
+                context_future,
+            ) if STORY_MEMORY_ENABLED else None
             chunk_number = start // BATCH_TARGET_SIZE + 1
             chunk_key = f"{hash_key(job['file_rel_path'])}-{chunk_number:05d}"
-            chunks.append(
-                {
-                    'key': chunk_key,
-                    'file_rel_path': job['file_rel_path'],
-                    'file_path': job['file_path'],
-                    'chunk_index': chunk_number,
-                    'line_numbers': [item['line'] for item in target_items],
-                    'context_past': context_past,
-                    'context_future': context_future,
-                    'glossary_hits': glossary_hits,
-                    'history_hits': history_hits,
-                    'rag_stats': rag_stats,
-                    'items': [
-                        {
-                            'id': item['id'],
-                            'text': item['text'],
-                            'line': item['line'],
-                            'start': item['start'],
-                            'end': item['end'],
-                            'prefix': item.get('prefix', ''),
-                            'quote': item['quote'],
-                        }
-                        for item in target_items
-                    ],
-                }
-            )
+            chunk = {
+                'key': chunk_key,
+                'file_rel_path': job['file_rel_path'],
+                'file_path': job['file_path'],
+                'chunk_index': chunk_number,
+                'line_numbers': [item['line'] for item in target_items],
+                'context_past': context_past,
+                'context_future': context_future,
+                'glossary_hits': glossary_hits,
+                'history_hits': history_hits,
+                'rag_stats': rag_stats,
+                'items': [
+                    {
+                        'id': item['id'],
+                        'text': item['text'],
+                        'line': item['line'],
+                        'start': item['start'],
+                        'end': item['end'],
+                        'prefix': item.get('prefix', ''),
+                        'quote': item['quote'],
+                    }
+                    for item in target_items
+                ],
+            }
+            if STORY_MEMORY_ENABLED:
+                chunk['story_hits'] = story_hits or {}
+            chunks.append(chunk)
     return chunks
 
 
@@ -1077,6 +1174,19 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             'chunks_with_glossary_hits': sum(1 for chunk in chunks if chunk.get('glossary_hits')),
             'chunks_with_history_hits': sum(1 for chunk in chunks if chunk.get('history_hits')),
         } if RAG_ENABLED else {},
+        'story_memory_enabled': STORY_MEMORY_ENABLED,
+        'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
+        'story_memory_settings': {
+            'max_context_chars': STORY_MEMORY_MAX_CONTEXT_CHARS,
+            'top_k_relations': STORY_MEMORY_TOP_K_RELATIONS,
+            'top_k_terms': STORY_MEMORY_TOP_K_TERMS,
+            'include_scene_summary': STORY_MEMORY_INCLUDE_SCENE_SUMMARY,
+        } if STORY_MEMORY_ENABLED else {},
+        'story_memory_summary': {
+            'chunks_with_story_hits': sum(
+                1 for chunk in chunks if chunk.get('story_hits')
+            ),
+        } if STORY_MEMORY_ENABLED else {},
         'summary': {
             'file_count': len(file_jobs),
             'chunk_count': len(chunks),
@@ -2878,4 +2988,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -951,7 +951,7 @@ def build_user_prompt(
         f'LOCKED TERMS:\n{format_glossary_hits_block(glossary_hits, "(none)")}\n\n'
         f'RETRIEVED MEMORY:\n{format_history_hits_block(history_hits, "(none)")}\n\n',
     ]
-    if story_hits is not None:
+    if story_memory.has_story_hits(story_hits):
         blocks.append(
             'STORY MEMORY:\n'
             f'{story_memory.format_story_hits_block(story_hits, STORY_MEMORY_MAX_CONTEXT_CHARS)}\n\n'
@@ -1074,8 +1074,8 @@ def build_chunks(file_jobs):
                     for item in target_items
                 ],
             }
-            if STORY_MEMORY_ENABLED:
-                chunk['story_hits'] = story_hits or {}
+            if STORY_MEMORY_ENABLED and story_memory.has_story_hits(story_hits):
+                chunk['story_hits'] = story_hits
             chunks.append(chunk)
     return chunks
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -286,11 +286,7 @@ def load_batch_settings():
     )
     graph_file = story_config.get('graph_file')
     if graph_file:
-        STORY_MEMORY_GRAPH_FILE = legacy._resolve_preferred_path(
-            legacy.BASE_DIR,
-            SCRIPT_DIR,
-            graph_file,
-        )
+        STORY_MEMORY_GRAPH_FILE = legacy.resolve_story_memory_graph_path(graph_file)
     else:
         STORY_MEMORY_GRAPH_FILE = ''
     _STORY_GRAPH = None
@@ -1072,6 +1068,8 @@ def build_chunks(file_jobs):
                         'end': item['end'],
                         'prefix': item.get('prefix', ''),
                         'quote': item['quote'],
+                        'speaker_id': item.get('speaker_id', ''),
+                        'speaker': item.get('speaker', ''),
                     }
                     for item in target_items
                 ],

--- a/story_memory.py
+++ b/story_memory.py
@@ -1,0 +1,500 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import re
+
+
+_EMPTY_GRAPH = {
+    "characters": {},
+    "relations": [],
+    "terms": [],
+    "scenes": [],
+}
+
+
+def _empty_graph():
+    return {
+        "characters": {},
+        "relations": [],
+        "terms": [],
+        "scenes": [],
+    }
+
+
+def _normalize_rel_path(value):
+    if not value:
+        return ""
+    text = str(value).replace("\\", "/").strip()
+    text = text.lstrip("./")
+    text = text.lstrip("/")
+    return text
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _clean_text(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _safe_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_character_map(value):
+    characters = {}
+    if isinstance(value, dict):
+        iterable = value.items()
+    elif isinstance(value, list):
+        iterable = []
+        for item in value:
+            if isinstance(item, dict):
+                char_id = item.get("id") or item.get("key") or item.get("name")
+                iterable.append((char_id, item))
+    else:
+        iterable = []
+
+    for char_id, raw_data in iterable:
+        char_id = _clean_text(char_id)
+        if not char_id:
+            continue
+        data = dict(raw_data) if isinstance(raw_data, dict) else {}
+        speaker_ids = [
+            _clean_text(item)
+            for item in _as_list(data.get("speaker_ids"))
+            if _clean_text(item)
+        ]
+        data["speaker_ids"] = speaker_ids
+        characters[char_id] = data
+    return characters
+
+
+def _normalize_terms(value):
+    terms = []
+    if isinstance(value, dict):
+        iterable = [
+            {"source": source, "target": target}
+            for source, target in value.items()
+        ]
+    elif isinstance(value, list):
+        iterable = value
+    else:
+        iterable = []
+
+    for item in iterable:
+        if isinstance(item, dict):
+            source = _clean_text(item.get("source") or item.get("term"))
+            target = _clean_text(item.get("target") or item.get("translation"))
+            note = _clean_text(item.get("note"))
+            aliases = [
+                _clean_text(alias)
+                for alias in _as_list(item.get("aliases"))
+                if _clean_text(alias)
+            ]
+            if source or target or aliases:
+                normalized = dict(item)
+                normalized["source"] = source
+                normalized["target"] = target
+                normalized["note"] = note
+                normalized["aliases"] = aliases
+                terms.append(normalized)
+        else:
+            source = _clean_text(item)
+            if source:
+                terms.append({"source": source, "target": "", "note": "", "aliases": []})
+    return terms
+
+
+def _normalize_dict_list(value):
+    return [dict(item) for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def normalize_story_graph(raw_graph):
+    if not isinstance(raw_graph, dict):
+        return _empty_graph()
+    return {
+        "characters": _normalize_character_map(raw_graph.get("characters")),
+        "relations": _normalize_dict_list(raw_graph.get("relations")),
+        "terms": _normalize_terms(raw_graph.get("terms")),
+        "scenes": _normalize_dict_list(raw_graph.get("scenes")),
+    }
+
+
+def load_story_graph(path):
+    if not path or not os.path.isfile(path):
+        return _empty_graph()
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            return normalize_story_graph(json.load(handle) or {})
+    except Exception:
+        return _empty_graph()
+
+
+def _item_texts(items):
+    texts = []
+    for item in items or []:
+        if isinstance(item, dict):
+            text = _clean_text(item.get("text"))
+        else:
+            text = _clean_text(item)
+        if text:
+            texts.append(text)
+    return texts
+
+
+def _context_texts(context):
+    texts = []
+    for item in context or []:
+        if isinstance(item, dict):
+            text = _clean_text(item.get("text"))
+        else:
+            text = _clean_text(item)
+        if text:
+            texts.append(text)
+    return texts
+
+
+def _combined_search_text(target_items, context_past, context_future):
+    parts = []
+    parts.extend(_context_texts(context_past))
+    parts.extend(_item_texts(target_items))
+    parts.extend(_context_texts(context_future))
+    return "\n".join(parts)
+
+
+def _speaker_ids_from_items(target_items):
+    speaker_ids = set()
+    for item in target_items or []:
+        if not isinstance(item, dict):
+            continue
+        for key in ("speaker", "speaker_id", "speaker_name", "character", "who"):
+            value = _clean_text(item.get(key))
+            if value:
+                speaker_ids.add(value)
+    return speaker_ids
+
+
+def _target_line_span(target_items):
+    lines = []
+    for item in target_items or []:
+        if not isinstance(item, dict):
+            continue
+        line_start = _safe_int(item.get("line_start"))
+        line_end = _safe_int(item.get("line_end"))
+        line_number = _safe_int(item.get("line_number"))
+        zero_based_line = _safe_int(item.get("line"))
+        if line_start is not None:
+            lines.append(line_start)
+        if line_end is not None:
+            lines.append(line_end)
+        elif line_number is not None:
+            lines.append(line_number)
+        elif zero_based_line is not None:
+            lines.append(zero_based_line + 1)
+    if not lines:
+        return None, None
+    return min(lines), max(lines)
+
+
+def _looks_word_like(text):
+    return bool(re.fullmatch(r"[A-Za-z0-9_ -]+", text or ""))
+
+
+def _text_contains_alias(search_text, alias):
+    alias = _clean_text(alias)
+    if len(alias) <= 1:
+        return False
+    if _looks_word_like(alias):
+        pattern = r"(?<![A-Za-z0-9_])" + re.escape(alias.lower()) + r"(?![A-Za-z0-9_])"
+        return re.search(pattern, search_text.lower()) is not None
+    return alias.lower() in search_text.lower()
+
+
+def _character_aliases(char_id, data):
+    aliases = [char_id]
+    if isinstance(data, dict):
+        aliases.extend(_as_list(data.get("speaker_ids")))
+        aliases.extend(_as_list(data.get("zh_name")))
+        aliases.extend(_as_list(data.get("name")))
+        aliases.extend(_as_list(data.get("aliases")))
+    cleaned = []
+    seen = set()
+    for alias in aliases:
+        text = _clean_text(alias)
+        if text and text not in seen:
+            cleaned.append(text)
+            seen.add(text)
+    return cleaned
+
+
+def _term_aliases(term):
+    aliases = []
+    if isinstance(term, dict):
+        aliases.extend(_as_list(term.get("source")))
+        aliases.extend(_as_list(term.get("target")))
+        aliases.extend(_as_list(term.get("aliases")))
+    cleaned = []
+    seen = set()
+    for alias in aliases:
+        text = _clean_text(alias)
+        if text and text not in seen:
+            cleaned.append(text)
+            seen.add(text)
+    return cleaned
+
+
+def _scene_line_span(scene):
+    line_start = _safe_int(scene.get("line_start"))
+    line_end = _safe_int(scene.get("line_end"))
+    if line_start is None and line_end is None:
+        return None, None
+    if line_start is None:
+        line_start = line_end
+    if line_end is None:
+        line_end = line_start
+    if line_start > line_end:
+        line_start, line_end = line_end, line_start
+    return line_start, line_end
+
+
+def _line_overlap_score(scene_start, scene_end, target_start, target_end):
+    if scene_start is None or target_start is None:
+        return 0
+    if scene_start <= target_end and target_start <= scene_end:
+        overlap = min(scene_end, target_end) - max(scene_start, target_start) + 1
+        return 100 + max(0, overlap)
+    if scene_end < target_start:
+        distance = target_start - scene_end
+    else:
+        distance = scene_start - target_end
+    return max(0, 40 - min(distance, 40))
+
+
+def _rank_matching_scenes(story_graph, file_rel_path, target_start, target_end, active_char_ids):
+    normalized_file = _normalize_rel_path(file_rel_path)
+    ranked = []
+    for scene in story_graph.get("scenes", []):
+        scene_file = _normalize_rel_path(scene.get("file_rel_path"))
+        if normalized_file and scene_file and scene_file != normalized_file:
+            continue
+        score = 0
+        if normalized_file and scene_file == normalized_file:
+            score += 50
+        scene_start, scene_end = _scene_line_span(scene)
+        score += _line_overlap_score(scene_start, scene_end, target_start, target_end)
+        scene_chars = {
+            _clean_text(char)
+            for char in _as_list(scene.get("characters"))
+            if _clean_text(char)
+        }
+        score += 8 * len(scene_chars & active_char_ids)
+        if score > 0:
+            ranked.append((score, scene))
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [scene for _, scene in ranked]
+
+
+def _collect_active_characters(story_graph, search_text, speaker_ids):
+    active = set()
+    characters = story_graph.get("characters", {})
+    for char_id, data in characters.items():
+        aliases = _character_aliases(char_id, data)
+        if any(alias in speaker_ids for alias in aliases):
+            active.add(char_id)
+            continue
+        if any(_text_contains_alias(search_text, alias) for alias in aliases):
+            active.add(char_id)
+    return active
+
+
+def retrieve_story_hits(
+    story_graph,
+    file_rel_path,
+    target_items,
+    context_past=None,
+    context_future=None,
+    top_k_relations=6,
+    top_k_terms=12,
+    include_scene_summary=True,
+):
+    story_graph = normalize_story_graph(story_graph)
+    search_text = _combined_search_text(target_items, context_past, context_future)
+    speaker_ids = _speaker_ids_from_items(target_items)
+    target_start, target_end = _target_line_span(target_items)
+    active_char_ids = _collect_active_characters(story_graph, search_text, speaker_ids)
+
+    matching_scenes = _rank_matching_scenes(
+        story_graph,
+        file_rel_path,
+        target_start,
+        target_end,
+        active_char_ids,
+    )
+    for scene in matching_scenes[:3]:
+        for char_id in _as_list(scene.get("characters")):
+            char_id = _clean_text(char_id)
+            if char_id:
+                active_char_ids.add(char_id)
+
+    characters = []
+    for char_id in sorted(active_char_ids):
+        data = story_graph.get("characters", {}).get(char_id, {})
+        item = {"id": char_id}
+        if isinstance(data, dict):
+            for key in ("zh_name", "style", "note"):
+                value = _clean_text(data.get(key))
+                if value:
+                    item[key] = value
+        characters.append(item)
+
+    term_hits = []
+    max_terms = max(0, int(top_k_terms or 0))
+    for term in story_graph.get("terms", []):
+        if len(term_hits) >= max_terms:
+            break
+        aliases = _term_aliases(term)
+        if any(_text_contains_alias(search_text, alias) for alias in aliases):
+            term_hits.append(term)
+
+    relation_hits = []
+    for relation in story_graph.get("relations", []):
+        left = _clean_text(relation.get("left"))
+        right = _clean_text(relation.get("right"))
+        if not left or not right:
+            continue
+        left_active = left in active_char_ids
+        right_active = right in active_char_ids
+        if not (left_active and right_active):
+            continue
+        relation_hits.append(relation)
+
+    def relation_confidence(item):
+        try:
+            return float(item.get("confidence", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    relation_hits.sort(key=relation_confidence, reverse=True)
+
+    scene_hits = matching_scenes[:3] if include_scene_summary else []
+    return {
+        "characters": characters,
+        "relations": relation_hits[:max(0, int(top_k_relations or 0))],
+        "terms": term_hits,
+        "scenes": scene_hits,
+    }
+
+
+def _format_confidence(value):
+    try:
+        return f" confidence={float(value):.2f}"
+    except (TypeError, ValueError):
+        return ""
+
+
+def _append_limited(lines, line, max_chars):
+    line = _clean_text(line)
+    if not line:
+        return False
+    candidate = "\n".join(lines + [line]) if lines else line
+    if len(candidate) <= max_chars:
+        lines.append(line)
+        return True
+    if not lines and max_chars > 3:
+        lines.append(line[:max_chars - 3].rstrip() + "...")
+    return False
+
+
+def format_story_hits_block(story_hits, max_chars, empty_label="(none)"):
+    if not isinstance(story_hits, dict):
+        return empty_label
+    max_chars = max(1, int(max_chars or 1))
+    lines = []
+
+    characters = story_hits.get("characters") or []
+    if characters:
+        _append_limited(lines, "Characters:", max_chars)
+        for item in characters:
+            char_id = _clean_text(item.get("id"))
+            zh_name = _clean_text(item.get("zh_name"))
+            style = _clean_text(item.get("style"))
+            note = _clean_text(item.get("note"))
+            label = char_id
+            if zh_name:
+                label = f"{label} ({zh_name})"
+            detail = style or note
+            line = f"- {label}: {detail}" if detail else f"- {label}"
+            if not _append_limited(lines, line, max_chars):
+                break
+
+    relations = story_hits.get("relations") or []
+    if relations:
+        _append_limited(lines, "Relations:", max_chars)
+        for item in relations:
+            left = _clean_text(item.get("left"))
+            right = _clean_text(item.get("right"))
+            relation_type = _clean_text(item.get("type"))
+            note = _clean_text(item.get("note"))
+            detail = relation_type or "related"
+            confidence = _format_confidence(item.get("confidence"))
+            line = f"- {left} -> {right} [{detail}{confidence}]"
+            if note:
+                line += f": {note}"
+            if not _append_limited(lines, line, max_chars):
+                break
+
+    terms = story_hits.get("terms") or []
+    if terms:
+        _append_limited(lines, "Terms:", max_chars)
+        for item in terms:
+            source = _clean_text(item.get("source"))
+            target = _clean_text(item.get("target"))
+            note = _clean_text(item.get("note"))
+            if source and target and source != target:
+                line = f"- {source} -> {target}"
+            else:
+                line = f"- Keep unchanged: {source or target}"
+            if note:
+                line += f": {note}"
+            if not _append_limited(lines, line, max_chars):
+                break
+
+    scenes = story_hits.get("scenes") or []
+    if scenes:
+        _append_limited(lines, "Scenes:", max_chars)
+        for item in scenes:
+            file_rel_path = _normalize_rel_path(item.get("file_rel_path"))
+            line_start, line_end = _scene_line_span(item)
+            summary = _clean_text(item.get("summary"))
+            chars = [
+                _clean_text(char)
+                for char in _as_list(item.get("characters"))
+                if _clean_text(char)
+            ]
+            location = file_rel_path or "scene"
+            if line_start is not None and line_end is not None:
+                location = f"{location}:{line_start}-{line_end}"
+            line = f"- {location}"
+            details = []
+            if summary:
+                details.append(summary)
+            if chars:
+                details.append("characters: " + ", ".join(chars))
+            if details:
+                line += ": " + "; ".join(details)
+            if not _append_limited(lines, line, max_chars):
+                break
+
+    if not lines:
+        return empty_label[:max_chars]
+    return "\n".join(lines)[:max_chars]

--- a/story_memory.py
+++ b/story_memory.py
@@ -211,14 +211,15 @@ def _looks_word_like(text):
     return bool(re.fullmatch(r"[A-Za-z0-9_ -]+", text or ""))
 
 
-def _text_contains_alias(search_text, alias):
+def _text_contains_alias(search_text_lower, alias):
     alias = _clean_text(alias)
     if len(alias) <= 1:
         return False
+    alias_lower = alias.lower()
     if _looks_word_like(alias):
-        pattern = r"(?<![A-Za-z0-9_])" + re.escape(alias.lower()) + r"(?![A-Za-z0-9_])"
-        return re.search(pattern, search_text.lower()) is not None
-    return alias.lower() in search_text.lower()
+        pattern = r"(?<![A-Za-z0-9_])" + re.escape(alias_lower) + r"(?![A-Za-z0-9_])"
+        return re.search(pattern, search_text_lower) is not None
+    return alias_lower in search_text_lower
 
 
 def _character_aliases(char_id, data):
@@ -305,7 +306,7 @@ def _rank_matching_scenes(story_graph, file_rel_path, target_start, target_end, 
     return [scene for _, scene in ranked]
 
 
-def _collect_active_characters(story_graph, search_text, speaker_ids):
+def _collect_active_characters(story_graph, search_text_lower, speaker_ids):
     active = set()
     characters = story_graph.get("characters", {})
     for char_id, data in characters.items():
@@ -313,7 +314,7 @@ def _collect_active_characters(story_graph, search_text, speaker_ids):
         if any(alias in speaker_ids for alias in aliases):
             active.add(char_id)
             continue
-        if any(_text_contains_alias(search_text, alias) for alias in aliases):
+        if any(_text_contains_alias(search_text_lower, alias) for alias in aliases):
             active.add(char_id)
     return active
 
@@ -330,9 +331,10 @@ def retrieve_story_hits(
 ):
     story_graph = normalize_story_graph(story_graph)
     search_text = _combined_search_text(target_items, context_past, context_future)
+    search_text_lower = search_text.lower()
     speaker_ids = _speaker_ids_from_items(target_items)
     target_start, target_end = _target_line_span(target_items)
-    active_char_ids = _collect_active_characters(story_graph, search_text, speaker_ids)
+    active_char_ids = _collect_active_characters(story_graph, search_text_lower, speaker_ids)
 
     matching_scenes = _rank_matching_scenes(
         story_graph,
@@ -364,7 +366,7 @@ def retrieve_story_hits(
         if len(term_hits) >= max_terms:
             break
         aliases = _term_aliases(term)
-        if any(_text_contains_alias(search_text, alias) for alias in aliases):
+        if any(_text_contains_alias(search_text_lower, alias) for alias in aliases):
             term_hits.append(term)
 
     relation_hits = []

--- a/story_memory.py
+++ b/story_memory.py
@@ -181,7 +181,7 @@ def _speaker_ids_from_items(target_items):
         for key in ("speaker", "speaker_id", "speaker_name", "character", "who"):
             value = _clean_text(item.get(key))
             if value:
-                speaker_ids.add(value)
+                speaker_ids.add(value.lower())
     return speaker_ids
 
 
@@ -311,7 +311,7 @@ def _collect_active_characters(story_graph, search_text_lower, speaker_ids):
     characters = story_graph.get("characters", {})
     for char_id, data in characters.items():
         aliases = _character_aliases(char_id, data)
-        if any(alias in speaker_ids for alias in aliases):
+        if any(alias.lower() in speaker_ids for alias in aliases):
             active.add(char_id)
             continue
         if any(_text_contains_alias(search_text_lower, alias) for alias in aliases):

--- a/story_memory.py
+++ b/story_memory.py
@@ -4,23 +4,25 @@ import os
 import re
 
 
-_NORMALIZED_GRAPH_MARKER = "_story_memory_normalized"
+class _NormalizedStoryGraph(dict):
+    pass
 
 
 def _empty_graph():
-    return {
+    return _NormalizedStoryGraph({
         "characters": {},
         "relations": [],
         "terms": [],
         "scenes": [],
-    }
+    })
 
 
 def _normalize_rel_path(value):
     if not value:
         return ""
     text = str(value).replace("\\", "/").strip()
-    text = text.lstrip("./")
+    while text.startswith("./"):
+        text = text[2:]
     text = text.lstrip("/")
     return text
 
@@ -115,7 +117,7 @@ def _normalize_dict_list(value):
 
 
 def _is_normalized_story_graph(value):
-    return isinstance(value, dict) and value.get(_NORMALIZED_GRAPH_MARKER) is True
+    return isinstance(value, _NormalizedStoryGraph)
 
 
 def normalize_story_graph(raw_graph):
@@ -123,13 +125,12 @@ def normalize_story_graph(raw_graph):
         return _empty_graph()
     if _is_normalized_story_graph(raw_graph):
         return raw_graph
-    return {
+    return _NormalizedStoryGraph({
         "characters": _normalize_character_map(raw_graph.get("characters")),
         "relations": _normalize_dict_list(raw_graph.get("relations")),
         "terms": _normalize_terms(raw_graph.get("terms")),
         "scenes": _normalize_dict_list(raw_graph.get("scenes")),
-        _NORMALIZED_GRAPH_MARKER: True,
-    }
+    })
 
 
 def load_story_graph(path):
@@ -143,7 +144,7 @@ def load_story_graph(path):
         return _empty_graph()
 
 
-def _item_texts(items):
+def _texts_from_items(items):
     texts = []
     for item in items or []:
         if isinstance(item, dict):
@@ -155,23 +156,11 @@ def _item_texts(items):
     return texts
 
 
-def _context_texts(context):
-    texts = []
-    for item in context or []:
-        if isinstance(item, dict):
-            text = _clean_text(item.get("text"))
-        else:
-            text = _clean_text(item)
-        if text:
-            texts.append(text)
-    return texts
-
-
 def _combined_search_text(target_items, context_past, context_future):
     parts = []
-    parts.extend(_context_texts(context_past))
-    parts.extend(_item_texts(target_items))
-    parts.extend(_context_texts(context_future))
+    parts.extend(_texts_from_items(context_past))
+    parts.extend(_texts_from_items(target_items))
+    parts.extend(_texts_from_items(context_future))
     return "\n".join(parts)
 
 

--- a/story_memory.py
+++ b/story_memory.py
@@ -4,12 +4,7 @@ import os
 import re
 
 
-_EMPTY_GRAPH = {
-    "characters": {},
-    "relations": [],
-    "terms": [],
-    "scenes": [],
-}
+_NORMALIZED_GRAPH_MARKER = "_story_memory_normalized"
 
 
 def _empty_graph():
@@ -119,14 +114,21 @@ def _normalize_dict_list(value):
     return [dict(item) for item in value if isinstance(item, dict)] if isinstance(value, list) else []
 
 
+def _is_normalized_story_graph(value):
+    return isinstance(value, dict) and value.get(_NORMALIZED_GRAPH_MARKER) is True
+
+
 def normalize_story_graph(raw_graph):
     if not isinstance(raw_graph, dict):
         return _empty_graph()
+    if _is_normalized_story_graph(raw_graph):
+        return raw_graph
     return {
         "characters": _normalize_character_map(raw_graph.get("characters")),
         "relations": _normalize_dict_list(raw_graph.get("relations")),
         "terms": _normalize_terms(raw_graph.get("terms")),
         "scenes": _normalize_dict_list(raw_graph.get("scenes")),
+        _NORMALIZED_GRAPH_MARKER: True,
     }
 
 

--- a/story_memory.py
+++ b/story_memory.py
@@ -136,7 +136,8 @@ def load_story_graph(path):
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
             return normalize_story_graph(json.load(handle) or {})
-    except Exception:
+    except Exception as exc:
+        print(f"Warning: Failed to load story graph {path}: {exc}")
         return _empty_graph()
 
 
@@ -415,6 +416,16 @@ def _append_limited(lines, line, max_chars):
     return False
 
 
+def has_story_hits(story_hits):
+    if not isinstance(story_hits, dict):
+        return False
+    for key in ("characters", "relations", "terms", "scenes"):
+        hits = story_hits.get(key)
+        if isinstance(hits, list) and hits:
+            return True
+    return False
+
+
 def format_story_hits_block(story_hits, max_chars, empty_label="(none)"):
     if not isinstance(story_hits, dict):
         return empty_label
@@ -462,8 +473,12 @@ def format_story_hits_block(story_hits, max_chars, empty_label="(none)"):
             note = _clean_text(item.get("note"))
             if source and target and source != target:
                 line = f"- {source} -> {target}"
+            elif source:
+                line = f"- Term: {source}"
+            elif target:
+                line = f"- Term target: {target}"
             else:
-                line = f"- Keep unchanged: {source or target}"
+                continue
             if note:
                 line += f": {note}"
             if not _append_limited(lines, line, max_chars):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
+import story_memory
 import translator_runtime as runtime
 
 
@@ -116,6 +117,135 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertIn('LOCKED TERMS', prompt)
         self.assertIn('RETRIEVED MEMORY', prompt)
         self.assertIn('\u4f60\u597d\uff0cAlice', prompt)
+
+    def test_story_memory_prompt_blocks_are_optional(self):
+        old_sync_rag_enabled = runtime.SYNC_RAG_ENABLED
+        old_sync_story_enabled = runtime.SYNC_STORY_MEMORY_ENABLED
+        old_batch_limit = batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS
+        try:
+            runtime.SYNC_RAG_ENABLED = False
+            runtime.SYNC_STORY_MEMORY_ENABLED = False
+            batch_prompt = batch_mod.build_user_prompt(
+                [],
+                [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
+                [],
+            )
+            sync_prompt = runtime.build_prompt(
+                [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
+            )
+
+            self.assertNotIn('STORY MEMORY', batch_prompt)
+            self.assertNotIn('STORY MEMORY', sync_prompt)
+
+            batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = 120
+            prompt_with_story = batch_mod.build_user_prompt(
+                [],
+                [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
+                [],
+                story_hits={
+                    'terms': [
+                        {
+                            'source': 'Void Gate',
+                            'target': '\u865a\u7a7a\u95e8',
+                            'note': '\u4e16\u754c\u89c2\u6838\u5fc3\u672f\u8bed',
+                        },
+                    ],
+                },
+            )
+        finally:
+            runtime.SYNC_RAG_ENABLED = old_sync_rag_enabled
+            runtime.SYNC_STORY_MEMORY_ENABLED = old_sync_story_enabled
+            batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = old_batch_limit
+
+        self.assertIn('STORY MEMORY', prompt_with_story)
+        self.assertIn('Void Gate -> \u865a\u7a7a\u95e8', prompt_with_story)
+
+    def test_sync_story_memory_uses_local_graph_when_enabled(self):
+        old_values = {
+            'enabled': runtime.SYNC_STORY_MEMORY_ENABLED,
+            'graph_file': runtime.SYNC_STORY_MEMORY_GRAPH_FILE,
+            'max_context_chars': runtime.SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS,
+            'top_k_relations': runtime.SYNC_STORY_MEMORY_TOP_K_RELATIONS,
+            'top_k_terms': runtime.SYNC_STORY_MEMORY_TOP_K_TERMS,
+            'include_scene_summary': runtime.SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY,
+            'graph': runtime._SYNC_STORY_GRAPH,
+            'graph_path': runtime._SYNC_STORY_GRAPH_PATH,
+        }
+        graph = {
+            'characters': {
+                'eileen': {
+                    'zh_name': '\u827e\u7433',
+                    'speaker_ids': ['eileen', 'eileen_side'],
+                    'style': '\u8bed\u6c14\u8f7b\u5feb',
+                },
+                'noah': {
+                    'zh_name': '\u8bfa\u4e9a',
+                    'speaker_ids': ['noah'],
+                },
+            },
+            'relations': [
+                {
+                    'left': 'eileen',
+                    'right': 'noah',
+                    'type': 'close_friend',
+                    'note': '\u4e24\u4eba\u5173\u7cfb\u4eb2\u8fd1',
+                    'confidence': 0.85,
+                },
+            ],
+            'terms': [
+                {
+                    'source': 'Void Gate',
+                    'target': '\u865a\u7a7a\u95e8',
+                    'note': '\u5fc5\u987b\u7edf\u4e00',
+                },
+            ],
+            'scenes': [
+                {
+                    'file_rel_path': 'chapter1.rpy',
+                    'line_start': 120,
+                    'line_end': 220,
+                    'summary': '\u827e\u7433\u548c\u8bfa\u4e9a\u5728\u5929\u53f0\u8c08\u8bdd',
+                    'characters': ['eileen', 'noah'],
+                },
+            ],
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                graph_file = Path(tmp) / 'story_graph.json'
+                graph_file.write_text(json.dumps(graph), encoding='utf-8')
+                runtime.SYNC_STORY_MEMORY_ENABLED = True
+                runtime.SYNC_STORY_MEMORY_GRAPH_FILE = str(graph_file)
+                runtime.SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS = 500
+                runtime.SYNC_STORY_MEMORY_TOP_K_RELATIONS = 4
+                runtime.SYNC_STORY_MEMORY_TOP_K_TERMS = 8
+                runtime.SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY = True
+                runtime._SYNC_STORY_GRAPH = None
+                runtime._SYNC_STORY_GRAPH_PATH = ''
+
+                items = [
+                    {
+                        'id': 'chapter1.rpy:129:0',
+                        'text': 'Noah opens the Void Gate.',
+                        'line': 129,
+                        'file_rel_path': 'chapter1.rpy',
+                    },
+                ]
+                hits = runtime.retrieve_sync_story_hits(items)
+                prompt = runtime.build_prompt(items, story_hits=hits)
+        finally:
+            runtime.SYNC_STORY_MEMORY_ENABLED = old_values['enabled']
+            runtime.SYNC_STORY_MEMORY_GRAPH_FILE = old_values['graph_file']
+            runtime.SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS = old_values['max_context_chars']
+            runtime.SYNC_STORY_MEMORY_TOP_K_RELATIONS = old_values['top_k_relations']
+            runtime.SYNC_STORY_MEMORY_TOP_K_TERMS = old_values['top_k_terms']
+            runtime.SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY = old_values['include_scene_summary']
+            runtime._SYNC_STORY_GRAPH = old_values['graph']
+            runtime._SYNC_STORY_GRAPH_PATH = old_values['graph_path']
+
+        self.assertIn('STORY MEMORY', prompt)
+        self.assertIn('Void Gate -> \u865a\u7a7a\u95e8', prompt)
+        self.assertIn('eileen -> noah', prompt)
+        self.assertLessEqual(len(story_memory.format_story_hits_block(hits, 80)), 80)
 
     def test_collect_translation_entries_does_not_skip_after_unmatched_source_markers(self):
         entries = runtime.collect_translation_entries_from_lines([

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -160,6 +160,33 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertIn('STORY MEMORY', prompt_with_story)
         self.assertIn('Void Gate -> \u865a\u7a7a\u95e8', prompt_with_story)
 
+        term_only_block = story_memory.format_story_hits_block(
+            {'terms': [{'source': 'Aether', 'target': '', 'note': 'Proper noun'}]},
+            200,
+        )
+        self.assertIn('Term: Aether', term_only_block)
+        self.assertNotIn('Keep unchanged', term_only_block)
+
+    def test_story_memory_hit_count_ignores_empty_categories(self):
+        self.assertFalse(story_memory.has_story_hits({}))
+        self.assertFalse(
+            story_memory.has_story_hits(
+                {'characters': [], 'relations': [], 'terms': [], 'scenes': []}
+            )
+        )
+        self.assertTrue(story_memory.has_story_hits({'terms': [{'source': 'Void Gate'}]}))
+
+    def test_load_story_graph_warns_on_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            graph_file = Path(tmp) / 'story_graph.json'
+            graph_file.write_text('{bad json', encoding='utf-8')
+            with mock.patch('builtins.print') as print_mock:
+                graph = story_memory.load_story_graph(str(graph_file))
+
+        self.assertEqual(graph, {'characters': {}, 'relations': [], 'terms': [], 'scenes': []})
+        self.assertTrue(print_mock.called)
+        self.assertIn('Failed to load story graph', print_mock.call_args[0][0])
+
     def test_sync_story_memory_uses_local_graph_when_enabled(self):
         old_values = {
             'enabled': runtime.SYNC_STORY_MEMORY_ENABLED,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -17,6 +17,17 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertNotEqual(tasks[0]['start'], tasks[1]['start'])
         self.assertNotEqual(tasks[0]['progress_entry'], tasks[1]['progress_entry'])
 
+    def test_collect_tasks_records_dialogue_speaker_id(self):
+        tasks = runtime.collect_tasks([
+            'e happy "Hello Noah"\n',
+            'text "Start Game"\n',
+        ])
+        by_text = {task['text']: task for task in tasks}
+
+        self.assertEqual(by_text['Hello Noah'].get('speaker_id'), 'e')
+        self.assertEqual(by_text['Hello Noah'].get('speaker'), 'e')
+        self.assertNotIn('speaker_id', by_text['Start Game'])
+
     def test_quote_with_round_trips_prefixed_literals(self):
         prefix, quote = runtime.parse_string_literal_format('u"Hello"')
         literal = runtime.quote_with('\u4f60\u597d', quote, prefix=prefix)
@@ -176,6 +187,37 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         )
         self.assertTrue(story_memory.has_story_hits({'terms': [{'source': 'Void Gate'}]}))
 
+    def test_story_memory_uses_speaker_id_to_activate_character(self):
+        graph = {
+            'characters': {
+                'eileen': {
+                    'speaker_ids': ['e'],
+                    'zh_name': '\u827e\u7433',
+                    'style': '\u8bed\u6c14\u8f7b\u5feb',
+                },
+                'noah': {
+                    'speaker_ids': ['n'],
+                    'zh_name': '\u8bfa\u4e9a',
+                },
+            },
+            'relations': [
+                {
+                    'left': 'eileen',
+                    'right': 'noah',
+                    'type': 'close_friend',
+                    'confidence': 0.85,
+                },
+            ],
+        }
+        hits = story_memory.retrieve_story_hits(
+            graph,
+            'chapter1.rpy',
+            [{'id': 'chapter1.rpy:10:4', 'text': 'We should go.', 'speaker_id': 'e'}],
+        )
+
+        self.assertEqual([item['id'] for item in hits['characters']], ['eileen'])
+        self.assertEqual(hits['relations'], [])
+
     def test_load_story_graph_warns_on_invalid_json(self):
         with tempfile.TemporaryDirectory() as tmp:
             graph_file = Path(tmp) / 'story_graph.json'
@@ -186,6 +228,39 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(graph, {'characters': {}, 'relations': [], 'terms': [], 'scenes': []})
         self.assertTrue(print_mock.called)
         self.assertIn('Failed to load story graph', print_mock.call_args[0][0])
+
+    def test_story_memory_graph_path_prefers_root_logs(self):
+        old_values = {
+            'root': runtime.ROOT_DIR,
+            'base': runtime.BASE_DIR,
+            'tool': runtime.TOOL_DIR,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp_path = Path(tmp)
+                root_dir = tmp_path / 'repo'
+                base_dir = tmp_path / 'game'
+                tool_dir = tmp_path / 'tool'
+                root_graph = root_dir / 'logs' / 'story_memory' / 'story_graph.json'
+                base_graph = base_dir / 'logs' / 'story_memory' / 'story_graph.json'
+                root_graph.parent.mkdir(parents=True)
+                base_graph.parent.mkdir(parents=True)
+                tool_dir.mkdir()
+                root_graph.write_text('{}', encoding='utf-8')
+                base_graph.write_text('{}', encoding='utf-8')
+                runtime.ROOT_DIR = str(root_dir)
+                runtime.BASE_DIR = str(base_dir)
+                runtime.TOOL_DIR = str(tool_dir)
+
+                resolved = runtime.resolve_story_memory_graph_path(
+                    'logs/story_memory/story_graph.json'
+                )
+        finally:
+            runtime.ROOT_DIR = old_values['root']
+            runtime.BASE_DIR = old_values['base']
+            runtime.TOOL_DIR = old_values['tool']
+
+        self.assertEqual(Path(resolved), root_graph)
 
     def test_sync_story_memory_uses_local_graph_when_enabled(self):
         old_values = {

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -35,6 +35,17 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             'e',
         )
 
+    def test_infer_dialogue_speaker_uses_inline_dialogue_segment(self):
+        line = 'if unlocked: e "Hello Noah"\n'
+        self.assertEqual(
+            runtime.infer_dialogue_speaker_id(line, line.index('"')),
+            'e',
+        )
+
+    def test_infer_dialogue_speaker_skips_define_expressions(self):
+        line = 'define e = Character("Eileen")\n'
+        self.assertEqual(runtime.infer_dialogue_speaker_id(line, line.index('"')), '')
+
     def test_quote_with_round_trips_prefixed_literals(self):
         prefix, quote = runtime.parse_string_literal_format('u"Hello"')
         literal = runtime.quote_with('\u4f60\u597d', quote, prefix=prefix)
@@ -193,6 +204,12 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             )
         )
         self.assertTrue(story_memory.has_story_hits({'terms': [{'source': 'Void Gate'}]}))
+
+    def test_story_memory_normalize_has_fast_path_for_normalized_graphs(self):
+        normalized = story_memory.normalize_story_graph({'terms': {'Void Gate': '\u865a\u7a7a\u95e8'}})
+
+        self.assertIs(story_memory.normalize_story_graph(normalized), normalized)
+        self.assertIn('Void Gate', normalized['terms'][0]['source'])
 
     def test_story_memory_uses_speaker_id_case_insensitively(self):
         graph = {

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -28,6 +28,13 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(by_text['Hello Noah'].get('speaker'), 'e')
         self.assertNotIn('speaker_id', by_text['Start Game'])
 
+    def test_infer_dialogue_speaker_skips_non_speaker_names(self):
+        line = 'call e happy "Hello Noah"\n'
+        self.assertEqual(
+            runtime.infer_dialogue_speaker_id(line, line.index('"')),
+            'e',
+        )
+
     def test_quote_with_round_trips_prefixed_literals(self):
         prefix, quote = runtime.parse_string_literal_format('u"Hello"')
         literal = runtime.quote_with('\u4f60\u597d', quote, prefix=prefix)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -28,6 +28,21 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(by_text['Hello Noah'].get('speaker'), 'e')
         self.assertNotIn('speaker_id', by_text['Start Game'])
 
+    def test_collect_tasks_allows_new_as_dialogue_speaker_id(self):
+        tasks = runtime.collect_tasks(['new "Hello Noah"\n'])
+
+        self.assertEqual(tasks[0].get('speaker_id'), 'new')
+
+    def test_collect_tasks_skips_new_speaker_id_in_translation_templates(self):
+        tasks = runtime.collect_tasks([
+            'translate schinese start_123:\n',
+            '    old "Hello Noah"\n',
+            '    new "Hello Noah"\n',
+        ])
+
+        self.assertEqual(len(tasks), 1)
+        self.assertNotIn('speaker_id', tasks[0])
+
     def test_infer_dialogue_speaker_skips_non_speaker_names(self):
         line = 'call e happy "Hello Noah"\n'
         self.assertEqual(
@@ -162,9 +177,21 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             sync_prompt = runtime.build_prompt(
                 [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
             )
+            batch_empty_story_prompt = batch_mod.build_user_prompt(
+                [],
+                [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
+                [],
+                story_hits={'characters': [], 'relations': [], 'terms': [], 'scenes': []},
+            )
+            sync_empty_story_prompt = runtime.build_prompt(
+                [{'id': 'chapter1.rpy:0:1', 'text': 'Open the Void Gate'}],
+                story_hits={'characters': [], 'relations': [], 'terms': [], 'scenes': []},
+            )
 
             self.assertNotIn('STORY MEMORY', batch_prompt)
             self.assertNotIn('STORY MEMORY', sync_prompt)
+            self.assertNotIn('STORY MEMORY', batch_empty_story_prompt)
+            self.assertNotIn('STORY MEMORY', sync_empty_story_prompt)
 
             batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = 120
             prompt_with_story = batch_mod.build_user_prompt(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -210,6 +210,11 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
 
         self.assertIs(story_memory.normalize_story_graph(normalized), normalized)
         self.assertIn('Void Gate', normalized['terms'][0]['source'])
+        self.assertNotIn('_story_memory_normalized', json.dumps(normalized))
+
+    def test_story_memory_rel_path_preserves_parent_segments(self):
+        self.assertEqual(story_memory._normalize_rel_path('./chapter1.rpy'), 'chapter1.rpy')
+        self.assertEqual(story_memory._normalize_rel_path('../chapter1.rpy'), '../chapter1.rpy')
 
     def test_story_memory_uses_speaker_id_case_insensitively(self):
         graph = {

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -194,7 +194,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         )
         self.assertTrue(story_memory.has_story_hits({'terms': [{'source': 'Void Gate'}]}))
 
-    def test_story_memory_uses_speaker_id_to_activate_character(self):
+    def test_story_memory_uses_speaker_id_case_insensitively(self):
         graph = {
             'characters': {
                 'eileen': {
@@ -219,7 +219,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         hits = story_memory.retrieve_story_hits(
             graph,
             'chapter1.rpy',
-            [{'id': 'chapter1.rpy:10:4', 'text': 'We should go.', 'speaker_id': 'e'}],
+            [{'id': 'chapter1.rpy:10:4', 'text': 'We should go.', 'speaker_id': 'E'}],
         )
 
         self.assertEqual([item['id'] for item in hits['characters']], ['eileen'])

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -24,6 +24,14 @@
       "history_char_limit": 220,
       "update_on_success": true,
       "store_dir": ""
+    },
+    "story_memory": {
+      "enabled": false,
+      "graph_file": "logs/story_memory/story_graph.json",
+      "max_context_chars": 800,
+      "top_k_relations": 4,
+      "top_k_terms": 8,
+      "include_scene_summary": true
     }
   },
   "batch": {
@@ -49,6 +57,14 @@
       "bootstrap_on_build": true,
       "history_char_limit": 220,
       "store_dir": ""
+    },
+    "story_memory": {
+      "enabled": false,
+      "graph_file": "logs/story_memory/story_graph.json",
+      "max_context_chars": 1200,
+      "top_k_relations": 6,
+      "top_k_terms": 12,
+      "include_scene_summary": true
     }
   }
 }

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -179,6 +179,34 @@ STRING_LITERAL_PREFIX_RE = re.compile(r"(?is)^(?P<prefix>[rubf]*)(?P<quote>'''|\
 TL_COMMENT_SOURCE_RE = re.compile(r'^\s*#\s*(?P<prefix>[^\"]*?)"(?P<text>.*)"\s*$')
 TL_OLD_LINE_RE = re.compile(r'^\s*old\s+"(?P<text>.*)"\s*$')
 TL_NEW_LINE_RE = re.compile(r'^\s*new\s+"(?P<text>.*)"\s*$')
+RENPLY_NON_SPEAKER_NAMES = {
+    "_",
+    "call",
+    "elif",
+    "else",
+    "extend",
+    "hide",
+    "if",
+    "image",
+    "init",
+    "jump",
+    "label",
+    "menu",
+    "new",
+    "old",
+    "python",
+    "renpy",
+    "return",
+    "scene",
+    "screen",
+    "set",
+    "show",
+    "text",
+    "translate",
+    "voice",
+    "window",
+    "with",
+}
 PRESERVE_TERMS_LOWER = {term.lower() for term in PRESERVE_TERMS}
 FILE_EXTENSIONS = (
     "png", "jpg", "jpeg", "bmp", "gif", "webp", "txt", "pdf", "mp3", "wav", "ogg", "zip"
@@ -326,7 +354,7 @@ def _resolve_path(base_dir, value):
     return os.path.abspath(os.path.join(base_dir, text))
 
 
-def _resolve_preferred_path(primary_base_dir, secondary_base_dir, value):
+def _resolve_preferred_path_from_bases(value, base_dirs):
     if value is None:
         return ""
     text = str(value).strip()
@@ -336,7 +364,7 @@ def _resolve_preferred_path(primary_base_dir, secondary_base_dir, value):
         return os.path.abspath(text)
 
     candidates = []
-    for base_dir in (primary_base_dir, secondary_base_dir):
+    for base_dir in base_dirs:
         if not base_dir:
             continue
         candidate = os.path.abspath(os.path.join(base_dir, text))
@@ -347,6 +375,14 @@ def _resolve_preferred_path(primary_base_dir, secondary_base_dir, value):
         if os.path.exists(candidate):
             return candidate
     return candidates[0] if candidates else ""
+
+
+def _resolve_preferred_path(primary_base_dir, secondary_base_dir, value):
+    return _resolve_preferred_path_from_bases(value, (primary_base_dir, secondary_base_dir))
+
+
+def resolve_story_memory_graph_path(value):
+    return _resolve_preferred_path_from_bases(value, (ROOT_DIR, BASE_DIR, TOOL_DIR))
 
 
 def _coerce_command(value):
@@ -495,11 +531,7 @@ def load_sync_story_memory_settings(config):
 
     graph_file = story_config.get("graph_file")
     if graph_file:
-        SYNC_STORY_MEMORY_GRAPH_FILE = _resolve_preferred_path(
-            BASE_DIR,
-            TOOL_DIR,
-            graph_file,
-        )
+        SYNC_STORY_MEMORY_GRAPH_FILE = resolve_story_memory_graph_path(graph_file)
     else:
         SYNC_STORY_MEMORY_GRAPH_FILE = ""
     _SYNC_STORY_GRAPH = None
@@ -2384,6 +2416,25 @@ def process_batch_with_retry(batch, replacements, retry_depth=0):
     log_failure(batch, f"Failed after retries: {error_str}")
     return []
 
+
+def infer_dialogue_speaker_id(line, string_start_col):
+    prefix = (line[:string_start_col] or "").strip()
+    if not prefix:
+        return ""
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(prefix).readline))
+    except Exception:
+        return ""
+    for token in tokens:
+        if token.type != tokenize.NAME:
+            continue
+        candidate = token.string.strip()
+        if candidate and candidate not in RENPLY_NON_SPEAKER_NAMES:
+            return candidate
+        return ""
+    return ""
+
+
 def collect_tasks(lines, skip_translated=True):
     # Logic to parse Ren'Py files
     # Note: caller handles filename lookup, this function just parses
@@ -2435,7 +2486,7 @@ def collect_tasks(lines, skip_translated=True):
 
                     if (" " in text_val or len(text_val) > 15 or (text_val and text_val[0].isupper())
                             or (ALLOW_SINGLE_WORD_TRANSLATION and is_english_like(text_val))):
-                        tasks.append({
+                        task = {
                             "id": f"line_{idx}_{token.start[1]}", # Temp ID, updated later
                             "text": text_val,
                             "line": idx,
@@ -2444,7 +2495,12 @@ def collect_tasks(lines, skip_translated=True):
                             "quote": quote,
                             "prefix": prefix,
                             "progress_entry": f"task:{idx}:{token.start[1]}",
-                        })
+                        }
+                        speaker_id = infer_dialogue_speaker_id(line, token.start[1])
+                        if speaker_id:
+                            task["speaker_id"] = speaker_id
+                            task["speaker"] = speaker_id
+                        tasks.append(task)
         except Exception:
             continue
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -194,7 +194,6 @@ RENPY_NON_SPEAKER_NAMES = {
     "jump",
     "label",
     "menu",
-    "new",
     "old",
     "python",
     "renpy",
@@ -2076,7 +2075,8 @@ def build_prompt(items, glossary_hits=None, history_hits=None, story_hits=None):
         ensure_ascii=False,
     )
     reference_blocks = ""
-    if SYNC_RAG_ENABLED or story_hits is not None:
+    has_story_hits = story_memory.has_story_hits(story_hits)
+    if SYNC_RAG_ENABLED or has_story_hits:
         parts = ["\nReference blocks:\n"]
         if SYNC_RAG_ENABLED:
             glossary_hits = glossary_hits or []
@@ -2085,7 +2085,7 @@ def build_prompt(items, glossary_hits=None, history_hits=None, story_hits=None):
                 f"LOCKED TERMS:\n{format_sync_glossary_hits_block(glossary_hits, '(none)')}\n\n"
                 f"RETRIEVED MEMORY:\n{format_sync_history_hits_block(history_hits, '(none)')}\n\n"
             )
-        if story_hits is not None:
+        if has_story_hits:
             parts.append(
                 "STORY MEMORY:\n"
                 f"{story_memory.format_story_hits_block(story_hits, SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS)}\n"
@@ -2500,7 +2500,9 @@ def collect_tasks(lines, skip_translated=True):
                             "prefix": prefix,
                             "progress_entry": f"task:{idx}:{token.start[1]}",
                         }
-                        speaker_id = infer_dialogue_speaker_id(line, token.start[1])
+                        speaker_id = ""
+                        if not (is_translation_file and sline.startswith("new ")):
+                            speaker_id = infer_dialogue_speaker_id(line, token.start[1])
                         if speaker_id:
                             task["speaker_id"] = speaker_id
                             task["speaker"] = speaker_id

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -182,6 +182,8 @@ TL_NEW_LINE_RE = re.compile(r'^\s*new\s+"(?P<text>.*)"\s*$')
 RENPLY_NON_SPEAKER_NAMES = {
     "_",
     "call",
+    "default",
+    "define",
     "elif",
     "else",
     "extend",
@@ -2421,6 +2423,9 @@ def infer_dialogue_speaker_id(line, string_start_col):
     prefix = (line[:string_start_col] or "").strip()
     if not prefix:
         return ""
+    prefix = prefix.rsplit(":", 1)[-1].strip()
+    if not prefix or any(marker in prefix for marker in ("=", "(", ")", "[", "]", "{", "}")):
+        return ""
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(prefix).readline))
     except Exception:
@@ -2429,7 +2434,7 @@ def infer_dialogue_speaker_id(line, string_start_col):
         if token.type != tokenize.NAME:
             continue
         candidate = token.string.strip()
-        if candidate and candidate not in RENPLY_NON_SPEAKER_NAMES:
+        if candidate and candidate.lower() not in RENPLY_NON_SPEAKER_NAMES:
             return candidate
     return ""
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -179,7 +179,7 @@ STRING_LITERAL_PREFIX_RE = re.compile(r"(?is)^(?P<prefix>[rubf]*)(?P<quote>'''|\
 TL_COMMENT_SOURCE_RE = re.compile(r'^\s*#\s*(?P<prefix>[^\"]*?)"(?P<text>.*)"\s*$')
 TL_OLD_LINE_RE = re.compile(r'^\s*old\s+"(?P<text>.*)"\s*$')
 TL_NEW_LINE_RE = re.compile(r'^\s*new\s+"(?P<text>.*)"\s*$')
-RENPLY_NON_SPEAKER_NAMES = {
+RENPY_NON_SPEAKER_NAMES = {
     "_",
     "call",
     "default",
@@ -2434,7 +2434,7 @@ def infer_dialogue_speaker_id(line, string_start_col):
         if token.type != tokenize.NAME:
             continue
         candidate = token.string.strip()
-        if candidate and candidate.lower() not in RENPLY_NON_SPEAKER_NAMES:
+        if candidate and candidate.lower() not in RENPY_NON_SPEAKER_NAMES:
             return candidate
     return ""
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -165,8 +165,8 @@ NON_TRANSLATABLE_EXACT = {
 
 NON_TRANSLATABLE_TAG_ONLY = re.compile(r"^\{[^}]+\}$")
 NON_TRANSLATABLE_SYMBOLS = re.compile(r"^[^A-Za-z0-9\u4e00-\u9fff]+$")
-RENPLY_TAG_RE = re.compile(r"\{[^}]*\}")
-RENPLY_FIELD_RE = re.compile(r"\[[^\]]+\]")
+RENPY_TAG_RE = re.compile(r"\{[^}]*\}")
+RENPY_FIELD_RE = re.compile(r"\[[^\]]+\]")
 WORD_TOKEN_RE = re.compile(r"[A-Za-z]+")
 VOWEL_RE = re.compile(r"[aeiou]", re.IGNORECASE)
 REPEATED_CHAR_RE = re.compile(r"(.)\\1{2,}")
@@ -1441,8 +1441,8 @@ def is_english_like(text):
 
 
 def is_name_hint(text):
-    cleaned = RENPLY_TAG_RE.sub("", text or "")
-    cleaned = RENPLY_FIELD_RE.sub("", cleaned)
+    cleaned = RENPY_TAG_RE.sub("", text or "")
+    cleaned = RENPY_FIELD_RE.sub("", cleaned)
     cleaned = cleaned.strip()
     if not cleaned:
         return False
@@ -1460,8 +1460,8 @@ def is_name_hint(text):
 
 
 def is_sound_name_hint(text):
-    cleaned = RENPLY_TAG_RE.sub("", text or "")
-    cleaned = RENPLY_FIELD_RE.sub("", cleaned)
+    cleaned = RENPY_TAG_RE.sub("", text or "")
+    cleaned = RENPY_FIELD_RE.sub("", cleaned)
     cleaned = cleaned.strip()
     if not cleaned:
         return False
@@ -1489,8 +1489,8 @@ def is_sound_name_hint(text):
 
 
 def is_name_like(text):
-    cleaned = RENPLY_TAG_RE.sub("", text or "")
-    cleaned = RENPLY_FIELD_RE.sub("", cleaned)
+    cleaned = RENPY_TAG_RE.sub("", text or "")
+    cleaned = RENPY_FIELD_RE.sub("", cleaned)
     cleaned = cleaned.strip()
     if not cleaned:
         return False
@@ -1506,8 +1506,8 @@ def is_name_like(text):
 def is_short_effect(text):
     if not text:
         return False
-    cleaned = RENPLY_TAG_RE.sub("", text)
-    cleaned = RENPLY_FIELD_RE.sub("", cleaned)
+    cleaned = RENPY_TAG_RE.sub("", text)
+    cleaned = RENPY_FIELD_RE.sub("", cleaned)
     cleaned = cleaned.strip()
     if not cleaned:
         return True
@@ -1546,8 +1546,8 @@ def apply_normalization(text):
 
 
 def _extract_word_tokens(text):
-    cleaned = RENPLY_TAG_RE.sub("", text or "")
-    cleaned = RENPLY_FIELD_RE.sub("", cleaned)
+    cleaned = RENPY_TAG_RE.sub("", text or "")
+    cleaned = RENPY_FIELD_RE.sub("", cleaned)
     return [token.lower() for token in WORD_TOKEN_RE.findall(cleaned)]
 
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -16,6 +16,7 @@ import zlib
 from datetime import datetime
 
 from rag_memory import JsonRagStore, hash_text, truncate_text
+import story_memory
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -111,6 +112,17 @@ SYNC_RAG_HISTORY_CHAR_LIMIT = 220
 SYNC_RAG_UPDATE_ON_SUCCESS = True
 SYNC_RAG_QUALITY_STATE = "sync_applied"
 _SYNC_RAG_STORE = None
+
+# Optional structured story memory for synchronous translation. Disabled by
+# default to keep sync repair and smoke-test runs lightweight unless configured.
+SYNC_STORY_MEMORY_ENABLED = False
+SYNC_STORY_MEMORY_GRAPH_FILE = ""
+SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS = 800
+SYNC_STORY_MEMORY_TOP_K_RELATIONS = 4
+SYNC_STORY_MEMORY_TOP_K_TERMS = 8
+SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY = True
+_SYNC_STORY_GRAPH = None
+_SYNC_STORY_GRAPH_PATH = ""
 
 # Optional allowlist to limit which files are processed (relative to TL_DIR).
 INCLUDE_FILES = set()
@@ -450,6 +462,50 @@ def load_sync_rag_settings(config):
     _SYNC_RAG_STORE = None
 
 
+def load_sync_story_memory_settings(config):
+    global SYNC_STORY_MEMORY_ENABLED, SYNC_STORY_MEMORY_GRAPH_FILE
+    global SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS, SYNC_STORY_MEMORY_TOP_K_RELATIONS
+    global SYNC_STORY_MEMORY_TOP_K_TERMS, SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY
+    global _SYNC_STORY_GRAPH, _SYNC_STORY_GRAPH_PATH
+
+    sync = config.get("sync")
+    if not isinstance(sync, dict):
+        sync = {}
+    story_config = sync.get("story_memory")
+    if not isinstance(story_config, dict):
+        story_config = {}
+
+    SYNC_STORY_MEMORY_ENABLED = _coerce_bool(story_config.get("enabled"), False)
+    SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS = _coerce_positive_int(
+        story_config.get("max_context_chars"),
+        800,
+    )
+    SYNC_STORY_MEMORY_TOP_K_RELATIONS = _coerce_positive_int(
+        story_config.get("top_k_relations"),
+        4,
+    )
+    SYNC_STORY_MEMORY_TOP_K_TERMS = _coerce_positive_int(
+        story_config.get("top_k_terms"),
+        8,
+    )
+    SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY = _coerce_bool(
+        story_config.get("include_scene_summary"),
+        True,
+    )
+
+    graph_file = story_config.get("graph_file")
+    if graph_file:
+        SYNC_STORY_MEMORY_GRAPH_FILE = _resolve_preferred_path(
+            BASE_DIR,
+            TOOL_DIR,
+            graph_file,
+        )
+    else:
+        SYNC_STORY_MEMORY_GRAPH_FILE = ""
+    _SYNC_STORY_GRAPH = None
+    _SYNC_STORY_GRAPH_PATH = ""
+
+
 def load_translator_settings():
     """Loads per-game settings (game root, tl subdir) from translator_config.json or env."""
     global BASE_DIR, TL_DIR, TL_SUBDIR, ENV_GAME_ROOT, WORK_GAME_DIR, SOURCE_GAME_DIR, GLOSSARY_FILE
@@ -524,6 +580,7 @@ def load_translator_settings():
     PREP_UNPACK_COMMAND = _coerce_command(prepare.get("unpack_command"))
     PREP_TEMPLATE_COMMAND = _coerce_command(prepare.get("template_command"))
     load_sync_rag_settings(config)
+    load_sync_story_memory_settings(config)
 
 
 def load_config():
@@ -1175,6 +1232,35 @@ def format_sync_history_hits_block(hits, empty_label="(none)"):
             f"- [{file_rel_path}:{line_start}-{line_end} score={score:.3f} quality={quality}] {translated_text}"
         )
     return "\n".join(lines) if lines else empty_label
+
+
+def get_sync_story_graph():
+    global _SYNC_STORY_GRAPH, _SYNC_STORY_GRAPH_PATH
+    if not SYNC_STORY_MEMORY_ENABLED:
+        return None
+    graph_path = os.path.abspath(SYNC_STORY_MEMORY_GRAPH_FILE) if SYNC_STORY_MEMORY_GRAPH_FILE else ""
+    if _SYNC_STORY_GRAPH is None or _SYNC_STORY_GRAPH_PATH != graph_path:
+        _SYNC_STORY_GRAPH = story_memory.load_story_graph(graph_path)
+        _SYNC_STORY_GRAPH_PATH = graph_path
+    return _SYNC_STORY_GRAPH
+
+
+def retrieve_sync_story_hits(target_items):
+    if not SYNC_STORY_MEMORY_ENABLED:
+        return None
+    file_rel_path = ""
+    for item in target_items or []:
+        if isinstance(item, dict) and item.get("file_rel_path"):
+            file_rel_path = item.get("file_rel_path")
+            break
+    return story_memory.retrieve_story_hits(
+        get_sync_story_graph(),
+        file_rel_path,
+        target_items,
+        top_k_relations=SYNC_STORY_MEMORY_TOP_K_RELATIONS,
+        top_k_terms=SYNC_STORY_MEMORY_TOP_K_TERMS,
+        include_scene_summary=SYNC_STORY_MEMORY_INCLUDE_SCENE_SUMMARY,
+    )
 
 
 def retrieve_sync_history_hits(target_items):
@@ -1949,22 +2035,32 @@ def log_failure(batch, error):
         print(f"  Warning: Could not log failure: {e}")
 
 
-def build_prompt(items, glossary_hits=None, history_hits=None):
+def build_prompt(items, glossary_hits=None, history_hits=None, story_hits=None):
     glossary = ", ".join(PRESERVE_TERMS)
     payload = json.dumps(
         [{"id": item["id"], "text": item["text"]} for item in items],
         ensure_ascii=False,
     )
     reference_blocks = ""
-    if SYNC_RAG_ENABLED:
-        glossary_hits = glossary_hits or []
-        history_hits = history_hits or []
-        reference_blocks = (
-            "\nReference blocks:\n"
-            f"LOCKED TERMS:\n{format_sync_glossary_hits_block(glossary_hits, '(none)')}\n\n"
-            f"RETRIEVED MEMORY:\n{format_sync_history_hits_block(history_hits, '(none)')}\n"
-            "Use retrieved memory only as style and terminology reference; ignore it when unrelated.\n"
+    if SYNC_RAG_ENABLED or story_hits is not None:
+        parts = ["\nReference blocks:\n"]
+        if SYNC_RAG_ENABLED:
+            glossary_hits = glossary_hits or []
+            history_hits = history_hits or []
+            parts.append(
+                f"LOCKED TERMS:\n{format_sync_glossary_hits_block(glossary_hits, '(none)')}\n\n"
+                f"RETRIEVED MEMORY:\n{format_sync_history_hits_block(history_hits, '(none)')}\n\n"
+            )
+        if story_hits is not None:
+            parts.append(
+                "STORY MEMORY:\n"
+                f"{story_memory.format_story_hits_block(story_hits, SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS)}\n"
+            )
+        parts.append(
+            "Use reference blocks only as style, terminology, and continuity reference; "
+            "ignore them when unrelated.\n"
         )
+        reference_blocks = "".join(parts)
     return (
         "You are translating a Ren'Py visual novel into Simplified Chinese (zh-CN).\n"
         "Rules:\n"
@@ -2166,9 +2262,15 @@ def call_gemini_sdk(prompt, items):
 def process_batch(batch, replacements):
     glossary_hits = retrieve_sync_glossary_hits(batch) if SYNC_RAG_ENABLED else []
     history_hits, rag_stats = retrieve_sync_history_hits(batch) if SYNC_RAG_ENABLED else ([], {})
+    story_hits = retrieve_sync_story_hits(batch) if SYNC_STORY_MEMORY_ENABLED else None
     if rag_stats.get("hit_count"):
         print(f"  Sync RAG memory hits: {rag_stats['hit_count']}", flush=True)
-    prompt = build_prompt(batch, glossary_hits=glossary_hits, history_hits=history_hits)
+    prompt = build_prompt(
+        batch,
+        glossary_hits=glossary_hits,
+        history_hits=history_hits,
+        story_hits=story_hits,
+    )
 
     # Call API (SDK handles connection details)
     results = call_gemini_sdk(prompt, batch)
@@ -2435,6 +2537,7 @@ def run_translation():
             # Update ID to be unique per file and string literal
             task["id"] = f"{progress_key}:{task['line']}:{task['start']}"
             task["progress_entry"] = _progress_entry_for_task(task)
+            task["file_rel_path"] = progress_key
 
             task_len = len(task["text"])
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2431,7 +2431,6 @@ def infer_dialogue_speaker_id(line, string_start_col):
         candidate = token.string.strip()
         if candidate and candidate not in RENPLY_NON_SPEAKER_NAMES:
             return candidate
-        return ""
     return ""
 
 


### PR DESCRIPTION
## 概要

本 PR 增加一个最小可用的 Structured Story Memory / 结构化剧情记忆层。它不替代现有 glossary 或 translation-memory RAG，而是在启用后额外向翻译 prompt 注入受长度限制的 `STORY MEMORY` 块。

## 主要改动

- 新增共享 `story_memory.py`，负责读取本地 `story_graph.json`、按角色/关系/术语/场景做轻量检索，并格式化 prompt 块。
- Batch 模式新增 `batch.story_memory` 配置，启用时在 `RETRIEVED MEMORY` 和 `CONTEXT BEFORE` 之间插入 `STORY MEMORY`。
- sync 模式新增 `sync.story_memory` 配置，默认关闭；关闭时不读取 story graph、不检索、不增加 prompt 内容。
- 更新 `translator_config.example.json`，给出 Batch 和 sync 的默认关闭配置示例。
- 更新 `README.md`，说明 Story Memory 的启用方式、最小 `story_graph.json` 结构和当前 MVP 边界。
- 增加回归测试，覆盖启用/关闭、sync 本地 graph 检索、prompt 块出现与字符上限。

## 边界

- 不接 Neo4j。
- 不调用额外 LLM 自动抽取 story graph。
- 不改变现有 RAG / glossary 行为。
- 这是 MVP / first pass，不声称完整完成 #8 的 schema、seed 生成、diagnostics 和 repair/probe 接入边界。

Refs #8

## 验证

- `python -m py_compile story_memory.py translator_runtime.py gemini_translate_batch.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`