### PR TITLE
[codex] 增强 RAG store 写入保护

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ python gemini_translate_batch.py apply
 - `check` 是干跑校验，不会修改 `.rpy`
 - `apply` 只会写回通过校验的结果
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
-- 当前不建议并行 `apply` 到同一个本地 RAG store；共享 `history.jsonl` 的写入保护还不算完整产品化
+- 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息
+- 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
 
 ### 可选：Structured Story Memory
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ python gemini_translate_batch.py apply
 - `check` 是干跑校验，不会修改 `.rpy`
 - `apply` 只会写回通过校验的结果
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
-- 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息
+- 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息；同机写入进程崩溃后留下的 stale lock 会在确认 PID 已退出时自动回收
+- 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning
 - 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
 
 ### 可选：Structured Story Memory

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -1,8 +1,10 @@
 ﻿# -*- coding: utf-8 -*-
+from contextlib import contextmanager
 import hashlib
 import json
 import math
 import os
+import socket
 from datetime import datetime
 
 
@@ -41,32 +43,47 @@ def cosine_similarity(left, right):
     return dot / math.sqrt(left_norm * right_norm)
 
 
+class JsonRagStoreLockError(RuntimeError):
+    pass
+
+
 class JsonRagStore(object):
     def __init__(self, store_dir):
         self.store_dir = os.path.abspath(store_dir)
         self.metadata_path = os.path.join(self.store_dir, 'metadata.json')
         self.history_path = os.path.join(self.store_dir, 'history.jsonl')
+        self.lock_path = os.path.join(self.store_dir, '.rag_store.lock')
         self._loaded = False
         self.metadata = {}
         self.history = {}
         self.file_index = {}
 
+    def _warn(self, message):
+        print(f'Warning: {message}')
+
     def load(self):
         if self._loaded:
             return
+        self._load_from_disk()
+
+    def _load_from_disk(self):
         os.makedirs(self.store_dir, exist_ok=True)
         self.metadata = self._load_json_file(self.metadata_path)
         self.history = {}
         self.file_index = {}
         if os.path.isfile(self.history_path):
             with open(self.history_path, 'r', encoding='utf-8-sig') as handle:
-                for raw_line in handle:
+                for line_number, raw_line in enumerate(handle, start=1):
                     line = raw_line.strip()
                     if not line:
                         continue
                     try:
                         record = json.loads(line)
-                    except json.JSONDecodeError:
+                    except json.JSONDecodeError as exc:
+                        self._warn(f'Skipping invalid RAG history row {self.history_path}:{line_number}: {exc}')
+                        continue
+                    if not isinstance(record, dict):
+                        self._warn(f'Skipping non-object RAG history row {self.history_path}:{line_number}')
                         continue
                     memory_id = record.get('memory_id')
                     if memory_id:
@@ -80,9 +97,13 @@ class JsonRagStore(object):
         try:
             with open(path, 'r', encoding='utf-8-sig') as handle:
                 data = json.load(handle)
-        except Exception:
+        except Exception as exc:
+            self._warn(f'Failed to load RAG metadata {path}: {exc}')
             return {}
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            self._warn(f'Ignoring non-object RAG metadata {path}')
+            return {}
+        return data
 
     def count_history(self):
         self.load()
@@ -93,26 +114,111 @@ class JsonRagStore(object):
         return self.history.get(memory_id)
 
     def set_metadata(self, **updates):
-        self.load()
+        with self._locked('set_metadata') as lock_info:
+            self._load_from_disk()
+            self._update_metadata_unlocked('set_metadata', updates, lock_info)
+
+    def _write_metadata(self):
+        def write(handle):
+            json.dump(self.metadata, handle, ensure_ascii=False, indent=2)
+
+        self._atomic_write(self.metadata_path, write)
+
+    def _write_history(self):
+        def write(handle):
+            for memory_id in sorted(self.history):
+                handle.write(json.dumps(self.history[memory_id], ensure_ascii=False) + '\n')
+
+        self._atomic_write(self.history_path, write)
+
+    def _atomic_write(self, path, writer):
+        os.makedirs(self.store_dir, exist_ok=True)
+        tmp_path = f'{path}.tmp.{os.getpid()}.{id(self)}'
+        try:
+            with open(tmp_path, 'w', encoding='utf-8') as handle:
+                writer(handle)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+
+    def _lock_owner(self, operation):
+        return {
+            'operation': operation,
+            'owner': socket.gethostname(),
+            'pid': os.getpid(),
+            'created_at': now_iso(),
+        }
+
+    def _format_lock_owner(self, data):
+        if not isinstance(data, dict):
+            return 'unknown owner'
+        parts = []
+        operation = data.get('operation')
+        owner = data.get('owner')
+        pid = data.get('pid')
+        created_at = data.get('created_at')
+        if operation:
+            parts.append(f'operation={operation}')
+        if owner:
+            parts.append(f'owner={owner}')
+        if pid:
+            parts.append(f'pid={pid}')
+        if created_at:
+            parts.append(f'created_at={created_at}')
+        return ', '.join(parts) if parts else 'unknown owner'
+
+    def _read_lock_owner(self):
+        try:
+            with open(self.lock_path, 'r', encoding='utf-8-sig') as handle:
+                return json.load(handle)
+        except Exception:
+            return {}
+
+    @contextmanager
+    def _locked(self, operation):
+        os.makedirs(self.store_dir, exist_ok=True)
+        lock_info = self._lock_owner(operation)
+        try:
+            fd = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            existing = self._read_lock_owner()
+            raise JsonRagStoreLockError(
+                f'RAG store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
+            )
+
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+                json.dump(lock_info, handle, ensure_ascii=False)
+            yield lock_info
+        finally:
+            try:
+                os.remove(self.lock_path)
+            except FileNotFoundError:
+                pass
+
+    def _update_metadata_unlocked(self, operation, updates, lock_info):
         if not isinstance(self.metadata, dict):
             self.metadata = {}
         for key, value in updates.items():
             self.metadata[key] = value
-        self.metadata['updated_at'] = now_iso()
+        updated_at = now_iso()
+        self.metadata['updated_at'] = updated_at
         if 'created_at' not in self.metadata:
-            self.metadata['created_at'] = self.metadata['updated_at']
+            self.metadata['created_at'] = updated_at
+        self.metadata['last_write'] = {
+            'operation': operation,
+            'owner': lock_info.get('owner'),
+            'pid': lock_info.get('pid'),
+            'lock_created_at': lock_info.get('created_at'),
+            'updated_at': updated_at,
+        }
         self._write_metadata()
-
-    def _write_metadata(self):
-        os.makedirs(self.store_dir, exist_ok=True)
-        with open(self.metadata_path, 'w', encoding='utf-8') as handle:
-            json.dump(self.metadata, handle, ensure_ascii=False, indent=2)
-
-    def _write_history(self):
-        os.makedirs(self.store_dir, exist_ok=True)
-        with open(self.history_path, 'w', encoding='utf-8') as handle:
-            for memory_id in sorted(self.history):
-                handle.write(json.dumps(self.history[memory_id], ensure_ascii=False) + '\n')
 
     def _index_record(self, memory_id, record):
         file_rel_path = record.get('file_rel_path')
@@ -132,40 +238,50 @@ class JsonRagStore(object):
             self.file_index.pop(file_rel_path, None)
 
     def upsert_history(self, records):
-        self.load()
-        changed = 0
-        for record in records:
-            if not isinstance(record, dict):
-                continue
-            memory_id = record.get('memory_id')
-            embedding = record.get('embedding')
-            if not memory_id or not isinstance(embedding, list) or not embedding:
-                continue
-            existing = self.history.get(memory_id)
-            if existing == record:
-                continue
-            if existing:
-                self._unindex_record(memory_id, existing)
-            self.history[memory_id] = record
-            self._index_record(memory_id, record)
-            changed += 1
-        if changed:
-            self._write_history()
-            self.set_metadata(history_count=len(self.history))
+        with self._locked('upsert_history') as lock_info:
+            self._load_from_disk()
+            changed = 0
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                memory_id = record.get('memory_id')
+                embedding = record.get('embedding')
+                if not memory_id or not isinstance(embedding, list) or not embedding:
+                    continue
+                existing = self.history.get(memory_id)
+                if existing == record:
+                    continue
+                if existing:
+                    self._unindex_record(memory_id, existing)
+                self.history[memory_id] = record
+                self._index_record(memory_id, record)
+                changed += 1
+            if changed:
+                self._write_history()
+                self._update_metadata_unlocked(
+                    'upsert_history',
+                    {'history_count': len(self.history)},
+                    lock_info,
+                )
         return changed
 
     def delete_history(self, memory_ids):
-        self.load()
-        changed = 0
-        for memory_id in memory_ids:
-            existing = self.history.pop(memory_id, None)
-            if not existing:
-                continue
-            self._unindex_record(memory_id, existing)
-            changed += 1
-        if changed:
-            self._write_history()
-            self.set_metadata(history_count=len(self.history))
+        with self._locked('delete_history') as lock_info:
+            self._load_from_disk()
+            changed = 0
+            for memory_id in memory_ids:
+                existing = self.history.pop(memory_id, None)
+                if not existing:
+                    continue
+                self._unindex_record(memory_id, existing)
+                changed += 1
+            if changed:
+                self._write_history()
+                self._update_metadata_unlocked(
+                    'delete_history',
+                    {'history_count': len(self.history)},
+                    lock_info,
+                )
         return changed
 
     def history_ids_for_file(self, file_rel_path, quality_state=None):

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -215,6 +215,12 @@ class JsonRagStore(object):
             return None
         return (datetime.now() - created_at).total_seconds()
 
+    def _lock_file_age_seconds(self):
+        try:
+            return datetime.now().timestamp() - os.path.getmtime(self.lock_path)
+        except OSError:
+            return None
+
     def _is_lock_owner_alive(self, pid):
         try:
             pid = int(pid)
@@ -262,7 +268,8 @@ class JsonRagStore(object):
 
     def _is_stale_lock(self, data):
         if not isinstance(data, dict):
-            return False
+            age_seconds = self._lock_file_age_seconds()
+            return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
         local_owner = data.get('owner') == socket.gethostname()
         if local_owner and data.get('pid') is not None:
             is_alive = self._is_lock_owner_alive(data.get('pid'))
@@ -271,6 +278,8 @@ class JsonRagStore(object):
             if is_alive is True:
                 return False
         age_seconds = self._lock_age_seconds(data)
+        if age_seconds is None and not data:
+            age_seconds = self._lock_file_age_seconds()
         return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
 
     def _recover_stale_lock(self, existing):

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -185,7 +185,7 @@ class JsonRagStore(object):
         os.makedirs(self.store_dir, exist_ok=True)
         lock_info = self._lock_owner(operation)
         try:
-            fd = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            fd = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
             existing = self._read_lock_owner()
             raise JsonRagStoreLockError(
@@ -201,6 +201,8 @@ class JsonRagStore(object):
                 os.remove(self.lock_path)
             except FileNotFoundError:
                 pass
+            except OSError as exc:
+                print(f'Warning: Failed to remove RAG store lock {self.lock_path}: {exc}')
 
     def _update_metadata_unlocked(self, operation, updates, lock_info):
         if not isinstance(self.metadata, dict):

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -8,6 +8,9 @@ import socket
 from datetime import datetime
 
 
+LOCK_STALE_AFTER_SECONDS = 60 * 60
+
+
 def now_iso():
     return datetime.now().isoformat(timespec='seconds')
 
@@ -54,6 +57,7 @@ class JsonRagStore(object):
         self.history_path = os.path.join(self.store_dir, 'history.jsonl')
         self.lock_path = os.path.join(self.store_dir, '.rag_store.lock')
         self._loaded = False
+        self._disk_snapshot = None
         self.metadata = {}
         self.history = {}
         self.file_index = {}
@@ -90,6 +94,24 @@ class JsonRagStore(object):
                         self.history[memory_id] = record
                         self._index_record(memory_id, record)
         self._loaded = True
+        self._disk_snapshot = self._disk_version()
+
+    def _file_version(self, path):
+        try:
+            stat = os.stat(path)
+        except FileNotFoundError:
+            return None
+        return (stat.st_mtime_ns, stat.st_size)
+
+    def _disk_version(self):
+        return (
+            self._file_version(self.metadata_path),
+            self._file_version(self.history_path),
+        )
+
+    def _refresh_from_disk_if_changed(self):
+        if not self._loaded or self._disk_snapshot != self._disk_version():
+            self._load_from_disk()
 
     def _load_json_file(self, path):
         if not os.path.isfile(path):
@@ -115,7 +137,7 @@ class JsonRagStore(object):
 
     def set_metadata(self, **updates):
         with self._locked('set_metadata') as lock_info:
-            self._load_from_disk()
+            self._refresh_from_disk_if_changed()
             self._update_metadata_unlocked('set_metadata', updates, lock_info)
 
     def _write_metadata(self):
@@ -140,12 +162,13 @@ class JsonRagStore(object):
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp_path, path)
+            self._disk_snapshot = self._disk_version()
         finally:
             if os.path.exists(tmp_path):
                 try:
                     os.remove(tmp_path)
-                except OSError:
-                    pass
+                except OSError as exc:
+                    self._warn(f'Failed to remove temporary RAG store file {tmp_path}: {exc}')
 
     def _lock_owner(self, operation):
         return {
@@ -180,17 +203,111 @@ class JsonRagStore(object):
         except Exception:
             return {}
 
+    def _lock_age_seconds(self, data):
+        if not isinstance(data, dict):
+            return None
+        created_at = data.get('created_at')
+        if not created_at:
+            return None
+        try:
+            created_at = datetime.fromisoformat(str(created_at))
+        except (TypeError, ValueError):
+            return None
+        return (datetime.now() - created_at).total_seconds()
+
+    def _is_lock_owner_alive(self, pid):
+        try:
+            pid = int(pid)
+        except (TypeError, ValueError):
+            return None
+        if pid <= 0:
+            return None
+        if os.name == 'nt':
+            return self._is_windows_process_alive(pid)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return None
+        return True
+
+    def _is_windows_process_alive(self, pid):
+        import ctypes
+
+        process_query_limited_information = 0x1000
+        error_invalid_parameter = 87
+        still_active = 259
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+        kernel32.OpenProcess.argtypes = (ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong)
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.GetExitCodeProcess.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong))
+        kernel32.GetExitCodeProcess.restype = ctypes.c_int
+        kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+        kernel32.CloseHandle.restype = ctypes.c_int
+        handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+        if not handle:
+            if ctypes.get_last_error() == error_invalid_parameter:
+                return False
+            return True
+        try:
+            exit_code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return True
+            return exit_code.value == still_active
+        finally:
+            kernel32.CloseHandle(handle)
+
+    def _is_stale_lock(self, data):
+        if not isinstance(data, dict):
+            return False
+        local_owner = data.get('owner') == socket.gethostname()
+        if local_owner and data.get('pid') is not None:
+            is_alive = self._is_lock_owner_alive(data.get('pid'))
+            if is_alive is False:
+                return True
+            if is_alive is True:
+                return False
+        age_seconds = self._lock_age_seconds(data)
+        return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
+
+    def _recover_stale_lock(self, existing):
+        if not self._is_stale_lock(existing):
+            return False
+        try:
+            os.remove(self.lock_path)
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            self._warn(f'Failed to remove stale RAG store lock {self.lock_path}: {exc}')
+            return False
+        self._warn(f'Recovered stale RAG store lock {self.lock_path} ({self._format_lock_owner(existing)})')
+        return True
+
+    def _open_lock_file(self):
+        return os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+
     @contextmanager
     def _locked(self, operation):
         os.makedirs(self.store_dir, exist_ok=True)
         lock_info = self._lock_owner(operation)
         try:
-            fd = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            fd = self._open_lock_file()
         except FileExistsError:
             existing = self._read_lock_owner()
-            raise JsonRagStoreLockError(
-                f'RAG store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
-            )
+            if not self._recover_stale_lock(existing):
+                raise JsonRagStoreLockError(
+                    f'RAG store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
+                )
+            try:
+                fd = self._open_lock_file()
+            except FileExistsError:
+                existing = self._read_lock_owner()
+                raise JsonRagStoreLockError(
+                    f'RAG store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
+                )
 
         try:
             with os.fdopen(fd, 'w', encoding='utf-8') as handle:
@@ -202,7 +319,7 @@ class JsonRagStore(object):
             except FileNotFoundError:
                 pass
             except OSError as exc:
-                print(f'Warning: Failed to remove RAG store lock {self.lock_path}: {exc}')
+                self._warn(f'Failed to remove RAG store lock {self.lock_path}: {exc}')
 
     def _update_metadata_unlocked(self, operation, updates, lock_info):
         if not isinstance(self.metadata, dict):
@@ -241,7 +358,7 @@ class JsonRagStore(object):
 
     def upsert_history(self, records):
         with self._locked('upsert_history') as lock_info:
-            self._load_from_disk()
+            self._refresh_from_disk_if_changed()
             changed = 0
             for record in records:
                 if not isinstance(record, dict):
@@ -269,7 +386,7 @@ class JsonRagStore(object):
 
     def delete_history(self, memory_ids):
         with self._locked('delete_history') as lock_info:
-            self._load_from_disk()
+            self._refresh_from_disk_if_changed()
             changed = 0
             for memory_id in memory_ids:
                 existing = self.history.pop(memory_id, None)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -840,6 +840,30 @@ class RagMemoryStoreTests(unittest.TestCase):
         self.assertEqual(persisted, json.dumps(original_record, ensure_ascii=False) + '\n')
         self.assertEqual(temp_files, [])
 
+    def test_json_rag_store_warns_when_temp_cleanup_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+            original_remove = rag_memory.os.remove
+
+            def remove_tmp(path):
+                if '.tmp.' in str(path):
+                    raise OSError('tmp remove denied')
+                return original_remove(path)
+
+            with (
+                mock.patch.object(rag_memory.os, 'replace', side_effect=OSError('replace failed')),
+                mock.patch.object(rag_memory.os, 'remove', side_effect=remove_tmp),
+                mock.patch('builtins.print') as print_mock,
+            ):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    store.upsert_history([self.make_record('m1')])
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertIn('Failed to remove temporary RAG store file', warnings)
+        self.assertIn('tmp remove denied', warnings)
+
     def test_json_rag_store_lock_conflict_fails_explicitly(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = Path(tmp)
@@ -870,6 +894,34 @@ class RagMemoryStoreTests(unittest.TestCase):
                 store.upsert_history([self.make_record('m1')])
 
         self.assertEqual(open_modes[0], 0o600)
+
+    def test_json_rag_store_recovers_stale_lock_from_dead_local_owner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.write_text(
+                json.dumps({
+                    'operation': 'upsert_history',
+                    'owner': rag_memory.socket.gethostname(),
+                    'pid': 987654,
+                    'created_at': rag_memory.now_iso(),
+                }),
+                encoding='utf-8',
+            )
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with (
+                mock.patch.object(rag_memory.JsonRagStore, '_is_lock_owner_alive', return_value=False),
+                mock.patch('builtins.print') as print_mock,
+            ):
+                store.upsert_history([self.make_record('m1')])
+
+            reloaded = rag_memory.JsonRagStore(str(store_dir))
+            history_ids = reloaded.history_ids_for_file('script.rpy')
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(history_ids, ['m1'])
+        self.assertIn('Recovered stale RAG store lock', warnings)
 
     def test_json_rag_store_lock_cleanup_warns_without_failing_write(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -903,6 +955,21 @@ class RagMemoryStoreTests(unittest.TestCase):
             history_ids = set(reloaded.history_ids_for_file('script.rpy'))
 
         self.assertEqual(history_ids, {'fresh', 'stale'})
+
+    def test_json_rag_store_skips_reload_when_disk_snapshot_is_current(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            store.upsert_history([self.make_record('m1')])
+            with mock.patch.object(store, '_load_from_disk', wraps=store._load_from_disk) as load_mock:
+                store.upsert_history([self.make_record('m2')])
+
+            reloaded = rag_memory.JsonRagStore(str(store_dir))
+            history_ids = set(reloaded.history_ids_for_file('script.rpy'))
+
+        load_mock.assert_not_called()
+        self.assertEqual(history_ids, {'m1', 'm2'})
 
     def test_json_rag_store_metadata_records_write_owner(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
+import rag_memory
 import story_memory
 import translator_runtime as runtime
 
@@ -781,6 +782,106 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 runtime.SYNC_RAG_SEGMENT_LINES = old_values['segment_lines']
                 runtime.TL_DIR = old_values['tl_dir']
                 runtime._SYNC_RAG_STORE = old_values['store']
+
+
+class RagMemoryStoreTests(unittest.TestCase):
+    def make_record(self, memory_id, file_rel_path='script.rpy', source='Hello', translation='\u4f60\u597d'):
+        return {
+            'memory_id': memory_id,
+            'file_rel_path': file_rel_path,
+            'source_text': source,
+            'translated_text': translation,
+            'embedding': [1.0, 0.0, 0.0],
+            'quality_state': 'seed',
+        }
+
+    def test_json_rag_store_recovers_valid_rows_and_warns_on_bad_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            metadata_path = store_dir / 'metadata.json'
+            history_path = store_dir / 'history.jsonl'
+            metadata_path.write_text('{bad json', encoding='utf-8')
+            history_path.write_text(
+                json.dumps(self.make_record('m1'), ensure_ascii=False) + '\n'
+                '{bad row\n'
+                '[]\n',
+                encoding='utf-8',
+            )
+
+            store = rag_memory.JsonRagStore(str(store_dir))
+            with mock.patch('builtins.print') as print_mock:
+                count = store.count_history()
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(count, 1)
+        self.assertIn('Failed to load RAG metadata', warnings)
+        self.assertIn('Skipping invalid RAG history row', warnings)
+        self.assertIn('Skipping non-object RAG history row', warnings)
+
+    def test_json_rag_store_writes_history_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            history_path = store_dir / 'history.jsonl'
+            original_record = self.make_record('old')
+            history_path.write_text(
+                json.dumps(original_record, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with mock.patch.object(rag_memory.os, 'replace', side_effect=OSError('replace failed')):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    store.upsert_history([self.make_record('new')])
+
+            persisted = history_path.read_text(encoding='utf-8')
+            temp_files = list(store_dir.glob('*.tmp.*'))
+
+        self.assertEqual(persisted, json.dumps(original_record, ensure_ascii=False) + '\n')
+        self.assertEqual(temp_files, [])
+
+    def test_json_rag_store_lock_conflict_fails_explicitly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.write_text(
+                json.dumps({'operation': 'upsert_history', 'owner': 'test-host', 'pid': 123}),
+                encoding='utf-8',
+            )
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'test-host'):
+                store.upsert_history([self.make_record('m1')])
+
+            self.assertFalse((store_dir / 'history.jsonl').exists())
+
+    def test_json_rag_store_reload_under_lock_prevents_stale_overwrite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            stale_store = rag_memory.JsonRagStore(str(store_dir))
+            fresh_store = rag_memory.JsonRagStore(str(store_dir))
+            self.assertEqual(stale_store.count_history(), 0)
+
+            fresh_store.upsert_history([self.make_record('fresh')])
+            stale_store.upsert_history([self.make_record('stale')])
+
+            reloaded = rag_memory.JsonRagStore(str(store_dir))
+            history_ids = set(reloaded.history_ids_for_file('script.rpy'))
+
+        self.assertEqual(history_ids, {'fresh', 'stale'})
+
+    def test_json_rag_store_metadata_records_write_owner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            store.upsert_history([self.make_record('m1')])
+
+            metadata = json.loads((store_dir / 'metadata.json').read_text(encoding='utf-8'))
+
+        self.assertEqual(metadata['history_count'], 1)
+        self.assertEqual(metadata['last_write']['operation'], 'upsert_history')
+        self.assertEqual(metadata['last_write']['pid'], os.getpid())
 
 
 class BatchRepairRegressionTests(unittest.TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -855,6 +855,40 @@ class RagMemoryStoreTests(unittest.TestCase):
 
             self.assertFalse((store_dir / 'history.jsonl').exists())
 
+    def test_json_rag_store_creates_lock_with_restrictive_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+            original_open = rag_memory.os.open
+            open_modes = []
+
+            def tracking_open(path, flags, mode=0o777):
+                open_modes.append(mode)
+                return original_open(path, flags, mode)
+
+            with mock.patch.object(rag_memory.os, 'open', side_effect=tracking_open):
+                store.upsert_history([self.make_record('m1')])
+
+        self.assertEqual(open_modes[0], 0o600)
+
+    def test_json_rag_store_lock_cleanup_warns_without_failing_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+            with (
+                mock.patch.object(rag_memory.os, 'remove', side_effect=OSError('remove denied')),
+                mock.patch('builtins.print') as print_mock,
+            ):
+                store.upsert_history([self.make_record('m1')])
+
+            reloaded = rag_memory.JsonRagStore(str(store_dir))
+            history_ids = reloaded.history_ids_for_file('script.rpy')
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(history_ids, ['m1'])
+        self.assertIn('Failed to remove RAG store lock', warnings)
+        self.assertIn('remove denied', warnings)
+
     def test_json_rag_store_reload_under_lock_prevents_stale_overwrite(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -6,6 +6,7 @@ import os
 import pickle
 import sys
 import tempfile
+import time
 import unittest
 import zlib
 from pathlib import Path
@@ -922,6 +923,38 @@ class RagMemoryStoreTests(unittest.TestCase):
 
         self.assertEqual(history_ids, ['m1'])
         self.assertIn('Recovered stale RAG store lock', warnings)
+
+    def test_json_rag_store_recovers_stale_unreadable_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.write_text('{bad json', encoding='utf-8')
+            stale_time = time.time() - rag_memory.LOCK_STALE_AFTER_SECONDS - 5
+            os.utime(lock_path, (stale_time, stale_time))
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with mock.patch('builtins.print') as print_mock:
+                store.upsert_history([self.make_record('m1')])
+
+            reloaded = rag_memory.JsonRagStore(str(store_dir))
+            history_ids = reloaded.history_ids_for_file('script.rpy')
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(history_ids, ['m1'])
+        self.assertIn('Recovered stale RAG store lock', warnings)
+        self.assertIn('unknown owner', warnings)
+
+    def test_json_rag_store_keeps_fresh_unreadable_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.write_text('{bad json', encoding='utf-8')
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'unknown owner'):
+                store.upsert_history([self.make_record('m1')])
+
+            self.assertFalse((store_dir / 'history.jsonl').exists())
 
     def test_json_rag_store_lock_cleanup_warns_without_failing_write(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 背景

本地 RAG store 通过 `metadata.json` 和 `history.jsonl` 保存历史记录。此前写入会直接重写文件，并且多个进程可能基于旧快照覆盖彼此结果；加载坏 metadata 或坏 JSONL 行时也缺少清晰 warning。

Closes #12

## 改动

- 给 `JsonRagStore` 增加 `.rag_store.lock` 轻量文件锁，写入冲突时明确失败并显示锁持有者信息。
- `upsert_history` / `delete_history` / `set_metadata` 在持锁后重新加载磁盘状态，再执行变更，避免 stale snapshot 覆盖已有记录。
- `history.jsonl` / `metadata.json` 写入改为临时文件 + `os.replace()` 原子替换，失败时清理临时文件并保留旧文件。
- metadata 增加 `last_write`，记录 operation、owner、pid 和更新时间，方便诊断。
- 加载时对损坏 metadata、坏 JSONL 行、非对象 JSONL 行输出 warning，并保留可恢复记录。
- README 更新 RAG store 并发写入和损坏恢复说明。

## 验证

- `python -m py_compile .\rag_memory.py .\translator_runtime.py .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest discover -s tests -q`