### PR TITLE
[codex] 修复 batch split 和 repair 边界问题

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2234,17 +2234,30 @@ def parse_repair_start_hint(item):
     raw_id = item.get('id')
     if not raw_id:
         return None
-    parts = str(raw_id).rsplit(':', 2)
-    if len(parts) != 3:
+    numeric_suffix = []
+    for part in reversed(str(raw_id).split(':')):
+        try:
+            numeric_suffix.append(int(part))
+        except (TypeError, ValueError):
+            break
+    numeric_suffix.reverse()
+    if len(numeric_suffix) < 2:
         return None
+
     try:
-        zero_based_line = int(parts[1])
-        start = int(parts[2])
+        item_line = int(item.get('line'))
     except (TypeError, ValueError):
         return None
-    if zero_based_line + 1 != item.get('line'):
-        return None
-    return start
+
+    candidates = []
+    if len(numeric_suffix) >= 3:
+        candidates.append((numeric_suffix[-3], numeric_suffix[-2]))
+    candidates.append((numeric_suffix[-2], numeric_suffix[-1]))
+
+    for line_hint, start in candidates:
+        if line_hint == item_line or line_hint + 1 == item_line:
+            return start
+    return None
 
 
 def find_repair_entry_for_item(item, candidates):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -723,14 +723,15 @@ def load_manifest(target=None):
     return manifest
 
 
-def save_manifest(manifest):
+def save_manifest(manifest, update_latest=True):
     manifest_path = manifest['_manifest_path']
     data = dict(manifest)
     data.pop('_manifest_path', None)
     data.pop('_package_dir', None)
     with open(manifest_path, 'w', encoding='utf-8') as handle:
         json.dump(data, handle, ensure_ascii=False, indent=2)
-    remember_latest_manifest(manifest_path)
+    if update_latest:
+        remember_latest_manifest(manifest_path)
 
 
 
@@ -760,6 +761,37 @@ def summarize_files_for_chunks(chunks):
             }
         files[rel_path]['task_count'] += len(chunk.get('items', []))
     return files
+
+
+def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
+    for key in ('rag_enabled', 'rag_store_path', 'rag_settings'):
+        if key in source_manifest:
+            part_manifest[key] = source_manifest[key]
+
+    if source_manifest.get('rag_enabled'):
+        rag_summary = dict(source_manifest.get('rag_summary') or {})
+        rag_summary['chunks_with_glossary_hits'] = sum(
+            1 for chunk in part_chunks if chunk.get('glossary_hits')
+        )
+        rag_summary['chunks_with_history_hits'] = sum(
+            1 for chunk in part_chunks if chunk.get('history_hits')
+        )
+        part_manifest['rag_summary'] = rag_summary
+
+    for key in (
+        'story_memory_enabled',
+        'story_memory_graph_file',
+        'story_memory_settings',
+    ):
+        if key in source_manifest:
+            part_manifest[key] = source_manifest[key]
+
+    if source_manifest.get('story_memory_enabled'):
+        story_summary = dict(source_manifest.get('story_memory_summary') or {})
+        story_summary['chunks_with_story_hits'] = sum(
+            1 for chunk in part_chunks if story_memory.has_story_hits(chunk.get('story_hits'))
+        )
+        part_manifest['story_memory_summary'] = story_summary
 
 
 def split_chunks_and_lines(chunks, request_lines, max_chunks=0, max_items=0):
@@ -1308,6 +1340,7 @@ def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix
                 'max_items': max_items,
             },
         }
+        copy_split_context_metadata(manifest, part_manifest, part_chunks)
 
         part_manifest_path = os.path.join(part_dir, 'manifest.json')
         with open(part_manifest_path, 'w', encoding='utf-8') as handle:
@@ -1323,9 +1356,11 @@ def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix
     manifest['split_children'] = created_manifests
     manifest['split_generated_at'] = now
     manifest['job_state'] = 'LOCAL_SPLIT_SOURCE'
-    save_manifest(manifest)
+    save_manifest(manifest, update_latest=False)
+    remember_latest_manifest(created_manifests[0])
 
     print(f'Source manifest updated: {manifest["_manifest_path"]}')
+    print(f'Latest manifest set to first split package: {created_manifests[0]}')
     return created_manifests
 
 def submit_manifest(target=None, display_name_override='', model_override=''):
@@ -1788,11 +1823,15 @@ def collect_result_actions(manifest):
 
             seen_ids = set()
             for result_item in result_items:
-                target_item = item_map.get(result_item['id'])
+                result_id = result_item['id']
+                target_item = item_map.get(result_id)
                 if not target_item:
                     bump_counter(summary['reason_counts'], 'schema_or_item_mismatch')
                     continue
-                seen_ids.add(result_item['id'])
+                if result_id in seen_ids:
+                    bump_counter(summary['reason_counts'], 'duplicate_result_id')
+                    continue
+                seen_ids.add(result_id)
 
                 valid, reason = legacy.validate_translation(target_item['text'], result_item['translation'])
                 if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
@@ -2154,6 +2193,81 @@ def collect_translation_entries_from_lines(lines):
     return entries
 
 
+def collect_repair_entries_from_lines(lines):
+    entries = collect_translation_entries_from_lines(lines)
+    seen_spans = {
+        (entry.get('line_number'), entry.get('start'), entry.get('end'))
+        for entry in entries
+    }
+
+    for task in legacy.collect_tasks(lines):
+        span = (int(task['line']) + 1, task.get('start'), task.get('end'))
+        if span in seen_spans:
+            continue
+        seen_spans.add(span)
+        entries.append(
+            {
+                'line_number': span[0],
+                'source': task.get('text', ''),
+                'translation': task.get('text', ''),
+                'start': task.get('start', 0),
+                'end': task.get('end', 0),
+                'prefix': task.get('prefix', ''),
+                'quote': task.get('quote', '"'),
+            }
+        )
+
+    entries.sort(key=lambda entry: (entry.get('line_number', 0), entry.get('start', 0), entry.get('end', 0)))
+    for entry_index, entry in enumerate(entries):
+        entry['entry_index'] = entry_index
+    return entries
+
+
+def parse_repair_start_hint(item):
+    for key in ('start', 'column', 'col'):
+        try:
+            if item.get(key) is not None:
+                return int(item.get(key))
+        except (TypeError, ValueError):
+            pass
+
+    raw_id = item.get('id')
+    if not raw_id:
+        return None
+    parts = str(raw_id).rsplit(':', 2)
+    if len(parts) != 3:
+        return None
+    try:
+        zero_based_line = int(parts[1])
+        start = int(parts[2])
+    except (TypeError, ValueError):
+        return None
+    if zero_based_line + 1 != item.get('line'):
+        return None
+    return start
+
+
+def find_repair_entry_for_item(item, candidates):
+    if not candidates:
+        return None
+    source = item.get('source', '')
+    start_hint = parse_repair_start_hint(item)
+
+    if start_hint is not None:
+        for candidate in candidates:
+            if candidate.get('start') == start_hint and candidate.get('source') == source:
+                return candidate
+        for candidate in candidates:
+            if candidate.get('start') == start_hint:
+                return candidate
+
+    for candidate in candidates:
+        if candidate.get('source') == source or candidate.get('translation') == source:
+            return candidate
+
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def should_index_rag_entry(entry):
     source = compact_text(entry.get('source', ''))
     translation = compact_text(entry.get('translation', ''))
@@ -2349,7 +2463,13 @@ def load_repair_report_items(report_path):
             normalized_row['line'] = line_number
             normalized_row['source'] = source_text
 
-            dedupe_key = (file_path, line_number)
+            dedupe_key = (
+                file_path,
+                line_number,
+                str(source_text),
+                str(row.get('id') or ''),
+                str(row.get('start') or ''),
+            )
             if dedupe_key in seen:
                 continue
             seen.add(dedupe_key)
@@ -2369,12 +2489,14 @@ def build_repair_jobs(report_items, batch_size=2, context_before=2, context_afte
         file_items = sorted(items_by_file[file_path], key=lambda item: item['line'])
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
-        entries = collect_translation_entries_from_lines(lines)
-        line_map = {entry['line_number']: entry for entry in entries}
+        entries = collect_repair_entries_from_lines(lines)
+        line_map = {}
+        for entry in entries:
+            line_map.setdefault(entry['line_number'], []).append(entry)
 
         targets = []
         for item in file_items:
-            entry = line_map.get(item['line'])
+            entry = find_repair_entry_for_item(item, line_map.get(item['line'], []))
             if not entry:
                 unresolved.append(
                     {

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2468,7 +2468,7 @@ def load_repair_report_items(report_path):
                 line_number,
                 str(source_text),
                 str(row.get('id') or ''),
-                str(row.get('start') or ''),
+                str(row.get('start')),
             )
             if dedupe_key in seen:
                 continue
@@ -2508,7 +2508,7 @@ def build_repair_jobs(report_items, batch_size=2, context_before=2, context_afte
                 )
                 continue
             target = dict(item)
-            target['id'] = f"{file_path}:{entry['line_number']}"
+            target['id'] = f"{file_path}:{entry['line_number']}:{entry['start']}:{entry['end']}"
             target['text'] = item['source']
             target['start'] = entry['start']
             target['end'] = entry['end']

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -799,6 +799,34 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(items[0]['source'], 'Hello')
         self.assertEqual(items[0]['line'], 1)
 
+    def test_load_repair_report_items_distinguishes_start_zero_from_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tl_dir = Path(tmp)
+            target_file = tl_dir / 'script.rpy'
+            target_file.write_text('label test:\n    "Menu"\n', encoding='utf-8')
+            report_path = tl_dir / 'failures.jsonl'
+            report_path.write_text(
+                json.dumps({
+                    'file_rel_path': 'script.rpy',
+                    'line': 1,
+                    'text': 'Menu',
+                }, ensure_ascii=False) + '\n' +
+                json.dumps({
+                    'file_rel_path': 'script.rpy',
+                    'line': 1,
+                    'text': 'Menu',
+                    'start': 0,
+                }, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                items = batch_mod.load_repair_report_items(str(report_path))
+
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].get('start'), None)
+        self.assertEqual(items[1]['start'], 0)
+
     def test_repair_jobs_keep_multiple_items_on_same_line(self):
         with tempfile.TemporaryDirectory() as tmp:
             tl_dir = Path(tmp)
@@ -833,6 +861,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(unresolved, [])
         self.assertEqual(len(jobs), 1)
         self.assertEqual([item['text'] for item in jobs[0]['items']], ['Hello', 'World'])
+        self.assertEqual(len({item['id'] for item in jobs[0]['items']}), 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -655,6 +655,126 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
 
 
 class BatchRepairRegressionTests(unittest.TestCase):
+    def test_split_manifest_keeps_first_child_latest_and_context_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_dir = root / 'package'
+            package_dir.mkdir()
+            input_path = package_dir / 'requests.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            latest_path = root / 'latest_manifest.txt'
+            chunks = [
+                {
+                    'key': 'chunk-1',
+                    'file_rel_path': 'script.rpy',
+                    'file_path': str(root / 'script.rpy'),
+                    'items': [{'id': 'script.rpy:0:4', 'text': 'Hello'}],
+                    'history_hits': [{'source_text': 'Hello', 'translated_text': '\u4f60\u597d'}],
+                    'story_hits': {'terms': [{'source': 'Void Gate', 'target': '\u865a\u7a7a\u95e8'}]},
+                },
+                {
+                    'key': 'chunk-2',
+                    'file_rel_path': 'script.rpy',
+                    'file_path': str(root / 'script.rpy'),
+                    'items': [{'id': 'script.rpy:1:4', 'text': 'World'}],
+                },
+            ]
+            input_path.write_text(
+                json.dumps({'key': 'chunk-1', 'request': {}}, ensure_ascii=False) + '\n' +
+                json.dumps({'key': 'chunk-2', 'request': {}}, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'display_name': 'demo',
+                        'batch_model': 'gemini-test',
+                        'input_jsonl_path': str(input_path),
+                        'settings': {'target_size': 1},
+                        'rag_enabled': True,
+                        'rag_store_path': str(root / 'rag_store'),
+                        'rag_settings': {'top_k_history': 4},
+                        'rag_summary': {'chunks_with_history_hits': 1},
+                        'story_memory_enabled': True,
+                        'story_memory_graph_file': str(root / 'story_graph.json'),
+                        'story_memory_settings': {'top_k_terms': 8},
+                        'story_memory_summary': {'chunks_with_story_hits': 1},
+                        'chunks': chunks,
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)):
+                created = batch_mod.split_manifest(str(manifest_path), max_chunks=1)
+
+            self.assertEqual(latest_path.read_text(encoding='utf-8'), created[0])
+            source_manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(source_manifest['job_state'], 'LOCAL_SPLIT_SOURCE')
+            first_child = json.loads(Path(created[0]).read_text(encoding='utf-8'))
+            self.assertTrue(first_child['rag_enabled'])
+            self.assertEqual(first_child['rag_settings'], {'top_k_history': 4})
+            self.assertTrue(first_child['story_memory_enabled'])
+            self.assertEqual(first_child['story_memory_settings'], {'top_k_terms': 8})
+            self.assertEqual(first_child['rag_summary']['chunks_with_history_hits'], 1)
+            self.assertEqual(first_child['story_memory_summary']['chunks_with_story_hits'], 1)
+
+    def test_collect_result_actions_ignores_duplicate_result_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            result_path = package_dir / 'results.jsonl'
+            response_text = json.dumps(
+                [
+                    {'id': 'script.rpy:0:4', 'translation': '\u4f60\u597d'},
+                    {'id': 'script.rpy:0:4', 'translation': '\u518d\u89c1'},
+                ],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest = {
+                '_package_dir': str(package_dir),
+                'result_jsonl_path': str(result_path),
+                'chunks': [
+                    {
+                        'key': 'chunk-1',
+                        'file_rel_path': 'script.rpy',
+                        'items': [
+                            {
+                                'id': 'script.rpy:0:4',
+                                'line': 0,
+                                'start': 4,
+                                'end': 11,
+                                'text': 'Hello',
+                                'prefix': '',
+                                'quote': '"',
+                            }
+                        ],
+                    }
+                ],
+            }
+
+            replacements, _translated, failures, summary = batch_mod.collect_result_actions(manifest)
+
+        self.assertEqual(summary['valid_items'], 1)
+        self.assertEqual(summary['reason_counts']['duplicate_result_id'], 1)
+        self.assertEqual(len(replacements['script.rpy'][0]), 1)
+        self.assertEqual(failures, [])
+
     def test_load_repair_report_items_accepts_batch_failure_log_shape(self):
         with tempfile.TemporaryDirectory() as tmp:
             tl_dir = Path(tmp)
@@ -678,6 +798,41 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(items[0]['file'], str(target_file.resolve()))
         self.assertEqual(items[0]['source'], 'Hello')
         self.assertEqual(items[0]['line'], 1)
+
+    def test_repair_jobs_keep_multiple_items_on_same_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tl_dir = Path(tmp)
+            target_file = tl_dir / 'script.rpy'
+            target_file.write_text(
+                'label test:\n'
+                '    call screen test("Hello", "World")\n',
+                encoding='utf-8',
+            )
+            report_path = tl_dir / 'failures.jsonl'
+            report_path.write_text(
+                json.dumps({
+                    'file_rel_path': 'script.rpy',
+                    'line': 1,
+                    'text': 'Hello',
+                    'id': 'script.rpy:1:21',
+                }, ensure_ascii=False) + '\n' +
+                json.dumps({
+                    'file_rel_path': 'script.rpy',
+                    'line': 1,
+                    'text': 'World',
+                    'id': 'script.rpy:1:30',
+                }, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                items = batch_mod.load_repair_report_items(str(report_path))
+                jobs, unresolved = batch_mod.build_repair_jobs(items, batch_size=2)
+
+        self.assertEqual([item['source'] for item in items], ['Hello', 'World'])
+        self.assertEqual(unresolved, [])
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual([item['text'] for item in jobs[0]['items']], ['Hello', 'World'])
 
 
 if __name__ == '__main__':

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -863,6 +863,35 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual([item['text'] for item in jobs[0]['items']], ['Hello', 'World'])
         self.assertEqual(len({item['id'] for item in jobs[0]['items']}), 2)
 
+    def test_repair_jobs_parse_line_start_end_repair_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tl_dir = Path(tmp)
+            target_file = tl_dir / 'script.rpy'
+            duplicate_line = '    call screen test("Menu", "Menu")\n'
+            second_start = duplicate_line.rindex('"Menu"')
+            second_end = second_start + len('"Menu"')
+            target_file.write_text(
+                'label test:\n' + duplicate_line,
+                encoding='utf-8',
+            )
+            report_path = tl_dir / 'repair_failures.jsonl'
+            report_path.write_text(
+                json.dumps({
+                    'file': str(target_file.resolve()),
+                    'line': 2,
+                    'source': 'Menu',
+                    'id': f'{target_file.resolve()}:2:{second_start}:{second_end}',
+                }, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            items = batch_mod.load_repair_report_items(str(report_path))
+            jobs, unresolved = batch_mod.build_repair_jobs(items, batch_size=2)
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]['items'][0]['start'], second_start)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 变更内容

- 修复 `split` 后 latest manifest 被 source manifest 覆盖的问题，默认后续 `submit` 会指向第一个 split child。
- split child manifest 继承 RAG / Story Memory 相关 metadata，并按子包 chunk 重算命中摘要。
- Batch 结果解析时跳过重复 result id，避免同一位置被重复写入。
- repair 流程支持同一行多个待修复字符串，按 source / start hint 匹配具体 string token。

## 背景

这组修复来自对 Batch split / apply / repair 边界行为的复查。原实现中 split 工作流、重复 id 和同行多 token repair 都有可能导致提交错误包、误写或漏修。

## 验证

- `python -m py_compile translator_runtime.py gemini_translate.py gemini_translate_batch.py rag_memory.py story_memory.py extract_relations.py`
- `python -m unittest tests.test_regressions -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`