### PR TITLE
[codex] 支持导入外部 RAG seed JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,28 @@ python gemini_translate_batch.py build
 python gemini_translate_batch.py submit
 ```
 
-命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
+也可以导入外部平行语料 JSONL 作为额外 seed：
+
+```bash
+python gemini_translate_batch.py bootstrap-rag --seed-jsonl parallel_corpus.jsonl
+```
+
+JSONL 每行是一个对象，支持以下字段：
+
+```json
+{"source": "Aether Gate", "translation": "以太门", "file_rel_path": "external/memory.txt", "line": 1}
+```
+
+字段说明：
+
+- `source` 或 `source_text`：原文
+- `translation`、`translated_text` 或 `target`：译文
+- `file_rel_path` / `file`、`line` / `line_start` / `line_end`：可选定位信息，用于生成稳定 memory id 和 diagnostics
+- `memory_id`：可选；不提供时会根据来源、行号和原文生成
+
+空行、坏 JSON、缺少原文/译文、或原文和译文完全相同的行会被跳过，并计入 `external_seed_skipped`。
+
+命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`external_seed_records`、`external_seed_skipped`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
 
 注意：`bootstrap-rag` 解决的是“build 前先用已有译文暖库”的问题；它不会让已经 build / split 完的旧请求动态吃到后续 apply 的新结果。需要滚动回灌时，仍要按波次重新 build，或等待后续动态波次编排能力。
 

--- a/README.md
+++ b/README.md
@@ -175,12 +175,12 @@ JSONL 每行是一个对象，支持以下字段：
 
 - `source` 或 `source_text`：原文
 - `translation`、`translated_text` 或 `target`：译文
-- `file_rel_path` / `file`、`line` / `line_start` / `line_end`：可选定位信息，用于生成稳定 memory id 和 diagnostics
+- `file_rel_path` / `file`、`line` / `line_start` / `line_end`：可选定位信息，用于生成稳定 memory id 和 diagnostics；如果未提供文件路径，会使用带 seed 文件路径指纹的默认来源名，避免多个同名 JSONL 相互覆盖
 - `memory_id`：可选；不提供时会根据来源、行号和原文生成
 
-空行、坏 JSON、缺少原文/译文、或原文和译文完全相同的行会被跳过，并计入 `external_seed_skipped`。
+空行会被忽略；坏 JSON 会计入 `external_seed_invalid_json`，缺少原文/译文、或原文和译文完全相同的有效行会计入 `external_seed_filtered`，两者合计为 `external_seed_skipped`。
 
-命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`external_seed_records`、`external_seed_skipped`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
+命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`external_seed_records`、`external_seed_invalid_json`、`external_seed_filtered`、`external_seed_skipped`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
 
 注意：`bootstrap-rag` 解决的是“build 前先用已有译文暖库”的问题；它不会让已经 build / split 完的旧请求动态吃到后续 apply 的新结果。需要滚动回灌时，仍要按波次重新 build，或等待后续动态波次编排能力。
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ python gemini_translate_batch.py submit
 python gemini_translate_batch.py bootstrap-rag --seed-jsonl parallel_corpus.jsonl
 ```
 
+如果只想导入外部 seed，`game/tl/schinese` 目录可以暂时不存在；此时 TL 扫描数量会是 0，只导入 JSONL 中的有效记录。
+
 JSONL 每行是一个对象，支持以下字段：
 
 ```json
@@ -175,7 +177,7 @@ JSONL 每行是一个对象，支持以下字段：
 
 - `source` 或 `source_text`：原文
 - `translation`、`translated_text` 或 `target`：译文
-- `file_rel_path` / `file`、`line` / `line_start` / `line_end`：可选定位信息，用于生成稳定 memory id 和 diagnostics；如果未提供文件路径，会使用带 seed 文件路径指纹的默认来源名，避免多个同名 JSONL 相互覆盖
+- `file_rel_path` / `file`、`line` / `line_start` / `line_end`：可选定位信息，用于生成稳定 memory id 和 diagnostics；如果未提供文件路径，会使用带 seed 文件内容指纹的默认来源名，避免多个同名 JSONL 相互覆盖，同时保持移动文件后的重复导入可去重
 - `memory_id`：可选；不提供时会根据来源、行号和原文生成
 
 空行会被忽略；坏 JSON 会计入 `external_seed_invalid_json`，缺少原文/译文、或原文和译文完全相同的有效行会计入 `external_seed_filtered`，两者合计为 `external_seed_skipped`。

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2657,10 +2657,16 @@ def coerce_external_seed_line(value, default=None):
     return line_number if line_number > 0 else default
 
 
+def hash_file_contents(path):
+    digest = hashlib.sha1()
+    with open(path, 'rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()[:10]
+
+
 def external_seed_source_name(seed_path):
-    basename = os.path.basename(seed_path) or 'seed.jsonl'
-    seed_fingerprint = hash_key(os.path.normcase(os.path.abspath(seed_path)))
-    return f'external/{seed_fingerprint}-{basename}'
+    return f'external/{hash_file_contents(seed_path)}'
 
 
 def build_external_rag_seed_record(row, source_name, row_number, quality_state='external_seed'):
@@ -2901,9 +2907,10 @@ def bootstrap_rag_store(skip_prepare=False, seed_jsonl_paths=None):
         print_rag_bootstrap_summary(summary)
         return summary
 
+    seed_jsonl_paths = [path for path in (seed_jsonl_paths or []) if path]
     if not skip_prepare:
         legacy.run_prepare_steps()
-    if not os.path.isdir(legacy.TL_DIR):
+    if not os.path.isdir(legacy.TL_DIR) and not seed_jsonl_paths:
         raise SystemExit(f'TL dir does not exist: {legacy.TL_DIR}')
 
     external_records, external_summary = load_external_rag_seed_records(seed_jsonl_paths)
@@ -3469,7 +3476,7 @@ def build_arg_parser():
     bootstrap_rag_parser.add_argument(
         '--seed-jsonl',
         action='append',
-        default=[],
+        default=None,
         help='Import external parallel corpus JSONL rows as additional RAG seed records. Can be repeated.',
     )
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2649,12 +2649,18 @@ def coerce_external_seed_text(row, keys):
     return ''
 
 
-def coerce_external_seed_line(value, default):
+def coerce_external_seed_line(value, default=None):
     try:
         line_number = int(value)
     except (TypeError, ValueError):
         return default
     return line_number if line_number > 0 else default
+
+
+def external_seed_source_name(seed_path):
+    basename = os.path.basename(seed_path) or 'seed.jsonl'
+    seed_fingerprint = hash_key(os.path.normcase(os.path.abspath(seed_path)))
+    return f'external/{seed_fingerprint}-{basename}'
 
 
 def build_external_rag_seed_record(row, source_name, row_number, quality_state='external_seed'):
@@ -2671,7 +2677,9 @@ def build_external_rag_seed_record(row, source_name, row_number, quality_state='
         file_rel_path = source_name
     file_rel_path = legacy._normalize_rel_path(file_rel_path.strip())
 
-    line_start = coerce_external_seed_line(row.get('line_start', row.get('line')), row_number)
+    line_start = coerce_external_seed_line(row.get('line_start'))
+    if line_start is None:
+        line_start = coerce_external_seed_line(row.get('line'), row_number)
     line_end = coerce_external_seed_line(row.get('line_end'), line_start)
     if line_end < line_start:
         line_end = line_start
@@ -2700,12 +2708,13 @@ def build_external_rag_seed_record(row, source_name, row_number, quality_state='
 
 def load_external_rag_seed_records(seed_jsonl_paths, quality_state='external_seed'):
     records = []
-    skipped = 0
+    invalid_json = 0
+    filtered = 0
     paths = [path for path in (seed_jsonl_paths or []) if path]
     for seed_path in paths:
         if not os.path.isfile(seed_path):
             raise SystemExit(f'External RAG seed JSONL not found: {seed_path}')
-        source_name = f'external/{os.path.basename(seed_path)}'
+        source_name = external_seed_source_name(seed_path)
         with open(seed_path, 'r', encoding='utf-8-sig') as handle:
             for row_number, raw_line in enumerate(handle, start=1):
                 line = raw_line.strip()
@@ -2714,17 +2723,19 @@ def load_external_rag_seed_records(seed_jsonl_paths, quality_state='external_see
                 try:
                     row = json.loads(line)
                 except json.JSONDecodeError:
-                    skipped += 1
+                    invalid_json += 1
                     continue
                 record = build_external_rag_seed_record(row, source_name, row_number, quality_state=quality_state)
                 if record is None:
-                    skipped += 1
+                    filtered += 1
                     continue
                 records.append(record)
     return records, {
         'external_seed_files': len(paths),
         'external_seed_records': len(records),
-        'external_seed_skipped': skipped,
+        'external_seed_invalid_json': invalid_json,
+        'external_seed_filtered': filtered,
+        'external_seed_skipped': invalid_json + filtered,
     }
 
 
@@ -2867,6 +2878,8 @@ def print_rag_bootstrap_summary(summary):
         'scanned',
         'external_seed_files',
         'external_seed_records',
+        'external_seed_invalid_json',
+        'external_seed_filtered',
         'external_seed_skipped',
         'pending',
         'embedding_pending',

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2641,6 +2641,93 @@ def collect_rag_seed_records_for_jobs(file_jobs, quality_state='seed'):
     return records
 
 
+def coerce_external_seed_text(row, keys):
+    for key in keys:
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ''
+
+
+def coerce_external_seed_line(value, default):
+    try:
+        line_number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return line_number if line_number > 0 else default
+
+
+def build_external_rag_seed_record(row, source_name, row_number, quality_state='external_seed'):
+    if not isinstance(row, dict):
+        return None
+
+    source_text = coerce_external_seed_text(row, ('source_text', 'source'))
+    translated_text = coerce_external_seed_text(row, ('translated_text', 'translation', 'target'))
+    if not should_index_rag_entry({'source': source_text, 'translation': translated_text}):
+        return None
+
+    file_rel_path = row.get('file_rel_path') or row.get('file') or source_name
+    if not isinstance(file_rel_path, str) or not file_rel_path.strip():
+        file_rel_path = source_name
+    file_rel_path = legacy._normalize_rel_path(file_rel_path.strip())
+
+    line_start = coerce_external_seed_line(row.get('line_start', row.get('line')), row_number)
+    line_end = coerce_external_seed_line(row.get('line_end'), line_start)
+    if line_end < line_start:
+        line_end = line_start
+
+    memory_id = row.get('memory_id')
+    if not isinstance(memory_id, str) or not memory_id.strip():
+        memory_id = hash_key(f'external:{file_rel_path}:{line_start}:{line_end}:{source_text}')
+    else:
+        memory_id = memory_id.strip()
+
+    combined_text = f"Source:\n{source_text}\n\nTranslation:\n{translated_text}"
+    return {
+        'memory_id': memory_id,
+        'file_rel_path': file_rel_path,
+        'line_start': line_start,
+        'line_end': line_end,
+        'source_text': source_text,
+        'translated_text': translated_text,
+        'combined_text': combined_text,
+        'quality_state': quality_state,
+        'created_at': datetime.now().isoformat(timespec='seconds'),
+        'source_checksum': hash_text(source_text),
+        'translation_checksum': hash_text(translated_text),
+    }
+
+
+def load_external_rag_seed_records(seed_jsonl_paths, quality_state='external_seed'):
+    records = []
+    skipped = 0
+    paths = [path for path in (seed_jsonl_paths or []) if path]
+    for seed_path in paths:
+        if not os.path.isfile(seed_path):
+            raise SystemExit(f'External RAG seed JSONL not found: {seed_path}')
+        source_name = f'external/{os.path.basename(seed_path)}'
+        with open(seed_path, 'r', encoding='utf-8-sig') as handle:
+            for row_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    skipped += 1
+                    continue
+                record = build_external_rag_seed_record(row, source_name, row_number, quality_state=quality_state)
+                if record is None:
+                    skipped += 1
+                    continue
+                records.append(record)
+    return records, {
+        'external_seed_files': len(paths),
+        'external_seed_records': len(records),
+        'external_seed_skipped': skipped,
+    }
+
+
 def embed_history_records(records):
     embedded_records = []
     batch_size = 16
@@ -2694,7 +2781,13 @@ def all_rag_file_jobs():
     ]
 
 
-def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=False):
+def sync_rag_store_for_jobs(
+    file_jobs,
+    quality_state='seed',
+    scan_all_files=False,
+    extra_records=None,
+    extra_summary=None,
+):
     if not RAG_ENABLED:
         return {'enabled': False}
     store = get_rag_store()
@@ -2703,6 +2796,7 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
 
     scan_jobs = all_rag_file_jobs() if scan_all_files else file_jobs
     base_records = collect_rag_seed_records_for_jobs(scan_jobs, quality_state=quality_state)
+    base_records.extend(extra_records or [])
     records_to_embed = []
     records_with_reused_embedding = []
     for record in base_records:
@@ -2728,6 +2822,7 @@ def sync_rag_store_for_jobs(file_jobs, quality_state='seed', scan_all_files=Fals
         'upserted': 0,
         'history_records_before': store.count_history(),
     }
+    stats.update(extra_summary or {})
     if not pending_records:
         stats['history_records_after'] = store.count_history()
         return stats
@@ -2770,6 +2865,9 @@ def print_rag_bootstrap_summary(summary):
         'scan_scope',
         'files_scanned',
         'scanned',
+        'external_seed_files',
+        'external_seed_records',
+        'external_seed_skipped',
         'pending',
         'embedding_pending',
         'reused_embeddings',
@@ -2784,7 +2882,7 @@ def print_rag_bootstrap_summary(summary):
         print(f"- error: {summary['error']}")
 
 
-def bootstrap_rag_store(skip_prepare=False):
+def bootstrap_rag_store(skip_prepare=False, seed_jsonl_paths=None):
     if not RAG_ENABLED:
         summary = {'enabled': False}
         print_rag_bootstrap_summary(summary)
@@ -2795,7 +2893,14 @@ def bootstrap_rag_store(skip_prepare=False):
     if not os.path.isdir(legacy.TL_DIR):
         raise SystemExit(f'TL dir does not exist: {legacy.TL_DIR}')
 
-    summary = sync_rag_store_for_jobs([], quality_state='seed', scan_all_files=True)
+    external_records, external_summary = load_external_rag_seed_records(seed_jsonl_paths)
+    summary = sync_rag_store_for_jobs(
+        [],
+        quality_state='seed',
+        scan_all_files=True,
+        extra_records=external_records,
+        extra_summary=external_summary,
+    )
     print_rag_bootstrap_summary(summary)
     return summary
 
@@ -3348,6 +3453,12 @@ def build_arg_parser():
         action='store_true',
         help='Skip auto prepare steps before scanning TL files.',
     )
+    bootstrap_rag_parser.add_argument(
+        '--seed-jsonl',
+        action='append',
+        default=[],
+        help='Import external parallel corpus JSONL rows as additional RAG seed records. Can be repeated.',
+    )
 
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
     submit_parser.add_argument(
@@ -3468,7 +3579,7 @@ def main(argv=None):
         return
 
     if command == 'bootstrap-rag':
-        bootstrap_rag_store(skip_prepare=args.skip_prepare)
+        bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)
         return
 
     if command == 'submit':

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1421,8 +1421,20 @@ class BatchRagRegressionTests(unittest.TestCase):
                     'source': 'Aether Gate',
                     'translation': '\u4ee5\u592a\u95e8',
                 }, ensure_ascii=False)
-                left_seed.write_text(seed_row, encoding='utf-8')
-                right_seed.write_text(seed_row, encoding='utf-8')
+                left_seed.write_text(
+                    '\n'.join([
+                        seed_row,
+                        json.dumps({'source': 'left noop', 'translation': 'left noop'}, ensure_ascii=False),
+                    ]),
+                    encoding='utf-8',
+                )
+                right_seed.write_text(
+                    '\n'.join([
+                        seed_row,
+                        json.dumps({'source': 'right noop', 'translation': 'right noop'}, ensure_ascii=False),
+                    ]),
+                    encoding='utf-8',
+                )
 
                 batch_mod.RAG_ENABLED = True
                 batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
@@ -1454,7 +1466,82 @@ class BatchRagRegressionTests(unittest.TestCase):
             self.assertEqual(len(file_rel_paths), 2)
             self.assertEqual(len(memory_ids), 2)
             self.assertTrue(all(path.startswith('external/') for path in file_rel_paths))
-            self.assertTrue(all(path.endswith('-parallel.jsonl') for path in file_rel_paths))
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.legacy.BASE_DIR = old_values['base_dir']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+            batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_external_jsonl_seed_default_source_name_is_content_stable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            left_seed = root / 'left' / 'parallel.jsonl'
+            right_seed = root / 'right' / 'renamed.jsonl'
+            left_seed.parent.mkdir()
+            right_seed.parent.mkdir()
+            seed_content = json.dumps({
+                'line': 1,
+                'source': 'Aether Gate',
+                'translation': '\u4ee5\u592a\u95e8',
+            }, ensure_ascii=False)
+            left_seed.write_text(seed_content, encoding='utf-8')
+            right_seed.write_text(seed_content, encoding='utf-8')
+
+            self.assertEqual(
+                batch_mod.external_seed_source_name(str(left_seed)),
+                batch_mod.external_seed_source_name(str(right_seed)),
+            )
+
+    def test_bootstrap_rag_store_imports_seed_when_tl_dir_is_missing(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                seed_path = root / 'parallel.jsonl'
+                seed_path.write_text(
+                    json.dumps({
+                        'source': 'Aether Gate',
+                        'translation': '\u4ee5\u592a\u95e8',
+                    }, ensure_ascii=False),
+                    encoding='utf-8',
+                )
+
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod._RAG_STORE = None
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(root / 'missing_tl')
+
+                with (
+                    mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0]]) as embed_mock,
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    summary = batch_mod.bootstrap_rag_store(
+                        skip_prepare=True,
+                        seed_jsonl_paths=[str(seed_path)],
+                    )
+
+                store = batch_mod.get_rag_store()
+
+            embed_mock.assert_called_once_with(['Aether Gate'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
+            self.assertEqual(summary['files_scanned'], 0)
+            self.assertEqual(summary['external_seed_records'], 1)
+            self.assertEqual(summary['upserted'], 1)
+            self.assertEqual(store.count_history(), 1)
         finally:
             batch_mod.RAG_ENABLED = old_values['rag_enabled']
             batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
@@ -1476,6 +1563,11 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(args.command, 'bootstrap-rag')
         self.assertTrue(args.skip_prepare)
         self.assertEqual(args.seed_jsonl, ['parallel.jsonl'])
+
+        parser = batch_mod.build_arg_parser()
+        parser.parse_args(['bootstrap-rag', '--seed-jsonl', 'first.jsonl'])
+        parsed_without_seed = parser.parse_args(['bootstrap-rag'])
+        self.assertIsNone(parsed_without_seed.seed_jsonl)
 
     def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
         summary = batch_mod.summarize_batch_rag(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1333,6 +1333,7 @@ class BatchRagRegressionTests(unittest.TestCase):
                     '\n'.join([
                         json.dumps({
                             'file_rel_path': 'external/memory.txt',
+                            'line_start': None,
                             'line': 7,
                             'source': 'Aether Gate',
                             'translation': '\u4ee5\u592a\u95e8',
@@ -1369,9 +1370,13 @@ class BatchRagRegressionTests(unittest.TestCase):
             embed_mock.assert_called_once_with(['Aether Gate'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
             self.assertIn('- external_seed_files: 1', output)
             self.assertIn('- external_seed_records: 1', output)
+            self.assertIn('- external_seed_invalid_json: 1', output)
+            self.assertIn('- external_seed_filtered: 1', output)
             self.assertIn('- external_seed_skipped: 2', output)
             self.assertEqual(summary['external_seed_files'], 1)
             self.assertEqual(summary['external_seed_records'], 1)
+            self.assertEqual(summary['external_seed_invalid_json'], 1)
+            self.assertEqual(summary['external_seed_filtered'], 1)
             self.assertEqual(summary['external_seed_skipped'], 2)
             self.assertEqual(summary['files_scanned'], 0)
             self.assertEqual(summary['scanned'], 1)
@@ -1381,6 +1386,75 @@ class BatchRagRegressionTests(unittest.TestCase):
             self.assertEqual(records[0]['quality_state'], 'external_seed')
             self.assertEqual(records[0]['source_text'], 'Aether Gate')
             self.assertEqual(records[0]['translated_text'], '\u4ee5\u592a\u95e8')
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.legacy.BASE_DIR = old_values['base_dir']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+            batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_external_jsonl_seed_default_source_name_preserves_path_uniqueness(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / 'game' / 'tl' / 'schinese'
+                tl_dir.mkdir(parents=True)
+                left_seed = root / 'left' / 'parallel.jsonl'
+                right_seed = root / 'right' / 'parallel.jsonl'
+                left_seed.parent.mkdir()
+                right_seed.parent.mkdir()
+                seed_row = json.dumps({
+                    'line': 1,
+                    'source': 'Aether Gate',
+                    'translation': '\u4ee5\u592a\u95e8',
+                }, ensure_ascii=False)
+                left_seed.write_text(seed_row, encoding='utf-8')
+                right_seed.write_text(seed_row, encoding='utf-8')
+
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod._RAG_STORE = None
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.INCLUDE_FILES = set()
+                batch_mod.legacy.INCLUDE_PREFIXES = set()
+
+                with (
+                    mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    summary = batch_mod.bootstrap_rag_store(
+                        skip_prepare=True,
+                        seed_jsonl_paths=[str(left_seed), str(right_seed)],
+                    )
+
+                store = batch_mod.get_rag_store()
+                records = list(store.history.values())
+                file_rel_paths = {record['file_rel_path'] for record in records}
+                memory_ids = {record['memory_id'] for record in records}
+
+            self.assertEqual(summary['external_seed_files'], 2)
+            self.assertEqual(summary['external_seed_records'], 2)
+            self.assertEqual(summary['upserted'], 2)
+            self.assertEqual(store.count_history(), 2)
+            self.assertEqual(len(file_rel_paths), 2)
+            self.assertEqual(len(memory_ids), 2)
+            self.assertTrue(all(path.startswith('external/') for path in file_rel_paths))
+            self.assertTrue(all(path.endswith('-parallel.jsonl') for path in file_rel_paths))
         finally:
             batch_mod.RAG_ENABLED = old_values['rag_enabled']
             batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1312,11 +1312,96 @@ class BatchRagRegressionTests(unittest.TestCase):
             batch_mod.RAG_ENABLED = old_values['rag_enabled']
             batch_mod.legacy.TL_DIR = old_values['tl_dir']
 
+    def test_bootstrap_rag_store_imports_external_jsonl_seed(self):
+        old_values = {
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store_dir': batch_mod.RAG_STORE_DIR,
+            'rag_store': batch_mod._RAG_STORE,
+            'rag_dim': batch_mod.RAG_OUTPUT_DIMENSIONALITY,
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / 'game' / 'tl' / 'schinese'
+                tl_dir.mkdir(parents=True)
+                seed_path = root / 'parallel.jsonl'
+                seed_path.write_text(
+                    '\n'.join([
+                        json.dumps({
+                            'file_rel_path': 'external/memory.txt',
+                            'line': 7,
+                            'source': 'Aether Gate',
+                            'translation': '\u4ee5\u592a\u95e8',
+                        }, ensure_ascii=False),
+                        '{"source": ',
+                        json.dumps({'source': 'Same', 'translation': 'Same'}, ensure_ascii=False),
+                    ]),
+                    encoding='utf-8',
+                )
+
+                batch_mod.RAG_ENABLED = True
+                batch_mod.RAG_STORE_DIR = str(root / 'rag_store')
+                batch_mod.RAG_OUTPUT_DIMENSIONALITY = 3
+                batch_mod._RAG_STORE = None
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.INCLUDE_FILES = set()
+                batch_mod.legacy.INCLUDE_PREFIXES = set()
+
+                stdout = io.StringIO()
+                with (
+                    mock.patch.object(batch_mod, 'embed_texts', return_value=[[1.0, 0.0, 0.0]]) as embed_mock,
+                    mock.patch('sys.stdout', stdout),
+                ):
+                    summary = batch_mod.bootstrap_rag_store(
+                        skip_prepare=True,
+                        seed_jsonl_paths=[str(seed_path)],
+                    )
+
+                store = batch_mod.get_rag_store()
+                records = list(store.history.values())
+                output = stdout.getvalue()
+
+            embed_mock.assert_called_once_with(['Aether Gate'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
+            self.assertIn('- external_seed_files: 1', output)
+            self.assertIn('- external_seed_records: 1', output)
+            self.assertIn('- external_seed_skipped: 2', output)
+            self.assertEqual(summary['external_seed_files'], 1)
+            self.assertEqual(summary['external_seed_records'], 1)
+            self.assertEqual(summary['external_seed_skipped'], 2)
+            self.assertEqual(summary['files_scanned'], 0)
+            self.assertEqual(summary['scanned'], 1)
+            self.assertEqual(summary['embedded'], 1)
+            self.assertEqual(records[0]['file_rel_path'], 'external/memory.txt')
+            self.assertEqual(records[0]['line_start'], 7)
+            self.assertEqual(records[0]['quality_state'], 'external_seed')
+            self.assertEqual(records[0]['source_text'], 'Aether Gate')
+            self.assertEqual(records[0]['translated_text'], '\u4ee5\u592a\u95e8')
+        finally:
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.RAG_STORE_DIR = old_values['rag_store_dir']
+            batch_mod._RAG_STORE = old_values['rag_store']
+            batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
+            batch_mod.legacy.BASE_DIR = old_values['base_dir']
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+            batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+
     def test_build_arg_parser_accepts_bootstrap_rag_command(self):
-        args = batch_mod.build_arg_parser().parse_args(['bootstrap-rag', '--skip-prepare'])
+        args = batch_mod.build_arg_parser().parse_args([
+            'bootstrap-rag',
+            '--skip-prepare',
+            '--seed-jsonl',
+            'parallel.jsonl',
+        ])
 
         self.assertEqual(args.command, 'bootstrap-rag')
         self.assertTrue(args.skip_prepare)
+        self.assertEqual(args.seed_jsonl, ['parallel.jsonl'])
 
     def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
         summary = batch_mod.summarize_batch_rag(


### PR DESCRIPTION
## 背景

#3 除了全 TL 文件预建库外，也提到希望能把外部平行语料作为 seed 数据导入 history store。#21 已经补了显式 `bootstrap-rag` 命令，这个 PR 继续给该命令增加可选 JSONL seed 导入能力。

Refs #3

## 改动

- `bootstrap-rag` 新增 `--seed-jsonl` 参数，可重复指定多个外部平行语料 JSONL 文件。
- JSONL 行会转换成普通 RAG history record，并复用现有 source-only embedding、checksum、embedding 复用和 upsert 逻辑。
- 支持字段：`source` / `source_text`、`translation` / `translated_text` / `target`，以及可选 `file_rel_path` / `file`、`line` / `line_start` / `line_end`、`memory_id`。
- summary 输出增加 `external_seed_files`、`external_seed_records`、`external_seed_skipped`，方便判断导入质量。
- README 增加外部 JSONL seed 格式说明和跳过规则。
- 增加回归测试覆盖外部 seed 导入、坏行跳过、parser 参数解析。

## 验证

- `python -m py_compile .\gemini_translate_batch.py .\tests\test_regressions.py`
- `python -m unittest tests.test_regressions.BatchRagRegressionTests -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`
- `python .\gemini_translate_batch.py bootstrap-rag --help`