### PR TITLE
[codex] 增加 Story Memory seed 导出

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,15 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 
 Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、预算内格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。
 
-当前实现仍是 MVP：检索逻辑是轻量启发式，`relation_analyzer` seed 导出、Neo4j 可视化导出，以及 sync / probe 等辅助路径的更完整 diagnostics 还属于后续工作。
+`relation_analyzer` 可以额外导出 `story_graph.seed.json` 候选数据，帮助从 Ren'Py 剧本里半自动整理 `speaker_ids`、候选角色和候选关系：
+
+```bash
+python extract_relations.py /path/to/game/tl/schinese --mode relation --story-seed-output logs/story_memory/story_graph.seed.json
+```
+
+seed 中的关系统一标记为 `candidate`，只包含共场景、对话往来、相互提及、来源文件和 speaker 统计等可审查信息；如果同一输入目录里存在 `define e = Character("Eileen")` 这类 Ren'Py 角色定义，seed 会优先用定义名作为 speaker 名称候选。它不会自动断言恋人、敌人、上下级等强语义关系。建议人工确认并编辑后，再作为正式 `story_graph.json` 使用。
+
+当前实现仍是 MVP：检索逻辑是轻量启发式，Neo4j 可视化导出，以及 sync / probe 等辅助路径的更完整 diagnostics 还属于后续工作。
 
 ## 角色关系 / 语义分析
 
@@ -296,6 +304,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 - 不传 `--characters` 时，会自动选择主要说话人
 - 可以用 `--auto-characters` 控制自动推断数量
 - 可以用 `--portraits off` 禁用从 `archive.rpa` 自动读取头像
+- 可以用 `--story-seed-output logs/story_memory/story_graph.seed.json` 在 relation 模式额外导出 Story Memory 候选 seed
 - `relation` 模式不需要 Gemini API
 - `semantic` 模式需要有效的 Gemini API key
 

--- a/relation_analyzer/README.md
+++ b/relation_analyzer/README.md
@@ -11,6 +11,8 @@
   - `relation` 模式的人物关系统计、打分和 CSV 数据生成
 - `semantic.py`
   - `semantic` 模式的 embedding 调用、重试、缓存和角色向量生成
+- `story_seed.py`
+  - 从 relation 模式结果导出 `story_graph.seed.json` 候选角色、speaker 映射和关系统计
 - `plotting.py`
   - 热力图、关系网络图和语义图绘制
 - `cli.py`
@@ -25,6 +27,9 @@
 - 如果不想读取立绘头像，可以加 `--portraits off`
 - `relation` 模式不需要 Gemini API
 - `semantic` 模式需要有效的 Gemini API key 和 `google-genai`
+- `--story-seed-output logs/story_memory/story_graph.seed.json` 可以在 `relation` 模式额外导出 Story Memory 候选 seed
+
+`story_graph.seed.json` 只保存可审查候选信息，例如 `speaker_ids`、speaker 名称候选、共场景、对话往来、相互提及和来源文件统计。同一输入目录里的 `define e = Character("Eileen")` 会用于 speaker 名称候选；关系类型统一为 `candidate`，需要人工确认后再合并进正式 `story_graph.json`。
 
 ## 依赖
 

--- a/relation_analyzer/cli.py
+++ b/relation_analyzer/cli.py
@@ -3,6 +3,7 @@ from .parsing import load_text_units, collect_character_texts, infer_characters_
 from .semantic import extract_character_vectors
 from .relations import compute_relation_data
 from .plotting import analyze_and_plot, analyze_and_plot_relation
+from .story_seed import write_story_graph_seed
 
 
 def parse_args():
@@ -21,6 +22,7 @@ def parse_args():
     parser.add_argument('--cache-dir', default=str(EMBEDDING_CACHE_DIR), help='embedding 缓存目录（semantic 模式使用）')
     parser.add_argument('--relation-window-size', type=int, default=12, help='relation 模式下划分局部剧情段的窗口大小')
     parser.add_argument('--csv-output', help='relation 模式导出 CSV 路径，默认与图片同目录同名后缀 _relations.csv')
+    parser.add_argument('--story-seed-output', help='relation 模式额外导出 story_graph.seed.json 候选数据，供人工确认后维护 story_graph.json')
     return parser.parse_args()
 
 
@@ -61,6 +63,8 @@ def main():
     if args.mode == 'relation':
         relation_data = compute_relation_data(units, characters, args.relation_window_size)
         if len(relation_data['characters']) > 1:
+            if args.story_seed_output:
+                write_story_graph_seed(resolve_path(args.story_seed_output), units, characters, relation_data)
             active_portraits = {char: portraits.get(char) for char in relation_data['characters']} if portraits else {}
             csv_output = resolve_path(args.csv_output) if args.csv_output else output_path.with_name(f"{output_path.stem}_relations.csv")
             analyze_and_plot_relation(relation_data, output_path, csv_output, active_portraits)

--- a/relation_analyzer/cli.py
+++ b/relation_analyzer/cli.py
@@ -64,7 +64,7 @@ def main():
         relation_data = compute_relation_data(units, characters, args.relation_window_size)
         if len(relation_data['characters']) > 1:
             if args.story_seed_output:
-                write_story_graph_seed(resolve_path(args.story_seed_output), units, characters, relation_data)
+                write_story_graph_seed(resolve_path(args.story_seed_output), units, characters, relation_data, source_root=input_path)
             active_portraits = {char: portraits.get(char) for char in relation_data['characters']} if portraits else {}
             csv_output = resolve_path(args.csv_output) if args.csv_output else output_path.with_name(f"{output_path.stem}_relations.csv")
             analyze_and_plot_relation(relation_data, output_path, csv_output, active_portraits)

--- a/relation_analyzer/parsing.py
+++ b/relation_analyzer/parsing.py
@@ -44,12 +44,22 @@ def normalize_text(text):
         return ""
     return text
 
+def normalize_character_display_name(text):
+    text = " ".join(str(text).split()).strip()
+    if not text:
+        return ""
+    if ONLY_SYMBOLS_RE.match(text):
+        return ""
+    if ASSET_FILE_RE.match(text):
+        return ""
+    return text
+
 def _literal_display_name(expr):
     if isinstance(expr, ast.Constant):
         if expr.value is None:
             return None
         if isinstance(expr.value, str):
-            return normalize_text(expr.value)
+            return normalize_character_display_name(expr.value)
         return None
     if (
         isinstance(expr, ast.Call)
@@ -220,8 +230,9 @@ def extract_units_from_raw_rpy(lines, file_path, speaker_map=None):
         last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker, speaker_map)
     return units
 
-def extract_units_from_rpy(file_path, speaker_map=None):
-    lines = file_path.read_text(encoding="utf-8-sig").splitlines()
+def extract_units_from_rpy(file_path, speaker_map=None, lines=None):
+    if lines is None:
+        lines = file_path.read_text(encoding="utf-8-sig").splitlines()
     active_speaker_map = dict(speaker_map or {})
     active_speaker_map.update(extract_character_definitions(lines))
     units = []
@@ -263,7 +274,7 @@ def extract_units_from_rpy(file_path, speaker_map=None):
 
     return units
 
-def collect_speaker_definitions(files):
+def collect_speaker_definitions(files, line_cache=None):
     definitions = {}
     for file_path in files:
         if file_path.suffix.lower() != ".rpy":
@@ -272,13 +283,16 @@ def collect_speaker_definitions(files):
             lines = file_path.read_text(encoding="utf-8-sig").splitlines()
         except OSError:
             continue
+        if line_cache is not None:
+            line_cache[file_path] = lines
         definitions.update(extract_character_definitions(lines))
     return definitions
 
 def load_text_units(input_path, context_window):
     units = []
     files = iter_input_files(input_path)
-    speaker_map = collect_speaker_definitions(files)
+    rpy_line_cache = {}
+    speaker_map = collect_speaker_definitions(files, rpy_line_cache)
 
     for file_path in files:
         suffix = file_path.suffix.lower()
@@ -298,7 +312,7 @@ def load_text_units(input_path, context_window):
             continue
 
         if suffix == ".rpy":
-            units.extend(extract_units_from_rpy(file_path, speaker_map))
+            units.extend(extract_units_from_rpy(file_path, speaker_map, rpy_line_cache.get(file_path)))
 
     if not units:
         raise SystemExit("❌ 没有抽取到可分析的剧情文本。")
@@ -389,13 +403,13 @@ def guess_character_name_from_speaker(speaker):
 def resolve_speaker_name(speaker, speaker_map=None):
     if not speaker:
         return None
+    mapped = SPEAKER_TO_CHARACTER.get(speaker)
+    if mapped:
+        return mapped
     if speaker_map:
         mapped = speaker_map.get(speaker)
         if mapped:
             return mapped
-    mapped = SPEAKER_TO_CHARACTER.get(speaker)
-    if mapped:
-        return mapped
     return guess_character_name_from_speaker(speaker)
 
 

--- a/relation_analyzer/parsing.py
+++ b/relation_analyzer/parsing.py
@@ -1,5 +1,10 @@
 from .common import *
 
+CHARACTER_DEFINE_RE = re.compile(
+    r"^\s*define\s+(?P<speaker>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*Character\s*\("
+)
+
+
 def iter_input_files(input_path):
     if input_path.is_file():
         return [input_path]
@@ -38,6 +43,23 @@ def normalize_text(text):
     if ASSET_FILE_RE.match(text):
         return ""
     return text
+
+def extract_character_definitions(lines):
+    definitions = {}
+    for line in lines:
+        match = CHARACTER_DEFINE_RE.match(line)
+        if not match:
+            continue
+        literal, _, _ = extract_first_string_token(line)
+        if not literal:
+            continue
+        try:
+            name = normalize_text(ast.literal_eval(literal))
+        except (SyntaxError, ValueError):
+            continue
+        if name:
+            definitions[match.group("speaker")] = name
+    return definitions
 
 def is_valid_say_attribute_token(token):
     return (
@@ -104,18 +126,18 @@ def parse_dialogue_line(line):
 
     return {"speaker": speaker, "text": text, "command": command}
 
-def apply_extend_speaker(parsed, last_speaker):
+def apply_extend_speaker(parsed, last_speaker, speaker_map=None):
     speaker = parsed["speaker"]
     if speaker is None and parsed.get("command") == "extend" and last_speaker:
         speaker = last_speaker
     return {
         "speaker": speaker,
-        "speaker_name": resolve_speaker_name(speaker),
+        "speaker_name": resolve_speaker_name(speaker, speaker_map),
         "text": parsed["text"],
     }
 
-def append_unit(units, parsed, file_path, line_no, last_speaker):
-    normalized = apply_extend_speaker(parsed, last_speaker)
+def append_unit(units, parsed, file_path, line_no, last_speaker, speaker_map=None):
+    normalized = apply_extend_speaker(parsed, last_speaker, speaker_map)
     units.append(
         {
             "source": str(file_path),
@@ -132,7 +154,7 @@ def append_unit(units, parsed, file_path, line_no, last_speaker):
 def get_line_indent(line):
     return len(line) - len(line.lstrip())
 
-def extract_units_from_translation_file(lines, file_path):
+def extract_units_from_translation_file(lines, file_path, speaker_map=None):
     units = []
     in_block = False
     in_strings_block = False
@@ -152,22 +174,24 @@ def extract_units_from_translation_file(lines, file_path):
         parsed = parse_dialogue_line(line)
         if not parsed:
             continue
-        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker)
+        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker, speaker_map)
 
     return units
 
-def extract_units_from_raw_rpy(lines, file_path):
+def extract_units_from_raw_rpy(lines, file_path, speaker_map=None):
     units = []
     last_speaker = None
     for line_no, line in enumerate(lines, start=1):
         parsed = parse_dialogue_line(line)
         if not parsed:
             continue
-        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker)
+        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker, speaker_map)
     return units
 
-def extract_units_from_rpy(file_path):
+def extract_units_from_rpy(file_path, speaker_map=None):
     lines = file_path.read_text(encoding="utf-8-sig").splitlines()
+    active_speaker_map = dict(speaker_map or {})
+    active_speaker_map.update(extract_character_definitions(lines))
     units = []
     in_translate_block = False
     in_strings_block = False
@@ -197,19 +221,32 @@ def extract_units_from_rpy(file_path):
             parsed = parse_dialogue_line(line)
             if not parsed:
                 continue
-            last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker)
+            last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker, active_speaker_map)
             continue
 
         parsed = parse_dialogue_line(line)
         if not parsed:
             continue
-        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker)
+        last_speaker = append_unit(units, parsed, file_path, line_no, last_speaker, active_speaker_map)
 
     return units
+
+def collect_speaker_definitions(files):
+    definitions = {}
+    for file_path in files:
+        if file_path.suffix.lower() != ".rpy":
+            continue
+        try:
+            lines = file_path.read_text(encoding="utf-8-sig").splitlines()
+        except OSError:
+            continue
+        definitions.update(extract_character_definitions(lines))
+    return definitions
 
 def load_text_units(input_path, context_window):
     units = []
     files = iter_input_files(input_path)
+    speaker_map = collect_speaker_definitions(files)
 
     for file_path in files:
         suffix = file_path.suffix.lower()
@@ -229,7 +266,7 @@ def load_text_units(input_path, context_window):
             continue
 
         if suffix == ".rpy":
-            units.extend(extract_units_from_rpy(file_path))
+            units.extend(extract_units_from_rpy(file_path, speaker_map))
 
     if not units:
         raise SystemExit("❌ 没有抽取到可分析的剧情文本。")
@@ -317,9 +354,13 @@ def guess_character_name_from_speaker(speaker):
     return raw_value
 
 
-def resolve_speaker_name(speaker):
+def resolve_speaker_name(speaker, speaker_map=None):
     if not speaker:
         return None
+    if speaker_map:
+        mapped = speaker_map.get(speaker)
+        if mapped:
+            return mapped
     mapped = SPEAKER_TO_CHARACTER.get(speaker)
     if mapped:
         return mapped

--- a/relation_analyzer/parsing.py
+++ b/relation_analyzer/parsing.py
@@ -1,7 +1,7 @@
 from .common import *
 
 CHARACTER_DEFINE_RE = re.compile(
-    r"^\s*define\s+(?P<speaker>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*Character\s*\("
+    r"^\s*define\s+(?P<speaker>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<call>Character\s*\(.*)"
 )
 
 
@@ -44,19 +44,51 @@ def normalize_text(text):
         return ""
     return text
 
+def _literal_display_name(expr):
+    if isinstance(expr, ast.Constant):
+        if expr.value is None:
+            return None
+        if isinstance(expr.value, str):
+            return normalize_text(expr.value)
+        return None
+    if (
+        isinstance(expr, ast.Call)
+        and isinstance(expr.func, ast.Name)
+        and expr.func.id == "_"
+        and len(expr.args) == 1
+        and not expr.keywords
+    ):
+        return _literal_display_name(expr.args[0])
+    return None
+
+def extract_character_display_name(call_source):
+    try:
+        parsed = ast.parse(call_source.strip(), mode="eval")
+    except SyntaxError:
+        return None
+    call = parsed.body
+    if not isinstance(call, ast.Call):
+        return None
+    if not isinstance(call.func, ast.Name) or call.func.id != "Character":
+        return None
+
+    if call.args:
+        name = _literal_display_name(call.args[0])
+        return name or None
+
+    for keyword_arg in call.keywords:
+        if keyword_arg.arg == "name":
+            name = _literal_display_name(keyword_arg.value)
+            return name or None
+    return None
+
 def extract_character_definitions(lines):
     definitions = {}
     for line in lines:
         match = CHARACTER_DEFINE_RE.match(line)
         if not match:
             continue
-        literal, _, _ = extract_first_string_token(line)
-        if not literal:
-            continue
-        try:
-            name = normalize_text(ast.literal_eval(literal))
-        except (SyntaxError, ValueError):
-            continue
+        name = extract_character_display_name(match.group("call"))
         if name:
             definitions[match.group("speaker")] = name
     return definitions

--- a/relation_analyzer/relations.py
+++ b/relation_analyzer/relations.py
@@ -147,6 +147,7 @@ def compute_relation_data(units, characters, segment_size):
     deduped_characters = list(dict.fromkeys(characters))
     relation_units, participation_counts, speaker_counts, mention_presence_counts = collect_relation_units(units, deduped_characters)
     active_characters = [char for char in deduped_characters if participation_counts.get(char, 0) > 0]
+    segment_size = max(1, int(segment_size))
 
     for char in deduped_characters:
         if char not in active_characters:
@@ -155,6 +156,7 @@ def compute_relation_data(units, characters, segment_size):
     if len(active_characters) < 2:
         return {
             'characters': active_characters,
+            'segment_size': segment_size,
             'presence_counts': {char: participation_counts.get(char, 0) for char in active_characters},
             'pair_rows': [],
             'total_matrix': np.zeros((len(active_characters), len(active_characters)), dtype=float),
@@ -165,8 +167,6 @@ def compute_relation_data(units, characters, segment_size):
     co_scene_raw = {}
     dialogue_raw = {}
     mention_raw = {}
-    segment_size = max(1, int(segment_size))
-
     for group in iter_source_groups(relation_units):
         for start in range(0, len(group), segment_size):
             segment = group[start:start + segment_size]
@@ -257,6 +257,7 @@ def compute_relation_data(units, characters, segment_size):
 
     return {
         'characters': active_characters,
+        'segment_size': segment_size,
         'presence_counts': {char: participation_counts.get(char, 0) for char in active_characters},
         'speaker_counts': {char: speaker_counts.get(char, 0) for char in active_characters},
         'scene_presence_counts': {char: scene_presence_counts.get(char, 0) for char in active_characters},

--- a/relation_analyzer/relations.py
+++ b/relation_analyzer/relations.py
@@ -159,6 +159,7 @@ def compute_relation_data(units, characters, segment_size):
             'segment_size': segment_size,
             'presence_counts': {char: participation_counts.get(char, 0) for char in active_characters},
             'pair_rows': [],
+            'pair_source_files': {},
             'total_matrix': np.zeros((len(active_characters), len(active_characters)), dtype=float),
         }
 
@@ -167,7 +168,14 @@ def compute_relation_data(units, characters, segment_size):
     co_scene_raw = {}
     dialogue_raw = {}
     mention_raw = {}
+    pair_source_files = {}
+
+    def add_pair_source(key, source):
+        if source:
+            pair_source_files.setdefault(key, set()).add(str(source))
+
     for group in iter_source_groups(relation_units):
+        source = group[0].get('source') if group else ''
         for start in range(0, len(group), segment_size):
             segment = group[start:start + segment_size]
             present = []
@@ -185,6 +193,7 @@ def compute_relation_data(units, characters, segment_size):
                 for right in range(left + 1, len(present)):
                     key = pair_key(present[left], present[right])
                     co_scene_raw[key] = co_scene_raw.get(key, 0.0) + 1.0
+                    add_pair_source(key, source)
 
         spoken = [unit for unit in group if unit['speaker_character'] in active_set]
         for previous, current in zip(spoken, spoken[1:]):
@@ -194,6 +203,7 @@ def compute_relation_data(units, characters, segment_size):
                 continue
             key = pair_key(left, right)
             dialogue_raw[key] = dialogue_raw.get(key, 0.0) + 1.0
+            add_pair_source(key, source)
 
         for unit in group:
             speaker_character = unit['speaker_character'] if unit['speaker_character'] in active_set else None
@@ -204,12 +214,14 @@ def compute_relation_data(units, characters, segment_size):
                         continue
                     key = pair_key(speaker_character, char)
                     mention_raw[key] = mention_raw.get(key, 0.0) + 1.0
+                    add_pair_source(key, source)
             if len(mentioned) >= 2:
                 bonus = 0.35 if speaker_character else 0.55
                 for left in range(len(mentioned)):
                     for right in range(left + 1, len(mentioned)):
                         key = pair_key(mentioned[left], mentioned[right])
                         mention_raw[key] = mention_raw.get(key, 0.0) + bonus
+                        add_pair_source(key, source)
 
     component_labels = {
         'co_scene': '共场景',
@@ -265,6 +277,10 @@ def compute_relation_data(units, characters, segment_size):
         'component_colors': component_colors,
         'component_weights': component_weights,
         'component_raw_counts': component_raw_counts,
+        'pair_source_files': {
+            key: sorted(sources)
+            for key, sources in pair_source_files.items()
+        },
         'component_density_matrices': component_density_matrices,
         'component_matrices': component_scaled_matrices,
         'total_matrix': total_matrix,

--- a/relation_analyzer/story_seed.py
+++ b/relation_analyzer/story_seed.py
@@ -1,4 +1,4 @@
-from .common import json, re
+from .common import Path, json, re
 from .relations import collect_relation_units, iter_source_groups, pair_key
 
 
@@ -21,11 +21,32 @@ def _dedupe_preserve_order(values):
     return result
 
 
-def _source_file(value):
-    return str(value or '').replace('\\', '/')
+def _source_root_dir(source_root):
+    if not source_root:
+        return None
+    root = Path(source_root)
+    if root.is_file():
+        root = root.parent
+    try:
+        return root.resolve()
+    except OSError:
+        return root
 
 
-def collect_speaker_seed_stats(units):
+def _source_file(value, source_root=None):
+    text = str(value or '').strip()
+    if not text:
+        return ''
+    root = _source_root_dir(source_root)
+    if root:
+        try:
+            return Path(text).resolve().relative_to(root).as_posix()
+        except (OSError, ValueError):
+            pass
+    return text.replace('\\', '/')
+
+
+def collect_speaker_seed_stats(units, source_root=None):
     speakers = {}
     for unit in units:
         speaker = str(unit.get('speaker') or '').strip()
@@ -42,7 +63,7 @@ def collect_speaker_seed_stats(units):
             },
         )
         info['count'] += 1
-        source = _source_file(unit.get('source'))
+        source = _source_file(unit.get('source'), source_root)
         if source:
             info['source_files'].add(source)
         line_no = unit.get('line_no')
@@ -74,8 +95,8 @@ def collect_speaker_seed_stats(units):
     return normalized
 
 
-def build_character_seed(units, characters):
-    speaker_stats = collect_speaker_seed_stats(units)
+def build_character_seed(units, characters, source_root=None):
+    speaker_stats = collect_speaker_seed_stats(units, source_root)
     by_name = {}
     for speaker, stats in speaker_stats.items():
         for candidate in stats['speaker_name_candidates']:
@@ -149,35 +170,27 @@ def _character_id_map(characters):
     return mapping
 
 
-def collect_pair_source_files(units, characters):
+def collect_pair_source_files(units, characters, segment_size=1, source_root=None):
     relation_units, _, _, _ = collect_relation_units(units, characters)
     pair_sources = {}
     active = set(characters)
-    for unit in relation_units:
-        source = _source_file(unit.get('source'))
-        participants = [
-            char for char in unit.get('participants', [])
-            if char in active
-        ]
-        if len(participants) < 2:
-            continue
-        for left_index in range(len(participants)):
-            for right_index in range(left_index + 1, len(participants)):
-                key = pair_key(participants[left_index], participants[right_index])
-                pair_sources.setdefault(key, set()).add(source)
+    segment_size = max(1, int(segment_size or 1))
 
     for group in iter_source_groups(relation_units):
-        source = _source_file(group[0].get('source')) if group else ''
-        present = []
-        seen = set()
-        for unit in group:
-            for char in unit.get('participants', []):
-                if char in active and char not in seen:
-                    present.append(char)
-                    seen.add(char)
-        for left_index in range(len(present)):
-            for right_index in range(left_index + 1, len(present)):
-                pair_sources.setdefault(pair_key(present[left_index], present[right_index]), set()).add(source)
+        source = _source_file(group[0].get('source'), source_root) if group else ''
+
+        for start in range(0, len(group), segment_size):
+            segment = group[start:start + segment_size]
+            present = []
+            seen = set()
+            for unit in segment:
+                for char in unit.get('participants', []):
+                    if char in active and char not in seen:
+                        present.append(char)
+                        seen.add(char)
+            for left_index in range(len(present)):
+                for right_index in range(left_index + 1, len(present)):
+                    pair_sources.setdefault(pair_key(present[left_index], present[right_index]), set()).add(source)
 
         spoken = [unit for unit in group if unit.get('speaker_character') in active]
         for previous, current in zip(spoken, spoken[1:]):
@@ -186,17 +199,45 @@ def collect_pair_source_files(units, characters):
             if left and right and left != right:
                 pair_sources.setdefault(pair_key(left, right), set()).add(source)
 
+        for unit in group:
+            speaker_character = unit.get('speaker_character') if unit.get('speaker_character') in active else None
+            mentioned = [char for char in unit.get('mentioned_characters', []) if char in active]
+            if speaker_character:
+                for char in mentioned:
+                    if char != speaker_character:
+                        pair_sources.setdefault(pair_key(speaker_character, char), set()).add(source)
+            if len(mentioned) >= 2:
+                for left_index in range(len(mentioned)):
+                    for right_index in range(left_index + 1, len(mentioned)):
+                        pair_sources.setdefault(pair_key(mentioned[left_index], mentioned[right_index]), set()).add(source)
+
     return {
         key: sorted(value for value in sources if value)
         for key, sources in pair_sources.items()
     }
 
 
-def build_relation_seed(units, characters, relation_data):
+def _has_relation_evidence(row):
+    raw_total = (
+        float(row.get('co_scene_raw', 0.0))
+        + float(row.get('dialogue_raw', 0.0))
+        + float(row.get('mention_raw', 0.0))
+    )
+    return float(row.get('score', 0.0)) > 0.0 and raw_total > 0.0
+
+
+def build_relation_seed(units, characters, relation_data, source_root=None):
     id_map = _character_id_map(characters)
-    source_files = collect_pair_source_files(units, characters)
+    source_files = collect_pair_source_files(
+        units,
+        characters,
+        relation_data.get('segment_size', 1),
+        source_root,
+    )
     relation_entries = []
     for row in relation_data.get('pair_rows', []):
+        if not _has_relation_evidence(row):
+            continue
         left_name = row['left']
         right_name = row['right']
         left_id = id_map.get(left_name, character_id_from_name(left_name))
@@ -225,18 +266,18 @@ def build_relation_seed(units, characters, relation_data):
     return relation_entries
 
 
-def build_story_graph_seed(units, characters, relation_data):
+def build_story_graph_seed(units, characters, relation_data, source_root=None):
     return {
         'schema_version': 1,
-        'characters': build_character_seed(units, relation_data.get('characters', characters)),
-        'relations': build_relation_seed(units, relation_data.get('characters', characters), relation_data),
+        'characters': build_character_seed(units, relation_data.get('characters', characters), source_root),
+        'relations': build_relation_seed(units, relation_data.get('characters', characters), relation_data, source_root),
         'terms': [],
         'scenes': [],
     }
 
 
-def write_story_graph_seed(output_path, units, characters, relation_data):
-    seed = build_story_graph_seed(units, characters, relation_data)
+def write_story_graph_seed(output_path, units, characters, relation_data, source_root=None):
+    seed = build_story_graph_seed(units, characters, relation_data, source_root)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
         json.dumps(seed, ensure_ascii=False, indent=2) + '\n',

--- a/relation_analyzer/story_seed.py
+++ b/relation_analyzer/story_seed.py
@@ -1,5 +1,6 @@
 from .common import Path, json, re
-from .relations import collect_relation_units, iter_source_groups, pair_key
+from .parsing import normalize_character_aliases, speaker_matches_character
+from .relations import pair_key
 
 
 def character_id_from_name(name):
@@ -44,6 +45,18 @@ def _source_file(value, source_root=None):
         except (OSError, ValueError):
             pass
     return text.replace('\\', '/')
+
+
+def _source_files(values, source_root=None):
+    normalized = []
+    seen = set()
+    for value in values or []:
+        source = _source_file(value, source_root)
+        if not source or source in seen:
+            continue
+        normalized.append(source)
+        seen.add(source)
+    return sorted(normalized)
 
 
 def collect_speaker_seed_stats(units, source_root=None):
@@ -97,12 +110,21 @@ def collect_speaker_seed_stats(units, source_root=None):
 
 def build_character_seed(units, characters, source_root=None):
     speaker_stats = collect_speaker_seed_stats(units, source_root)
-    by_name = {}
-    for speaker, stats in speaker_stats.items():
-        for candidate in stats['speaker_name_candidates']:
-            key = candidate['name'].strip().lower()
-            if key:
-                by_name.setdefault(key, []).append(speaker)
+    alias_map = normalize_character_aliases(characters)
+    speakers_by_character = {character: [] for character in characters}
+    seen_by_character = {character: set() for character in characters}
+
+    for unit in units:
+        speaker = str(unit.get('speaker') or '').strip()
+        if not speaker or speaker not in speaker_stats:
+            continue
+        for character in characters:
+            if not speaker_matches_character(unit, alias_map[character]):
+                continue
+            if speaker not in seen_by_character[character]:
+                speakers_by_character[character].append(speaker)
+                seen_by_character[character].add(speaker)
+            break
 
     character_entries = {}
     used_ids = set()
@@ -118,7 +140,7 @@ def build_character_seed(units, characters, source_root=None):
             suffix += 1
         used_ids.add(char_id)
 
-        speaker_ids = _dedupe_preserve_order(by_name.get(name.lower(), []))
+        speaker_ids = _dedupe_preserve_order(speakers_by_character.get(character, []))
         candidate_details = []
         source_files = set()
         speaker_count = 0
@@ -170,53 +192,6 @@ def _character_id_map(characters):
     return mapping
 
 
-def collect_pair_source_files(units, characters, segment_size=1, source_root=None):
-    relation_units, _, _, _ = collect_relation_units(units, characters)
-    pair_sources = {}
-    active = set(characters)
-    segment_size = max(1, int(segment_size or 1))
-
-    for group in iter_source_groups(relation_units):
-        source = _source_file(group[0].get('source'), source_root) if group else ''
-
-        for start in range(0, len(group), segment_size):
-            segment = group[start:start + segment_size]
-            present = []
-            seen = set()
-            for unit in segment:
-                for char in unit.get('participants', []):
-                    if char in active and char not in seen:
-                        present.append(char)
-                        seen.add(char)
-            for left_index in range(len(present)):
-                for right_index in range(left_index + 1, len(present)):
-                    pair_sources.setdefault(pair_key(present[left_index], present[right_index]), set()).add(source)
-
-        spoken = [unit for unit in group if unit.get('speaker_character') in active]
-        for previous, current in zip(spoken, spoken[1:]):
-            left = previous.get('speaker_character')
-            right = current.get('speaker_character')
-            if left and right and left != right:
-                pair_sources.setdefault(pair_key(left, right), set()).add(source)
-
-        for unit in group:
-            speaker_character = unit.get('speaker_character') if unit.get('speaker_character') in active else None
-            mentioned = [char for char in unit.get('mentioned_characters', []) if char in active]
-            if speaker_character:
-                for char in mentioned:
-                    if char != speaker_character:
-                        pair_sources.setdefault(pair_key(speaker_character, char), set()).add(source)
-            if len(mentioned) >= 2:
-                for left_index in range(len(mentioned)):
-                    for right_index in range(left_index + 1, len(mentioned)):
-                        pair_sources.setdefault(pair_key(mentioned[left_index], mentioned[right_index]), set()).add(source)
-
-    return {
-        key: sorted(value for value in sources if value)
-        for key, sources in pair_sources.items()
-    }
-
-
 def _has_relation_evidence(row):
     raw_total = (
         float(row.get('co_scene_raw', 0.0))
@@ -228,12 +203,7 @@ def _has_relation_evidence(row):
 
 def build_relation_seed(units, characters, relation_data, source_root=None):
     id_map = _character_id_map(characters)
-    source_files = collect_pair_source_files(
-        units,
-        characters,
-        relation_data.get('segment_size', 1),
-        source_root,
-    )
+    pair_source_files = relation_data.get('pair_source_files', {})
     relation_entries = []
     for row in relation_data.get('pair_rows', []):
         if not _has_relation_evidence(row):
@@ -258,7 +228,7 @@ def build_relation_seed(units, characters, relation_data, source_root=None):
                     'dialogue_raw': float(row.get('dialogue_raw', 0.0)),
                     'mention_raw': float(row.get('mention_raw', 0.0)),
                     'dominant_component': row.get('dominant_component', ''),
-                    'source_files': source_files.get(key, []),
+                    'source_files': _source_files(pair_source_files.get(key, []), source_root),
                     'needs_human_review': True,
                 },
             }

--- a/relation_analyzer/story_seed.py
+++ b/relation_analyzer/story_seed.py
@@ -1,0 +1,246 @@
+from .common import json, re
+from .relations import collect_relation_units, iter_source_groups, pair_key
+
+
+def character_id_from_name(name):
+    text = str(name or '').strip().lower()
+    text = re.sub(r'[^\w]+', '_', text, flags=re.UNICODE)
+    text = text.strip('_')
+    return text or 'character'
+
+
+def _dedupe_preserve_order(values):
+    result = []
+    seen = set()
+    for value in values:
+        text = str(value or '').strip()
+        if not text or text in seen:
+            continue
+        result.append(text)
+        seen.add(text)
+    return result
+
+
+def _source_file(value):
+    return str(value or '').replace('\\', '/')
+
+
+def collect_speaker_seed_stats(units):
+    speakers = {}
+    for unit in units:
+        speaker = str(unit.get('speaker') or '').strip()
+        if not speaker:
+            continue
+        info = speakers.setdefault(
+            speaker,
+            {
+                'speaker_id': speaker,
+                'speaker_name_candidates': {},
+                'count': 0,
+                'source_files': set(),
+                'line_numbers': [],
+            },
+        )
+        info['count'] += 1
+        source = _source_file(unit.get('source'))
+        if source:
+            info['source_files'].add(source)
+        line_no = unit.get('line_no')
+        if isinstance(line_no, int):
+            info['line_numbers'].append(line_no)
+        speaker_name = str(unit.get('speaker_name') or '').strip()
+        if speaker_name:
+            candidates = info['speaker_name_candidates']
+            candidates[speaker_name] = candidates.get(speaker_name, 0) + 1
+
+    normalized = {}
+    for speaker, info in speakers.items():
+        candidates = [
+            {'name': name, 'count': count}
+            for name, count in sorted(
+                info['speaker_name_candidates'].items(),
+                key=lambda item: (-item[1], item[0].lower()),
+            )
+        ]
+        lines = info['line_numbers']
+        normalized[speaker] = {
+            'speaker_id': speaker,
+            'speaker_name_candidates': candidates,
+            'count': info['count'],
+            'source_files': sorted(info['source_files']),
+            'line_min': min(lines) if lines else None,
+            'line_max': max(lines) if lines else None,
+        }
+    return normalized
+
+
+def build_character_seed(units, characters):
+    speaker_stats = collect_speaker_seed_stats(units)
+    by_name = {}
+    for speaker, stats in speaker_stats.items():
+        for candidate in stats['speaker_name_candidates']:
+            key = candidate['name'].strip().lower()
+            if key:
+                by_name.setdefault(key, []).append(speaker)
+
+    character_entries = {}
+    used_ids = set()
+    for character in characters:
+        name = str(character or '').strip()
+        if not name:
+            continue
+        base_id = character_id_from_name(name)
+        char_id = base_id
+        suffix = 2
+        while char_id in used_ids:
+            char_id = f'{base_id}_{suffix}'
+            suffix += 1
+        used_ids.add(char_id)
+
+        speaker_ids = _dedupe_preserve_order(by_name.get(name.lower(), []))
+        candidate_details = []
+        source_files = set()
+        speaker_count = 0
+        for speaker_id in speaker_ids:
+            stats = speaker_stats[speaker_id]
+            speaker_count += stats['count']
+            source_files.update(stats['source_files'])
+            candidate_details.append(
+                {
+                    'speaker_id': speaker_id,
+                    'speaker_name_candidates': stats['speaker_name_candidates'],
+                    'count': stats['count'],
+                    'source_files': stats['source_files'],
+                    'line_min': stats['line_min'],
+                    'line_max': stats['line_max'],
+                }
+            )
+
+        entry = {
+            'name': name,
+            'speaker_ids': speaker_ids,
+            'speaker_name_candidates': candidate_details,
+            'seed_stats': {
+                'speaker_count': speaker_count,
+                'source_files': sorted(source_files),
+                'needs_human_review': True,
+            },
+        }
+        character_entries[char_id] = entry
+
+    return character_entries
+
+
+def _character_id_map(characters):
+    mapping = {}
+    used_ids = set()
+    for character in characters:
+        name = str(character or '').strip()
+        if not name:
+            continue
+        base_id = character_id_from_name(name)
+        char_id = base_id
+        suffix = 2
+        while char_id in used_ids:
+            char_id = f'{base_id}_{suffix}'
+            suffix += 1
+        used_ids.add(char_id)
+        mapping[name] = char_id
+    return mapping
+
+
+def collect_pair_source_files(units, characters):
+    relation_units, _, _, _ = collect_relation_units(units, characters)
+    pair_sources = {}
+    active = set(characters)
+    for unit in relation_units:
+        source = _source_file(unit.get('source'))
+        participants = [
+            char for char in unit.get('participants', [])
+            if char in active
+        ]
+        if len(participants) < 2:
+            continue
+        for left_index in range(len(participants)):
+            for right_index in range(left_index + 1, len(participants)):
+                key = pair_key(participants[left_index], participants[right_index])
+                pair_sources.setdefault(key, set()).add(source)
+
+    for group in iter_source_groups(relation_units):
+        source = _source_file(group[0].get('source')) if group else ''
+        present = []
+        seen = set()
+        for unit in group:
+            for char in unit.get('participants', []):
+                if char in active and char not in seen:
+                    present.append(char)
+                    seen.add(char)
+        for left_index in range(len(present)):
+            for right_index in range(left_index + 1, len(present)):
+                pair_sources.setdefault(pair_key(present[left_index], present[right_index]), set()).add(source)
+
+        spoken = [unit for unit in group if unit.get('speaker_character') in active]
+        for previous, current in zip(spoken, spoken[1:]):
+            left = previous.get('speaker_character')
+            right = current.get('speaker_character')
+            if left and right and left != right:
+                pair_sources.setdefault(pair_key(left, right), set()).add(source)
+
+    return {
+        key: sorted(value for value in sources if value)
+        for key, sources in pair_sources.items()
+    }
+
+
+def build_relation_seed(units, characters, relation_data):
+    id_map = _character_id_map(characters)
+    source_files = collect_pair_source_files(units, characters)
+    relation_entries = []
+    for row in relation_data.get('pair_rows', []):
+        left_name = row['left']
+        right_name = row['right']
+        left_id = id_map.get(left_name, character_id_from_name(left_name))
+        right_id = id_map.get(right_name, character_id_from_name(right_name))
+        key = pair_key(left_name, right_name)
+        relation_entries.append(
+            {
+                'left': left_id,
+                'right': right_id,
+                'type': 'candidate',
+                'confidence': round(max(0.0, min(float(row.get('score', 0.0)), 1.0)), 4),
+                'note': '候选关系；请人工确认具体语义类型后再用于正式 story_graph.json。',
+                'seed_stats': {
+                    'left_name': left_name,
+                    'right_name': right_name,
+                    'score': round(float(row.get('score', 0.0)), 6),
+                    'co_scene_raw': float(row.get('co_scene_raw', 0.0)),
+                    'dialogue_raw': float(row.get('dialogue_raw', 0.0)),
+                    'mention_raw': float(row.get('mention_raw', 0.0)),
+                    'dominant_component': row.get('dominant_component', ''),
+                    'source_files': source_files.get(key, []),
+                    'needs_human_review': True,
+                },
+            }
+        )
+    return relation_entries
+
+
+def build_story_graph_seed(units, characters, relation_data):
+    return {
+        'schema_version': 1,
+        'characters': build_character_seed(units, relation_data.get('characters', characters)),
+        'relations': build_relation_seed(units, relation_data.get('characters', characters), relation_data),
+        'terms': [],
+        'scenes': [],
+    }
+
+
+def write_story_graph_seed(output_path, units, characters, relation_data):
+    seed = build_story_graph_seed(units, characters, relation_data)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(seed, ensure_ascii=False, indent=2) + '\n',
+        encoding='utf-8',
+    )
+    print(f"🧩 已导出 Story Memory seed: {output_path}")
+    return seed

--- a/tests/test_relation_analyzer.py
+++ b/tests/test_relation_analyzer.py
@@ -64,10 +64,12 @@ class RelationAnalyzerTests(unittest.TestCase):
         definitions = extract_character_definitions([
             'define e = Character("Eileen")\n',
             'define n = Character(_("Noah"), color="#fff")\n',
+            'define c = Character(name="Cora", image="cora")\n',
+            'define img = Character(None, image="not_a_name")\n',
             'default title = "Not a character"\n',
         ])
 
-        self.assertEqual(definitions, {'e': 'Eileen', 'n': 'Noah'})
+        self.assertEqual(definitions, {'e': 'Eileen', 'n': 'Noah', 'c': 'Cora'})
 
     def test_infer_characters_from_units_prefers_most_frequent_speakers(self):
         units = [
@@ -129,6 +131,36 @@ class RelationAnalyzerTests(unittest.TestCase):
         self.assertGreater(relation['seed_stats']['dialogue_raw'], 0.0)
         self.assertIn('scene_1.rpy', relation['seed_stats']['source_files'])
         self.assertTrue(relation['seed_stats']['needs_human_review'])
+
+    def test_build_story_graph_seed_uses_relative_source_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            scene_path = root / 'scene_1.rpy'
+            units = [
+                {'source': str(scene_path), 'line_no': 1, 'speaker': 'e', 'speaker_name': 'E', 'text': 'Hello Noah.', 'context': 'E: Hello Noah.'},
+                {'source': str(scene_path), 'line_no': 2, 'speaker': 'noah', 'speaker_name': 'Noah', 'text': 'Hello.', 'context': 'Noah: Hello.'},
+            ]
+            relation_data = compute_relation_data(units, ['E', 'Noah'], segment_size=2)
+
+            seed = build_story_graph_seed(units, ['E', 'Noah'], relation_data, source_root=root)
+
+        self.assertEqual(seed['characters']['e']['seed_stats']['source_files'], ['scene_1.rpy'])
+        self.assertEqual(seed['relations'][0]['seed_stats']['source_files'], ['scene_1.rpy'])
+
+    def test_build_story_graph_seed_filters_zero_evidence_pairs(self):
+        units = [
+            {'source': 'scene_1.rpy', 'line_no': 1, 'speaker': 'a', 'speaker_name': 'A', 'text': 'Solo.', 'context': 'A: Solo.'},
+            {'source': 'scene_1.rpy', 'line_no': 2, 'speaker': 'c', 'speaker_name': 'C', 'text': 'Solo.', 'context': 'C: Solo.'},
+            {'source': 'scene_1.rpy', 'line_no': 3, 'speaker': 'b', 'speaker_name': 'B', 'text': 'Solo.', 'context': 'B: Solo.'},
+        ]
+        relation_data = compute_relation_data(units, ['A', 'B', 'C'], segment_size=1)
+
+        seed = build_story_graph_seed(units, ['A', 'B', 'C'], relation_data)
+        relation_pairs = {(item['left'], item['right']) for item in seed['relations']}
+
+        self.assertNotIn(('a', 'b'), relation_pairs)
+        self.assertIn(('a', 'c'), relation_pairs)
+        self.assertIn(('b', 'c'), relation_pairs)
 
     def test_write_story_graph_seed_creates_parent_directory(self):
         units = [
@@ -297,6 +329,7 @@ class RelationAnalyzerTests(unittest.TestCase):
             max_texts_per_character=0,
             relation_window_size=12,
             csv_output=None,
+            story_seed_output=None,
         )
         with patch.object(cli, 'parse_args', return_value=args), \
              patch.object(cli, 'resolve_path', side_effect=lambda value: Path(value)), \
@@ -323,6 +356,7 @@ class RelationAnalyzerTests(unittest.TestCase):
             max_texts_per_character=0,
             relation_window_size=12,
             csv_output=None,
+            story_seed_output=None,
         )
         with patch.object(cli, 'parse_args', return_value=args), \
              patch.object(cli, 'resolve_path', side_effect=lambda value: Path(value)), \

--- a/tests/test_relation_analyzer.py
+++ b/tests/test_relation_analyzer.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,9 +8,10 @@ from unittest.mock import patch
 
 from relation_analyzer import cli
 from relation_analyzer import semantic
-from relation_analyzer.parsing import extract_units_from_rpy, infer_characters_from_units, load_text_units, parse_dialogue_line, resolve_speaker_name
+from relation_analyzer.parsing import extract_character_definitions, extract_units_from_rpy, infer_characters_from_units, load_text_units, parse_dialogue_line, resolve_speaker_name
 from relation_analyzer.plotting import project_vectors_2d
 from relation_analyzer.relations import compute_relation_data, write_relation_csv
+from relation_analyzer.story_seed import build_story_graph_seed, write_story_graph_seed
 
 
 class RelationAnalyzerTests(unittest.TestCase):
@@ -58,6 +60,15 @@ class RelationAnalyzerTests(unittest.TestCase):
         self.assertEqual(resolve_speaker_name('spencer_no_side'), 'Spencer')
         self.assertEqual(resolve_speaker_name('mr_smith'), 'Mr Smith')
 
+    def test_extract_character_definitions_reads_renpy_character_names(self):
+        definitions = extract_character_definitions([
+            'define e = Character("Eileen")\n',
+            'define n = Character(_("Noah"), color="#fff")\n',
+            'default title = "Not a character"\n',
+        ])
+
+        self.assertEqual(definitions, {'e': 'Eileen', 'n': 'Noah'})
+
     def test_infer_characters_from_units_prefers_most_frequent_speakers(self):
         units = [
             {'speaker_name': 'Spencer'},
@@ -93,6 +104,45 @@ class RelationAnalyzerTests(unittest.TestCase):
         self.assertEqual(len(data['pair_rows']), 1)
         self.assertEqual(data['pair_rows'][0]['left'], 'Ian')
         self.assertEqual(data['pair_rows'][0]['right'], 'Spencer')
+
+    def test_build_story_graph_seed_exports_reviewable_candidates(self):
+        units = [
+            {'source': 'scene_1.rpy', 'line_no': 1, 'speaker': 'eileen_side', 'speaker_name': 'Eileen', 'text': 'Noah, open the gate.', 'context': 'Eileen: Noah, open the gate.'},
+            {'source': 'scene_1.rpy', 'line_no': 2, 'speaker': 'noah', 'speaker_name': 'Noah', 'text': 'I am opening it.', 'context': 'Noah: I am opening it.'},
+            {'source': 'scene_2.rpy', 'line_no': 1, 'speaker': 'eileen_happy', 'speaker_name': 'Eileen', 'text': 'Good work, Noah.', 'context': 'Eileen: Good work, Noah.'},
+        ]
+        relation_data = compute_relation_data(units, ['Eileen', 'Noah'], segment_size=2)
+
+        seed = build_story_graph_seed(units, ['Eileen', 'Noah'], relation_data)
+
+        self.assertEqual(seed['schema_version'], 1)
+        self.assertEqual(seed['characters']['eileen']['name'], 'Eileen')
+        self.assertEqual(seed['characters']['eileen']['speaker_ids'], ['eileen_side', 'eileen_happy'])
+        self.assertEqual(seed['characters']['eileen']['seed_stats']['speaker_count'], 2)
+        self.assertEqual(seed['characters']['noah']['speaker_ids'], ['noah'])
+        self.assertEqual(len(seed['relations']), 1)
+        relation = seed['relations'][0]
+        self.assertEqual(relation['left'], 'eileen')
+        self.assertEqual(relation['right'], 'noah')
+        self.assertEqual(relation['type'], 'candidate')
+        self.assertIn('人工确认', relation['note'])
+        self.assertGreater(relation['seed_stats']['dialogue_raw'], 0.0)
+        self.assertIn('scene_1.rpy', relation['seed_stats']['source_files'])
+        self.assertTrue(relation['seed_stats']['needs_human_review'])
+
+    def test_write_story_graph_seed_creates_parent_directory(self):
+        units = [
+            {'source': 'scene_1.rpy', 'line_no': 1, 'speaker': 'e', 'speaker_name': 'E', 'text': 'Hello Noah.', 'context': 'E: Hello Noah.'},
+            {'source': 'scene_1.rpy', 'line_no': 2, 'speaker': 'noah', 'speaker_name': 'Noah', 'text': 'Hello.', 'context': 'Noah: Hello.'},
+        ]
+        relation_data = compute_relation_data(units, ['E', 'Noah'], segment_size=2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / 'logs' / 'story_memory' / 'story_graph.seed.json'
+            write_story_graph_seed(output_path, units, ['E', 'Noah'], relation_data)
+            loaded = json.loads(output_path.read_text(encoding='utf-8'))
+
+        self.assertEqual(loaded['characters']['e']['speaker_ids'], ['e'])
+        self.assertEqual(loaded['relations'][0]['type'], 'candidate')
 
     def test_load_text_units_reads_utf8_sig_for_rpy_and_txt(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -135,6 +185,25 @@ class RelationAnalyzerTests(unittest.TestCase):
             self.assertEqual(rpy_units[1]['speaker'], 'e')
             self.assertEqual(rpy_units[1]['speaker_name'], 'E')
             self.assertEqual(rpy_units[1]['text'], 'And another line.')
+
+    def test_load_text_units_uses_character_defines_across_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / 'characters.rpy').write_text(
+                'define e = Character("Eileen")\n',
+                encoding='utf-8-sig',
+            )
+            (root / 'scene.rpy').write_text(
+                'label start:\n'
+                '    e happy "Hello there."\n',
+                encoding='utf-8-sig',
+            )
+
+            rpy_units = load_text_units(root, context_window=0)
+
+            self.assertEqual(len(rpy_units), 1)
+            self.assertEqual(rpy_units[0]['speaker'], 'e')
+            self.assertEqual(rpy_units[0]['speaker_name'], 'Eileen')
 
     def test_load_text_units_resets_speaker_context_after_narrator_line(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_relation_analyzer.py
+++ b/tests/test_relation_analyzer.py
@@ -65,11 +65,16 @@ class RelationAnalyzerTests(unittest.TestCase):
             'define e = Character("Eileen")\n',
             'define n = Character(_("Noah"), color="#fff")\n',
             'define c = Character(name="Cora", image="cora")\n',
+            'define a = Character("艾")\n',
             'define img = Character(None, image="not_a_name")\n',
             'default title = "Not a character"\n',
         ])
 
-        self.assertEqual(definitions, {'e': 'Eileen', 'n': 'Noah', 'c': 'Cora'})
+        self.assertEqual(definitions, {'e': 'Eileen', 'n': 'Noah', 'c': 'Cora', 'a': '艾'})
+
+    def test_resolve_speaker_name_prefers_explicit_mapping_over_character_define(self):
+        with patch.dict('relation_analyzer.parsing.SPEAKER_TO_CHARACTER', {'e': '艾琳'}):
+            self.assertEqual(resolve_speaker_name('e', {'e': 'Eileen'}), '艾琳')
 
     def test_infer_characters_from_units_prefers_most_frequent_speakers(self):
         units = [
@@ -131,6 +136,17 @@ class RelationAnalyzerTests(unittest.TestCase):
         self.assertGreater(relation['seed_stats']['dialogue_raw'], 0.0)
         self.assertIn('scene_1.rpy', relation['seed_stats']['source_files'])
         self.assertTrue(relation['seed_stats']['needs_human_review'])
+
+    def test_build_story_graph_seed_uses_character_aliases_for_speaker_ids(self):
+        units = [
+            {'source': 'scene_1.rpy', 'line_no': 1, 'speaker': 'e', 'speaker_name': 'Eileen', 'text': 'Noah, open the gate.', 'context': 'Eileen: Noah, open the gate.'},
+            {'source': 'scene_1.rpy', 'line_no': 2, 'speaker': 'noah', 'speaker_name': 'Noah', 'text': 'I am opening it.', 'context': 'Noah: I am opening it.'},
+        ]
+        with patch.dict('relation_analyzer.parsing.CHARACTER_ALIASES', {'艾琳': ['Eileen']}):
+            relation_data = compute_relation_data(units, ['艾琳', 'Noah'], segment_size=2)
+            seed = build_story_graph_seed(units, ['艾琳', 'Noah'], relation_data)
+
+        self.assertEqual(seed['characters']['艾琳']['speaker_ids'], ['e'])
 
     def test_build_story_graph_seed_uses_relative_source_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -237,6 +253,35 @@ class RelationAnalyzerTests(unittest.TestCase):
             self.assertEqual(rpy_units[0]['speaker'], 'e')
             self.assertEqual(rpy_units[0]['speaker_name'], 'Eileen')
 
+    def test_load_text_units_reuses_cached_rpy_lines_for_character_defines(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            characters_path = root / 'characters.rpy'
+            scene_path = root / 'scene.rpy'
+            characters_path.write_text(
+                'define e = Character("Eileen")\n',
+                encoding='utf-8-sig',
+            )
+            scene_path.write_text(
+                'label start:\n'
+                '    e happy "Hello there."\n',
+                encoding='utf-8-sig',
+            )
+            original_read_text = Path.read_text
+            read_counts = {}
+
+            def counting_read_text(path, *args, **kwargs):
+                if path.suffix.lower() == '.rpy':
+                    read_counts[path] = read_counts.get(path, 0) + 1
+                return original_read_text(path, *args, **kwargs)
+
+            with patch.object(Path, 'read_text', counting_read_text):
+                rpy_units = load_text_units(root, context_window=0)
+
+            self.assertEqual(len(rpy_units), 1)
+            self.assertEqual(read_counts[characters_path], 1)
+            self.assertEqual(read_counts[scene_path], 1)
+
     def test_load_text_units_resets_speaker_context_after_narrator_line(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -339,6 +384,43 @@ class RelationAnalyzerTests(unittest.TestCase):
                 cli.main()
 
         self.assertEqual(str(exc.exception), '❌ 提取到的有效角色少于 2 个，无法计算关系。')
+
+    def test_cli_relation_mode_writes_story_seed_with_input_root(self):
+        args = SimpleNamespace(
+            input='input_dir',
+            output='output.png',
+            cache_dir='cache',
+            characters='E,Noah',
+            auto_characters=0,
+            portraits='off',
+            mode='relation',
+            batch_size=1,
+            context_window=0,
+            model='gemini-embedding-001',
+            output_dimensionality=768,
+            max_texts_per_character=0,
+            relation_window_size=12,
+            csv_output=None,
+            story_seed_output='seed.json',
+        )
+        units = [{'source': 'scene.rpy', 'line_no': 1, 'speaker': 'e', 'speaker_name': 'E', 'text': 'Hello.', 'context': 'E: Hello.'}]
+        relation_data = {'characters': ['E', 'Noah'], 'pair_rows': [], 'segment_size': 12, 'pair_source_files': {}}
+
+        with patch.object(cli, 'parse_args', return_value=args), \
+             patch.object(cli, 'resolve_path', side_effect=lambda value: Path(value)), \
+             patch.object(cli, 'load_text_units', return_value=units), \
+             patch.object(cli, 'compute_relation_data', return_value=relation_data), \
+             patch.object(cli, 'write_story_graph_seed') as write_seed, \
+             patch.object(cli, 'analyze_and_plot_relation'):
+            cli.main()
+
+        write_seed.assert_called_once_with(
+            Path('seed.json'),
+            units,
+            ['E', 'Noah'],
+            relation_data,
+            source_root=Path('input_dir'),
+        )
 
     def test_cli_semantic_mode_exits_nonzero_when_active_characters_drop_below_two(self):
         args = SimpleNamespace(


### PR DESCRIPTION
## 背景

Refs #8。

这个 PR 先收口 #8 中 `relation_analyzer` seed 导出的一个小切片：从已有关系分析结果生成可人工审查的 `story_graph.seed.json`，帮助后续维护正式 `story_graph.json`。

## 改动

- 新增 `relation_analyzer/story_seed.py`，从 relation 模式结果导出候选 characters / relations。
- `extract_relations.py` 增加 `--story-seed-output` 参数，可在 relation 模式额外写出 `story_graph.seed.json`。
- 解析 `.rpy` 时读取 `define e = Character("Eileen")` 这类 Ren'Py 角色定义，用于更准确的 speaker 名称候选。
- seed 中的关系统一标记为 `candidate`，只包含共场景、对话往来、相互提及、来源文件和 speaker 统计，不自动断言恋人、敌人、上下级等强语义关系。
- 补充 README 与 `relation_analyzer/README.md` 使用说明。
- 增加 relation_analyzer 测试覆盖 seed 内容、目录创建和 Character define 映射。

## 验证

- `python -m py_compile relation_analyzer\parsing.py relation_analyzer\story_seed.py relation_analyzer\cli.py tests\test_relation_analyzer.py`
- `python -m unittest tests.test_relation_analyzer -q`
- `python -m unittest discover -s tests -q`
- `python extract_relations.py --help`
- `git diff --check`

## 后续边界

这个 PR 不关闭 #8。sync / probe 更完整 diagnostics、Neo4j 可选导出等仍建议继续拆后续 PR。