### PR TITLE
[codex] 修复 RAG 锁清理失败后的自锁

### DIFF
--- a/rag_memory.py
+++ b/rag_memory.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import socket
+import sys
 from datetime import datetime
 
 
@@ -186,6 +187,7 @@ class JsonRagStore(object):
         owner = data.get('owner')
         pid = data.get('pid')
         created_at = data.get('created_at')
+        released_at = data.get('released_at')
         if operation:
             parts.append(f'operation={operation}')
         if owner:
@@ -194,6 +196,8 @@ class JsonRagStore(object):
             parts.append(f'pid={pid}')
         if created_at:
             parts.append(f'created_at={created_at}')
+        if released_at:
+            parts.append(f'released_at={released_at}')
         return ', '.join(parts) if parts else 'unknown owner'
 
     def _read_lock_owner(self):
@@ -270,6 +274,8 @@ class JsonRagStore(object):
         if not isinstance(data, dict):
             age_seconds = self._lock_file_age_seconds()
             return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
+        if data.get('released_at'):
+            return True
         local_owner = data.get('owner') == socket.gethostname()
         if local_owner and data.get('pid') is not None:
             is_alive = self._is_lock_owner_alive(data.get('pid'))
@@ -298,6 +304,24 @@ class JsonRagStore(object):
     def _open_lock_file(self):
         return os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
 
+    def _mark_lock_released(self, lock_info):
+        released_info = dict(lock_info)
+        released_info['released_at'] = now_iso()
+        try:
+            fd = os.open(self.lock_path, os.O_WRONLY | os.O_TRUNC)
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
+            return False
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+                json.dump(released_info, handle, ensure_ascii=False)
+        except OSError as exc:
+            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
+            return False
+        return True
+
     @contextmanager
     def _locked(self, operation):
         os.makedirs(self.store_dir, exist_ok=True)
@@ -323,12 +347,18 @@ class JsonRagStore(object):
                 json.dump(lock_info, handle, ensure_ascii=False)
             yield lock_info
         finally:
+            operation_failed = sys.exc_info()[0] is not None
             try:
                 os.remove(self.lock_path)
             except FileNotFoundError:
                 pass
             except OSError as exc:
+                self._mark_lock_released(lock_info)
                 self._warn(f'Failed to remove RAG store lock {self.lock_path}: {exc}')
+                if not operation_failed:
+                    raise JsonRagStoreLockError(
+                        f'Failed to remove RAG store lock {self.lock_path}: {exc}'
+                    )
 
     def _update_metadata_unlocked(self, operation, updates, lock_info):
         if not isinstance(self.metadata, dict):

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import socket
+import stat
 from datetime import datetime
 
 
@@ -303,31 +304,46 @@ class JsonRagStore(object):
     def _open_lock_file(self):
         return os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
 
-    def _mark_lock_released(self, lock_info):
-        released_info = dict(lock_info)
-        released_info['released_at'] = now_iso()
+    def _lock_path_is_regular_file(self):
         try:
-            fd = os.open(self.lock_path, os.O_WRONLY | os.O_TRUNC)
+            lock_stat = os.lstat(self.lock_path)
         except FileNotFoundError:
             return True
-        except OSError as exc:
-            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
+        return stat.S_ISREG(lock_stat.st_mode)
+
+    def _mark_lock_released(self, lock_info):
+        if not os.path.exists(self.lock_path):
+            return True
+        if not self._lock_path_is_regular_file():
+            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: not a regular file')
             return False
+        released_info = dict(lock_info)
+        released_info['released_at'] = now_iso()
+        tmp_path = f'{self.lock_path}.released.tmp.{os.getpid()}.{id(self)}'
         try:
-            handle = os.fdopen(fd, 'w', encoding='utf-8')
-        except OSError as exc:
+            fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
             try:
-                os.close(fd)
+                handle = os.fdopen(fd, 'w', encoding='utf-8')
             except OSError:
-                pass
-            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
-            return False
-        try:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
             with handle:
                 json.dump(released_info, handle, ensure_ascii=False)
-        except OSError as exc:
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.lock_path)
+        except Exception as exc:
             self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
             return False
+        finally:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError as exc:
+                    self._warn(f'Failed to remove temporary RAG store lock marker {tmp_path}: {exc}')
         return True
 
     @contextmanager
@@ -367,7 +383,7 @@ class JsonRagStore(object):
                 if operation_succeeded:
                     raise JsonRagStoreLockError(
                         f'Failed to remove RAG store lock {self.lock_path}: {exc}'
-                    )
+                    ) from exc
 
     def _update_metadata_unlocked(self, operation, updates, lock_info):
         if not isinstance(self.metadata, dict):

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -5,7 +5,6 @@ import json
 import math
 import os
 import socket
-import sys
 from datetime import datetime
 
 
@@ -315,7 +314,16 @@ class JsonRagStore(object):
             self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
             return False
         try:
-            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            handle = os.fdopen(fd, 'w', encoding='utf-8')
+        except OSError as exc:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
+            return False
+        try:
+            with handle:
                 json.dump(released_info, handle, ensure_ascii=False)
         except OSError as exc:
             self._warn(f'Failed to mark RAG store lock released {self.lock_path}: {exc}')
@@ -343,11 +351,12 @@ class JsonRagStore(object):
                 )
 
         try:
+            operation_succeeded = False
             with os.fdopen(fd, 'w', encoding='utf-8') as handle:
                 json.dump(lock_info, handle, ensure_ascii=False)
             yield lock_info
+            operation_succeeded = True
         finally:
-            operation_failed = sys.exc_info()[0] is not None
             try:
                 os.remove(self.lock_path)
             except FileNotFoundError:
@@ -355,7 +364,7 @@ class JsonRagStore(object):
             except OSError as exc:
                 self._mark_lock_released(lock_info)
                 self._warn(f'Failed to remove RAG store lock {self.lock_path}: {exc}')
-                if not operation_failed:
+                if operation_succeeded:
                     raise JsonRagStoreLockError(
                         f'Failed to remove RAG store lock {self.lock_path}: {exc}'
                     )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -965,7 +965,7 @@ class RagMemoryStoreTests(unittest.TestCase):
                 mock.patch.object(rag_memory.os, 'remove', side_effect=OSError('remove denied')),
                 mock.patch('builtins.print') as print_mock,
             ):
-                with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'remove denied'):
+                with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'remove denied') as raised:
                     store.upsert_history([self.make_record('m1')])
 
                 released_lock = json.loads(lock_path.read_text(encoding='utf-8'))
@@ -977,6 +977,7 @@ class RagMemoryStoreTests(unittest.TestCase):
             history_ids = set(reloaded.history_ids_for_file('script.rpy'))
 
         self.assertIn('released_at', released_lock)
+        self.assertIsInstance(raised.exception.__cause__, OSError)
         self.assertEqual(history_ids, {'m1', 'm2'})
         self.assertIn('Failed to remove RAG store lock', warnings)
         self.assertIn('remove denied', warnings)
@@ -1018,6 +1019,47 @@ class RagMemoryStoreTests(unittest.TestCase):
         close_mock.assert_called_once_with(fake_fd)
         self.assertIn('Failed to mark RAG store lock released', warnings)
         self.assertIn('fdopen denied', warnings)
+
+    def test_json_rag_store_mark_released_preserves_lock_on_write_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            original_lock = json.dumps({'operation': 'upsert_history', 'owner': 'test-host'})
+            lock_path.write_text(original_lock, encoding='utf-8')
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with (
+                mock.patch.object(rag_memory.json, 'dump', side_effect=OSError('dump denied')),
+                mock.patch('builtins.print') as print_mock,
+            ):
+                marked = store._mark_lock_released({'operation': 'upsert_history'})
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+            persisted_lock = lock_path.read_text(encoding='utf-8')
+            temp_files = list(store_dir.glob('*.released.tmp.*'))
+
+        self.assertFalse(marked)
+        self.assertEqual(persisted_lock, original_lock)
+        self.assertEqual(temp_files, [])
+        self.assertIn('Failed to mark RAG store lock released', warnings)
+        self.assertIn('dump denied', warnings)
+
+    def test_json_rag_store_mark_released_rejects_non_regular_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.mkdir()
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with mock.patch('builtins.print') as print_mock:
+                marked = store._mark_lock_released({'operation': 'upsert_history'})
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+            lock_is_dir = lock_path.is_dir()
+
+        self.assertFalse(marked)
+        self.assertTrue(lock_is_dir)
+        self.assertIn('not a regular file', warnings)
 
     def test_json_rag_store_reload_under_lock_prevents_stale_overwrite(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -981,6 +981,44 @@ class RagMemoryStoreTests(unittest.TestCase):
         self.assertIn('Failed to remove RAG store lock', warnings)
         self.assertIn('remove denied', warnings)
 
+    def test_json_rag_store_lock_cleanup_failure_fails_inside_outer_except(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            store = rag_memory.JsonRagStore(str(store_dir))
+
+            with (
+                mock.patch.object(rag_memory.os, 'remove', side_effect=OSError('remove denied')),
+                mock.patch('builtins.print'),
+            ):
+                try:
+                    raise RuntimeError('outer error')
+                except RuntimeError:
+                    with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'remove denied'):
+                        store.upsert_history([self.make_record('m1')])
+
+    def test_json_rag_store_mark_released_closes_fdopen_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
+            lock_path.write_text('{}', encoding='utf-8')
+            store = rag_memory.JsonRagStore(str(store_dir))
+            fake_fd = 777
+
+            with (
+                mock.patch.object(rag_memory.os, 'open', return_value=fake_fd),
+                mock.patch.object(rag_memory.os, 'fdopen', side_effect=OSError('fdopen denied')),
+                mock.patch.object(rag_memory.os, 'close') as close_mock,
+                mock.patch('builtins.print') as print_mock,
+            ):
+                marked = store._mark_lock_released({'operation': 'upsert_history'})
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertFalse(marked)
+        close_mock.assert_called_once_with(fake_fd)
+        self.assertIn('Failed to mark RAG store lock released', warnings)
+        self.assertIn('fdopen denied', warnings)
+
     def test_json_rag_store_reload_under_lock_prevents_stale_overwrite(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -956,21 +956,28 @@ class RagMemoryStoreTests(unittest.TestCase):
 
             self.assertFalse((store_dir / 'history.jsonl').exists())
 
-    def test_json_rag_store_lock_cleanup_warns_without_failing_write(self):
+    def test_json_rag_store_lock_cleanup_failure_fails_and_releases_lock(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = Path(tmp)
+            lock_path = store_dir / '.rag_store.lock'
             store = rag_memory.JsonRagStore(str(store_dir))
             with (
                 mock.patch.object(rag_memory.os, 'remove', side_effect=OSError('remove denied')),
                 mock.patch('builtins.print') as print_mock,
             ):
-                store.upsert_history([self.make_record('m1')])
+                with self.assertRaisesRegex(rag_memory.JsonRagStoreLockError, 'remove denied'):
+                    store.upsert_history([self.make_record('m1')])
 
+                released_lock = json.loads(lock_path.read_text(encoding='utf-8'))
+                warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+            with mock.patch('builtins.print'):
+                store.upsert_history([self.make_record('m2')])
             reloaded = rag_memory.JsonRagStore(str(store_dir))
-            history_ids = reloaded.history_ids_for_file('script.rpy')
-            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+            history_ids = set(reloaded.history_ids_for_file('script.rpy'))
 
-        self.assertEqual(history_ids, ['m1'])
+        self.assertIn('released_at', released_lock)
+        self.assertEqual(history_ids, {'m1', 'm2'})
         self.assertIn('Failed to remove RAG store lock', warnings)
         self.assertIn('remove denied', warnings)
 


### PR DESCRIPTION
## 背景

PR #18 合并后，Codex review 继续指出一个锁清理边界：如果 `.rag_store.lock` 在写入结束后的 `os.remove()` 阶段失败，旧实现只输出 warning 并返回成功，但残留 lock 的 owner/pid 仍指向当前存活进程，后续写入会把它当作活跃锁，从而在长进程里自锁。

## 改动

- lock 清理失败时，将残留 lock 标记为 `released_at`，让后续写入可安全回收这个已释放锁。
- 如果业务写入本身成功但 lock 清理失败，本次操作改为抛出 `JsonRagStoreLockError`，避免把清理失败误报为完全成功。
- 如果业务写入本身已经异常，清理失败只保留 warning，不遮蔽原始异常。
- stale lock 判断新增对 `released_at` 的快速回收。
- 回归测试覆盖清理失败后：本次写入失败、lock 带 `released_at`、后续写入能回收残留锁并继续写入。

## 验证

- `python -m py_compile .\rag_memory.py .\tests\test_regressions.py`
- `python -m unittest tests.test_regressions.RagMemoryStoreTests -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`