### PR TITLE
[codex] 加固 RPA 解析与 Batch 路径边界

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -724,6 +724,67 @@ def load_manifest(target=None):
     return manifest
 
 
+def _normalized_abs_path(path):
+    return os.path.normcase(os.path.abspath(path))
+
+
+def path_is_within_dir(base_dir, candidate):
+    base = _normalized_abs_path(base_dir)
+    target = _normalized_abs_path(candidate)
+    try:
+        return os.path.commonpath([base, target]) == base
+    except ValueError:
+        return False
+
+
+def normalize_safe_rel_path(value, field_name):
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f'Unsafe {field_name}: empty path.')
+    text = value.strip().replace('\\', '/')
+    if os.path.isabs(text) or re.match(r'^[A-Za-z]:', text):
+        raise SystemExit(f'Unsafe {field_name}: absolute paths are not allowed here.')
+    parts = []
+    for part in text.split('/'):
+        if not part or part == '.':
+            continue
+        if part == '..':
+            raise SystemExit(f'Unsafe {field_name}: parent directory segments are not allowed.')
+        parts.append(part)
+    if not parts:
+        raise SystemExit(f'Unsafe {field_name}: empty path.')
+    return os.path.join(*parts)
+
+
+def resolve_path_under_dir(base_dir, value, field_name):
+    if not base_dir:
+        raise SystemExit(f'Unsafe {field_name}: base directory is missing.')
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f'Unsafe {field_name}: empty path.')
+    raw = value.strip()
+    if os.path.isabs(raw):
+        candidate = os.path.abspath(raw)
+    else:
+        candidate = os.path.abspath(os.path.join(base_dir, normalize_safe_rel_path(raw, field_name)))
+    if not path_is_within_dir(base_dir, candidate):
+        raise SystemExit(f'Unsafe {field_name}: {value} escapes {base_dir}.')
+    return candidate
+
+
+def resolve_manifest_result_path(manifest):
+    package_dir = manifest.get('_package_dir')
+    result_path = manifest.get('result_jsonl_path')
+    if result_path:
+        return resolve_path_under_dir(package_dir, result_path, 'result_jsonl_path')
+    return os.path.join(package_dir, 'results.jsonl')
+
+
+def resolve_manifest_file_path(manifest, file_key, file_info):
+    path_value = file_info.get('path') if isinstance(file_info, dict) else ''
+    if path_value:
+        return resolve_path_under_dir(legacy.TL_DIR, path_value, f'manifest file path for {file_key}')
+    return resolve_path_under_dir(legacy.TL_DIR, file_key, f'manifest file key {file_key}')
+
+
 def save_manifest(manifest, update_latest=True):
     manifest_path = manifest['_manifest_path']
     data = dict(manifest)
@@ -1507,7 +1568,7 @@ def download_results(target=None, force=False):
     if state != 'JOB_STATE_SUCCEEDED':
         raise SystemExit(f'Batch job is not succeeded yet: {state}')
 
-    result_path = manifest.get('result_jsonl_path') or os.path.join(manifest['_package_dir'], 'results.jsonl')
+    result_path = resolve_manifest_result_path(manifest)
     if os.path.isfile(result_path) and not force:
         print(f'Result file already exists: {result_path}')
         return result_path
@@ -1686,8 +1747,8 @@ def append_failure_entries(entries, package_dir=''):
 
 
 def collect_result_actions(manifest):
-    result_path = manifest.get('result_jsonl_path')
-    if not result_path or not os.path.isfile(result_path):
+    result_path = resolve_manifest_result_path(manifest)
+    if not os.path.isfile(result_path):
         raise SystemExit('Result JSONL not found. Run download first.')
 
     chunk_map = {chunk['key']: chunk for chunk in manifest.get('chunks', [])}
@@ -2069,7 +2130,7 @@ def apply_results(target=None):
         file_info = manifest['files'].get(file_key)
         if not file_info:
             continue
-        file_path = file_info['path']
+        file_path = resolve_manifest_file_path(manifest, file_key, file_info)
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
         legacy.commit_replacements(file_path, lines, replacements)
@@ -2436,20 +2497,12 @@ def load_repair_report_items(report_path):
             batch_style = False
             file_path = row.get('file')
             if isinstance(file_path, str) and file_path.strip():
-                file_path = file_path.strip()
-                if not os.path.isabs(file_path):
-                    normalized_rel = legacy._normalize_rel_path(file_path)
-                    candidate = os.path.abspath(os.path.join(legacy.TL_DIR, normalized_rel))
-                    file_path = candidate if os.path.isfile(candidate) else os.path.abspath(file_path)
+                file_path = resolve_path_under_dir(legacy.TL_DIR, file_path, 'repair file')
             else:
                 file_rel_path = row.get('file_rel_path')
                 if isinstance(file_rel_path, str) and file_rel_path.strip():
-                    normalized_rel = legacy._normalize_rel_path(file_rel_path)
-                    if normalized_rel:
-                        file_path = os.path.abspath(os.path.join(legacy.TL_DIR, normalized_rel))
-                        batch_style = True
-                    else:
-                        file_path = ''
+                    file_path = resolve_path_under_dir(legacy.TL_DIR, file_rel_path, 'repair file_rel_path')
+                    batch_style = True
                 else:
                     file_path = ''
 
@@ -2903,9 +2956,10 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
         )
 
     for file_path, replacements in replacements_by_file.items():
-        with open(file_path, 'r', encoding='utf-8-sig') as handle:
+        safe_file_path = resolve_path_under_dir(legacy.TL_DIR, file_path, 'repair writeback file')
+        with open(safe_file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
-        legacy.commit_replacements(file_path, lines, replacements)
+        legacy.commit_replacements(safe_file_path, lines, replacements)
         summary['applied_files'] += 1
 
     summary['failure_items'] = len(failure_entries)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,9 +2,12 @@ import ast
 import importlib
 import io
 import json
+import os
+import pickle
 import sys
 import tempfile
 import unittest
+import zlib
 from pathlib import Path
 from unittest import mock
 
@@ -148,6 +151,59 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         prefix, quote = runtime.parse_string_literal_format('"""Hello"""')
         literal = runtime.quote_with('\u4f60\u597d', quote, prefix=prefix)
         self.assertEqual(ast.literal_eval(literal), '\u4f60\u597d')
+
+    def test_rpa_index_loads_primitive_pickle_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive_path = Path(tmp) / 'archive.rpa'
+            raw_index = {'game/script.rpy': [(123, 4, b'')]}
+            payload = zlib.compress(pickle.dumps(raw_index, protocol=4))
+            header = b'RPA-3.0 %016x %08x\n' % (34, 0)
+            archive_path.write_bytes(header + payload)
+
+            index = runtime._read_rpa_index(str(archive_path))
+
+        self.assertEqual(index, raw_index)
+
+    def test_rpa_index_rejects_pickle_globals_without_executing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive_path = Path(tmp) / 'archive.rpa'
+            marker_path = Path(tmp) / 'pickle-executed.txt'
+
+            class Payload:
+                def __reduce__(self):
+                    return (os.system, (f'echo unsafe > "{marker_path}"',))
+
+            payload = zlib.compress(pickle.dumps(Payload(), protocol=4))
+            header = b'RPA-3.0 %016x %08x\n' % (34, 0)
+            archive_path.write_bytes(header + payload)
+
+            with self.assertRaises(pickle.UnpicklingError):
+                runtime._read_rpa_index(str(archive_path))
+            self.assertFalse(marker_path.exists())
+
+    def test_prepare_launcher_does_not_guess_unrelated_python_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'tools.py').write_text('print("maintenance helper")\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(root)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+            ):
+                self.assertEqual(runtime._resolve_prepare_launcher(), '')
+
+    def test_prepare_launcher_still_detects_renpy_bootstrap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher = root / 'Game.py'
+            launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
+            (root / 'tools.py').write_text('print("maintenance helper")\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(root)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+            ):
+                self.assertEqual(runtime._resolve_prepare_launcher(), str(launcher))
 
     def test_process_batch_returns_only_successful_progress_entries(self):
         batch = [
@@ -848,6 +904,90 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(len(replacements['script.rpy'][0]), 1)
         self.assertEqual(failures, [])
 
+    def test_manifest_result_path_must_stay_in_package_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_dir = root / 'package'
+            package_dir.mkdir()
+            manifest = {
+                '_package_dir': str(package_dir),
+                'result_jsonl_path': str(root / 'outside-results.jsonl'),
+            }
+
+            with self.assertRaisesRegex(SystemExit, 'escapes'):
+                batch_mod.resolve_manifest_result_path(manifest)
+
+    def test_manifest_result_path_rejects_parent_segments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp) / 'package'
+            package_dir.mkdir()
+            manifest = {
+                '_package_dir': str(package_dir),
+                'result_jsonl_path': '../outside-results.jsonl',
+            }
+
+            with self.assertRaisesRegex(SystemExit, 'parent directory'):
+                batch_mod.resolve_manifest_result_path(manifest)
+
+    def test_apply_results_rejects_manifest_file_path_outside_tl_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [{'id': 'script.rpy:0:4', 'translation': '\u4f60\u597d'}],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'files': {'script.rpy': {'path': str(root / 'outside.rpy')}},
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'chunk-1',
+                                'file_rel_path': 'script.rpy',
+                                'items': [
+                                    {
+                                        'id': 'script.rpy:0:4',
+                                        'line': 0,
+                                        'start': 4,
+                                        'end': 11,
+                                        'text': 'Hello',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                with self.assertRaisesRegex(SystemExit, 'escapes'):
+                    batch_mod.apply_results(str(manifest_path))
+
     def test_load_repair_report_items_accepts_batch_failure_log_shape(self):
         with tempfile.TemporaryDirectory() as tmp:
             tl_dir = Path(tmp)
@@ -871,6 +1011,44 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(items[0]['file'], str(target_file.resolve()))
         self.assertEqual(items[0]['source'], 'Hello')
         self.assertEqual(items[0]['line'], 1)
+
+    def test_load_repair_report_items_rejects_file_outside_tl_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            tl_dir.mkdir()
+            outside_file = root / 'outside.rpy'
+            outside_file.write_text('label outside:\n    pass\n', encoding='utf-8')
+            report_path = tl_dir / 'failures.jsonl'
+            report_path.write_text(
+                json.dumps({
+                    'file': str(outside_file),
+                    'line': 1,
+                    'source': 'Hello',
+                }, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                with self.assertRaisesRegex(SystemExit, 'escapes'):
+                    batch_mod.load_repair_report_items(str(report_path))
+
+    def test_load_repair_report_items_rejects_parent_segments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tl_dir = Path(tmp)
+            report_path = tl_dir / 'failures.jsonl'
+            report_path.write_text(
+                json.dumps({
+                    'file_rel_path': '../outside.rpy',
+                    'line': 0,
+                    'text': 'Hello',
+                }, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                with self.assertRaisesRegex(SystemExit, 'parent directory'):
+                    batch_mod.load_repair_report_items(str(report_path))
 
     def test_load_repair_report_items_distinguishes_start_zero_from_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -958,8 +1136,9 @@ class BatchRepairRegressionTests(unittest.TestCase):
                 encoding='utf-8',
             )
 
-            items = batch_mod.load_repair_report_items(str(report_path))
-            jobs, unresolved = batch_mod.build_repair_jobs(items, batch_size=2)
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                items = batch_mod.load_repair_report_items(str(report_path))
+                jobs, unresolved = batch_mod.build_repair_jobs(items, batch_size=2)
 
         self.assertEqual(unresolved, [])
         self.assertEqual(len(jobs), 1)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -812,8 +812,21 @@ def _safe_archive_relpath(raw_name):
     return os.path.join(*parts)
 
 
+class _RestrictedRpaUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        raise pickle.UnpicklingError(
+            f"Disallowed pickle global during RPA index load: {module}.{name}"
+        )
+
+
 def _load_pickle_blob(blob):
-    return pickle.loads(blob, encoding="bytes")
+    return _RestrictedRpaUnpickler(io.BytesIO(blob), encoding="bytes").load()
+
+
+def _validate_rpa_index(raw_index):
+    if not isinstance(raw_index, dict):
+        raise RuntimeError("Invalid RPA index: expected a dictionary.")
+    return raw_index
 
 
 def _read_rpa_index(archive_path):
@@ -824,7 +837,7 @@ def _read_rpa_index(archive_path):
             offset = int(header[8:24], 16)
             key = int(header[25:33], 16)
             infile.seek(offset)
-            raw_index = _load_pickle_blob(zlib.decompress(infile.read()))
+            raw_index = _validate_rpa_index(_load_pickle_blob(zlib.decompress(infile.read())))
 
             index = {}
             for name, chunks in raw_index.items():
@@ -850,7 +863,7 @@ def _read_rpa_index(archive_path):
             line = infile.read(24)
             offset = int(line[8:], 16)
             infile.seek(offset)
-            raw_index = _load_pickle_blob(zlib.decompress(infile.read()))
+            raw_index = _validate_rpa_index(_load_pickle_blob(zlib.decompress(infile.read())))
 
             index = {}
             for name, chunks in raw_index.items():
@@ -946,7 +959,7 @@ def _resolve_prepare_launcher():
         if stem in exe_stems:
             return path
 
-    return py_files[0]
+    return ""
 
 
 def _render_prepare_command(command, variables):


### PR DESCRIPTION
﻿## 背景

安全扫描发现几个可直接修复的风险点：

- RPA index 读取使用普通 `pickle.loads`，恶意 `.rpa` 可以在 prepare unpack 阶段触发 pickle gadget。
- prepare template launcher 在找不到明确 Ren'Py launcher 时会回退执行根目录第一个 `.py` 文件。
- Batch manifest / result / repair report 中的路径字段缺少统一边界校验，可能把读取、写回或修复上下文导向项目预期目录外。

## 改动

- RPA index 改为受限 unpickler，只允许 primitive pickle 数据结构，不允许加载任意 global。
- prepare launcher 只接受显式配置、包含 `renpy.bootstrap` 的 launcher，或与 `.exe` 同名的 launcher；不再默认执行任意第一个 `.py`。
- Batch 结果下载、结果读取、apply 写回、repair report 读取与 repair 写回统一走目录边界校验。
- 增加回归测试覆盖 RPA pickle globals、launcher fallback、manifest/result/apply/repair 路径逃逸。

## 验证

- `python -m py_compile .\translator_runtime.py .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest discover -s tests -q`
