### PR TITLE
[codex] 增加 Story Memory Batch diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 
 加载 `story_graph.json` 时会做轻量基础校验：顶层集合类型、角色别名字段、关系 `left/right/confidence`、术语有效内容、场景行号与角色列表等明显问题会输出 warning。校验是非阻塞的；有效部分仍会被规范化后继续用于检索，避免一个局部坏条目导致整个图谱不可用。
 
-当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出和更完整 diagnostics 还属于后续工作。
+Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。
+
+当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出，以及 sync / probe 等辅助路径的更完整 diagnostics 还属于后续工作。
 
 ## 角色关系 / 语义分析
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 
 加载 `story_graph.json` 时会做轻量基础校验：顶层集合类型、角色别名字段、关系 `left/right/confidence`、术语有效内容、场景行号与角色列表等明显问题会输出 warning。校验是非阻塞的；有效部分仍会被规范化后继续用于检索，避免一个局部坏条目导致整个图谱不可用。
 
-Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。
+Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、预算内格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。
 
 当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出，以及 sync / probe 等辅助路径的更完整 diagnostics 还属于后续工作。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -850,11 +850,12 @@ def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
             part_manifest[key] = source_manifest[key]
 
     if source_manifest.get('story_memory_enabled'):
-        story_summary = dict(source_manifest.get('story_memory_summary') or {})
-        story_summary['chunks_with_story_hits'] = sum(
-            1 for chunk in part_chunks if story_memory.has_story_hits(chunk.get('story_hits'))
+        story_settings = source_manifest.get('story_memory_settings') or {}
+        part_manifest['story_memory_summary'] = summarize_batch_story_memory(
+            part_chunks,
+            graph_file=source_manifest.get('story_memory_graph_file', ''),
+            max_context_chars=story_settings.get('max_context_chars'),
         )
-        part_manifest['story_memory_summary'] = story_summary
 
 
 def split_chunks_and_lines(chunks, request_lines, max_chunks=0, max_items=0):
@@ -1192,6 +1193,42 @@ def summarize_batch_rag(chunks, prepare_summary):
     }
 
 
+def summarize_batch_story_memory(chunks, graph_file=None, max_context_chars=None):
+    chunk_count = len(chunks)
+    hit_counts = {key: 0 for key in story_memory.STORY_HIT_CATEGORIES}
+    chunks_with_story_hits = 0
+    truncated_story_blocks = 0
+    formatted_char_count = 0
+    max_context_chars = max_context_chars if max_context_chars is not None else STORY_MEMORY_MAX_CONTEXT_CHARS
+    try:
+        context_limit = max(1, int(max_context_chars or 1))
+    except (TypeError, ValueError):
+        context_limit = 1
+
+    for chunk in chunks:
+        story_hits = chunk.get('story_hits')
+        if not story_memory.has_story_hits(story_hits):
+            continue
+        chunks_with_story_hits += 1
+        chunk_counts = story_memory.story_hit_counts(story_hits)
+        for key in hit_counts:
+            hit_counts[key] += chunk_counts.get(key, 0)
+        full_block = story_memory.format_story_hits_block(story_hits, 1_000_000)
+        formatted_char_count += len(full_block)
+        if len(full_block) > context_limit:
+            truncated_story_blocks += 1
+
+    return {
+        'graph_file': STORY_MEMORY_GRAPH_FILE if graph_file is None else graph_file,
+        'chunks_with_story_hits': chunks_with_story_hits,
+        'story_hit_rate': (chunks_with_story_hits / chunk_count) if chunk_count else 0.0,
+        'hit_counts': hit_counts,
+        'total_hit_count': sum(hit_counts.values()),
+        'truncated_story_blocks': truncated_story_blocks,
+        'formatted_char_count': formatted_char_count,
+    }
+
+
 
 def get_batch_risk_warnings():
     warnings_list = []
@@ -1288,11 +1325,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             'top_k_terms': STORY_MEMORY_TOP_K_TERMS,
             'include_scene_summary': STORY_MEMORY_INCLUDE_SCENE_SUMMARY,
         } if STORY_MEMORY_ENABLED else {},
-        'story_memory_summary': {
-            'chunks_with_story_hits': sum(
-                1 for chunk in chunks if story_memory.has_story_hits(chunk.get('story_hits'))
-            ),
-        } if STORY_MEMORY_ENABLED else {},
+        'story_memory_summary': summarize_batch_story_memory(chunks) if STORY_MEMORY_ENABLED else {},
         'summary': {
             'file_count': len(file_jobs),
             'chunk_count': len(chunks),

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1199,11 +1199,14 @@ def summarize_batch_story_memory(chunks, graph_file=None, max_context_chars=None
     chunks_with_story_hits = 0
     truncated_story_blocks = 0
     formatted_char_count = 0
-    max_context_chars = max_context_chars if max_context_chars is not None else STORY_MEMORY_MAX_CONTEXT_CHARS
+    requested_limit = max_context_chars if max_context_chars is not None else STORY_MEMORY_MAX_CONTEXT_CHARS
     try:
-        context_limit = max(1, int(max_context_chars or 1))
+        context_limit = max(1, int(requested_limit or 1))
     except (TypeError, ValueError):
-        context_limit = 1
+        try:
+            context_limit = max(1, int(STORY_MEMORY_MAX_CONTEXT_CHARS or 1))
+        except (TypeError, ValueError):
+            context_limit = 1
 
     for chunk in chunks:
         story_hits = chunk.get('story_hits')
@@ -1213,9 +1216,10 @@ def summarize_batch_story_memory(chunks, graph_file=None, max_context_chars=None
         chunk_counts = story_memory.story_hit_counts(story_hits)
         for key in hit_counts:
             hit_counts[key] += chunk_counts.get(key, 0)
-        full_block = story_memory.format_story_hits_block(story_hits, 1_000_000)
-        formatted_char_count += len(full_block)
-        if len(full_block) > context_limit:
+        formatted_block = story_memory.format_story_hits_block(story_hits, context_limit)
+        over_limit_probe = story_memory.format_story_hits_block(story_hits, context_limit + 1)
+        formatted_char_count += len(formatted_block)
+        if len(over_limit_probe) > context_limit:
             truncated_story_blocks += 1
 
     return {

--- a/story_memory.py
+++ b/story_memory.py
@@ -6,6 +6,7 @@ import re
 
 
 STORY_GRAPH_SCHEMA_VERSION = 1
+STORY_HIT_CATEGORIES = ("characters", "relations", "terms", "scenes")
 
 
 class _NormalizedStoryGraph(dict):
@@ -611,11 +612,21 @@ def _append_limited(lines, line, max_chars):
 def has_story_hits(story_hits):
     if not isinstance(story_hits, dict):
         return False
-    for key in ("characters", "relations", "terms", "scenes"):
+    for key in STORY_HIT_CATEGORIES:
         hits = story_hits.get(key)
         if isinstance(hits, list) and hits:
             return True
     return False
+
+
+def story_hit_counts(story_hits):
+    counts = {}
+    if not isinstance(story_hits, dict):
+        return {key: 0 for key in STORY_HIT_CATEGORIES}
+    for key in STORY_HIT_CATEGORIES:
+        hits = story_hits.get(key)
+        counts[key] = len(hits) if isinstance(hits, list) else 0
+    return counts
 
 
 def format_story_hits_block(story_hits, max_chars, empty_label="(none)"):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -363,6 +363,35 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         )
         self.assertTrue(story_memory.has_story_hits({'terms': [{'source': 'Void Gate'}]}))
 
+    def test_story_memory_hit_counts_reports_categories(self):
+        counts = story_memory.story_hit_counts(
+            {
+                'characters': [{'id': 'eileen'}],
+                'relations': [{'left': 'eileen', 'right': 'noah'}],
+                'terms': [{'source': 'Void Gate'}, {'source': 'Aether'}],
+                'scenes': [{'file_rel_path': 'chapter1.rpy'}],
+            }
+        )
+
+        self.assertEqual(
+            counts,
+            {
+                'characters': 1,
+                'relations': 1,
+                'terms': 2,
+                'scenes': 1,
+            },
+        )
+        self.assertEqual(
+            story_memory.story_hit_counts(None),
+            {
+                'characters': 0,
+                'relations': 0,
+                'terms': 0,
+                'scenes': 0,
+            },
+        )
+
     def test_story_memory_normalize_has_fast_path_for_normalized_graphs(self):
         normalized = story_memory.normalize_story_graph({'terms': {'Void Gate': '\u865a\u7a7a\u95e8'}})
 
@@ -1737,6 +1766,44 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(summary['history_hit_rate'], 0.5)
         self.assertEqual(summary['history_retrieval_errors'], 1)
 
+    def test_summarize_batch_story_memory_reports_diagnostics(self):
+        summary = batch_mod.summarize_batch_story_memory(
+            [
+                {
+                    'story_hits': {
+                        'characters': [{'id': 'eileen'}],
+                        'relations': [{'left': 'eileen', 'right': 'noah'}],
+                        'terms': [{'source': 'Void Gate', 'target': '\u865a\u7a7a\u95e8'}],
+                        'scenes': [{'file_rel_path': 'chapter1.rpy'}],
+                    },
+                },
+                {
+                    'story_hits': {
+                        'terms': [{'source': 'Aether', 'note': 'x' * 80}],
+                    },
+                },
+                {},
+            ],
+            graph_file='logs/story_memory/story_graph.json',
+            max_context_chars=30,
+        )
+
+        self.assertEqual(summary['graph_file'], 'logs/story_memory/story_graph.json')
+        self.assertEqual(summary['chunks_with_story_hits'], 2)
+        self.assertEqual(summary['story_hit_rate'], 2 / 3)
+        self.assertEqual(
+            summary['hit_counts'],
+            {
+                'characters': 1,
+                'relations': 1,
+                'terms': 2,
+                'scenes': 1,
+            },
+        )
+        self.assertEqual(summary['total_hit_count'], 5)
+        self.assertGreaterEqual(summary['truncated_story_blocks'], 1)
+        self.assertGreater(summary['formatted_char_count'], 0)
+
     def test_sync_rag_store_reuses_embedding_when_only_translation_changes(self):
         old_values = {
             'rag_enabled': batch_mod.RAG_ENABLED,
@@ -1873,6 +1940,12 @@ class BatchRepairRegressionTests(unittest.TestCase):
             self.assertEqual(first_child['rag_summary']['history_retrieval_errors'], 0)
             self.assertEqual(first_child['rag_summary']['prepare'], {'upserted': 3})
             self.assertEqual(first_child['story_memory_summary']['chunks_with_story_hits'], 1)
+            self.assertEqual(first_child['story_memory_summary']['graph_file'], str(root / 'story_graph.json'))
+            self.assertEqual(first_child['story_memory_summary']['hit_counts']['terms'], 1)
+            self.assertEqual(first_child['story_memory_summary']['total_hit_count'], 1)
+            self.assertEqual(first_child['story_memory_summary']['story_hit_rate'], 1.0)
+            self.assertEqual(first_child['story_memory_summary']['truncated_story_blocks'], 0)
+            self.assertGreater(first_child['story_memory_summary']['formatted_char_count'], 0)
 
     def test_collect_result_actions_ignores_duplicate_result_ids(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1803,6 +1803,28 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(summary['total_hit_count'], 5)
         self.assertGreaterEqual(summary['truncated_story_blocks'], 1)
         self.assertGreater(summary['formatted_char_count'], 0)
+        self.assertLessEqual(summary['formatted_char_count'], 60)
+
+    def test_summarize_batch_story_memory_uses_default_limit_for_bad_context_chars(self):
+        old_limit = batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS
+        try:
+            batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = 200
+            summary = batch_mod.summarize_batch_story_memory(
+                [
+                    {
+                        'story_hits': {
+                            'terms': [{'source': 'Aether', 'target': '\u4ee5\u592a'}],
+                        },
+                    },
+                ],
+                max_context_chars={'bad': 'shape'},
+            )
+        finally:
+            batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = old_limit
+
+        self.assertEqual(summary['chunks_with_story_hits'], 1)
+        self.assertEqual(summary['truncated_story_blocks'], 0)
+        self.assertGreater(summary['formatted_char_count'], 1)
 
     def test_sync_rag_store_reuses_embedding_when_only_translation_changes(self):
         old_values = {


### PR DESCRIPTION
## 摘要
- 为 Batch `story_memory_summary` 增加 diagnostics：graph file、命中 chunk 数、命中率、各类命中数、总命中数、格式化字符数和截断块数量
- split 子包按子包 chunks 重新计算 Story Memory diagnostics，避免沿用父包摘要
- 新增 `story_memory.story_hit_counts()` 并补充 README 说明

## 验证
- `python -m py_compile story_memory.py gemini_translate_batch.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`

Refs #8