### PR TITLE
[codex] 增加 Batch RAG 预建库命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ python gemini_translate.py
 Batch 模式：
 
 ```bash
+python gemini_translate_batch.py bootstrap-rag
 python gemini_translate_batch.py build
 python gemini_translate_batch.py submit
 python gemini_translate_batch.py status
@@ -131,6 +132,7 @@ python gemini_translate_batch.py apply
 - Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
 - 不带子命令直接运行 `gemini_translate_batch.py` 时，默认等价于 `submit`
 - Batch 产物默认会写到本地 `logs/` 目录
+- `bootstrap-rag` 会扫描当前允许处理的全部 TL `.rpy` 文件，把已有译文预先写入本地 history store；适合在正式 `build / submit` 前先暖库
 - `probe` 会用同步请求做最小 smoke test
 - `check` 是干跑校验，不会修改 `.rpy`
 - `apply` 只会写回通过校验的结果
@@ -138,6 +140,28 @@ python gemini_translate_batch.py apply
 - 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息；同机写入进程崩溃后留下的 stale lock 会在确认 PID 已退出时自动回收
 - 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning
 - 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
+
+### 可选：Batch RAG 预建库
+
+如果项目里已经有一部分人工译文或旧译文，可以先运行：
+
+```bash
+python gemini_translate_batch.py bootstrap-rag
+```
+
+这个命令只刷新本地 RAG history store，不会创建 Batch package，也不会修改 `.rpy`。它会复用 `batch.rag` 配置，扫描 `game/tl/schinese` 下当前允许处理的 `.rpy` 文件，提取已有 `old/new` 译文记录并生成 source-only embedding。
+
+典型流程：
+
+```bash
+python gemini_translate_batch.py bootstrap-rag
+python gemini_translate_batch.py build
+python gemini_translate_batch.py submit
+```
+
+命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
+
+注意：`bootstrap-rag` 解决的是“build 前先用已有译文暖库”的问题；它不会让已经 build / split 完的旧请求动态吃到后续 apply 的新结果。需要滚动回灌时，仍要按波次重新 build，或等待后续动态波次编排能力。
 
 ### 可选：Structured Story Memory
 
@@ -255,7 +279,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - Excel / HTML 协作流
 - 面向普通用户的零配置体验
 - 完整的游戏解包 / 打包一体化发布流程
-- 面向超大项目的完整 RAG 生产工作流（例如全项目 bootstrap 建库、严格的波次式回灌编排、并发写保护）
+- 面向超大项目的完整 RAG 生产工作流（例如严格的波次式回灌编排、多阶段调度策略）
 - 完整的结构化剧情图谱生产工作流（例如 schema 校验、自动 seed 生成、Neo4j 可视化导出）
 
 ## 项目状态

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2785,6 +2785,11 @@ def print_rag_bootstrap_summary(summary):
 
 
 def bootstrap_rag_store(skip_prepare=False):
+    if not RAG_ENABLED:
+        summary = {'enabled': False}
+        print_rag_bootstrap_summary(summary)
+        return summary
+
     if not skip_prepare:
         legacy.run_prepare_steps()
     if not os.path.isdir(legacy.TL_DIR):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2759,6 +2759,42 @@ def prepare_rag_store(file_jobs):
     return summary
 
 
+def print_rag_bootstrap_summary(summary):
+    if not summary.get('enabled'):
+        print('RAG is disabled. Enable batch.rag.enabled=true before bootstrapping.')
+        return
+
+    print('RAG bootstrap summary:')
+    for key in (
+        'store_dir',
+        'scan_scope',
+        'files_scanned',
+        'scanned',
+        'pending',
+        'embedding_pending',
+        'reused_embeddings',
+        'embedded',
+        'upserted',
+        'history_records_before',
+        'history_records_after',
+    ):
+        if key in summary:
+            print(f'- {key}: {summary[key]}')
+    if summary.get('error'):
+        print(f"- error: {summary['error']}")
+
+
+def bootstrap_rag_store(skip_prepare=False):
+    if not skip_prepare:
+        legacy.run_prepare_steps()
+    if not os.path.isdir(legacy.TL_DIR):
+        raise SystemExit(f'TL dir does not exist: {legacy.TL_DIR}')
+
+    summary = sync_rag_store_for_jobs([], quality_state='seed', scan_all_files=True)
+    print_rag_bootstrap_summary(summary)
+    return summary
+
+
 
 def entry_context_text(entry):
     translated = entry.get('translation', '')
@@ -3298,6 +3334,16 @@ def build_arg_parser():
         help='Skip auto prepare steps before collecting tasks.',
     )
 
+    bootstrap_rag_parser = subparsers.add_parser(
+        'bootstrap-rag',
+        help='Prebuild or refresh the Batch RAG history store from all allowed TL files.',
+    )
+    bootstrap_rag_parser.add_argument(
+        '--skip-prepare',
+        action='store_true',
+        help='Skip auto prepare steps before scanning TL files.',
+    )
+
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
     submit_parser.add_argument(
         'target',
@@ -3414,6 +3460,10 @@ def main(argv=None):
             display_name_override=args.display_name,
             skip_prepare=args.skip_prepare,
         )
+        return
+
+    if command == 'bootstrap-rag':
+        bootstrap_rag_store(skip_prepare=args.skip_prepare)
         return
 
     if command == 'submit':

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1289,6 +1289,29 @@ class BatchRagRegressionTests(unittest.TestCase):
             batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
             batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
 
+    def test_bootstrap_rag_store_disabled_does_not_require_tl_dir(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+        }
+        try:
+            batch_mod.RAG_ENABLED = False
+            batch_mod.legacy.TL_DIR = str(Path('missing') / 'tl')
+
+            stdout = io.StringIO()
+            with (
+                mock.patch.object(batch_mod.legacy, 'run_prepare_steps') as prepare_mock,
+                mock.patch('sys.stdout', stdout),
+            ):
+                summary = batch_mod.bootstrap_rag_store(skip_prepare=False)
+
+            prepare_mock.assert_not_called()
+            self.assertEqual(summary, {'enabled': False})
+            self.assertIn('RAG is disabled', stdout.getvalue())
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+
     def test_build_arg_parser_accepts_bootstrap_rag_command(self):
         args = batch_mod.build_arg_parser().parse_args(['bootstrap-rag', '--skip-prepare'])
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1225,6 +1225,76 @@ class BatchRagRegressionTests(unittest.TestCase):
             batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
             batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
 
+    def test_bootstrap_rag_store_scans_all_allowed_tl_files_explicitly(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_bootstrap': batch_mod.RAG_BOOTSTRAP_ON_BUILD,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'rag_segment_lines': batch_mod.RAG_SEGMENT_LINES,
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / 'game' / 'tl' / 'schinese'
+                tl_dir.mkdir(parents=True)
+                memory_file = tl_dir / 'memory.rpy'
+                memory_file.write_text('old "Aether Gate"\nnew "\u4ee5\u592a\u95e8"\n', encoding='utf-8')
+
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_BOOTSTRAP_ON_BUILD = False
+                batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod.RAG_SEGMENT_LINES = 4
+                batch_mod._RAG_STORE = None
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.INCLUDE_FILES = set()
+                batch_mod.legacy.INCLUDE_PREFIXES = set()
+
+                stdout = io.StringIO()
+                with (
+                    mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0]]) as embed_mock,
+                    mock.patch('sys.stdout', stdout),
+                ):
+                    summary = batch_mod.bootstrap_rag_store(skip_prepare=True)
+
+                store = batch_mod.get_rag_store()
+                output = stdout.getvalue()
+
+            embed_mock.assert_called_once_with(['Aether Gate'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
+            self.assertIn('RAG bootstrap summary:', output)
+            self.assertIn('- scan_scope: all_files', output)
+            self.assertIn('- embedded: 1', output)
+            self.assertEqual(summary['scan_scope'], 'all_files')
+            self.assertEqual(summary['files_scanned'], 1)
+            self.assertEqual(summary['scanned'], 1)
+            self.assertEqual(summary['embedded'], 1)
+            self.assertEqual(summary['upserted'], 1)
+            self.assertEqual(store.count_history(), 1)
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_BOOTSTRAP_ON_BUILD = old_values['rag_bootstrap']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.RAG_SEGMENT_LINES = old_values['rag_segment_lines']
+            batch_mod.legacy.BASE_DIR = old_values['base_dir']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+            batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_build_arg_parser_accepts_bootstrap_rag_command(self):
+        args = batch_mod.build_arg_parser().parse_args(['bootstrap-rag', '--skip-prepare'])
+
+        self.assertEqual(args.command, 'bootstrap-rag')
+        self.assertTrue(args.skip_prepare)
+
     def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
         summary = batch_mod.summarize_batch_rag(
             [


### PR DESCRIPTION
## 背景

#3 里提到需要更明确的全项目预建库 / bootstrap 工作流。#20 已经把 Batch RAG 的全 TL 文件扫描能力接进了 `bootstrap_on_build`，这个 PR 在此基础上补一个显式命令，方便用户在正式 build/submit 前先暖库。

Refs #3

## 改动

- 新增 `python gemini_translate_batch.py bootstrap-rag` 子命令。
- 命令会扫描当前允许处理的全部 TL `.rpy` 文件，并复用现有 `sync_rag_store_for_jobs(..., scan_all_files=True)` 更新本地 history store。
- 输出 `scan_scope`、`files_scanned`、`scanned`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否生效。
- README 增加 Batch RAG 预建库推荐流程，并明确它不等同于动态波次回灌。
- 增加回归测试覆盖显式 bootstrap 命令不依赖 `bootstrap_on_build=true` 的行为。

## 验证

- `python -m py_compile .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest tests.test_regressions.BatchRagRegressionTests -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`
- `python .\gemini_translate_batch.py bootstrap-rag --help`