### PR TITLE
[codex] 补充 Story Memory schema 与基础校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 }
 ```
 
+为了兼容早期手写图谱，加载器仍接受 `terms` 对象映射、术语字符串条目，以及 `term` / `translation` 这类旧字段名；新图谱建议优先使用示例里的 `source` / `target` 写法。
+
 加载 `story_graph.json` 时会做轻量基础校验：顶层集合类型、角色别名字段、关系 `left/right/confidence`、术语有效内容、场景行号与角色列表等明显问题会输出 warning。校验是非阻塞的；有效部分仍会被规范化后继续用于检索，避免一个局部坏条目导致整个图谱不可用。
 
 当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出和更完整 diagnostics 还属于后续工作。

--- a/README.md
+++ b/README.md
@@ -217,14 +217,22 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 }
 ```
 
-`story_graph.json` 可以先手写或半自动维护，初版结构类似：
+仓库提供了两个公开参考文件：
+
+- `docs/story_graph.schema.json`：正式的 JSON Schema，描述推荐的 `schema_version=1` 结构
+- `docs/story_graph.example.json`：可复制后按项目修改的示例图谱
+
+`story_graph.json` 可以先手写或半自动维护，推荐结构类似：
 
 ```json
 {
+  "schema_version": 1,
   "characters": {
     "eileen": {
+      "name": "Eileen",
       "zh_name": "艾琳",
       "speaker_ids": ["eileen", "eileen_side"],
+      "aliases": ["Miss Eileen"],
       "style": "语气轻快，常吐槽，但关键时刻认真。"
     }
   },
@@ -256,7 +264,9 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 }
 ```
 
-当前实现仍是 MVP：检索逻辑是轻量启发式，正式 schema 校验、`relation_analyzer` seed 导出、Neo4j 可视化导出和更完整 diagnostics 还属于后续工作。
+加载 `story_graph.json` 时会做轻量基础校验：顶层集合类型、角色别名字段、关系 `left/right/confidence`、术语有效内容、场景行号与角色列表等明显问题会输出 warning。校验是非阻塞的；有效部分仍会被规范化后继续用于检索，避免一个局部坏条目导致整个图谱不可用。
+
+当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出和更完整 diagnostics 还属于后续工作。
 
 ## 角色关系 / 语义分析
 
@@ -303,7 +313,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - 面向普通用户的零配置体验
 - 完整的游戏解包 / 打包一体化发布流程
 - 面向超大项目的完整 RAG 生产工作流（例如严格的波次式回灌编排、多阶段调度策略）
-- 完整的结构化剧情图谱生产工作流（例如 schema 校验、自动 seed 生成、Neo4j 可视化导出）
+- 完整的结构化剧情图谱生产工作流（例如自动 seed 生成、Neo4j 可视化导出）
 
 ## 项目状态
 

--- a/docs/story_graph.example.json
+++ b/docs/story_graph.example.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "characters": {
+    "eileen": {
+      "name": "Eileen",
+      "zh_name": "艾琳",
+      "speaker_ids": ["e", "eileen", "eileen_side"],
+      "aliases": ["Miss Eileen"],
+      "style": "语气轻快，常吐槽，但关键时刻认真。",
+      "note": "主角之一，熟悉遗迹机关。"
+    },
+    "noah": {
+      "name": "Noah",
+      "zh_name": "诺亚",
+      "speaker_ids": ["n", "noah"],
+      "aliases": ["Noa"],
+      "style": "说话谨慎，遇到危险时会压低语气。",
+      "note": "艾琳的同行者，负责记录路线。"
+    }
+  },
+  "relations": [
+    {
+      "left": "eileen",
+      "right": "noah",
+      "type": "close_friend",
+      "note": "两人关系亲近，可以使用自然熟悉的中文语气。",
+      "confidence": 0.85
+    }
+  ],
+  "terms": [
+    {
+      "source": "Void Gate",
+      "target": "虚空门",
+      "aliases": ["Gate of Void"],
+      "note": "世界观核心术语，必须统一。"
+    }
+  ],
+  "scenes": [
+    {
+      "file_rel_path": "chapter1.rpy",
+      "line_start": 120,
+      "line_end": 220,
+      "summary": "艾琳和诺亚在天台讨论是否进入危险区域。",
+      "characters": ["eileen", "noah"]
+    }
+  ]
+}

--- a/docs/story_graph.schema.json
+++ b/docs/story_graph.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hu-border-collie/renpy-translation-lab/blob/main/docs/story_graph.schema.json",
+  "title": "Ren'Py Translation Lab Story Graph",
+  "description": "Canonical schema for the optional Structured Story Memory graph.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "characters", "relations", "terms", "scenes"],
+  "properties": {
+    "schema_version": {
+      "description": "Schema version for this public JSON format.",
+      "const": 1
+    },
+    "characters": {
+      "description": "Character records keyed by stable character id.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/character"
+      }
+    },
+    "relations": {
+      "description": "Human-reviewed relation hints between known characters.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/relation"
+      }
+    },
+    "terms": {
+      "description": "Story-specific terms that may be retrieved into prompts.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/term"
+      }
+    },
+    "scenes": {
+      "description": "Scene summaries and line ranges keyed to Ren'Py script files.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/scene"
+      }
+    }
+  },
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "character": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "zh_name": {
+          "type": "string"
+        },
+        "speaker_ids": {
+          "$ref": "#/$defs/stringList"
+        },
+        "aliases": {
+          "$ref": "#/$defs/stringList"
+        },
+        "style": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        }
+      }
+    },
+    "relation": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["left", "right"],
+      "properties": {
+        "left": {
+          "type": "string",
+          "minLength": 1
+        },
+        "right": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "term": {
+      "type": "object",
+      "additionalProperties": true,
+      "anyOf": [
+        {
+          "required": ["source"]
+        },
+        {
+          "required": ["target"]
+        },
+        {
+          "required": ["aliases"]
+        }
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "aliases": {
+          "$ref": "#/$defs/stringList"
+        },
+        "note": {
+          "type": "string"
+        }
+      }
+    },
+    "scene": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["file_rel_path"],
+      "properties": {
+        "file_rel_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "line_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "line_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "characters": {
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/docs/story_graph.schema.json
+++ b/docs/story_graph.schema.json
@@ -5,7 +5,7 @@
   "description": "Canonical schema for the optional Structured Story Memory graph.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "characters", "relations", "terms", "scenes"],
+  "required": ["schema_version"],
   "properties": {
     "schema_version": {
       "description": "Schema version for this public JSON format.",
@@ -26,11 +26,29 @@
       }
     },
     "terms": {
-      "description": "Story-specific terms that may be retrieved into prompts.",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/term"
-      }
+      "description": "Story-specific terms that may be retrieved into prompts. Prefer an array of term objects; object maps and string items are accepted for compatibility with the loader.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/term"
+              },
+              {
+                "type": "string",
+                "minLength": 1
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "scenes": {
       "description": "Scene summaries and line ranges keyed to Ren'Py script files.",
@@ -106,7 +124,13 @@
           "required": ["source"]
         },
         {
+          "required": ["term"]
+        },
+        {
           "required": ["target"]
+        },
+        {
+          "required": ["translation"]
         },
         {
           "required": ["aliases"]
@@ -116,7 +140,13 @@
         "source": {
           "type": "string"
         },
+        "term": {
+          "type": "string"
+        },
         "target": {
+          "type": "string"
+        },
+        "translation": {
           "type": "string"
         },
         "aliases": {

--- a/docs/story_graph.schema.json
+++ b/docs/story_graph.schema.json
@@ -60,11 +60,19 @@
   },
   "$defs": {
     "stringList": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
     },
     "character": {
       "type": "object",

--- a/story_memory.py
+++ b/story_memory.py
@@ -45,6 +45,10 @@ def _clean_text(value):
     return re.sub(r"\s+", " ", str(value)).strip()
 
 
+def _has_string_content(value):
+    return isinstance(value, str) and bool(_clean_text(value))
+
+
 def _safe_int(value):
     try:
         return int(value)
@@ -147,11 +151,11 @@ def _field_label(*parts):
 def _validate_alias_field(value, label, warnings):
     if value is None:
         return
-    if isinstance(value, (str, int, float)):
+    if isinstance(value, str):
         return
     if isinstance(value, list):
         for index, item in enumerate(value):
-            if not isinstance(item, (str, int, float)):
+            if not isinstance(item, str):
                 warnings.append(f"{label}[{index}] should be a string")
         return
     warnings.append(f"{label} should be a string or list of strings")
@@ -197,10 +201,10 @@ def _validate_relations(value, warnings):
         if not isinstance(item, dict):
             warnings.append(f"{label} should be an object")
             continue
-        if not _clean_text(item.get("left")):
-            warnings.append(f"{label}.left is required")
-        if not _clean_text(item.get("right")):
-            warnings.append(f"{label}.right is required")
+        if not _has_string_content(item.get("left")):
+            warnings.append(f"{label}.left should be a non-empty string")
+        if not _has_string_content(item.get("right")):
+            warnings.append(f"{label}.right should be a non-empty string")
         if item.get("confidence") is not None:
             if not _is_numeric_like(item.get("confidence")):
                 warnings.append(f"{label}.confidence should be a finite number from 0 to 1")
@@ -215,9 +219,9 @@ def _validate_terms(value, warnings):
         return
     if isinstance(value, dict):
         for source, target in value.items():
-            if not _clean_text(source):
-                warnings.append("terms object contains an entry without a usable source")
-            if target is not None and not isinstance(target, (str, int, float)):
+            if not _has_string_content(source):
+                warnings.append("terms object keys should be non-empty strings")
+            if target is not None and not isinstance(target, str):
                 warnings.append(f"terms.{source} should be a string")
         return
     if not isinstance(value, list):
@@ -232,12 +236,16 @@ def _validate_terms(value, warnings):
             continue
         aliases = item.get("aliases")
         _validate_alias_field(aliases, f"{label}.aliases", warnings)
-        has_term_content = (
-            _clean_text(item.get("source"))
-            or _clean_text(item.get("term"))
-            or _clean_text(item.get("target"))
-            or _clean_text(item.get("translation"))
-            or any(_clean_text(alias) for alias in _as_list(aliases))
+        has_term_content = False
+        for key in ("source", "term", "target", "translation"):
+            if key not in item or item.get(key) is None:
+                continue
+            if isinstance(item.get(key), str):
+                has_term_content = has_term_content or bool(_clean_text(item.get(key)))
+            else:
+                warnings.append(f"{label}.{key} should be a string")
+        has_term_content = has_term_content or any(
+            _has_string_content(alias) for alias in _as_list(aliases)
         )
         if not has_term_content:
             warnings.append(
@@ -263,8 +271,8 @@ def _validate_scenes(value, warnings):
         line_end = _safe_int(item.get("line_end"))
         if line_start is not None and line_end is not None and line_start > line_end:
             warnings.append(f"{label}.line_start should be <= line_end")
-        if not _normalize_rel_path(item.get("file_rel_path")):
-            warnings.append(f"{label}.file_rel_path is required")
+        if not _has_string_content(item.get("file_rel_path")):
+            warnings.append(f"{label}.file_rel_path should be a non-empty string")
         _validate_alias_field(item.get("characters"), f"{label}.characters", warnings)
         if not (
             _normalize_rel_path(item.get("file_rel_path"))

--- a/story_memory.py
+++ b/story_memory.py
@@ -4,6 +4,9 @@ import os
 import re
 
 
+STORY_GRAPH_SCHEMA_VERSION = 1
+
+
 class _NormalizedStoryGraph(dict):
     pass
 
@@ -116,6 +119,171 @@ def _normalize_dict_list(value):
     return [dict(item) for item in value if isinstance(item, dict)] if isinstance(value, list) else []
 
 
+def _is_int_like(value):
+    if isinstance(value, bool):
+        return False
+    try:
+        int(value)
+    except (TypeError, ValueError):
+        return False
+    return str(value).strip() == str(int(value))
+
+
+def _is_numeric_like(value):
+    if isinstance(value, bool):
+        return False
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _field_label(*parts):
+    return ".".join(str(part) for part in parts if part != "")
+
+
+def _validate_alias_field(value, label, warnings):
+    if value is None:
+        return
+    if isinstance(value, (str, int, float)):
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            if not isinstance(item, (str, int, float)):
+                warnings.append(f"{label}[{index}] should be a string")
+        return
+    warnings.append(f"{label} should be a string or list of strings")
+
+
+def _validate_characters(value, warnings):
+    if value is None:
+        return
+    if isinstance(value, dict):
+        iterable = value.items()
+    elif isinstance(value, list):
+        iterable = []
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                warnings.append(f"characters[{index}] should be an object")
+                continue
+            char_id = item.get("id") or item.get("key") or item.get("name")
+            iterable.append((char_id, item))
+    else:
+        warnings.append("characters should be an object keyed by character id")
+        return
+
+    for char_id, data in iterable:
+        clean_id = _clean_text(char_id)
+        label = _field_label("characters", clean_id or "<empty>")
+        if not clean_id:
+            warnings.append("characters contains an entry without a usable id")
+        if not isinstance(data, dict):
+            warnings.append(f"{label} should be an object")
+            continue
+        _validate_alias_field(data.get("speaker_ids"), f"{label}.speaker_ids", warnings)
+        _validate_alias_field(data.get("aliases"), f"{label}.aliases", warnings)
+
+
+def _validate_relations(value, warnings):
+    if value is None:
+        return
+    if not isinstance(value, list):
+        warnings.append("relations should be a list")
+        return
+    for index, item in enumerate(value):
+        label = f"relations[{index}]"
+        if not isinstance(item, dict):
+            warnings.append(f"{label} should be an object")
+            continue
+        if not _clean_text(item.get("left")):
+            warnings.append(f"{label}.left is required")
+        if not _clean_text(item.get("right")):
+            warnings.append(f"{label}.right is required")
+        if item.get("confidence") is not None:
+            if not _is_numeric_like(item.get("confidence")):
+                warnings.append(f"{label}.confidence should be a number from 0 to 1")
+            else:
+                confidence = float(item.get("confidence"))
+                if confidence < 0 or confidence > 1:
+                    warnings.append(f"{label}.confidence should be between 0 and 1")
+
+
+def _validate_terms(value, warnings):
+    if value is None:
+        return
+    if isinstance(value, dict):
+        return
+    if not isinstance(value, list):
+        warnings.append("terms should be a list or object")
+        return
+    for index, item in enumerate(value):
+        label = f"terms[{index}]"
+        if isinstance(item, str):
+            continue
+        if not isinstance(item, dict):
+            warnings.append(f"{label} should be an object or string")
+            continue
+        aliases = item.get("aliases")
+        _validate_alias_field(aliases, f"{label}.aliases", warnings)
+        has_term_content = (
+            _clean_text(item.get("source"))
+            or _clean_text(item.get("term"))
+            or _clean_text(item.get("target"))
+            or any(_clean_text(alias) for alias in _as_list(aliases))
+        )
+        if not has_term_content:
+            warnings.append(f"{label} should define source, term, target, or aliases")
+
+
+def _validate_scenes(value, warnings):
+    if value is None:
+        return
+    if not isinstance(value, list):
+        warnings.append("scenes should be a list")
+        return
+    for index, item in enumerate(value):
+        label = f"scenes[{index}]"
+        if not isinstance(item, dict):
+            warnings.append(f"{label} should be an object")
+            continue
+        for key in ("line_start", "line_end"):
+            if item.get(key) is not None and not _is_int_like(item.get(key)):
+                warnings.append(f"{label}.{key} should be an integer")
+        line_start = _safe_int(item.get("line_start"))
+        line_end = _safe_int(item.get("line_end"))
+        if line_start is not None and line_end is not None and line_start > line_end:
+            warnings.append(f"{label}.line_start should be <= line_end")
+        _validate_alias_field(item.get("characters"), f"{label}.characters", warnings)
+        if not (
+            _normalize_rel_path(item.get("file_rel_path"))
+            or _clean_text(item.get("summary"))
+            or any(_clean_text(char) for char in _as_list(item.get("characters")))
+        ):
+            warnings.append(f"{label} should include file_rel_path, summary, or characters")
+
+
+def validate_story_graph(raw_graph):
+    """Return non-fatal schema warnings for a story graph JSON object."""
+    if _is_normalized_story_graph(raw_graph):
+        return []
+    if not isinstance(raw_graph, dict):
+        return ["root should be a JSON object"]
+
+    warnings = []
+    version = raw_graph.get("schema_version")
+    if version is not None and version != STORY_GRAPH_SCHEMA_VERSION:
+        warnings.append(
+            f"schema_version should be {STORY_GRAPH_SCHEMA_VERSION}"
+        )
+
+    _validate_characters(raw_graph.get("characters"), warnings)
+    _validate_relations(raw_graph.get("relations"), warnings)
+    _validate_terms(raw_graph.get("terms"), warnings)
+    _validate_scenes(raw_graph.get("scenes"), warnings)
+    return warnings
+
+
 def _is_normalized_story_graph(value):
     return isinstance(value, _NormalizedStoryGraph)
 
@@ -138,7 +306,10 @@ def load_story_graph(path):
         return _empty_graph()
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
-            return normalize_story_graph(json.load(handle) or {})
+            raw_graph = json.load(handle) or {}
+        for warning in validate_story_graph(raw_graph):
+            print(f"Warning: Story graph {path}: {warning}")
+        return normalize_story_graph(raw_graph)
     except Exception as exc:
         print(f"Warning: Failed to load story graph {path}: {exc}")
         return _empty_graph()

--- a/story_memory.py
+++ b/story_memory.py
@@ -165,7 +165,7 @@ def _validate_characters(value, warnings):
     if value is None:
         return
     if isinstance(value, dict):
-        iterable = value.items()
+        iterable = [(char_id, data, None) for char_id, data in value.items()]
     elif isinstance(value, list):
         iterable = []
         for index, item in enumerate(value):
@@ -173,16 +173,16 @@ def _validate_characters(value, warnings):
                 warnings.append(f"characters[{index}] should be an object")
                 continue
             char_id = item.get("id") or item.get("key") or item.get("name")
-            iterable.append((char_id, item))
+            iterable.append((char_id, item, f"characters[{index}]"))
     else:
         warnings.append("characters should be an object keyed by character id")
         return
 
-    for char_id, data in iterable:
+    for char_id, data, source_label in iterable:
         clean_id = _clean_text(char_id)
-        label = _field_label("characters", clean_id or "<empty>")
+        label = source_label or _field_label("characters", clean_id or "<empty>")
         if not clean_id:
-            warnings.append("characters contains an entry without a usable id")
+            warnings.append(f"{label} is missing a usable id")
         if not isinstance(data, dict):
             warnings.append(f"{label} should be an object")
             continue
@@ -269,6 +269,10 @@ def _validate_scenes(value, warnings):
                 warnings.append(f"{label}.{key} should be an integer")
         line_start = _safe_int(item.get("line_start"))
         line_end = _safe_int(item.get("line_end"))
+        if line_start is not None and line_start < 1:
+            warnings.append(f"{label}.line_start should be >= 1")
+        if line_end is not None and line_end < 1:
+            warnings.append(f"{label}.line_end should be >= 1")
         if line_start is not None and line_end is not None and line_start > line_end:
             warnings.append(f"{label}.line_start should be <= line_end")
         if not _has_string_content(item.get("file_rel_path")):

--- a/story_memory.py
+++ b/story_memory.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import math
 import os
 import re
 
@@ -133,10 +134,10 @@ def _is_numeric_like(value):
     if isinstance(value, bool):
         return False
     try:
-        float(value)
+        number = float(value)
     except (TypeError, ValueError):
         return False
-    return True
+    return math.isfinite(number)
 
 
 def _field_label(*parts):
@@ -202,7 +203,7 @@ def _validate_relations(value, warnings):
             warnings.append(f"{label}.right is required")
         if item.get("confidence") is not None:
             if not _is_numeric_like(item.get("confidence")):
-                warnings.append(f"{label}.confidence should be a number from 0 to 1")
+                warnings.append(f"{label}.confidence should be a finite number from 0 to 1")
             else:
                 confidence = float(item.get("confidence"))
                 if confidence < 0 or confidence > 1:
@@ -213,6 +214,11 @@ def _validate_terms(value, warnings):
     if value is None:
         return
     if isinstance(value, dict):
+        for source, target in value.items():
+            if not _clean_text(source):
+                warnings.append("terms object contains an entry without a usable source")
+            if target is not None and not isinstance(target, (str, int, float)):
+                warnings.append(f"terms.{source} should be a string")
         return
     if not isinstance(value, list):
         warnings.append("terms should be a list or object")
@@ -230,10 +236,13 @@ def _validate_terms(value, warnings):
             _clean_text(item.get("source"))
             or _clean_text(item.get("term"))
             or _clean_text(item.get("target"))
+            or _clean_text(item.get("translation"))
             or any(_clean_text(alias) for alias in _as_list(aliases))
         )
         if not has_term_content:
-            warnings.append(f"{label} should define source, term, target, or aliases")
+            warnings.append(
+                f"{label} should define source, term, target, translation, or aliases"
+            )
 
 
 def _validate_scenes(value, warnings):
@@ -254,6 +263,8 @@ def _validate_scenes(value, warnings):
         line_end = _safe_int(item.get("line_end"))
         if line_start is not None and line_end is not None and line_start > line_end:
             warnings.append(f"{label}.line_start should be <= line_end")
+        if not _normalize_rel_path(item.get("file_rel_path")):
+            warnings.append(f"{label}.file_rel_path is required")
         _validate_alias_field(item.get("characters"), f"{label}.characters", warnings)
         if not (
             _normalize_rel_path(item.get("file_rel_path"))
@@ -272,7 +283,11 @@ def validate_story_graph(raw_graph):
 
     warnings = []
     version = raw_graph.get("schema_version")
-    if version is not None and version != STORY_GRAPH_SCHEMA_VERSION:
+    if version is None:
+        warnings.append(
+            f"schema_version is required and should be {STORY_GRAPH_SCHEMA_VERSION}"
+        )
+    elif version != STORY_GRAPH_SCHEMA_VERSION:
         warnings.append(
             f"schema_version should be {STORY_GRAPH_SCHEMA_VERSION}"
         )
@@ -545,9 +560,10 @@ def retrieve_story_hits(
 
     def relation_confidence(item):
         try:
-            return float(item.get("confidence", 0.0) or 0.0)
+            value = float(item.get("confidence", 0.0) or 0.0)
         except (TypeError, ValueError):
             return 0.0
+        return value if math.isfinite(value) else 0.0
 
     relation_hits.sort(key=relation_confidence, reverse=True)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -414,6 +414,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 ],
                 'relations': [
                     {'left': 'eileen', 'confidence': 'very'},
+                    {'left': 'eileen', 'right': 'noah', 'confidence': 'nan'},
                     'bad-relation',
                 ],
                 'terms': [
@@ -429,8 +430,40 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertTrue(any('schema_version' in warning for warning in warnings))
         self.assertTrue(any('characters[0]' in warning for warning in warnings))
         self.assertTrue(any('relations[0].right' in warning for warning in warnings))
+        self.assertTrue(any('relations[1].confidence' in warning for warning in warnings))
         self.assertTrue(any('terms[0]' in warning for warning in warnings))
         self.assertTrue(any('scenes[0].line_start' in warning for warning in warnings))
+        self.assertTrue(any('scenes[0].file_rel_path' in warning for warning in warnings))
+
+    def test_validate_story_graph_accepts_legacy_term_shapes(self):
+        self.assertEqual(
+            story_memory.validate_story_graph(
+                {
+                    'schema_version': story_memory.STORY_GRAPH_SCHEMA_VERSION,
+                    'terms': {
+                        'Void Gate': '\u865a\u7a7a\u95e8',
+                    },
+                }
+            ),
+            [],
+        )
+        self.assertEqual(
+            story_memory.validate_story_graph(
+                {
+                    'schema_version': story_memory.STORY_GRAPH_SCHEMA_VERSION,
+                    'terms': [
+                        {'term': 'Aether'},
+                        {'translation': '\u4ee5\u592a\u95e8'},
+                    ],
+                }
+            ),
+            [],
+        )
+
+    def test_validate_story_graph_warns_when_schema_version_missing(self):
+        warnings = story_memory.validate_story_graph({'terms': {'Void Gate': '\u865a\u7a7a\u95e8'}})
+
+        self.assertTrue(any('schema_version is required' in warning for warning in warnings))
 
     def test_story_memory_rel_path_preserves_parent_segments(self):
         self.assertEqual(story_memory._normalize_rel_path('./chapter1.rpy'), 'chapter1.rpy')
@@ -508,6 +541,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertTrue(print_mock.called)
         printed = '\n'.join(call.args[0] for call in print_mock.call_args_list)
         self.assertIn('Story graph', printed)
+        self.assertIn('schema_version is required', printed)
         self.assertIn('relations[0].right', printed)
         self.assertIn('scenes[0].line_start', printed)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -370,6 +370,68 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertIn('Void Gate', normalized['terms'][0]['source'])
         self.assertNotIn('_story_memory_normalized', json.dumps(normalized))
 
+    def test_story_graph_example_passes_lightweight_validation(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        schema_path = repo_root / 'docs' / 'story_graph.schema.json'
+        example_path = repo_root / 'docs' / 'story_graph.example.json'
+
+        schema = json.loads(schema_path.read_text(encoding='utf-8'))
+        raw_graph = json.loads(example_path.read_text(encoding='utf-8'))
+
+        self.assertEqual(
+            schema['properties']['schema_version']['const'],
+            story_memory.STORY_GRAPH_SCHEMA_VERSION,
+        )
+        self.assertEqual(story_memory.validate_story_graph(raw_graph), [])
+
+        hits = story_memory.retrieve_story_hits(
+            raw_graph,
+            'chapter1.rpy',
+            [
+                {
+                    'id': 'chapter1.rpy:129:0',
+                    'text': 'Noah opens the Void Gate.',
+                    'line': 129,
+                    'speaker_id': 'e',
+                },
+            ],
+        )
+
+        self.assertTrue(story_memory.has_story_hits(hits))
+        self.assertEqual({item['id'] for item in hits['characters']}, {'eileen', 'noah'})
+        self.assertEqual(hits['relations'][0]['type'], 'close_friend')
+        self.assertEqual(hits['terms'][0]['source'], 'Void Gate')
+        self.assertEqual(hits['scenes'][0]['file_rel_path'], 'chapter1.rpy')
+
+    def test_validate_story_graph_reports_non_fatal_schema_warnings(self):
+        warnings = story_memory.validate_story_graph(
+            {
+                'schema_version': 2,
+                'characters': [
+                    'bad-character',
+                    {'id': '', 'speaker_ids': {'bad': 'shape'}},
+                    {'id': 'eileen', 'aliases': [{}]},
+                ],
+                'relations': [
+                    {'left': 'eileen', 'confidence': 'very'},
+                    'bad-relation',
+                ],
+                'terms': [
+                    {'note': 'missing source'},
+                    42,
+                ],
+                'scenes': [
+                    {'line_start': 'ten', 'characters': {'bad': 'shape'}},
+                ],
+            }
+        )
+
+        self.assertTrue(any('schema_version' in warning for warning in warnings))
+        self.assertTrue(any('characters[0]' in warning for warning in warnings))
+        self.assertTrue(any('relations[0].right' in warning for warning in warnings))
+        self.assertTrue(any('terms[0]' in warning for warning in warnings))
+        self.assertTrue(any('scenes[0].line_start' in warning for warning in warnings))
+
     def test_story_memory_rel_path_preserves_parent_segments(self):
         self.assertEqual(story_memory._normalize_rel_path('./chapter1.rpy'), 'chapter1.rpy')
         self.assertEqual(story_memory._normalize_rel_path('../chapter1.rpy'), '../chapter1.rpy')
@@ -415,6 +477,39 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(graph, {'characters': {}, 'relations': [], 'terms': [], 'scenes': []})
         self.assertTrue(print_mock.called)
         self.assertIn('Failed to load story graph', print_mock.call_args[0][0])
+
+    def test_load_story_graph_warns_on_schema_issues_but_keeps_valid_entries(self):
+        graph = {
+            'characters': {
+                'eileen': {
+                    'speaker_ids': 'e',
+                    'zh_name': '\u827e\u7433',
+                },
+            },
+            'relations': [
+                {'left': 'eileen'},
+            ],
+            'terms': [
+                {'source': 'Void Gate', 'target': '\u865a\u7a7a\u95e8'},
+            ],
+            'scenes': [
+                {'file_rel_path': 'chapter1.rpy', 'line_start': 'bad'},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            graph_file = Path(tmp) / 'story_graph.json'
+            graph_file.write_text(json.dumps(graph), encoding='utf-8')
+            with mock.patch('builtins.print') as print_mock:
+                loaded = story_memory.load_story_graph(str(graph_file))
+
+        self.assertIn('eileen', loaded['characters'])
+        self.assertEqual(loaded['characters']['eileen']['speaker_ids'], ['e'])
+        self.assertEqual(loaded['terms'][0]['source'], 'Void Gate')
+        self.assertTrue(print_mock.called)
+        printed = '\n'.join(call.args[0] for call in print_mock.call_args_list)
+        self.assertIn('Story graph', printed)
+        self.assertIn('relations[0].right', printed)
+        self.assertIn('scenes[0].line_start', printed)
 
     def test_story_memory_graph_path_prefers_root_logs(self):
         old_values = {

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -428,14 +428,16 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 'scenes': [
                     {'line_start': 'ten', 'characters': {'bad': 'shape'}},
                     {'file_rel_path': {'bad': 'shape'}, 'summary': 'invalid path'},
+                    {'file_rel_path': 'chapter1.rpy', 'line_start': 0, 'line_end': -1},
                 ],
             }
         )
 
         self.assertTrue(any('schema_version' in warning for warning in warnings))
         self.assertTrue(any('characters[0]' in warning for warning in warnings))
-        self.assertTrue(any('characters.numeric-alias.speaker_ids' in warning for warning in warnings))
-        self.assertTrue(any('characters.numeric-alias.aliases[1]' in warning for warning in warnings))
+        self.assertTrue(any('characters[1] is missing a usable id' in warning for warning in warnings))
+        self.assertTrue(any('characters[3].speaker_ids' in warning for warning in warnings))
+        self.assertTrue(any('characters[3].aliases[1]' in warning for warning in warnings))
         self.assertTrue(any('relations[0].right' in warning for warning in warnings))
         self.assertTrue(any('relations[1].confidence' in warning for warning in warnings))
         self.assertTrue(any('relations[2].left' in warning for warning in warnings))
@@ -446,6 +448,8 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertTrue(any('scenes[0].line_start' in warning for warning in warnings))
         self.assertTrue(any('scenes[0].file_rel_path' in warning for warning in warnings))
         self.assertTrue(any('scenes[1].file_rel_path' in warning for warning in warnings))
+        self.assertTrue(any('scenes[2].line_start should be >= 1' in warning for warning in warnings))
+        self.assertTrue(any('scenes[2].line_end should be >= 1' in warning for warning in warnings))
 
     def test_validate_story_graph_accepts_legacy_term_shapes(self):
         self.assertEqual(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -411,29 +411,41 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     'bad-character',
                     {'id': '', 'speaker_ids': {'bad': 'shape'}},
                     {'id': 'eileen', 'aliases': [{}]},
+                    {'id': 'numeric-alias', 'speaker_ids': 1, 'aliases': ['ok', 2]},
                 ],
                 'relations': [
                     {'left': 'eileen', 'confidence': 'very'},
                     {'left': 'eileen', 'right': 'noah', 'confidence': 'nan'},
+                    {'left': {'bad': 'shape'}, 'right': ['bad']},
                     'bad-relation',
                 ],
                 'terms': [
                     {'note': 'missing source'},
+                    {'source': {'bad': 'shape'}},
+                    {'target': {'bad': 'shape'}},
                     42,
                 ],
                 'scenes': [
                     {'line_start': 'ten', 'characters': {'bad': 'shape'}},
+                    {'file_rel_path': {'bad': 'shape'}, 'summary': 'invalid path'},
                 ],
             }
         )
 
         self.assertTrue(any('schema_version' in warning for warning in warnings))
         self.assertTrue(any('characters[0]' in warning for warning in warnings))
+        self.assertTrue(any('characters.numeric-alias.speaker_ids' in warning for warning in warnings))
+        self.assertTrue(any('characters.numeric-alias.aliases[1]' in warning for warning in warnings))
         self.assertTrue(any('relations[0].right' in warning for warning in warnings))
         self.assertTrue(any('relations[1].confidence' in warning for warning in warnings))
+        self.assertTrue(any('relations[2].left' in warning for warning in warnings))
+        self.assertTrue(any('relations[2].right' in warning for warning in warnings))
         self.assertTrue(any('terms[0]' in warning for warning in warnings))
+        self.assertTrue(any('terms[1].source' in warning for warning in warnings))
+        self.assertTrue(any('terms[2].target' in warning for warning in warnings))
         self.assertTrue(any('scenes[0].line_start' in warning for warning in warnings))
         self.assertTrue(any('scenes[0].file_rel_path' in warning for warning in warnings))
+        self.assertTrue(any('scenes[1].file_rel_path' in warning for warning in warnings))
 
     def test_validate_story_graph_accepts_legacy_term_shapes(self):
         self.assertEqual(


### PR DESCRIPTION
## 摘要
- 新增 `docs/story_graph.schema.json` 和 `docs/story_graph.example.json`，明确 Story Memory 的推荐 JSON 结构
- 为 `story_memory.py` 增加非阻塞基础校验，加载图谱时对明显结构问题输出 warning，同时保留有效条目
- 更新 README，并补充 schema/example 与校验行为的回归测试

## 验证
- `python -m py_compile story_memory.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`

Refs #8