### PR TITLE
[codex] 增强 Batch apply 写回安全校验

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1746,7 +1746,174 @@ def append_failure_entries(entries, package_dir=''):
             print(f'Warning: Could not write failure log {path}: {exc}')
 
 
-def collect_result_actions(manifest):
+def extract_string_token_at(line, start, end):
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(line).readline))
+    except Exception:
+        return None
+    for token in tokens:
+        if token.type != tokenize.STRING:
+            continue
+        if token.start[1] != start or token.end[1] != end:
+            continue
+        try:
+            text_value = ast.literal_eval(token.string)
+        except Exception:
+            return None
+        if not isinstance(text_value, str):
+            return None
+        prefix, quote = legacy.parse_string_literal_format(token.string)
+        return {
+            'text': text_value,
+            'start': token.start[1],
+            'end': token.end[1],
+            'prefix': prefix,
+            'quote': quote,
+        }
+    return None
+
+
+def unpack_replacement_for_validation(replacement):
+    start, end, translated, prefix, quote = replacement[:5]
+    source_text = replacement[5] if len(replacement) > 5 else ''
+    item_id = replacement[6] if len(replacement) > 6 else ''
+    chunk_key = replacement[7] if len(replacement) > 7 else ''
+    return start, end, translated, prefix, quote, source_text, item_id, chunk_key
+
+
+def make_failure_entry(manifest, error, file_rel_path='', item_id='', line=None, text='', **extra):
+    entry = {
+        'timestamp': datetime.now().isoformat(timespec='seconds'),
+        'package': manifest.get('_package_dir', ''),
+        'error': error,
+    }
+    if file_rel_path:
+        entry['file_rel_path'] = file_rel_path
+    if item_id:
+        entry['id'] = item_id
+    if line is not None:
+        entry['line'] = line
+    if text:
+        entry['text'] = text
+    entry.update(extra)
+    return entry
+
+
+def validate_result_replacements(manifest, replacements_by_file, translated_lines_by_file, summary):
+    validated_replacements = {}
+    validated_lines_by_file = {}
+    failure_entries = []
+    skipped_items = 0
+    source_mismatch_items = 0
+    candidate_items = summary.get('valid_items', 0)
+    files_info = manifest.get('files') or {}
+
+    for file_key, replacements_by_line in replacements_by_file.items():
+        file_info = files_info.get(file_key)
+        if not file_info:
+            for line_idx, repls in replacements_by_line.items():
+                for repl in repls:
+                    start, end, _translated, _prefix, _quote, source_text, item_id, chunk_key = unpack_replacement_for_validation(repl)
+                    skipped_items += 1
+                    bump_counter(summary['reason_counts'], 'missing_manifest_file')
+                    failure_entries.append(make_failure_entry(
+                        manifest,
+                        'Manifest file entry missing for result item',
+                        file_rel_path=file_key,
+                        item_id=item_id,
+                        line=line_idx,
+                        text=source_text,
+                        key=chunk_key,
+                        start=start,
+                        end=end,
+                    ))
+            continue
+
+        file_path = resolve_manifest_file_path(manifest, file_key, file_info)
+        if not os.path.isfile(file_path):
+            for line_idx, repls in replacements_by_line.items():
+                for repl in repls:
+                    start, end, _translated, _prefix, _quote, source_text, item_id, chunk_key = unpack_replacement_for_validation(repl)
+                    skipped_items += 1
+                    bump_counter(summary['reason_counts'], 'target_file_missing')
+                    failure_entries.append(make_failure_entry(
+                        manifest,
+                        'Target file missing during source validation',
+                        file_rel_path=file_key,
+                        item_id=item_id,
+                        line=line_idx,
+                        text=source_text,
+                        key=chunk_key,
+                        start=start,
+                        end=end,
+                        file=file_path,
+                    ))
+            continue
+
+        with open(file_path, 'r', encoding='utf-8-sig') as handle:
+            lines = handle.readlines()
+
+        for line_idx, repls in replacements_by_line.items():
+            for repl in repls:
+                start, end, _translated, _prefix, _quote, source_text, item_id, chunk_key = unpack_replacement_for_validation(repl)
+                if line_idx < 0 or line_idx >= len(lines):
+                    skipped_items += 1
+                    bump_counter(summary['reason_counts'], 'source_line_missing')
+                    failure_entries.append(make_failure_entry(
+                        manifest,
+                        'Source line missing during apply validation',
+                        file_rel_path=file_key,
+                        item_id=item_id,
+                        line=line_idx,
+                        text=source_text,
+                        key=chunk_key,
+                        start=start,
+                        end=end,
+                    ))
+                    continue
+
+                token = extract_string_token_at(lines[line_idx], start, end)
+                if not token or token.get('text') != source_text:
+                    skipped_items += 1
+                    source_mismatch_items += 1
+                    bump_counter(summary['reason_counts'], 'source_text_mismatch')
+                    failure_entries.append(make_failure_entry(
+                        manifest,
+                        'Source text mismatch during apply validation',
+                        file_rel_path=file_key,
+                        item_id=item_id,
+                        line=line_idx,
+                        text=source_text,
+                        key=chunk_key,
+                        start=start,
+                        end=end,
+                        current_text=token.get('text') if token else '',
+                    ))
+                    continue
+
+                validated_replacements.setdefault(file_key, {}).setdefault(line_idx, []).append(repl)
+                validated_lines_by_file.setdefault(file_key, set()).add(line_idx)
+
+    pending_files = len(validated_replacements)
+    pending_lines = sum(len(lines) for lines in validated_lines_by_file.values())
+    summary['candidate_valid_items'] = candidate_items
+    summary['valid_items'] = candidate_items - skipped_items
+    summary['source_mismatch_items'] = source_mismatch_items
+    summary['skipped_items'] = skipped_items
+    summary['pending_files'] = pending_files
+    summary['pending_lines'] = pending_lines
+    return validated_replacements, validated_lines_by_file, failure_entries
+
+
+def summarize_pending_replacements(replacements_by_file, translated_lines_by_file, summary):
+    summary.setdefault('candidate_valid_items', summary.get('valid_items', 0))
+    summary.setdefault('source_mismatch_items', 0)
+    summary.setdefault('skipped_items', 0)
+    summary['pending_files'] = len(replacements_by_file)
+    summary['pending_lines'] = sum(len(lines) for lines in translated_lines_by_file.values())
+
+
+def collect_result_actions(manifest, validate_sources=False):
     result_path = resolve_manifest_result_path(manifest)
     if not os.path.isfile(result_path):
         raise SystemExit('Result JSONL not found. Run download first.')
@@ -1933,6 +2100,9 @@ def collect_result_actions(manifest):
                         result_item['translation'],
                         target_item.get('prefix', ''),
                         target_item['quote'],
+                        target_item['text'],
+                        target_item['id'],
+                        key,
                     )
                 )
                 translated_lines_by_file.setdefault(file_key, set()).add(target_item['line'])
@@ -1978,6 +2148,17 @@ def collect_result_actions(manifest):
 
     summary['failure_items'] = len(failure_entries)
     summary['processed_chunks'] = len(processed_keys)
+    if validate_sources:
+        replacements_by_file, translated_lines_by_file, validation_failures = validate_result_replacements(
+            manifest,
+            replacements_by_file,
+            translated_lines_by_file,
+            summary,
+        )
+        failure_entries.extend(validation_failures)
+        summary['failure_items'] = len(failure_entries)
+    else:
+        summarize_pending_replacements(replacements_by_file, translated_lines_by_file, summary)
     return replacements_by_file, translated_lines_by_file, failure_entries, summary
 
 
@@ -1986,7 +2167,13 @@ def print_check_summary(summary):
     print(f"Result rows: {summary['result_rows']}")
     print(f"Processed chunks: {summary['processed_chunks']}")
     print(f"Expected items: {summary['expected_items']}")
+    if 'candidate_valid_items' in summary:
+        print(f"Candidate valid items: {summary['candidate_valid_items']}")
     print(f"Recoverable valid items: {summary['valid_items']}")
+    print(f"Pending files: {summary.get('pending_files', 0)}")
+    print(f"Pending lines: {summary.get('pending_lines', 0)}")
+    print(f"Skipped items: {summary.get('skipped_items', 0)}")
+    print(f"Source mismatches: {summary.get('source_mismatch_items', 0)}")
     print(f"Failure items: {summary['failure_items']}")
     print(f"Chunk row errors: {summary['chunk_row_errors']}")
     print(f"Missing-response chunks: {summary['missing_response_chunks']}")
@@ -2110,7 +2297,7 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
 
 def check_results(target=None):
     manifest = load_manifest(target)
-    _replacements, _translated, _failures, summary = collect_result_actions(manifest)
+    _replacements, _translated, _failures, summary = collect_result_actions(manifest, validate_sources=True)
     manifest['last_check_at'] = datetime.now().isoformat(timespec='seconds')
     manifest['last_check_summary'] = summary
     save_manifest(manifest)
@@ -2119,9 +2306,15 @@ def check_results(target=None):
     return manifest
 
 
-def apply_results(target=None):
+def apply_results(target=None, force=False):
     manifest = load_manifest(target)
-    replacements_by_file, translated_lines_by_file, failure_entries, summary = collect_result_actions(manifest)
+    if manifest.get('applied_at') and not force:
+        raise SystemExit('Manifest was already applied. Re-run apply with --force to apply it again.')
+
+    replacements_by_file, translated_lines_by_file, failure_entries, summary = collect_result_actions(
+        manifest,
+        validate_sources=True,
+    )
 
     applied_files = 0
     applied_lines = 0
@@ -2151,7 +2344,10 @@ def apply_results(target=None):
     manifest['apply_summary'] = {
         'applied_files': applied_files,
         'applied_lines': applied_lines,
+        'candidate_items': summary.get('candidate_valid_items', summary['valid_items']),
         'recoverable_items': summary['valid_items'],
+        'skipped_items': summary.get('skipped_items', 0),
+        'source_mismatch_items': summary.get('source_mismatch_items', 0),
         'failure_count': len(failure_entries),
         'rag': rag_apply_summary,
     }
@@ -3062,6 +3258,7 @@ def build_arg_parser():
         default='',
         help='Manifest path or package dir. Defaults to latest package.',
     )
+    apply_parser.add_argument('--force', action='store_true', help='Apply a manifest even if it already has applied_at.')
 
     split_parser = subparsers.add_parser('split', help='Split an existing batch package into smaller local packages.')
     split_parser.add_argument(
@@ -3152,7 +3349,7 @@ def main(argv=None):
         return
 
     if command == 'apply':
-        apply_results(args.target or None)
+        apply_results(args.target or None, force=args.force)
         return
 
     if command == 'split':

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1854,7 +1854,7 @@ def validate_result_replacements(manifest, replacements_by_file, summary):
                     bump_counter(summary['reason_counts'], 'source_line_missing')
                     failure_entries.append(make_failure_entry(
                         manifest,
-                        'Source line missing during apply validation',
+                        'Source line missing during source validation',
                         file_rel_path=file_key,
                         item_id=item_id,
                         line=line_idx,
@@ -1872,7 +1872,7 @@ def validate_result_replacements(manifest, replacements_by_file, summary):
                     bump_counter(summary['reason_counts'], 'source_text_mismatch')
                     failure_entries.append(make_failure_entry(
                         manifest,
-                        'Source text mismatch during apply validation',
+                        'Source text mismatch during source validation',
                         file_rel_path=file_key,
                         item_id=item_id,
                         line=line_idx,
@@ -2301,7 +2301,7 @@ def check_results(target=None):
 def apply_results(target=None, force=False):
     manifest = load_manifest(target)
     if manifest.get('applied_at') and not force:
-        raise SystemExit('Manifest was already applied. Re-run apply with --force to apply it again.')
+        raise SystemExit('Manifest was already applied. Re-run apply with --force to bypass this guard; source validation still applies.')
 
     replacements_by_file, translated_lines_by_file, failure_entries, summary = collect_result_actions(
         manifest,
@@ -3250,7 +3250,11 @@ def build_arg_parser():
         default='',
         help='Manifest path or package dir. Defaults to latest package.',
     )
-    apply_parser.add_argument('--force', action='store_true', help='Apply a manifest even if it already has applied_at.')
+    apply_parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Bypass the applied_at guard; source validation still applies.',
+    )
 
     split_parser = subparsers.add_parser('split', help='Split an existing batch package into smaller local packages.')
     split_parser.add_argument(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1746,7 +1746,7 @@ def append_failure_entries(entries, package_dir=''):
             print(f'Warning: Could not write failure log {path}: {exc}')
 
 
-def extract_string_token_at(line, start, end):
+def extract_string_token_text_at(line, start, end):
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(line).readline))
     except Exception:
@@ -1762,14 +1762,7 @@ def extract_string_token_at(line, start, end):
             return None
         if not isinstance(text_value, str):
             return None
-        prefix, quote = legacy.parse_string_literal_format(token.string)
-        return {
-            'text': text_value,
-            'start': token.start[1],
-            'end': token.end[1],
-            'prefix': prefix,
-            'quote': quote,
-        }
+        return text_value
     return None
 
 
@@ -1799,7 +1792,7 @@ def make_failure_entry(manifest, error, file_rel_path='', item_id='', line=None,
     return entry
 
 
-def validate_result_replacements(manifest, replacements_by_file, translated_lines_by_file, summary):
+def validate_result_replacements(manifest, replacements_by_file, summary):
     validated_replacements = {}
     validated_lines_by_file = {}
     failure_entries = []
@@ -1872,8 +1865,8 @@ def validate_result_replacements(manifest, replacements_by_file, translated_line
                     ))
                     continue
 
-                token = extract_string_token_at(lines[line_idx], start, end)
-                if not token or token.get('text') != source_text:
+                current_text = extract_string_token_text_at(lines[line_idx], start, end)
+                if current_text != source_text:
                     skipped_items += 1
                     source_mismatch_items += 1
                     bump_counter(summary['reason_counts'], 'source_text_mismatch')
@@ -1887,7 +1880,7 @@ def validate_result_replacements(manifest, replacements_by_file, translated_line
                         key=chunk_key,
                         start=start,
                         end=end,
-                        current_text=token.get('text') if token else '',
+                        current_text=current_text if current_text is not None else '',
                     ))
                     continue
 
@@ -2152,7 +2145,6 @@ def collect_result_actions(manifest, validate_sources=False):
         replacements_by_file, translated_lines_by_file, validation_failures = validate_result_replacements(
             manifest,
             replacements_by_file,
-            translated_lines_by_file,
             summary,
         )
         failure_entries.extend(validation_failures)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1792,6 +1792,57 @@ def make_failure_entry(manifest, error, file_rel_path='', item_id='', line=None,
     return entry
 
 
+def validate_replacements_for_lines(manifest, file_key, replacements_by_line, lines, summary):
+    validated_replacements = {}
+    validated_lines = set()
+    failure_entries = []
+    skipped_items = 0
+    source_mismatch_items = 0
+
+    for line_idx, repls in replacements_by_line.items():
+        for repl in repls:
+            start, end, _translated, _prefix, _quote, source_text, item_id, chunk_key = unpack_replacement_for_validation(repl)
+            if line_idx < 0 or line_idx >= len(lines):
+                skipped_items += 1
+                bump_counter(summary['reason_counts'], 'source_line_missing')
+                failure_entries.append(make_failure_entry(
+                    manifest,
+                    'Source line missing during source validation',
+                    file_rel_path=file_key,
+                    item_id=item_id,
+                    line=line_idx,
+                    text=source_text,
+                    key=chunk_key,
+                    start=start,
+                    end=end,
+                ))
+                continue
+
+            current_text = extract_string_token_text_at(lines[line_idx], start, end)
+            if current_text != source_text:
+                skipped_items += 1
+                source_mismatch_items += 1
+                bump_counter(summary['reason_counts'], 'source_text_mismatch')
+                failure_entries.append(make_failure_entry(
+                    manifest,
+                    'Source text mismatch during source validation',
+                    file_rel_path=file_key,
+                    item_id=item_id,
+                    line=line_idx,
+                    text=source_text,
+                    key=chunk_key,
+                    start=start,
+                    end=end,
+                    current_text=current_text if current_text is not None else '',
+                ))
+                continue
+
+            validated_replacements.setdefault(line_idx, []).append(repl)
+            validated_lines.add(line_idx)
+
+    return validated_replacements, validated_lines, failure_entries, skipped_items, source_mismatch_items
+
+
 def validate_result_replacements(manifest, replacements_by_file, summary):
     validated_replacements = {}
     validated_lines_by_file = {}
@@ -1846,46 +1897,19 @@ def validate_result_replacements(manifest, replacements_by_file, summary):
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
 
-        for line_idx, repls in replacements_by_line.items():
-            for repl in repls:
-                start, end, _translated, _prefix, _quote, source_text, item_id, chunk_key = unpack_replacement_for_validation(repl)
-                if line_idx < 0 or line_idx >= len(lines):
-                    skipped_items += 1
-                    bump_counter(summary['reason_counts'], 'source_line_missing')
-                    failure_entries.append(make_failure_entry(
-                        manifest,
-                        'Source line missing during source validation',
-                        file_rel_path=file_key,
-                        item_id=item_id,
-                        line=line_idx,
-                        text=source_text,
-                        key=chunk_key,
-                        start=start,
-                        end=end,
-                    ))
-                    continue
-
-                current_text = extract_string_token_text_at(lines[line_idx], start, end)
-                if current_text != source_text:
-                    skipped_items += 1
-                    source_mismatch_items += 1
-                    bump_counter(summary['reason_counts'], 'source_text_mismatch')
-                    failure_entries.append(make_failure_entry(
-                        manifest,
-                        'Source text mismatch during source validation',
-                        file_rel_path=file_key,
-                        item_id=item_id,
-                        line=line_idx,
-                        text=source_text,
-                        key=chunk_key,
-                        start=start,
-                        end=end,
-                        current_text=current_text if current_text is not None else '',
-                    ))
-                    continue
-
-                validated_replacements.setdefault(file_key, {}).setdefault(line_idx, []).append(repl)
-                validated_lines_by_file.setdefault(file_key, set()).add(line_idx)
+        file_replacements, file_lines, file_failures, file_skipped, file_mismatches = validate_replacements_for_lines(
+            manifest,
+            file_key,
+            replacements_by_line,
+            lines,
+            summary,
+        )
+        if file_replacements:
+            validated_replacements[file_key] = file_replacements
+            validated_lines_by_file[file_key] = file_lines
+        failure_entries.extend(file_failures)
+        skipped_items += file_skipped
+        source_mismatch_items += file_mismatches
 
     pending_files = len(validated_replacements)
     pending_lines = sum(len(lines) for lines in validated_lines_by_file.values())
@@ -2303,13 +2327,15 @@ def apply_results(target=None, force=False):
     if manifest.get('applied_at') and not force:
         raise SystemExit('Manifest was already applied. Re-run apply with --force to bypass this guard; source validation still applies.')
 
-    replacements_by_file, translated_lines_by_file, failure_entries, summary = collect_result_actions(
+    replacements_by_file, _translated_lines_by_file, failure_entries, summary = collect_result_actions(
         manifest,
         validate_sources=True,
     )
 
     applied_files = 0
     applied_lines = 0
+    final_pending_files = 0
+    final_pending_lines = 0
     rag_jobs = []
     for file_key, replacements in replacements_by_file.items():
         file_info = manifest['files'].get(file_key)
@@ -2318,14 +2344,33 @@ def apply_results(target=None, force=False):
         file_path = resolve_manifest_file_path(manifest, file_key, file_info)
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
+        replacements, line_numbers_set, revalidation_failures, revalidated_skipped, revalidated_mismatches = validate_replacements_for_lines(
+            manifest,
+            file_key,
+            replacements,
+            lines,
+            summary,
+        )
+        if revalidated_skipped:
+            summary['valid_items'] = max(0, summary['valid_items'] - revalidated_skipped)
+            summary['skipped_items'] = summary.get('skipped_items', 0) + revalidated_skipped
+            summary['source_mismatch_items'] = summary.get('source_mismatch_items', 0) + revalidated_mismatches
+            failure_entries.extend(revalidation_failures)
+            summary['failure_items'] = len(failure_entries)
+        if not replacements:
+            continue
         legacy.commit_replacements(file_path, lines, replacements)
-        line_numbers = sorted(translated_lines_by_file.get(file_key, set()))
+        line_numbers = sorted(line_numbers_set)
         update_progress(file_key, line_numbers)
         applied_files += 1
         applied_lines += len(line_numbers)
+        final_pending_files += 1
+        final_pending_lines += len(line_numbers)
         if line_numbers:
             rag_jobs.append({'file_rel_path': file_key, 'file_path': file_path})
 
+    summary['pending_files'] = final_pending_files
+    summary['pending_lines'] = final_pending_lines
     append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
 
     rag_apply_summary = {}

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1068,6 +1068,91 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(manifest['apply_summary']['skipped_items'], 0)
         self.assertIn('applied_at', saved_manifest)
 
+    def test_apply_results_revalidates_snapshot_before_writing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            target_file = tl_dir / 'script.rpy'
+            original_line = '    e "Hello"\n'
+            changed_line = '    e "Hallo"\n'
+            start = original_line.index('"Hello"')
+            end = start + len('"Hello"')
+            target_file.write_text(original_line, encoding='utf-8')
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [{'id': f'script.rpy:0:{start}', 'translation': '\u4f60\u597d'}],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'files': {'script.rpy': {'path': str(target_file)}},
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'chunk-1',
+                                'file_rel_path': 'script.rpy',
+                                'items': [
+                                    {
+                                        'id': f'script.rpy:0:{start}',
+                                        'line': 0,
+                                        'start': start,
+                                        'end': end,
+                                        'text': 'Hello',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+            collect_result_actions = batch_mod.collect_result_actions
+
+            def mutate_after_initial_validation(*args, **kwargs):
+                result = collect_result_actions(*args, **kwargs)
+                target_file.write_text(changed_line, encoding='utf-8')
+                return result
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod, 'collect_result_actions', side_effect=mutate_after_initial_validation),
+                mock.patch.object(batch_mod, 'update_progress') as update_progress,
+                mock.patch.object(batch_mod, 'append_failure_entries') as append_failures,
+            ):
+                manifest = batch_mod.apply_results(str(manifest_path))
+
+            final_script = target_file.read_text(encoding='utf-8')
+
+        self.assertEqual(final_script, changed_line)
+        update_progress.assert_not_called()
+        append_failures.assert_called_once()
+        self.assertEqual(manifest['apply_summary']['applied_files'], 0)
+        self.assertEqual(manifest['apply_summary']['recoverable_items'], 0)
+        self.assertEqual(manifest['apply_summary']['skipped_items'], 1)
+        self.assertEqual(manifest['apply_summary']['source_mismatch_items'], 1)
+
     def test_apply_results_rejects_already_applied_manifest_without_force(self):
         with tempfile.TemporaryDirectory() as tmp:
             package_dir = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -904,6 +904,181 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(len(replacements['script.rpy'][0]), 1)
         self.assertEqual(failures, [])
 
+    def test_collect_result_actions_skips_source_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            target_file = tl_dir / 'script.rpy'
+            line = '    e "Hallo"\n'
+            start = line.index('"Hallo"')
+            end = start + len('"Hallo"')
+            target_file.write_text(line, encoding='utf-8')
+            result_path = package_dir / 'results.jsonl'
+            response_text = json.dumps(
+                [{'id': f'script.rpy:0:{start}', 'translation': '\u4f60\u597d'}],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest = {
+                '_package_dir': str(package_dir),
+                'result_jsonl_path': str(result_path),
+                'files': {'script.rpy': {'path': str(target_file)}},
+                'chunks': [
+                    {
+                        'key': 'chunk-1',
+                        'file_rel_path': 'script.rpy',
+                        'items': [
+                            {
+                                'id': f'script.rpy:0:{start}',
+                                'line': 0,
+                                'start': start,
+                                'end': end,
+                                'text': 'Hello',
+                                'prefix': '',
+                                'quote': '"',
+                            }
+                        ],
+                    }
+                ],
+            }
+
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                replacements, translated, failures, summary = batch_mod.collect_result_actions(
+                    manifest,
+                    validate_sources=True,
+                )
+
+        self.assertEqual(replacements, {})
+        self.assertEqual(translated, {})
+        self.assertEqual(summary['candidate_valid_items'], 1)
+        self.assertEqual(summary['valid_items'], 0)
+        self.assertEqual(summary['skipped_items'], 1)
+        self.assertEqual(summary['source_mismatch_items'], 1)
+        self.assertEqual(summary['pending_files'], 0)
+        self.assertEqual(summary['pending_lines'], 0)
+        self.assertEqual(summary['reason_counts']['source_text_mismatch'], 1)
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]['current_text'], 'Hallo')
+
+    def test_apply_results_handles_multiple_replacements_on_same_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            target_file = tl_dir / 'script.rpy'
+            dialogue_line = '    call screen test("Hello", "World")\n'
+            hello_start = dialogue_line.index('"Hello"')
+            hello_end = hello_start + len('"Hello"')
+            world_start = dialogue_line.index('"World"')
+            world_end = world_start + len('"World"')
+            target_file.write_text('label test:\n' + dialogue_line, encoding='utf-8')
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [
+                    {'id': f'script.rpy:1:{hello_start}', 'translation': '\u4f60\u597d'},
+                    {'id': f'script.rpy:1:{world_start}', 'translation': '\u4e16\u754c'},
+                ],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'files': {'script.rpy': {'path': str(target_file)}},
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'chunk-1',
+                                'file_rel_path': 'script.rpy',
+                                'items': [
+                                    {
+                                        'id': f'script.rpy:1:{hello_start}',
+                                        'line': 1,
+                                        'start': hello_start,
+                                        'end': hello_end,
+                                        'text': 'Hello',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    },
+                                    {
+                                        'id': f'script.rpy:1:{world_start}',
+                                        'line': 1,
+                                        'start': world_start,
+                                        'end': world_end,
+                                        'text': 'World',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod, 'update_progress') as update_progress,
+            ):
+                manifest = batch_mod.apply_results(str(manifest_path))
+
+            updated_script = target_file.read_text(encoding='utf-8')
+            saved_manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+
+        self.assertIn('call screen test("\u4f60\u597d", "\u4e16\u754c")', updated_script)
+        update_progress.assert_called_once_with('script.rpy', [1])
+        self.assertEqual(manifest['apply_summary']['applied_files'], 1)
+        self.assertEqual(manifest['apply_summary']['applied_lines'], 1)
+        self.assertEqual(manifest['apply_summary']['recoverable_items'], 2)
+        self.assertEqual(manifest['apply_summary']['skipped_items'], 0)
+        self.assertIn('applied_at', saved_manifest)
+
+    def test_apply_results_rejects_already_applied_manifest_without_force(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest_path = package_dir / 'manifest.json'
+            manifest_path.write_text(
+                json.dumps({'applied_at': '2026-05-12T12:00:00'}, ensure_ascii=False),
+                encoding='utf-8',
+            )
+
+            with self.assertRaisesRegex(SystemExit, 'already applied'):
+                batch_mod.apply_results(str(manifest_path))
+
     def test_manifest_result_path_must_stay_in_package_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -974,6 +974,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(summary['pending_lines'], 0)
         self.assertEqual(summary['reason_counts']['source_text_mismatch'], 1)
         self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]['error'], 'Source text mismatch during source validation')
         self.assertEqual(failures[0]['current_text'], 'Hallo')
 
     def test_apply_results_handles_multiple_replacements_on_same_line(self):
@@ -1078,6 +1079,82 @@ class BatchRepairRegressionTests(unittest.TestCase):
 
             with self.assertRaisesRegex(SystemExit, 'already applied'):
                 batch_mod.apply_results(str(manifest_path))
+
+    def test_apply_results_force_keeps_source_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            target_file = tl_dir / 'script.rpy'
+            line = '    e "Hallo"\n'
+            start = line.index('"Hallo"')
+            end = start + len('"Hallo"')
+            target_file.write_text(line, encoding='utf-8')
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [{'id': f'script.rpy:0:{start}', 'translation': '\u4f60\u597d'}],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'chunk-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'applied_at': '2026-05-12T12:00:00',
+                        'files': {'script.rpy': {'path': str(target_file)}},
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'chunk-1',
+                                'file_rel_path': 'script.rpy',
+                                'items': [
+                                    {
+                                        'id': f'script.rpy:0:{start}',
+                                        'line': 0,
+                                        'start': start,
+                                        'end': end,
+                                        'text': 'Hello',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod, 'append_failure_entries') as append_failures,
+            ):
+                manifest = batch_mod.apply_results(str(manifest_path), force=True)
+
+            unchanged_script = target_file.read_text(encoding='utf-8')
+
+        self.assertEqual(unchanged_script, line)
+        self.assertEqual(manifest['apply_summary']['applied_files'], 0)
+        self.assertEqual(manifest['apply_summary']['recoverable_items'], 0)
+        self.assertEqual(manifest['apply_summary']['skipped_items'], 1)
+        self.assertEqual(manifest['apply_summary']['source_mismatch_items'], 1)
+        append_failures.assert_called_once()
 
     def test_manifest_result_path_must_stay_in_package_dir(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1739,7 +1739,7 @@ def commit_replacements(path, lines, replacements):
                 start, end, translated, quote = repl
                 prefix = ""
             else:
-                start, end, translated, prefix, quote = repl
+                start, end, translated, prefix, quote = repl[:5]
             # Safety check indices
             if start < 0 or end > len(line):
                 continue


### PR DESCRIPTION
## 背景

Batch `apply` 依赖 manifest 里的 `line/start/end` 把下载结果写回 `.rpy` 文件。此前只做了基础索引边界检查，如果 build/download/apply 之间目标文件被用户或工具修改，旧坐标仍可能落在有效范围内，导致译文写到错误位置；同一个 manifest 也可以重复 apply。

Closes #11

## 改动

- 在 `check` / `apply` 阶段重新读取目标文件，并按 manifest 中的 `line/start/end/text` 解析当前字符串 token。
- 当前源文本不匹配时跳过该 item，写入 failure，并在摘要里记录 `source_text_mismatch`、跳过数量、待写入文件/行数。
- `apply` 默认拒绝已有 `applied_at` 的 manifest，新增 `--force` 用于显式重复执行。
- 让 `commit_replacements()` 兼容带校验元数据的 replacement tuple，保留同一行多个 replacement 的倒序写回行为。

## 验证

- `python -m py_compile .\translator_runtime.py .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest discover -s tests -q`