### PR TITLE
[codex] 增强 Batch RAG 已有记忆注入

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -834,14 +834,11 @@ def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
             part_manifest[key] = source_manifest[key]
 
     if source_manifest.get('rag_enabled'):
-        rag_summary = dict(source_manifest.get('rag_summary') or {})
-        rag_summary['chunks_with_glossary_hits'] = sum(
-            1 for chunk in part_chunks if chunk.get('glossary_hits')
+        source_rag_summary = source_manifest.get('rag_summary') or {}
+        part_manifest['rag_summary'] = summarize_batch_rag(
+            part_chunks,
+            dict(source_rag_summary.get('prepare') or {}),
         )
-        rag_summary['chunks_with_history_hits'] = sum(
-            1 for chunk in part_chunks if chunk.get('history_hits')
-        )
-        part_manifest['rag_summary'] = rag_summary
 
     for key in (
         'story_memory_enabled',
@@ -2661,6 +2658,34 @@ def embed_history_records(records):
     return embedded_records
 
 
+def has_current_source_embedding(existing, record):
+    return (
+        existing
+        and existing.get('source_checksum') == record['source_checksum']
+        and existing.get('embedding_model') == RAG_EMBEDDING_MODEL
+        and existing.get('embedding_task_type') == RAG_DOCUMENT_TASK_TYPE
+        and existing.get('embedding_dim') == RAG_OUTPUT_DIMENSIONALITY
+        and existing.get('embedding_text_kind') == 'source_text'
+        and existing.get('embedding_text_checksum') == hash_text(record.get('source_text', ''))
+        and isinstance(existing.get('embedding'), list)
+        and bool(existing.get('embedding'))
+    )
+
+
+def reuse_existing_source_embedding(record, existing):
+    enriched = dict(record)
+    for key in (
+        'embedding',
+        'embedding_model',
+        'embedding_task_type',
+        'embedding_dim',
+        'embedding_text_kind',
+        'embedding_text_checksum',
+    ):
+        enriched[key] = existing.get(key)
+    return enriched
+
+
 def all_rag_file_jobs():
     return [
         {'file_rel_path': rel_path, 'file_path': file_path}
@@ -2677,21 +2702,17 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
 
     scan_jobs = all_rag_file_jobs() if scan_all_files else file_jobs
     base_records = collect_rag_seed_records_for_jobs(scan_jobs, quality_state=quality_state)
-    pending_records = []
+    records_to_embed = []
+    records_with_reused_embedding = []
     for record in base_records:
         existing = store.get_history_record(record['memory_id'])
-        if (
-            existing
-            and existing.get('source_checksum') == record['source_checksum']
-            and existing.get('translation_checksum') == record['translation_checksum']
-            and existing.get('embedding_model') == RAG_EMBEDDING_MODEL
-            and existing.get('embedding_task_type') == RAG_DOCUMENT_TASK_TYPE
-            and existing.get('embedding_dim') == RAG_OUTPUT_DIMENSIONALITY
-            and existing.get('embedding_text_kind') == 'source_text'
-            and existing.get('embedding_text_checksum') == hash_text(record.get('source_text', ''))
-        ):
-            continue
-        pending_records.append(record)
+        if has_current_source_embedding(existing, record):
+            if existing.get('translation_checksum') == record['translation_checksum']:
+                continue
+            records_with_reused_embedding.append(reuse_existing_source_embedding(record, existing))
+        else:
+            records_to_embed.append(record)
+    pending_records = records_with_reused_embedding + records_to_embed
 
     stats = {
         'enabled': True,
@@ -2700,6 +2721,8 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
         'files_scanned': len(scan_jobs),
         'scanned': len(base_records),
         'pending': len(pending_records),
+        'embedding_pending': len(records_to_embed),
+        'reused_embeddings': len(records_with_reused_embedding),
         'upserted': 0,
         'history_records_before': store.count_history(),
     }
@@ -2708,8 +2731,9 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
         return stats
 
     try:
-        embedded_records = embed_history_records(pending_records)
-        stats['upserted'] = store.upsert_history(embedded_records)
+        embedded_records = embed_history_records(records_to_embed)
+        stats['embedded'] = len(embedded_records)
+        stats['upserted'] = store.upsert_history(records_with_reused_embedding + embedded_records)
         stats['history_records_after'] = store.count_history()
     except Exception as exc:
         print(f'Warning: Failed to update RAG store: {exc}')

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -605,11 +605,12 @@ def format_history_hits_block(hits, empty_label='(none)'):
         line_end = hit.get('line_end', '')
         score = hit.get('score', 0.0)
         quality = hit.get('quality_state', '')
-        source_text = truncate_text(hit.get('source_text', ''), RAG_HISTORY_CHAR_LIMIT)
-        translated_text = hit.get('translated_text', '') or hit.get('source_text', '')
-        translated_text = truncate_text(translated_text, RAG_HISTORY_CHAR_LIMIT)
+        raw_source_text = hit.get('source_text', '')
+        raw_translated_text = hit.get('translated_text', '') or raw_source_text
+        source_text = truncate_text(raw_source_text, RAG_HISTORY_CHAR_LIMIT)
+        translated_text = truncate_text(raw_translated_text, RAG_HISTORY_CHAR_LIMIT)
         prefix = f'- [{file_rel_path}:{line_start}-{line_end} score={score:.3f} quality={quality}]'
-        if source_text and translated_text and source_text != translated_text:
+        if source_text and translated_text and raw_source_text != raw_translated_text:
             lines.append(f'{prefix} Source: {source_text} -> Translation: {translated_text}')
         else:
             lines.append(f'{prefix} Translation: {translated_text}')
@@ -2723,6 +2724,7 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
         'pending': len(pending_records),
         'embedding_pending': len(records_to_embed),
         'reused_embeddings': len(records_with_reused_embedding),
+        'embedded': 0,
         'upserted': 0,
         'history_records_before': store.count_history(),
     }

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -605,11 +605,14 @@ def format_history_hits_block(hits, empty_label='(none)'):
         line_end = hit.get('line_end', '')
         score = hit.get('score', 0.0)
         quality = hit.get('quality_state', '')
+        source_text = truncate_text(hit.get('source_text', ''), RAG_HISTORY_CHAR_LIMIT)
         translated_text = hit.get('translated_text', '') or hit.get('source_text', '')
         translated_text = truncate_text(translated_text, RAG_HISTORY_CHAR_LIMIT)
-        lines.append(
-            f'- [{file_rel_path}:{line_start}-{line_end} score={score:.3f} quality={quality}] {translated_text}'
-        )
+        prefix = f'- [{file_rel_path}:{line_start}-{line_end} score={score:.3f} quality={quality}]'
+        if source_text and translated_text and source_text != translated_text:
+            lines.append(f'{prefix} Source: {source_text} -> Translation: {translated_text}')
+        else:
+            lines.append(f'{prefix} Translation: {translated_text}')
     return '\n'.join(lines) if lines else empty_label
 
 
@@ -1174,6 +1177,23 @@ def build_chunks(file_jobs):
     return chunks
 
 
+def summarize_batch_rag(chunks, prepare_summary):
+    chunk_count = len(chunks)
+    chunks_with_history_hits = sum(1 for chunk in chunks if chunk.get('history_hits'))
+    history_hit_count = sum(len(chunk.get('history_hits') or []) for chunk in chunks)
+    return {
+        'prepare': prepare_summary,
+        'chunks_with_glossary_hits': sum(1 for chunk in chunks if chunk.get('glossary_hits')),
+        'chunks_with_history_hits': chunks_with_history_hits,
+        'history_hit_count': history_hit_count,
+        'history_hit_rate': (chunks_with_history_hits / chunk_count) if chunk_count else 0.0,
+        'history_retrieval_errors': sum(
+            1 for chunk in chunks
+            if (chunk.get('rag_stats') or {}).get('error')
+        ),
+    }
+
+
 
 def get_batch_risk_warnings():
     warnings_list = []
@@ -1261,11 +1281,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             'segment_lines': RAG_SEGMENT_LINES,
             'bootstrap_on_build': RAG_BOOTSTRAP_ON_BUILD,
         } if RAG_ENABLED else {},
-        'rag_summary': {
-            'prepare': rag_prepare_summary,
-            'chunks_with_glossary_hits': sum(1 for chunk in chunks if chunk.get('glossary_hits')),
-            'chunks_with_history_hits': sum(1 for chunk in chunks if chunk.get('history_hits')),
-        } if RAG_ENABLED else {},
+        'rag_summary': summarize_batch_rag(chunks, rag_prepare_summary) if RAG_ENABLED else {},
         'story_memory_enabled': STORY_MEMORY_ENABLED,
         'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
         'story_memory_settings': {
@@ -2632,25 +2648,35 @@ def embed_history_records(records):
     batch_size = 16
     for start in range(0, len(records), batch_size):
         batch = records[start:start + batch_size]
-        vectors = embed_texts([record['combined_text'] for record in batch], RAG_DOCUMENT_TASK_TYPE)
+        vectors = embed_texts([record['source_text'] for record in batch], RAG_DOCUMENT_TASK_TYPE)
         for record, vector in zip(batch, vectors):
             enriched = dict(record)
             enriched['embedding'] = vector
             enriched['embedding_model'] = RAG_EMBEDDING_MODEL
             enriched['embedding_task_type'] = RAG_DOCUMENT_TASK_TYPE
             enriched['embedding_dim'] = len(vector)
+            enriched['embedding_text_kind'] = 'source_text'
+            enriched['embedding_text_checksum'] = hash_text(record.get('source_text', ''))
             embedded_records.append(enriched)
     return embedded_records
 
 
-def sync_rag_store_for_jobs(file_jobs, quality_state='seed'):
+def all_rag_file_jobs():
+    return [
+        {'file_rel_path': rel_path, 'file_path': file_path}
+        for rel_path, file_path in collect_files_to_process()
+    ]
+
+
+def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=False):
     if not RAG_ENABLED:
         return {'enabled': False}
     store = get_rag_store()
     if store is None:
         return {'enabled': True, 'error': 'RAG store unavailable'}
 
-    base_records = collect_rag_seed_records_for_jobs(file_jobs, quality_state=quality_state)
+    scan_jobs = all_rag_file_jobs() if scan_all_files else file_jobs
+    base_records = collect_rag_seed_records_for_jobs(scan_jobs, quality_state=quality_state)
     pending_records = []
     for record in base_records:
         existing = store.get_history_record(record['memory_id'])
@@ -2661,6 +2687,8 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed'):
             and existing.get('embedding_model') == RAG_EMBEDDING_MODEL
             and existing.get('embedding_task_type') == RAG_DOCUMENT_TASK_TYPE
             and existing.get('embedding_dim') == RAG_OUTPUT_DIMENSIONALITY
+            and existing.get('embedding_text_kind') == 'source_text'
+            and existing.get('embedding_text_checksum') == hash_text(record.get('source_text', ''))
         ):
             continue
         pending_records.append(record)
@@ -2668,6 +2696,8 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed'):
     stats = {
         'enabled': True,
         'store_dir': store.store_dir,
+        'scan_scope': 'all_files' if scan_all_files else 'pending_files',
+        'files_scanned': len(scan_jobs),
         'scanned': len(base_records),
         'pending': len(pending_records),
         'upserted': 0,
@@ -2699,7 +2729,7 @@ def prepare_rag_store(file_jobs):
         'bootstrap_on_build': RAG_BOOTSTRAP_ON_BUILD,
     }
     if RAG_BOOTSTRAP_ON_BUILD:
-        summary.update(sync_rag_store_for_jobs(file_jobs, quality_state='seed'))
+        summary.update(sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=True))
     return summary
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1147,7 +1147,7 @@ class BatchRagRegressionTests(unittest.TestCase):
             'base_dir': batch_mod.legacy.BASE_DIR,
             'tl_dir': batch_mod.legacy.TL_DIR,
             'include_files': set(batch_mod.legacy.INCLUDE_FILES),
-            'include_prefixes': tuple(batch_mod.legacy.INCLUDE_PREFIXES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
         }
         try:
             with tempfile.TemporaryDirectory() as tmp:
@@ -1168,7 +1168,7 @@ class BatchRagRegressionTests(unittest.TestCase):
                 batch_mod.legacy.BASE_DIR = str(root)
                 batch_mod.legacy.TL_DIR = str(tl_dir)
                 batch_mod.legacy.INCLUDE_FILES = set()
-                batch_mod.legacy.INCLUDE_PREFIXES = ()
+                batch_mod.legacy.INCLUDE_PREFIXES = set()
 
                 embedded_inputs = []
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1122,6 +1122,24 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertIn('Source: Aether Gate -> Translation: \u4ee5\u592a\u95e8', block)
         self.assertIn('score=0.812', block)
 
+    def test_format_history_hits_block_compares_untruncated_text(self):
+        shared_prefix = 'A' * batch_mod.RAG_HISTORY_CHAR_LIMIT
+        block = batch_mod.format_history_hits_block([
+            {
+                'file_rel_path': 'script.rpy',
+                'line_start': 10,
+                'line_end': 12,
+                'score': 0.8123,
+                'quality_state': 'seed',
+                'source_text': shared_prefix + 'S',
+                'translated_text': shared_prefix + 'T',
+            }
+        ])
+
+        self.assertIn(' Source: ', block)
+        self.assertIn(' -> Translation: ', block)
+        self.assertNotIn('] Translation: ', block)
+
     def test_embed_history_records_uses_source_text_only(self):
         record = batch_mod.build_rag_record(
             'script.rpy',
@@ -1258,15 +1276,21 @@ class BatchRagRegressionTests(unittest.TestCase):
                 with mock.patch.object(batch_mod, 'embed_texts') as embed_mock_second:
                     second_summary = batch_mod.sync_rag_store_for_jobs(file_jobs)
 
+                with mock.patch.object(batch_mod, 'embed_texts') as embed_mock_third:
+                    third_summary = batch_mod.sync_rag_store_for_jobs(file_jobs)
+
                 store = batch_mod.get_rag_store()
                 records = list(store.history.values())
 
             embed_mock.assert_called_once()
             embed_mock_second.assert_not_called()
+            embed_mock_third.assert_not_called()
             self.assertEqual(first_summary['embedded'], 1)
             self.assertEqual(second_summary['embedding_pending'], 0)
             self.assertEqual(second_summary['reused_embeddings'], 1)
             self.assertEqual(second_summary['upserted'], 1)
+            self.assertEqual(third_summary['pending'], 0)
+            self.assertEqual(third_summary['embedded'], 0)
             self.assertEqual(records[0]['translated_text'], '\u65b0\u8bd1')
             self.assertEqual(records[0]['embedding'], [1.0, 0.0, 0.0])
         finally:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1230,6 +1230,52 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(summary['history_hit_rate'], 0.5)
         self.assertEqual(summary['history_retrieval_errors'], 1)
 
+    def test_sync_rag_store_reuses_embedding_when_only_translation_changes(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'rag_segment_lines': batch_mod.RAG_SEGMENT_LINES,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                store_dir = root / 'rag_store'
+                target_file = root / 'script.rpy'
+                target_file.write_text('old "Aether Gate"\nnew "\u65e7\u8bd1"\n', encoding='utf-8')
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_STORE_DIR = str(store_dir)
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod.RAG_SEGMENT_LINES = 4
+                batch_mod._RAG_STORE = None
+                file_jobs = [{'file_rel_path': 'script.rpy', 'file_path': str(target_file)}]
+
+                with mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0]]) as embed_mock:
+                    first_summary = batch_mod.sync_rag_store_for_jobs(file_jobs)
+
+                target_file.write_text('old "Aether Gate"\nnew "\u65b0\u8bd1"\n', encoding='utf-8')
+                with mock.patch.object(batch_mod, 'embed_texts') as embed_mock_second:
+                    second_summary = batch_mod.sync_rag_store_for_jobs(file_jobs)
+
+                store = batch_mod.get_rag_store()
+                records = list(store.history.values())
+
+            embed_mock.assert_called_once()
+            embed_mock_second.assert_not_called()
+            self.assertEqual(first_summary['embedded'], 1)
+            self.assertEqual(second_summary['embedding_pending'], 0)
+            self.assertEqual(second_summary['reused_embeddings'], 1)
+            self.assertEqual(second_summary['upserted'], 1)
+            self.assertEqual(records[0]['translated_text'], '\u65b0\u8bd1')
+            self.assertEqual(records[0]['embedding'], [1.0, 0.0, 0.0])
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.RAG_SEGMENT_LINES = old_values['rag_segment_lines']
+
 
 class BatchRepairRegressionTests(unittest.TestCase):
     def test_split_manifest_keeps_first_child_latest_and_context_metadata(self):
@@ -1246,7 +1292,11 @@ class BatchRepairRegressionTests(unittest.TestCase):
                     'file_rel_path': 'script.rpy',
                     'file_path': str(root / 'script.rpy'),
                     'items': [{'id': 'script.rpy:0:4', 'text': 'Hello'}],
-                    'history_hits': [{'source_text': 'Hello', 'translated_text': '\u4f60\u597d'}],
+                    'glossary_hits': [{'source': 'Hello', 'target': '\u4f60\u597d'}],
+                    'history_hits': [
+                        {'source_text': 'Hello', 'translated_text': '\u4f60\u597d'},
+                        {'source_text': 'Hi', 'translated_text': '\u55e8'},
+                    ],
                     'story_hits': {'terms': [{'source': 'Void Gate', 'target': '\u865a\u7a7a\u95e8'}]},
                 },
                 {
@@ -1254,6 +1304,8 @@ class BatchRepairRegressionTests(unittest.TestCase):
                     'file_rel_path': 'script.rpy',
                     'file_path': str(root / 'script.rpy'),
                     'items': [{'id': 'script.rpy:1:4', 'text': 'World'}],
+                    'history_hits': [{'source_text': 'World', 'translated_text': '\u4e16\u754c'}],
+                    'rag_stats': {'error': 'embedding failed'},
                 },
             ]
             input_path.write_text(
@@ -1272,7 +1324,13 @@ class BatchRepairRegressionTests(unittest.TestCase):
                         'rag_enabled': True,
                         'rag_store_path': str(root / 'rag_store'),
                         'rag_settings': {'top_k_history': 4},
-                        'rag_summary': {'chunks_with_history_hits': 1},
+                        'rag_summary': {
+                            'prepare': {'upserted': 3},
+                            'chunks_with_history_hits': 2,
+                            'history_hit_count': 3,
+                            'history_hit_rate': 1.0,
+                            'history_retrieval_errors': 1,
+                        },
                         'story_memory_enabled': True,
                         'story_memory_graph_file': str(root / 'story_graph.json'),
                         'story_memory_settings': {'top_k_terms': 8},
@@ -1296,6 +1354,11 @@ class BatchRepairRegressionTests(unittest.TestCase):
             self.assertTrue(first_child['story_memory_enabled'])
             self.assertEqual(first_child['story_memory_settings'], {'top_k_terms': 8})
             self.assertEqual(first_child['rag_summary']['chunks_with_history_hits'], 1)
+            self.assertEqual(first_child['rag_summary']['chunks_with_glossary_hits'], 1)
+            self.assertEqual(first_child['rag_summary']['history_hit_count'], 2)
+            self.assertEqual(first_child['rag_summary']['history_hit_rate'], 1.0)
+            self.assertEqual(first_child['rag_summary']['history_retrieval_errors'], 0)
+            self.assertEqual(first_child['rag_summary']['prepare'], {'upserted': 3})
             self.assertEqual(first_child['story_memory_summary']['chunks_with_story_hits'], 1)
 
     def test_collect_result_actions_ignores_duplicate_result_ids(self):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1105,6 +1105,132 @@ class RagMemoryStoreTests(unittest.TestCase):
         self.assertEqual(metadata['last_write']['pid'], os.getpid())
 
 
+class BatchRagRegressionTests(unittest.TestCase):
+    def test_format_history_hits_block_shows_source_translation_pair(self):
+        block = batch_mod.format_history_hits_block([
+            {
+                'file_rel_path': 'script.rpy',
+                'line_start': 10,
+                'line_end': 12,
+                'score': 0.8123,
+                'quality_state': 'seed',
+                'source_text': 'Aether Gate',
+                'translated_text': '\u4ee5\u592a\u95e8',
+            }
+        ])
+
+        self.assertIn('Source: Aether Gate -> Translation: \u4ee5\u592a\u95e8', block)
+        self.assertIn('score=0.812', block)
+
+    def test_embed_history_records_uses_source_text_only(self):
+        record = batch_mod.build_rag_record(
+            'script.rpy',
+            [{'line_number': 3, 'source': 'Aether Gate', 'translation': '\u4ee5\u592a\u95e8'}],
+            'seed',
+        )
+
+        with mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0]]) as embed_mock:
+            embedded = batch_mod.embed_history_records([record])
+
+        embed_mock.assert_called_once_with(['Aether Gate'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
+        self.assertEqual(embedded[0]['embedding_text_kind'], 'source_text')
+        self.assertEqual(embedded[0]['embedding_text_checksum'], batch_mod.hash_text('Aether Gate'))
+
+    def test_prepare_rag_store_bootstraps_all_allowed_tl_files(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_bootstrap': batch_mod.RAG_BOOTSTRAP_ON_BUILD,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'rag_segment_lines': batch_mod.RAG_SEGMENT_LINES,
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': tuple(batch_mod.legacy.INCLUDE_PREFIXES),
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / 'game' / 'tl' / 'schinese'
+                tl_dir.mkdir(parents=True)
+                pending_file = tl_dir / 'pending.rpy'
+                memory_file = tl_dir / 'memory.rpy'
+                pending_file.write_text('old "Needs translation"\nnew ""\n', encoding='utf-8')
+                memory_file.write_text('old "Aether Gate"\nnew "\u4ee5\u592a\u95e8"\n', encoding='utf-8')
+
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_BOOTSTRAP_ON_BUILD = True
+                batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod.RAG_SEGMENT_LINES = 4
+                batch_mod._RAG_STORE = None
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.INCLUDE_FILES = set()
+                batch_mod.legacy.INCLUDE_PREFIXES = ()
+
+                embedded_inputs = []
+
+                def fake_embed(contents, task_type):
+                    embedded_inputs.extend(contents)
+                    return [[1.0, 0.0, 0.0] for _ in contents]
+
+                file_jobs = [{
+                    'file_rel_path': 'pending.rpy',
+                    'file_path': str(pending_file),
+                    'task_count': 1,
+                    'tasks': [],
+                }]
+                with mock.patch.object(batch_mod, 'embed_texts', side_effect=fake_embed):
+                    summary = batch_mod.prepare_rag_store(file_jobs)
+
+                store = batch_mod.get_rag_store()
+                records = list(store.history.values())
+
+            self.assertEqual(summary['scan_scope'], 'all_files')
+            self.assertEqual(summary['files_scanned'], 2)
+            self.assertEqual(summary['scanned'], 1)
+            self.assertEqual(summary['upserted'], 1)
+            self.assertEqual(embedded_inputs, ['Aether Gate'])
+            self.assertEqual(records[0]['source_text'], 'Aether Gate')
+            self.assertEqual(records[0]['translated_text'], '\u4ee5\u592a\u95e8')
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_BOOTSTRAP_ON_BUILD = old_values['rag_bootstrap']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.RAG_SEGMENT_LINES = old_values['rag_segment_lines']
+            batch_mod.legacy.BASE_DIR = old_values['base_dir']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+            batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
+        summary = batch_mod.summarize_batch_rag(
+            [
+                {
+                    'glossary_hits': [{'source': 'Aether', 'target': '\u4ee5\u592a'}],
+                    'history_hits': [{'memory_id': 'm1'}, {'memory_id': 'm2'}],
+                    'rag_stats': {'hit_count': 2},
+                },
+                {
+                    'history_hits': [],
+                    'rag_stats': {'error': 'embedding failed'},
+                },
+            ],
+            {'upserted': 1},
+        )
+
+        self.assertEqual(summary['prepare'], {'upserted': 1})
+        self.assertEqual(summary['chunks_with_glossary_hits'], 1)
+        self.assertEqual(summary['chunks_with_history_hits'], 1)
+        self.assertEqual(summary['history_hit_count'], 2)
+        self.assertEqual(summary['history_hit_rate'], 0.5)
+        self.assertEqual(summary['history_retrieval_errors'], 1)
+
+
 class BatchRepairRegressionTests(unittest.TestCase):
     def test_split_manifest_keeps_first_child_latest_and_context_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 背景

Batch RAG 目前更像在 build 阶段做静态快照。这个 PR 不改变 Batch 的异步/波次架构，只增强“引用已有翻译记忆”的可靠性和可观察性。

Closes #6

## 改动

- `bootstrap_on_build=true` 时，RAG store 预建库改为扫描 `TL_DIR` 下所有允许处理的 `.rpy` 文件，而不是只扫描当前 pending 文件。
- history record 的 embedding 改为只使用 `source_text`，并记录 `embedding_text_kind` / `embedding_text_checksum`，避免旧的 `Source+Translation` 混合 embedding 继续复用。
- `RETRIEVED MEMORY` 输出改为明确的 `Source: ... -> Translation: ...` 对照，帮助模型理解已有译法。
- `rag_summary` 增加 `history_hit_count`、`history_hit_rate`、`history_retrieval_errors`，prepare summary 增加 `scan_scope` / `files_scanned`，方便判断 Batch RAG 是否真的命中。
- 增加回归测试覆盖全 TL 文件 bootstrap、source-only embedding、Source/Translation prompt 格式和 summary 统计。

## 验证

- `python -m py_compile .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest tests.test_regressions.BatchRagRegressionTests -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`