### PR TITLE
[codex] 收敛 Batch CLI 入口副作用

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -34,11 +34,7 @@ PROGRESS_LOG = os.path.join(LOG_DIR, 'translation_progress_batch.json')
 CONSOLE_LOG = os.path.join(LOG_DIR, 'translation_batch_console_output.log')
 BATCH_JOBS_DIR = os.path.join(LOG_DIR, 'batch_jobs')
 LATEST_MANIFEST_FILE = os.path.join(BATCH_JOBS_DIR, 'latest_manifest.txt')
-
-os.makedirs(LOG_DIR, exist_ok=True)
-os.makedirs(BATCH_JOBS_DIR, exist_ok=True)
 REPAIR_RUNS_DIR = os.path.join(LOG_DIR, 'repair_runs')
-os.makedirs(REPAIR_RUNS_DIR, exist_ok=True)
 
 
 class DualLogger(object):
@@ -56,7 +52,17 @@ class DualLogger(object):
         self.log.flush()
 
 
-sys.stdout = DualLogger(CONSOLE_LOG)
+def ensure_batch_dirs():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    os.makedirs(BATCH_JOBS_DIR, exist_ok=True)
+    os.makedirs(REPAIR_RUNS_DIR, exist_ok=True)
+
+
+def initialize_batch_logging():
+    if isinstance(sys.stdout, DualLogger):
+        return
+    ensure_batch_dirs()
+    sys.stdout = DualLogger(CONSOLE_LOG)
 
 BATCH_MODEL = 'gemini-3-flash-preview'
 BATCH_TARGET_SIZE = 4
@@ -66,10 +72,7 @@ BATCH_MAX_OUTPUT_TOKENS = 4096
 BATCH_TEMPERATURE = 0.2
 BATCH_THINKING_LEVEL = 'minimal'
 BATCH_DISPLAY_NAME_PREFIX = 'renpy-translate'
-BATCH_MACRO_SETTING = (
-    '???? Ren\'Py ???????????????????????????'
-    '??????????????????'
-)
+BATCH_MACRO_SETTING = ''
 
 RAG_ENABLED = False
 RAG_STORE_DIR = ''
@@ -292,10 +295,6 @@ def load_batch_settings():
     _STORY_GRAPH = None
     _STORY_GRAPH_PATH = ''
 
-
-load_batch_settings()
-
-
 def load_progress():
     if not os.path.exists(PROGRESS_LOG):
         return {}
@@ -307,6 +306,7 @@ def load_progress():
 
 
 def save_progress(progress):
+    ensure_batch_dirs()
     with open(PROGRESS_LOG, 'w', encoding='utf-8') as handle:
         json.dump(progress, handle, ensure_ascii=False, indent=2)
 
@@ -710,6 +710,7 @@ def manifest_path_for_target(target):
 
 
 def remember_latest_manifest(manifest_path):
+    ensure_batch_dirs()
     with open(LATEST_MANIFEST_FILE, 'w', encoding='utf-8') as handle:
         handle.write(manifest_path)
 
@@ -1670,6 +1671,7 @@ def append_failure_entries(entries, package_dir=''):
     if not entries:
         return
 
+    ensure_batch_dirs()
     paths = [FAILED_LOG]
     if package_dir:
         paths.append(os.path.join(package_dir, 'failures.jsonl'))
@@ -3044,16 +3046,20 @@ def build_arg_parser():
     return parser
 
 
-def main():
+def main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    command = args.command
+    if command is None:
+        parser.print_help()
+        return
+
+    initialize_batch_logging()
     legacy.load_config()
     legacy.load_translator_settings()
     legacy.load_glossary()
     load_batch_settings()
     print_banner()
-
-    parser = build_arg_parser()
-    args = parser.parse_args()
-    command = args.command or 'submit'
 
     if command == 'build':
         create_batch_package(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -16,15 +16,23 @@ import translator_runtime as runtime
 class TranslatorRuntimeRegressionTests(unittest.TestCase):
     def test_batch_module_import_has_no_stdout_or_directory_side_effects(self):
         sentinel_stdout = io.StringIO()
+        module_name = 'gemini_translate_batch'
+        original_module = sys.modules.pop(module_name, None)
+        try:
+            with (
+                mock.patch('sys.stdout', sentinel_stdout),
+                mock.patch('os.makedirs') as makedirs_mock,
+            ):
+                imported = importlib.import_module(module_name)
+                self.assertIs(sys.stdout, sentinel_stdout)
+                self.assertEqual(imported.BATCH_MACRO_SETTING, '')
 
-        with (
-            mock.patch('sys.stdout', sentinel_stdout),
-            mock.patch('os.makedirs') as makedirs_mock,
-        ):
-            importlib.reload(batch_mod)
-            self.assertIs(sys.stdout, sentinel_stdout)
-
-        makedirs_mock.assert_not_called()
+            makedirs_mock.assert_not_called()
+        finally:
+            if original_module is not None:
+                sys.modules[module_name] = original_module
+            else:
+                sys.modules.pop(module_name, None)
 
     def test_batch_cli_without_command_prints_help_without_submit(self):
         output = io.StringIO()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,8 @@
 import ast
+import importlib
+import io
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +14,68 @@ import translator_runtime as runtime
 
 
 class TranslatorRuntimeRegressionTests(unittest.TestCase):
+    def test_batch_module_import_has_no_stdout_or_directory_side_effects(self):
+        sentinel_stdout = io.StringIO()
+
+        with (
+            mock.patch('sys.stdout', sentinel_stdout),
+            mock.patch('os.makedirs') as makedirs_mock,
+        ):
+            importlib.reload(batch_mod)
+            self.assertIs(sys.stdout, sentinel_stdout)
+
+        makedirs_mock.assert_not_called()
+
+    def test_batch_cli_without_command_prints_help_without_submit(self):
+        output = io.StringIO()
+
+        with (
+            mock.patch('sys.stdout', output),
+            mock.patch.object(batch_mod, 'initialize_batch_logging') as logging_mock,
+            mock.patch.object(batch_mod.legacy, 'load_config') as load_config_mock,
+            mock.patch.object(batch_mod, 'submit_manifest') as submit_mock,
+        ):
+            batch_mod.main([])
+
+        self.assertIn('usage:', output.getvalue())
+        logging_mock.assert_not_called()
+        load_config_mock.assert_not_called()
+        submit_mock.assert_not_called()
+
+    def test_batch_cli_help_does_not_load_runtime_settings(self):
+        output = io.StringIO()
+
+        with (
+            mock.patch('sys.stdout', output),
+            mock.patch.object(batch_mod, 'initialize_batch_logging') as logging_mock,
+            mock.patch.object(batch_mod.legacy, 'load_config') as load_config_mock,
+            mock.patch.object(batch_mod.legacy, 'load_translator_settings') as settings_mock,
+            mock.patch.object(batch_mod.legacy, 'load_glossary') as glossary_mock,
+            mock.patch.object(batch_mod, 'load_batch_settings') as batch_settings_mock,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                batch_mod.main(['--help'])
+
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn('usage:', output.getvalue())
+        logging_mock.assert_not_called()
+        load_config_mock.assert_not_called()
+        settings_mock.assert_not_called()
+        glossary_mock.assert_not_called()
+        batch_settings_mock.assert_not_called()
+
+    def test_batch_system_instruction_has_readable_empty_macro_default(self):
+        old_macro_setting = batch_mod.BATCH_MACRO_SETTING
+        try:
+            batch_mod.BATCH_MACRO_SETTING = ''
+            instruction = batch_mod.build_system_instruction()
+        finally:
+            batch_mod.BATCH_MACRO_SETTING = old_macro_setting
+
+        self.assertIn('Setting:', instruction)
+        setting_block = instruction.split('Task:', 1)[0]
+        self.assertNotIn('????', setting_block)
+
     def test_collect_tasks_keeps_distinct_entries_on_same_line(self):
         tasks = runtime.collect_tasks(['call screen test("Hello", "World")\n'])
         self.assertEqual(len(tasks), 2)


### PR DESCRIPTION
## 变更
- 调整 Batch CLI 初始化顺序，先解析 argparse，再对真实子命令加载配置、词表和日志。
- 移除模块导入时创建日志目录、接管 stdout、加载 batch 配置的副作用。
- 不带子命令时只显示 help，不再默认 submit。
- 将缺省 Batch macro 设置改为空文本，避免缺少 macro_setting.md 时把占位问号写入 prompt。
- 增加回归测试覆盖 import、help、无子命令和 macro 默认值。

## 影响
- 降低误触发远程 Batch 提交的风险。
- 让测试和复用场景 import 模块时不再污染 stdout。

## 验证
- python -m py_compile gemini_translate_batch.py translator_runtime.py rag_memory.py story_memory.py tests\test_regressions.py
- python -m unittest discover -s tests -q
- python gemini_translate_batch.py --help
- python gemini_translate_batch.py

Closes #10