### PR TITLE
[codex] Close Story Memory repair boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ Structured Story Memory 是现有 glossary / translation-memory RAG 之外的可
 
 加载 `story_graph.json` 时会做轻量基础校验：顶层集合类型、角色别名字段、关系 `left/right/confidence`、术语有效内容、场景行号与角色列表等明显问题会输出 warning。校验是非阻塞的；有效部分仍会被规范化后继续用于检索，避免一个局部坏条目导致整个图谱不可用。
 
-Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、预算内格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。
+Batch `build` 生成的 `manifest.json` 会在 `story_memory_summary` 中记录 diagnostics，包括 `graph_file`、命中 chunk 数、命中率、characters / relations / terms / scenes 各类命中数量、总命中数、预算内格式化字符数，以及有多少个 `STORY MEMORY` 块会被 `max_context_chars` 截断。`split` 会按子包重新计算这些统计。
+
+`repair` 在 `batch.story_memory.enabled=true` 时也会复用同一个 `story_memory.py` 读取和格式化路径，为 repair request 注入受 `max_context_chars` 限制的 `STORY MEMORY` 块，并在 `repair_summary.json` 记录 repair job 的 Story Memory 命中统计。`probe` 只探测当前 package 里的既有 `requests.jsonl`，不会重新读取或刷新 `story_graph.json`；如果这些请求是在 Story Memory 启用时 build 出来的，probe 会自然测试已经写入请求的 prompt。
 
 `relation_analyzer` 可以额外导出 `story_graph.seed.json` 候选数据，帮助从 Ren'Py 剧本里半自动整理 `speaker_ids`、候选角色和候选关系：
 
@@ -278,7 +280,7 @@ python extract_relations.py /path/to/game/tl/schinese --mode relation --story-se
 
 seed 中的关系统一标记为 `candidate`，只包含共场景、对话往来、相互提及、来源文件和 speaker 统计等可审查信息；如果同一输入目录里存在 `define e = Character("Eileen")` 这类 Ren'Py 角色定义，seed 会优先用定义名作为 speaker 名称候选。它不会自动断言恋人、敌人、上下级等强语义关系。建议人工确认并编辑后，再作为正式 `story_graph.json` 使用。
 
-当前实现仍是 MVP：检索逻辑是轻量启发式，Neo4j 可视化导出，以及 sync / probe 等辅助路径的更完整 diagnostics 还属于后续工作。
+当前实现仍是 MVP：检索逻辑是轻量启发式，Neo4j 可视化导出，以及 sync 运行日志里的更完整 Story Memory diagnostics 还属于后续工作。
 
 ## 角色关系 / 语义分析
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2488,6 +2488,21 @@ def extract_string_token_from_line(line):
         }
     return None
 
+
+def infer_repair_speaker_id(prefix='', line='', string_start_col=None):
+    if line and string_start_col is not None:
+        stripped = line.lstrip()
+        if not stripped.startswith(('old ', 'new ')):
+            speaker_id = legacy.infer_dialogue_speaker_id(line, string_start_col)
+            if speaker_id:
+                return speaker_id
+
+    prefix = str(prefix or '')
+    if not prefix.strip():
+        return ''
+    return legacy.infer_dialogue_speaker_id(f'{prefix}"x"', len(prefix))
+
+
 def collect_translation_entries_from_lines(lines):
     entries = []
     index = 0
@@ -2501,16 +2516,25 @@ def collect_translation_entries_from_lines(lines):
             if next_index < len(lines):
                 token = extract_string_token_from_line(lines[next_index])
                 if token:
+                    speaker_id = infer_repair_speaker_id(
+                        comment_match.group('prefix'),
+                        lines[next_index],
+                        token['start'],
+                    )
+                    entry = {
+                        'line_number': next_index + 1,
+                        'source': comment_match.group('text'),
+                        'translation': token['text'],
+                        'start': token['start'],
+                        'end': token['end'],
+                        'prefix': token.get('prefix', ''),
+                        'quote': token['quote'],
+                    }
+                    if speaker_id:
+                        entry['speaker_id'] = speaker_id
+                        entry['speaker'] = speaker_id
                     entries.append(
-                        {
-                            'line_number': next_index + 1,
-                            'source': comment_match.group('text'),
-                            'translation': token['text'],
-                            'start': token['start'],
-                            'end': token['end'],
-                            'prefix': token.get('prefix', ''),
-                            'quote': token['quote'],
-                        }
+                        entry
                     )
             index = next_index
         else:
@@ -2561,6 +2585,8 @@ def collect_repair_entries_from_lines(lines):
                 'end': task.get('end', 0),
                 'prefix': task.get('prefix', ''),
                 'quote': task.get('quote', '"'),
+                'speaker_id': task.get('speaker_id', ''),
+                'speaker': task.get('speaker', ''),
             }
         )
 
@@ -2987,6 +3013,7 @@ def load_repair_report_items(report_path):
                 raise SystemExit(f'Invalid repair report JSONL row: {exc}') from exc
 
             batch_style = False
+            file_rel_path = ''
             file_path = row.get('file')
             if isinstance(file_path, str) and file_path.strip():
                 file_path = resolve_path_under_dir(legacy.TL_DIR, file_path, 'repair file')
@@ -3020,6 +3047,7 @@ def load_repair_report_items(report_path):
 
             normalized_row = dict(row)
             normalized_row['file'] = file_path
+            normalized_row['file_rel_path'] = file_rel_path_for_repair(file_path, file_rel_path)
             normalized_row['line'] = line_number
             normalized_row['source'] = source_text
 
@@ -3038,6 +3066,17 @@ def load_repair_report_items(report_path):
     items.sort(key=lambda item: (item.get('game', ''), item['file'], item['line']))
     return items
 
+
+def file_rel_path_for_repair(file_path, preferred=''):
+    preferred = str(preferred or '').strip()
+    if preferred:
+        return legacy._normalize_rel_path(preferred)
+    try:
+        return legacy._normalize_rel_path(os.path.relpath(file_path, legacy.TL_DIR))
+    except Exception:
+        return legacy._normalize_rel_path(os.path.basename(file_path))
+
+
 def build_repair_jobs(report_items, batch_size=2, context_before=2, context_after=2):
     jobs = []
     unresolved = []
@@ -3047,6 +3086,10 @@ def build_repair_jobs(report_items, batch_size=2, context_before=2, context_afte
 
     for file_path in sorted(items_by_file):
         file_items = sorted(items_by_file[file_path], key=lambda item: item['line'])
+        file_rel_path = file_rel_path_for_repair(
+            file_path,
+            file_items[0].get('file_rel_path') if file_items else '',
+        )
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             lines = handle.readlines()
         entries = collect_repair_entries_from_lines(lines)
@@ -3075,6 +3118,9 @@ def build_repair_jobs(report_items, batch_size=2, context_before=2, context_afte
             target['prefix'] = entry.get('prefix', '')
             target['quote'] = entry['quote']
             target['entry_index'] = entry['entry_index']
+            target['file_rel_path'] = file_rel_path
+            target['speaker_id'] = target.get('speaker_id') or entry.get('speaker_id', '')
+            target['speaker'] = target.get('speaker') or entry.get('speaker', '')
             targets.append(target)
 
         if not targets:
@@ -3092,17 +3138,17 @@ def build_repair_jobs(report_items, batch_size=2, context_before=2, context_afte
                     or current_index != previous_index + 1
                 )
             ):
-                jobs.append(_build_repair_job(file_path, entries, current_group, context_before, context_after))
+                jobs.append(_build_repair_job(file_rel_path, file_path, entries, current_group, context_before, context_after))
                 current_group = []
             current_group.append(target)
             previous_index = current_index
         if current_group:
-            jobs.append(_build_repair_job(file_path, entries, current_group, context_before, context_after))
+            jobs.append(_build_repair_job(file_rel_path, file_path, entries, current_group, context_before, context_after))
 
     return jobs, unresolved
 
 
-def _build_repair_job(file_path, entries, target_group, context_before, context_after):
+def _build_repair_job(file_rel_path, file_path, entries, target_group, context_before, context_after):
     first_index = target_group[0]['entry_index']
     last_index = target_group[-1]['entry_index']
     context_past = [
@@ -3113,8 +3159,9 @@ def _build_repair_job(file_path, entries, target_group, context_before, context_
         entry_context_text(entry)
         for entry in entries[last_index + 1:last_index + 1 + context_after]
     ]
-    return {
+    job = {
         'key': hashlib.sha1(f"repair:{file_path}:{target_group[0]['line']}:{target_group[-1]['line']}".encode('utf-8')).hexdigest()[:12],
+        'file_rel_path': file_rel_path,
         'file_path': file_path,
         'context_past': context_past,
         'context_future': context_future,
@@ -3123,14 +3170,27 @@ def _build_repair_job(file_path, entries, target_group, context_before, context_
                 'id': target['id'],
                 'text': target['text'],
                 'line': target['line'],
+                'line_number': target['line'],
                 'start': target['start'],
                 'end': target['end'],
                 'prefix': target.get('prefix', ''),
                 'quote': target['quote'],
+                'file_rel_path': target.get('file_rel_path', file_rel_path),
+                'speaker_id': target.get('speaker_id', ''),
+                'speaker': target.get('speaker', ''),
             }
             for target in target_group
         ],
     }
+    story_hits = retrieve_batch_story_hits(
+        file_rel_path,
+        job['items'],
+        context_past,
+        context_future,
+    ) if STORY_MEMORY_ENABLED else None
+    if STORY_MEMORY_ENABLED and story_memory.has_story_hits(story_hits):
+        job['story_hits'] = story_hits
+    return job
 
 
 def build_repair_request(job):
@@ -3151,6 +3211,7 @@ def build_repair_request(job):
                                 job['context_past'],
                                 job['items'],
                                 job['context_future'],
+                                story_hits=job.get('story_hits') if 'story_hits' in job else None,
                             )
                         }
                     ],
@@ -3210,6 +3271,12 @@ def print_repair_summary(summary):
     print(f"Validation failures: {summary['validation_failures']}")
     print(f"Missing item ids: {summary['missing_item_ids']}")
     print(f"Unresolved items: {summary['unresolved_items']}")
+    if summary.get('story_memory_enabled'):
+        story_summary = summary.get('story_memory_summary') or {}
+        print(
+            'Story Memory repair hits: '
+            f"{story_summary.get('chunks_with_story_hits', 0)}/{summary['job_count']} jobs"
+        )
     if summary.get('reason_counts'):
         print('Failure categories:')
         for name in sorted(summary['reason_counts']):
@@ -3261,6 +3328,9 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
         'validation_failures': 0,
         'missing_item_ids': 0,
         'unresolved_items': len(unresolved),
+        'story_memory_enabled': STORY_MEMORY_ENABLED,
+        'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
+        'story_memory_summary': summarize_batch_story_memory(jobs) if STORY_MEMORY_ENABLED else {},
         'reason_counts': reason_counts,
     }
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2600,6 +2600,105 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(len(jobs), 1)
         self.assertEqual(jobs[0]['items'][0]['start'], second_start)
 
+    def test_repair_jobs_include_story_memory_when_enabled(self):
+        old_values = {
+            'enabled': batch_mod.STORY_MEMORY_ENABLED,
+            'graph_file': batch_mod.STORY_MEMORY_GRAPH_FILE,
+            'max_context_chars': batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS,
+            'graph': batch_mod._STORY_GRAPH,
+            'graph_path': batch_mod._STORY_GRAPH_PATH,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                tl_dir = Path(tmp)
+                target_file = tl_dir / 'script.rpy'
+                graph_file = tl_dir / 'story_graph.json'
+                target_file.write_text(
+                    'label test:\n'
+                    '    e "Open the Void Gate"\n',
+                    encoding='utf-8',
+                )
+                graph_file.write_text(
+                    json.dumps(
+                        {
+                            'schema_version': 1,
+                            'characters': {
+                                'eileen': {
+                                    'zh_name': '艾琳',
+                                    'speaker_ids': ['e'],
+                                    'style': '语气轻快',
+                                },
+                            },
+                            'relations': [],
+                            'terms': [
+                                {
+                                    'source': 'Void Gate',
+                                    'target': '虚空门',
+                                    'note': '世界观核心术语',
+                                },
+                            ],
+                            'scenes': [
+                                {
+                                    'file_rel_path': 'script.rpy',
+                                    'line_start': 3,
+                                    'line_end': 3,
+                                    'summary': '偏后一行的场景。',
+                                    'characters': ['eileen'],
+                                },
+                                {
+                                    'file_rel_path': 'script.rpy',
+                                    'line_start': 2,
+                                    'line_end': 2,
+                                    'summary': '正确边界场景。',
+                                    'characters': ['eileen'],
+                                },
+                            ],
+                        },
+                        ensure_ascii=False,
+                    ),
+                    encoding='utf-8',
+                )
+
+                batch_mod.STORY_MEMORY_ENABLED = True
+                batch_mod.STORY_MEMORY_GRAPH_FILE = str(graph_file)
+                batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = 500
+                batch_mod._STORY_GRAPH = None
+                batch_mod._STORY_GRAPH_PATH = ''
+                with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                    jobs, unresolved = batch_mod.build_repair_jobs(
+                        [
+                            {
+                                'file': str(target_file),
+                                'line': 2,
+                                'source': 'Open the Void Gate',
+                            },
+                        ],
+                        batch_size=1,
+                    )
+                request = batch_mod.build_repair_request(jobs[0])
+                prompt = request['request']['contents'][0]['parts'][0]['text']
+                summary = batch_mod.summarize_batch_story_memory(
+                    jobs,
+                    graph_file=str(graph_file),
+                    max_context_chars=500,
+                )
+        finally:
+            batch_mod.STORY_MEMORY_ENABLED = old_values['enabled']
+            batch_mod.STORY_MEMORY_GRAPH_FILE = old_values['graph_file']
+            batch_mod.STORY_MEMORY_MAX_CONTEXT_CHARS = old_values['max_context_chars']
+            batch_mod._STORY_GRAPH = old_values['graph']
+            batch_mod._STORY_GRAPH_PATH = old_values['graph_path']
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(jobs[0]['file_rel_path'], 'script.rpy')
+        self.assertEqual(jobs[0]['items'][0]['speaker_id'], 'e')
+        self.assertEqual(jobs[0]['items'][0]['line_number'], 2)
+        self.assertIn('story_hits', jobs[0])
+        self.assertEqual(jobs[0]['story_hits']['scenes'][0]['summary'], '正确边界场景。')
+        self.assertIn('STORY MEMORY', prompt)
+        self.assertIn('Void Gate -> 虚空门', prompt)
+        self.assertEqual(summary['chunks_with_story_hits'], 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Let Batch `repair` reuse the shared Story Memory retrieval and formatting path when `batch.story_memory.enabled=true`.
- Preserve repair `file_rel_path` and speaker metadata so story graph scene, term, and character matching can work in repair requests.
- Record Story Memory repair diagnostics in `repair_summary.json` and document the `repair` / `probe` boundary.

## Why

#8 left the auxiliary path boundary ambiguous after the schema, diagnostics, and seed-export slices landed. `repair` creates fresh synchronous requests, so it should use the same bounded `story_memory.py` path as Batch build. `probe` only sends existing `requests.jsonl`, so it should not refresh or re-read `story_graph.json`.

## Validation

- `python -m py_compile gemini_translate_batch.py story_memory.py translator_runtime.py`
- `python -m unittest tests.test_regressions -q`
- `python -m unittest tests.test_relation_analyzer -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`

Refs #8