### PR TITLE
[codex] Add keyword extraction batch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ python gemini_translate_batch.py export-keywords logs/batch_jobs/<package>/manif
 - `probe` 会用同步请求做最小 smoke test
 - `check` 是干跑校验，不会修改 `.rpy`
 - `apply` 只会写回通过校验的结果
-- `build-keywords` 会复用 include 过滤和 Batch manifest，按较大 chunk 扫描 TL 文本并要求模型输出 `source`、`suggested_target`、`category`、`confidence`、`evidence`；`export-keywords` 会导出去重后的 `keyword_candidates.jsonl` 和 `keyword_candidates.md`
+- `build-keywords` 会复用 include 过滤和 Batch manifest，默认不运行 prepare，按较大 chunk 扫描 TL 文本并要求模型输出 `source`、`suggested_target`、`category`、`confidence`、`evidence`、`source_item_ids`；如果确实要先刷新 TL 模板，可显式传 `--prepare`
+- `export-keywords` 会导出去重后的 `keyword_candidates.jsonl` 和 `keyword_candidates.md`，并在报告里标出缺失 chunk row 或无法精确定位的候选来源
 - 关键词 manifest 的 `mode=keyword_extraction`，普通 `check/apply` 会拒绝处理，避免把非翻译结果误写回 `.rpy`
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
 - 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息；同机写入进程崩溃后留下的 stale lock 会在确认 PID 已退出时自动回收

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ python gemini_translate_batch.py check
 python gemini_translate_batch.py apply
 ```
 
+关键词提取模式（只生成候选报告，不写回 `.rpy` / `glossary.json` / `story_graph.json`）：
+
+```bash
+python gemini_translate_batch.py build-keywords
+python gemini_translate_batch.py submit logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py status logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py download logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py export-keywords logs/batch_jobs/<package>/manifest.json
+```
+
 说明：
 
 - `python gemini_translate.py --help` 会显示同步脚本的最小 CLI 帮助
@@ -136,6 +146,8 @@ python gemini_translate_batch.py apply
 - `probe` 会用同步请求做最小 smoke test
 - `check` 是干跑校验，不会修改 `.rpy`
 - `apply` 只会写回通过校验的结果
+- `build-keywords` 会复用 include 过滤和 Batch manifest，按较大 chunk 扫描 TL 文本并要求模型输出 `source`、`suggested_target`、`category`、`confidence`、`evidence`；`export-keywords` 会导出去重后的 `keyword_candidates.jsonl` 和 `keyword_candidates.md`
+- 关键词 manifest 的 `mode=keyword_extraction`，普通 `check/apply` 会拒绝处理，避免把非翻译结果误写回 `.rpy`
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
 - 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息；同机写入进程崩溃后留下的 stale lock 会在确认 PID 已退出时自动回收
 - 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -864,6 +864,19 @@ def summarize_files_for_chunks(chunks):
     return files
 
 
+def create_batch_package_dir(package_name):
+    base_dir = os.path.join(BATCH_JOBS_DIR, package_name)
+    candidates = [base_dir]
+    candidates.extend(f'{base_dir}_{index:02d}' for index in range(1, 1000))
+    for candidate in candidates:
+        try:
+            os.makedirs(candidate, exist_ok=False)
+            return candidate
+        except FileExistsError:
+            continue
+    raise SystemExit(f'Could not create unique batch package directory for {package_name}.')
+
+
 def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
     if source_manifest.get('keyword_settings'):
         part_manifest['keyword_settings'] = dict(source_manifest.get('keyword_settings') or {})
@@ -1411,6 +1424,17 @@ def should_include_keyword_source(text):
     return any(ch.isalnum() or '\u4e00' <= ch <= '\u9fff' for ch in stripped)
 
 
+def keyword_source_line_number(entry):
+    for key in ('source_line_number', 'line_number'):
+        try:
+            value = int(entry.get(key))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 0
+
+
 def collect_keyword_file_jobs():
     jobs = []
     for rel_path, file_path in collect_files_to_process():
@@ -1422,15 +1446,13 @@ def collect_keyword_file_jobs():
             source_text = str(entry.get('source') or '').strip()
             if not should_include_keyword_source(source_text):
                 continue
-            try:
-                line_number = int(entry.get('line_number'))
-            except (TypeError, ValueError):
-                line_number = 0
+            line_number = keyword_source_line_number(entry)
             item = {
                 'id': f"{rel_path}:{line_number}:keyword:{entry.get('entry_index', len(items))}",
                 'text': source_text,
                 'file_rel_path': rel_path,
                 'line_number': line_number,
+                'translation_line_number': entry.get('line_number', 0),
             }
             speaker_id = entry.get('speaker_id') or entry.get('speaker')
             if speaker_id:
@@ -1471,19 +1493,34 @@ def build_keyword_chunks(file_jobs, chunk_size=None):
     return chunks
 
 
+def format_keyword_glossary_block():
+    lines = []
+    for term in legacy.PRESERVE_TERMS:
+        if isinstance(term, str) and term.strip():
+            lines.append(f'- Preserve: {term.strip()}')
+    for source, target in (legacy.NORMALIZE_TRANSLATION_MAP or {}).items():
+        if source:
+            lines.append(f'- Existing mapping: {source} -> {target}')
+    for term in sorted(getattr(legacy, 'NON_TRANSLATABLE_EXACT', set()) or []):
+        if isinstance(term, str) and term.strip():
+            lines.append(f'- Non-translatable: {term.strip()}')
+    return '\n'.join(lines) if lines else '(none)'
+
+
 def build_keyword_system_instruction(max_candidates_per_chunk=None):
     max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
-    known_terms = ', '.join(legacy.PRESERVE_TERMS)
     return (
         'Setting:\n'
         f'{BATCH_MACRO_SETTING}\n\n'
+        'Existing glossary entries:\n'
+        f'{format_keyword_glossary_block()}\n\n'
         'Task:\n'
         'Extract glossary or story-memory keyword candidates from Ren\'Py TL source text. '
         'Do not translate full lines. Return only high-value terms, names, places, items, concepts, abilities, '
         'relationship labels, or recurring phrasing that a human may want to add to glossary.json or story_graph.json.\n'
         f'Return at most {max_candidates} candidates for this chunk. '
-        f'Known locked terms: {known_terms or "(none)"}\n'
-        'Avoid generic words, common function words, UI filler, and candidates already covered by locked terms. '
+        'Avoid generic words, common function words, UI filler, and candidates already covered by existing glossary entries. '
+        'Set source_item_ids to the input id values that support the candidate. '
         'Use concise evidence that cites the relevant input id or phrase. Return JSON only.'
     )
 
@@ -1506,7 +1543,7 @@ def build_keyword_user_prompt(target_items):
     return (
         'TARGET LINES:\n'
         f'{target_payload}\n\n'
-        'Return candidate objects with source, suggested_target, category, confidence, and evidence.'
+        'Return candidate objects with source, suggested_target, category, confidence, evidence, and source_item_ids.'
     )
 
 
@@ -1528,6 +1565,10 @@ def build_keyword_response_json_schema(max_candidates_per_chunk=None):
                 },
                 'confidence': {'type': 'number'},
                 'evidence': {'type': 'string'},
+                'source_item_ids': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                },
             },
         },
     }
@@ -1565,7 +1606,7 @@ def build_keyword_request(chunk, max_candidates_per_chunk=None):
     }
 
 
-def create_keyword_package(display_name_override='', skip_prepare=False, chunk_size=None, max_candidates_per_chunk=None):
+def create_keyword_package(display_name_override='', skip_prepare=True, chunk_size=None, max_candidates_per_chunk=None):
     if not skip_prepare:
         legacy.run_prepare_steps()
     if not os.path.isdir(legacy.TL_DIR):
@@ -1583,10 +1624,9 @@ def create_keyword_package(display_name_override='', skip_prepare=False, chunk_s
         print('No keyword chunks built.')
         return None
 
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
     package_name = f'{timestamp}_{guess_project_slug()}_keywords'
-    package_dir = os.path.join(BATCH_JOBS_DIR, package_name)
-    os.makedirs(package_dir, exist_ok=True)
+    package_dir = create_batch_package_dir(package_name)
 
     display_name = display_name_override.strip() if display_name_override else ''
     if not display_name:
@@ -2102,6 +2142,9 @@ def normalize_keyword_candidates(payload):
         category = compact_text(str(item.get('category') or 'other')).lower()
         if category not in KEYWORD_CATEGORIES:
             category = 'other'
+        raw_source_item_ids = item.get('source_item_ids')
+        if not isinstance(raw_source_item_ids, list):
+            raw_source_item_ids = []
         normalized.append(
             {
                 'source': source,
@@ -2109,6 +2152,7 @@ def normalize_keyword_candidates(payload):
                 'category': category,
                 'confidence': coerce_keyword_confidence(item.get('confidence')),
                 'evidence': compact_text(str(item.get('evidence') or '')),
+                'source_item_ids': [str(value) for value in raw_source_item_ids if str(value).strip()],
             }
         )
     return normalized
@@ -2148,6 +2192,59 @@ def resolve_keyword_export_path(manifest, value, default_name, field_name):
     return os.path.join(package_dir, default_name)
 
 
+def validate_keyword_export_paths(manifest, jsonl_path, markdown_path):
+    normalized_jsonl = _normalized_abs_path(jsonl_path)
+    normalized_markdown = _normalized_abs_path(markdown_path)
+    if normalized_jsonl == normalized_markdown:
+        raise SystemExit('Keyword export JSONL and Markdown outputs must be different files.')
+
+    reserved_paths = {
+        os.path.join(manifest.get('_package_dir', ''), 'manifest.json'),
+        os.path.join(manifest.get('_package_dir', ''), 'requests.jsonl'),
+        os.path.join(manifest.get('_package_dir', ''), 'results.jsonl'),
+        os.path.join(manifest.get('_package_dir', ''), 'failures.jsonl'),
+    }
+    for manifest_key in ('_manifest_path', 'input_jsonl_path', 'result_jsonl_path'):
+        value = manifest.get(manifest_key)
+        if value:
+            reserved_paths.add(value)
+    normalized_reserved = {_normalized_abs_path(path) for path in reserved_paths if path}
+    for output_path in (jsonl_path, markdown_path):
+        if _normalized_abs_path(output_path) in normalized_reserved:
+            raise SystemExit(f'Keyword export output would overwrite reserved package file: {output_path}')
+
+
+def match_keyword_candidate_items(candidate, chunk):
+    items = chunk.get('items') or []
+    requested_ids = {str(value) for value in candidate.get('source_item_ids') or [] if str(value).strip()}
+    evidence = compact_text(candidate.get('evidence', '')).lower()
+    source = compact_text(candidate.get('source', '')).lower()
+    matched = []
+
+    for item in items:
+        item_id = str(item.get('id') or '')
+        item_text = compact_text(item.get('text', '')).lower()
+        if item_id and item_id in requested_ids:
+            matched.append(item)
+            continue
+        if item_id and evidence and item_id.lower() in evidence:
+            matched.append(item)
+            continue
+        if source and item_text and source in item_text:
+            matched.append(item)
+
+    deduped = []
+    seen = set()
+    for item in matched:
+        item_id = item.get('id')
+        key = item_id or (item.get('line_number'), item.get('text'))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
 def markdown_escape_cell(value):
     return compact_text(str(value or '')).replace('|', '\\|').replace('\n', ' ')
 
@@ -2157,7 +2254,9 @@ def write_keyword_markdown(path, candidates, summary):
         '# Keyword Candidates',
         '',
         f"- Candidate count: {len(candidates)}",
-        f"- Parsed chunks: {summary.get('parsed_chunks', 0)}/{summary.get('result_rows', 0)}",
+        f"- Parsed chunks: {summary.get('parsed_chunks', 0)}/{summary.get('expected_chunks', summary.get('result_rows', 0))}",
+        f"- Missing chunk rows: {summary.get('missing_chunk_rows', 0)}",
+        f"- Ambiguous provenance candidates: {summary.get('ambiguous_provenance_candidates', 0)}",
         '',
         '| Source | Suggested target | Category | Confidence | Evidence | Files |',
         '| --- | --- | --- | ---: | --- | --- |',
@@ -2190,14 +2289,20 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
         raise SystemExit('Result JSONL not found. Run download first.')
 
     chunk_map = {chunk['key']: chunk for chunk in manifest.get('chunks', [])}
+    processed_keys = set()
     merged_candidates = {}
     summary = {
+        'expected_chunks': len(chunk_map),
         'result_rows': 0,
+        'processed_chunks': 0,
         'parsed_chunks': 0,
         'candidate_count_raw': 0,
         'candidate_count_deduped': 0,
         'chunk_row_errors': 0,
         'unknown_chunk_keys': 0,
+        'missing_response_chunks': 0,
+        'missing_chunk_rows': 0,
+        'ambiguous_provenance_candidates': 0,
         'parse_errors': 0,
         'reason_counts': {},
     }
@@ -2220,6 +2325,7 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
                 summary['unknown_chunk_keys'] += 1
                 bump_counter(summary['reason_counts'], 'unknown_chunk_key')
                 continue
+            processed_keys.add(key)
             if row.get('error'):
                 summary['chunk_row_errors'] += 1
                 bump_counter(summary['reason_counts'], 'row_error')
@@ -2227,6 +2333,7 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
             response_text = extract_text_from_response_payload(row.get('response', {}))
             if not response_text:
                 summary['parse_errors'] += 1
+                summary['missing_response_chunks'] += 1
                 bump_counter(summary['reason_counts'], 'missing_response_text')
                 continue
             try:
@@ -2238,14 +2345,19 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
 
             summary['parsed_chunks'] += 1
             summary['candidate_count_raw'] += len(candidates)
-            source_files = [chunk.get('file_rel_path', '')] if chunk.get('file_rel_path') else []
-            source_lines = sorted({line_no for line_no in (chunk.get('line_numbers') or []) if line_no})
-            source_item_ids = [item.get('id') for item in chunk.get('items') or [] if item.get('id')]
             for candidate in candidates:
+                matched_items = match_keyword_candidate_items(candidate, chunk)
+                if not matched_items:
+                    summary['ambiguous_provenance_candidates'] += 1
+                    bump_counter(summary['reason_counts'], 'ambiguous_candidate_provenance')
                 enriched = dict(candidate)
-                enriched['source_files'] = source_files
-                enriched['source_lines'] = source_lines
-                enriched['source_item_ids'] = source_item_ids
+                enriched['source_files'] = [chunk.get('file_rel_path', '')] if chunk.get('file_rel_path') else []
+                enriched['source_lines'] = sorted(
+                    {item.get('line_number', 0) for item in matched_items if item.get('line_number')}
+                )
+                enriched['source_item_ids'] = [
+                    item.get('id') for item in matched_items if item.get('id')
+                ]
                 enriched['evidence_items'] = [candidate['evidence']] if candidate.get('evidence') else []
                 enriched['occurrences'] = 1
                 key_tuple = keyword_candidate_key(enriched)
@@ -2253,6 +2365,12 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
                     merge_keyword_candidate(merged_candidates[key_tuple], enriched)
                 else:
                     merged_candidates[key_tuple] = enriched
+
+    missing_keys = set(chunk_map.keys()) - processed_keys
+    if missing_keys:
+        summary['missing_chunk_rows'] = len(missing_keys)
+        bump_counter(summary['reason_counts'], 'missing_chunk_rows', len(missing_keys))
+    summary['processed_chunks'] = len(processed_keys)
 
     candidates = sorted(
         merged_candidates.values(),
@@ -2262,6 +2380,9 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
 
     jsonl_path = resolve_keyword_export_path(manifest, output_jsonl, 'keyword_candidates.jsonl', 'keyword JSONL output')
     markdown_path = resolve_keyword_export_path(manifest, output_markdown, 'keyword_candidates.md', 'keyword Markdown output')
+    validate_keyword_export_paths(manifest, jsonl_path, markdown_path)
+    os.makedirs(os.path.dirname(jsonl_path), exist_ok=True)
+    os.makedirs(os.path.dirname(markdown_path), exist_ok=True)
     with open(jsonl_path, 'w', encoding='utf-8') as handle:
         for candidate in candidates:
             serializable = dict(candidate)
@@ -3033,6 +3154,7 @@ def collect_translation_entries_from_lines(lines):
                     )
                     entry = {
                         'line_number': next_index + 1,
+                        'source_line_number': index + 1,
                         'source': comment_match.group('text'),
                         'translation': token['text'],
                         'start': token['start'],
@@ -3059,6 +3181,7 @@ def collect_translation_entries_from_lines(lines):
                         entries.append(
                             {
                                 'line_number': next_index + 1,
+                                'source_line_number': index + 1,
                                 'source': old_match.group('text'),
                                 'translation': token['text'],
                                 'start': token['start'],
@@ -3089,6 +3212,7 @@ def collect_repair_entries_from_lines(lines):
         entries.append(
             {
                 'line_number': span[0],
+                'source_line_number': span[0],
                 'source': task.get('text', ''),
                 'translation': task.get('text', ''),
                 'start': task.get('start', 0),
@@ -4089,7 +4213,12 @@ def build_arg_parser():
     keyword_build_parser.add_argument(
         '--skip-prepare',
         action='store_true',
-        help='Skip auto prepare steps before collecting keyword sources.',
+        help='Compatibility no-op; keyword builds skip prepare by default.',
+    )
+    keyword_build_parser.add_argument(
+        '--prepare',
+        action='store_true',
+        help='Run auto prepare steps before collecting keyword sources.',
     )
     keyword_build_parser.add_argument(
         '--chunk-size',
@@ -4254,7 +4383,7 @@ def main(argv=None):
     if command == 'build-keywords':
         create_keyword_package(
             display_name_override=args.display_name,
-            skip_prepare=args.skip_prepare,
+            skip_prepare=(not args.prepare) or args.skip_prepare,
             chunk_size=args.chunk_size,
             max_candidates_per_chunk=args.max_candidates_per_chunk,
         )

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -73,6 +73,11 @@ BATCH_TEMPERATURE = 0.2
 BATCH_THINKING_LEVEL = 'minimal'
 BATCH_DISPLAY_NAME_PREFIX = 'renpy-translate'
 BATCH_MACRO_SETTING = ''
+MANIFEST_MODE_TRANSLATION = 'translation'
+MANIFEST_MODE_KEYWORD_EXTRACTION = 'keyword_extraction'
+KEYWORD_DISPLAY_NAME_PREFIX = 'renpy-keywords'
+KEYWORD_CHUNK_SIZE = 40
+KEYWORD_MAX_CANDIDATES_PER_CHUNK = 12
 
 RAG_ENABLED = False
 RAG_STORE_DIR = ''
@@ -165,6 +170,7 @@ def load_batch_settings():
     global BATCH_MODEL, BATCH_TARGET_SIZE, BATCH_CONTEXT_BEFORE, BATCH_CONTEXT_AFTER
     global BATCH_MAX_OUTPUT_TOKENS, BATCH_TEMPERATURE, BATCH_THINKING_LEVEL
     global BATCH_DISPLAY_NAME_PREFIX, BATCH_MACRO_SETTING
+    global KEYWORD_DISPLAY_NAME_PREFIX, KEYWORD_CHUNK_SIZE, KEYWORD_MAX_CANDIDATES_PER_CHUNK
     global RAG_ENABLED, RAG_STORE_DIR, RAG_EMBEDDING_MODEL, RAG_QUERY_TASK_TYPE
     global RAG_DOCUMENT_TASK_TYPE, RAG_OUTPUT_DIMENSIONALITY, RAG_TOP_K_HISTORY
     global RAG_TOP_K_TERMS, RAG_MIN_SIMILARITY, RAG_SEGMENT_LINES
@@ -227,6 +233,21 @@ def load_batch_settings():
         batch.get('thinking_level'),
         BATCH_THINKING_LEVEL,
     )
+
+    keyword_config = batch.get('keyword_extraction')
+    if not isinstance(keyword_config, dict):
+        keyword_config = {}
+    KEYWORD_CHUNK_SIZE = coerce_positive_int(
+        keyword_config.get('chunk_size'),
+        KEYWORD_CHUNK_SIZE,
+    )
+    KEYWORD_MAX_CANDIDATES_PER_CHUNK = coerce_positive_int(
+        keyword_config.get('max_candidates_per_chunk'),
+        KEYWORD_MAX_CANDIDATES_PER_CHUNK,
+    )
+    display_name_prefix = keyword_config.get('display_name_prefix')
+    if isinstance(display_name_prefix, str) and display_name_prefix.strip():
+        KEYWORD_DISPLAY_NAME_PREFIX = display_name_prefix.strip()
 
     macro_setting_file = batch.get('macro_setting_file')
     if macro_setting_file:
@@ -728,6 +749,20 @@ def load_manifest(target=None):
     return manifest
 
 
+def manifest_mode(manifest):
+    mode = manifest.get('mode', MANIFEST_MODE_TRANSLATION)
+    return mode if isinstance(mode, str) and mode.strip() else MANIFEST_MODE_TRANSLATION
+
+
+def require_manifest_mode(manifest, expected_mode, command_name):
+    current_mode = manifest_mode(manifest)
+    if current_mode != expected_mode:
+        raise SystemExit(
+            f'{command_name} only supports {expected_mode} manifests; '
+            f'this manifest is {current_mode}.'
+        )
+
+
 def _normalized_abs_path(path):
     return os.path.normcase(os.path.abspath(path))
 
@@ -830,6 +865,9 @@ def summarize_files_for_chunks(chunks):
 
 
 def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
+    if source_manifest.get('keyword_settings'):
+        part_manifest['keyword_settings'] = dict(source_manifest.get('keyword_settings') or {})
+
     for key in ('rag_enabled', 'rag_store_path', 'rag_settings'):
         if key in source_manifest:
             part_manifest[key] = source_manifest[key]
@@ -1287,6 +1325,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
 
     manifest = {
         'version': 1,
+        'mode': MANIFEST_MODE_TRANSLATION,
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
         'batch_model': BATCH_MODEL,
@@ -1363,6 +1402,254 @@ def create_batch_package(display_name_override='', skip_prepare=False):
 
 
 
+def should_include_keyword_source(text):
+    if not isinstance(text, str):
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+    return any(ch.isalnum() or '\u4e00' <= ch <= '\u9fff' for ch in stripped)
+
+
+def collect_keyword_file_jobs():
+    jobs = []
+    for rel_path, file_path in collect_files_to_process():
+        with open(file_path, 'r', encoding='utf-8-sig') as handle:
+            entries = collect_repair_entries_from_lines(handle.readlines())
+
+        items = []
+        for entry in entries:
+            source_text = str(entry.get('source') or '').strip()
+            if not should_include_keyword_source(source_text):
+                continue
+            try:
+                line_number = int(entry.get('line_number'))
+            except (TypeError, ValueError):
+                line_number = 0
+            item = {
+                'id': f"{rel_path}:{line_number}:keyword:{entry.get('entry_index', len(items))}",
+                'text': source_text,
+                'file_rel_path': rel_path,
+                'line_number': line_number,
+            }
+            speaker_id = entry.get('speaker_id') or entry.get('speaker')
+            if speaker_id:
+                item['speaker_id'] = speaker_id
+            items.append(item)
+
+        if items:
+            jobs.append(
+                {
+                    'file_rel_path': rel_path,
+                    'file_path': file_path,
+                    'task_count': len(items),
+                    'items': items,
+                }
+            )
+    return jobs
+
+
+def build_keyword_chunks(file_jobs, chunk_size=None):
+    chunk_size = max(1, int(chunk_size or KEYWORD_CHUNK_SIZE))
+    chunks = []
+    for job in file_jobs:
+        items = job['items']
+        for start in range(0, len(items), chunk_size):
+            target_items = items[start:start + chunk_size]
+            chunk_number = start // chunk_size + 1
+            chunks.append(
+                {
+                    'key': f"kw-{hash_key(job['file_rel_path'])}-{chunk_number:05d}",
+                    'mode': MANIFEST_MODE_KEYWORD_EXTRACTION,
+                    'file_rel_path': job['file_rel_path'],
+                    'file_path': job['file_path'],
+                    'chunk_index': chunk_number,
+                    'line_numbers': [item.get('line_number', 0) for item in target_items],
+                    'items': target_items,
+                }
+            )
+    return chunks
+
+
+def build_keyword_system_instruction(max_candidates_per_chunk=None):
+    max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
+    known_terms = ', '.join(legacy.PRESERVE_TERMS)
+    return (
+        'Setting:\n'
+        f'{BATCH_MACRO_SETTING}\n\n'
+        'Task:\n'
+        'Extract glossary or story-memory keyword candidates from Ren\'Py TL source text. '
+        'Do not translate full lines. Return only high-value terms, names, places, items, concepts, abilities, '
+        'relationship labels, or recurring phrasing that a human may want to add to glossary.json or story_graph.json.\n'
+        f'Return at most {max_candidates} candidates for this chunk. '
+        f'Known locked terms: {known_terms or "(none)"}\n'
+        'Avoid generic words, common function words, UI filler, and candidates already covered by locked terms. '
+        'Use concise evidence that cites the relevant input id or phrase. Return JSON only.'
+    )
+
+
+def build_keyword_user_prompt(target_items):
+    target_payload = json.dumps(
+        [
+            {
+                'id': item['id'],
+                'file': item.get('file_rel_path', ''),
+                'line': item.get('line_number', 0),
+                'speaker_id': item.get('speaker_id', ''),
+                'text': item['text'],
+            }
+            for item in target_items
+        ],
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+    return (
+        'TARGET LINES:\n'
+        f'{target_payload}\n\n'
+        'Return candidate objects with source, suggested_target, category, confidence, and evidence.'
+    )
+
+
+def build_keyword_response_json_schema(max_candidates_per_chunk=None):
+    max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
+    return {
+        'type': 'array',
+        'maxItems': max_candidates,
+        'items': {
+            'type': 'object',
+            'required': ['source', 'suggested_target', 'category', 'confidence', 'evidence'],
+            'additionalProperties': False,
+            'properties': {
+                'source': {'type': 'string'},
+                'suggested_target': {'type': 'string'},
+                'category': {
+                    'type': 'string',
+                    'enum': ['term', 'character', 'place', 'item', 'ability', 'concept', 'relationship', 'style', 'other'],
+                },
+                'confidence': {'type': 'number'},
+                'evidence': {'type': 'string'},
+            },
+        },
+    }
+
+
+def build_keyword_generation_config(max_candidates_per_chunk=None):
+    config = {
+        'temperature': BATCH_TEMPERATURE,
+        'max_output_tokens': BATCH_MAX_OUTPUT_TOKENS,
+        'response_mime_type': 'application/json',
+        'response_json_schema': build_keyword_response_json_schema(max_candidates_per_chunk),
+    }
+    if BATCH_THINKING_LEVEL and BATCH_MODEL.startswith('gemini-3'):
+        config['thinking_config'] = {
+            'thinking_level': BATCH_THINKING_LEVEL.upper(),
+        }
+    return config
+
+
+def build_keyword_request(chunk, max_candidates_per_chunk=None):
+    return {
+        'key': chunk['key'],
+        'request': {
+            'system_instruction': {
+                'parts': [{'text': build_keyword_system_instruction(max_candidates_per_chunk)}],
+            },
+            'contents': [
+                {
+                    'role': 'user',
+                    'parts': [{'text': build_keyword_user_prompt(chunk['items'])}],
+                }
+            ],
+            'generation_config': build_keyword_generation_config(max_candidates_per_chunk),
+        },
+    }
+
+
+def create_keyword_package(display_name_override='', skip_prepare=False, chunk_size=None, max_candidates_per_chunk=None):
+    if not skip_prepare:
+        legacy.run_prepare_steps()
+    if not os.path.isdir(legacy.TL_DIR):
+        raise SystemExit(f'TL dir does not exist: {legacy.TL_DIR}')
+
+    file_jobs = collect_keyword_file_jobs()
+    if not file_jobs:
+        print('No keyword source lines found.')
+        return None
+
+    chunk_size = max(1, int(chunk_size or KEYWORD_CHUNK_SIZE))
+    max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
+    chunks = build_keyword_chunks(file_jobs, chunk_size=chunk_size)
+    if not chunks:
+        print('No keyword chunks built.')
+        return None
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    package_name = f'{timestamp}_{guess_project_slug()}_keywords'
+    package_dir = os.path.join(BATCH_JOBS_DIR, package_name)
+    os.makedirs(package_dir, exist_ok=True)
+
+    display_name = display_name_override.strip() if display_name_override else ''
+    if not display_name:
+        display_name = f'{KEYWORD_DISPLAY_NAME_PREFIX}-{guess_project_slug()}-{timestamp}'
+
+    input_jsonl_path = os.path.join(package_dir, 'requests.jsonl')
+    with open(input_jsonl_path, 'w', encoding='utf-8') as handle:
+        for chunk in chunks:
+            handle.write(json.dumps(build_keyword_request(chunk, max_candidates), ensure_ascii=False) + '\n')
+
+    manifest = {
+        'version': 1,
+        'mode': MANIFEST_MODE_KEYWORD_EXTRACTION,
+        'created_at': datetime.now().isoformat(timespec='seconds'),
+        'display_name': display_name,
+        'batch_model': BATCH_MODEL,
+        'base_dir': legacy.BASE_DIR,
+        'tl_dir': legacy.TL_DIR,
+        'input_jsonl_path': input_jsonl_path,
+        'result_jsonl_path': '',
+        'job_name': '',
+        'job_state': 'LOCAL_ONLY',
+        'uploaded_file_name': '',
+        'result_file_name': '',
+        'settings': {
+            'keyword_chunk_size': chunk_size,
+            'keyword_max_candidates_per_chunk': max_candidates,
+            'max_output_tokens': BATCH_MAX_OUTPUT_TOKENS,
+            'temperature': BATCH_TEMPERATURE,
+            'thinking_level': BATCH_THINKING_LEVEL,
+        },
+        'keyword_settings': {
+            'chunk_size': chunk_size,
+            'max_candidates_per_chunk': max_candidates,
+        },
+        'summary': {
+            'file_count': len(file_jobs),
+            'chunk_count': len(chunks),
+            'item_count': sum(len(chunk['items']) for chunk in chunks),
+        },
+        'files': {
+            job['file_rel_path']: {
+                'path': job['file_path'],
+                'task_count': job['task_count'],
+            }
+            for job in file_jobs
+        },
+        'chunks': chunks,
+    }
+
+    manifest_path = os.path.join(package_dir, 'manifest.json')
+    with open(manifest_path, 'w', encoding='utf-8') as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2)
+    remember_latest_manifest(manifest_path)
+
+    print(f'Created keyword package: {package_dir}')
+    print(f"Source files: {manifest['summary']['file_count']}")
+    print(f"Chunks: {manifest['summary']['chunk_count']}")
+    print(f"Source lines: {manifest['summary']['item_count']}")
+    print('Mode: keyword_extraction')
+    return manifest_path
+
+
 def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix=''):
     manifest = load_manifest(target)
     chunks = manifest.get('chunks') or []
@@ -1425,6 +1712,7 @@ def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix
         part_files = summarize_files_for_chunks(part_chunks)
         part_manifest = {
             'version': manifest.get('version', 1),
+            'mode': manifest_mode(manifest),
             'created_at': now,
             'display_name': f'{part_name_prefix}-part{index:02d}',
             'batch_model': manifest.get('batch_model', BATCH_MODEL),
@@ -1777,6 +2065,226 @@ def normalize_result_items(payload):
             continue
         normalized.append({'id': str(item_id), 'translation': str(translation)})
     return normalized
+
+
+KEYWORD_CATEGORIES = {'term', 'character', 'place', 'item', 'ability', 'concept', 'relationship', 'style', 'other'}
+
+
+def coerce_keyword_confidence(value):
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not confidence == confidence:
+        return 0.0
+    return max(0.0, min(confidence, 1.0))
+
+
+def normalize_keyword_candidates(payload):
+    data = payload
+    if isinstance(data, dict):
+        if isinstance(data.get('candidates'), list):
+            data = data['candidates']
+        elif isinstance(data.get('items'), list):
+            data = data['items']
+        elif isinstance(data.get('keywords'), list):
+            data = data['keywords']
+    if not isinstance(data, list):
+        raise ValueError(f'Response JSON is not a candidate list: {type(data)}')
+
+    normalized = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        source = compact_text(str(item.get('source') or ''))
+        if not source:
+            continue
+        category = compact_text(str(item.get('category') or 'other')).lower()
+        if category not in KEYWORD_CATEGORIES:
+            category = 'other'
+        normalized.append(
+            {
+                'source': source,
+                'suggested_target': compact_text(str(item.get('suggested_target') or '')),
+                'category': category,
+                'confidence': coerce_keyword_confidence(item.get('confidence')),
+                'evidence': compact_text(str(item.get('evidence') or '')),
+            }
+        )
+    return normalized
+
+
+def keyword_candidate_key(candidate):
+    return (
+        compact_text(candidate.get('source', '')).lower(),
+        compact_text(candidate.get('suggested_target', '')).lower(),
+        compact_text(candidate.get('category', '')).lower(),
+    )
+
+
+def merge_keyword_candidate(existing, incoming):
+    existing['confidence'] = max(existing.get('confidence', 0.0), incoming.get('confidence', 0.0))
+    for field in ('source_files', 'source_item_ids', 'source_lines'):
+        values = list(existing.get(field) or [])
+        for value in incoming.get(field) or []:
+            if value not in values:
+                values.append(value)
+        existing[field] = values
+    evidence_values = list(existing.get('evidence_items') or [])
+    evidence = incoming.get('evidence')
+    if evidence and evidence not in evidence_values:
+        evidence_values.append(evidence)
+    existing['evidence_items'] = evidence_values
+    if evidence_values:
+        existing['evidence'] = ' / '.join(evidence_values[:3])
+    existing['occurrences'] = int(existing.get('occurrences', 1)) + int(incoming.get('occurrences', 1))
+    return existing
+
+
+def resolve_keyword_export_path(manifest, value, default_name, field_name):
+    package_dir = manifest.get('_package_dir')
+    if value:
+        return resolve_path_under_dir(package_dir, value, field_name)
+    return os.path.join(package_dir, default_name)
+
+
+def markdown_escape_cell(value):
+    return compact_text(str(value or '')).replace('|', '\\|').replace('\n', ' ')
+
+
+def write_keyword_markdown(path, candidates, summary):
+    lines = [
+        '# Keyword Candidates',
+        '',
+        f"- Candidate count: {len(candidates)}",
+        f"- Parsed chunks: {summary.get('parsed_chunks', 0)}/{summary.get('result_rows', 0)}",
+        '',
+        '| Source | Suggested target | Category | Confidence | Evidence | Files |',
+        '| --- | --- | --- | ---: | --- | --- |',
+    ]
+    for candidate in candidates:
+        files = ', '.join(candidate.get('source_files') or [])
+        lines.append(
+            '| '
+            + ' | '.join(
+                [
+                    markdown_escape_cell(candidate.get('source')),
+                    markdown_escape_cell(candidate.get('suggested_target')),
+                    markdown_escape_cell(candidate.get('category')),
+                    f"{candidate.get('confidence', 0.0):.2f}",
+                    markdown_escape_cell(candidate.get('evidence')),
+                    markdown_escape_cell(files),
+                ]
+            )
+            + ' |'
+        )
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write('\n'.join(lines) + '\n')
+
+
+def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
+    manifest = load_manifest(target)
+    require_manifest_mode(manifest, MANIFEST_MODE_KEYWORD_EXTRACTION, 'export-keywords')
+    result_path = resolve_manifest_result_path(manifest)
+    if not os.path.isfile(result_path):
+        raise SystemExit('Result JSONL not found. Run download first.')
+
+    chunk_map = {chunk['key']: chunk for chunk in manifest.get('chunks', [])}
+    merged_candidates = {}
+    summary = {
+        'result_rows': 0,
+        'parsed_chunks': 0,
+        'candidate_count_raw': 0,
+        'candidate_count_deduped': 0,
+        'chunk_row_errors': 0,
+        'unknown_chunk_keys': 0,
+        'parse_errors': 0,
+        'reason_counts': {},
+    }
+
+    with open(result_path, 'r', encoding='utf-8') as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            summary['result_rows'] += 1
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                summary['chunk_row_errors'] += 1
+                bump_counter(summary['reason_counts'], 'invalid_result_jsonl_row')
+                continue
+            key = row.get('key')
+            chunk = chunk_map.get(key)
+            if not chunk:
+                summary['unknown_chunk_keys'] += 1
+                bump_counter(summary['reason_counts'], 'unknown_chunk_key')
+                continue
+            if row.get('error'):
+                summary['chunk_row_errors'] += 1
+                bump_counter(summary['reason_counts'], 'row_error')
+                continue
+            response_text = extract_text_from_response_payload(row.get('response', {}))
+            if not response_text:
+                summary['parse_errors'] += 1
+                bump_counter(summary['reason_counts'], 'missing_response_text')
+                continue
+            try:
+                candidates = normalize_keyword_candidates(parse_json_payload(response_text))
+            except Exception:
+                summary['parse_errors'] += 1
+                bump_counter(summary['reason_counts'], 'failed_to_parse_keyword_json')
+                continue
+
+            summary['parsed_chunks'] += 1
+            summary['candidate_count_raw'] += len(candidates)
+            source_files = [chunk.get('file_rel_path', '')] if chunk.get('file_rel_path') else []
+            source_lines = sorted({line_no for line_no in (chunk.get('line_numbers') or []) if line_no})
+            source_item_ids = [item.get('id') for item in chunk.get('items') or [] if item.get('id')]
+            for candidate in candidates:
+                enriched = dict(candidate)
+                enriched['source_files'] = source_files
+                enriched['source_lines'] = source_lines
+                enriched['source_item_ids'] = source_item_ids
+                enriched['evidence_items'] = [candidate['evidence']] if candidate.get('evidence') else []
+                enriched['occurrences'] = 1
+                key_tuple = keyword_candidate_key(enriched)
+                if key_tuple in merged_candidates:
+                    merge_keyword_candidate(merged_candidates[key_tuple], enriched)
+                else:
+                    merged_candidates[key_tuple] = enriched
+
+    candidates = sorted(
+        merged_candidates.values(),
+        key=lambda item: (-item.get('confidence', 0.0), item.get('category', ''), item.get('source', '').lower()),
+    )
+    summary['candidate_count_deduped'] = len(candidates)
+
+    jsonl_path = resolve_keyword_export_path(manifest, output_jsonl, 'keyword_candidates.jsonl', 'keyword JSONL output')
+    markdown_path = resolve_keyword_export_path(manifest, output_markdown, 'keyword_candidates.md', 'keyword Markdown output')
+    with open(jsonl_path, 'w', encoding='utf-8') as handle:
+        for candidate in candidates:
+            serializable = dict(candidate)
+            serializable.pop('evidence_items', None)
+            handle.write(json.dumps(serializable, ensure_ascii=False) + '\n')
+    write_keyword_markdown(markdown_path, candidates, summary)
+
+    manifest['keyword_exported_at'] = datetime.now().isoformat(timespec='seconds')
+    manifest['keyword_export'] = {
+        'jsonl_path': jsonl_path,
+        'markdown_path': markdown_path,
+        'summary': summary,
+    }
+    save_manifest(manifest)
+
+    print(f'Keyword candidates: {summary["candidate_count_deduped"]} deduped from {summary["candidate_count_raw"]} raw')
+    print(f'JSONL: {jsonl_path}')
+    print(f'Markdown: {markdown_path}')
+    if summary.get('reason_counts'):
+        print('Warnings:')
+        for name in sorted(summary['reason_counts']):
+            print(f"- {name}: {summary['reason_counts'][name]}")
+    return manifest['keyword_export']
 
 
 def append_failure_entries(entries, package_dir=''):
@@ -2364,6 +2872,7 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
 
 def check_results(target=None):
     manifest = load_manifest(target)
+    require_manifest_mode(manifest, MANIFEST_MODE_TRANSLATION, 'check')
     _replacements, _translated, _failures, summary = collect_result_actions(manifest, validate_sources=True)
     manifest['last_check_at'] = datetime.now().isoformat(timespec='seconds')
     manifest['last_check_summary'] = summary
@@ -2375,6 +2884,7 @@ def check_results(target=None):
 
 def apply_results(target=None, force=False):
     manifest = load_manifest(target)
+    require_manifest_mode(manifest, MANIFEST_MODE_TRANSLATION, 'apply')
     if manifest.get('applied_at') and not force:
         raise SystemExit('Manifest was already applied. Re-run apply with --force to bypass this guard; source validation still applies.')
 
@@ -3571,6 +4081,29 @@ def build_arg_parser():
         help='Skip auto prepare steps before collecting tasks.',
     )
 
+    keyword_build_parser = subparsers.add_parser(
+        'build-keywords',
+        help='Build a keyword extraction batch package without changing translation files.',
+    )
+    keyword_build_parser.add_argument('--display-name', default='', help='Override Batch display name.')
+    keyword_build_parser.add_argument(
+        '--skip-prepare',
+        action='store_true',
+        help='Skip auto prepare steps before collecting keyword sources.',
+    )
+    keyword_build_parser.add_argument(
+        '--chunk-size',
+        type=int,
+        default=0,
+        help='Source line count per keyword extraction chunk. Defaults to batch.keyword_extraction.chunk_size.',
+    )
+    keyword_build_parser.add_argument(
+        '--max-candidates-per-chunk',
+        type=int,
+        default=0,
+        help='Maximum keyword candidates requested from each chunk.',
+    )
+
     bootstrap_rag_parser = subparsers.add_parser(
         'bootstrap-rag',
         help='Prebuild or refresh the Batch RAG history store from all allowed TL files.',
@@ -3646,6 +4179,19 @@ def build_arg_parser():
         help='Bypass the applied_at guard; source validation still applies.',
     )
 
+    keyword_export_parser = subparsers.add_parser(
+        'export-keywords',
+        help='Export keyword extraction batch results to JSONL and Markdown review files.',
+    )
+    keyword_export_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Keyword manifest path or package dir. Defaults to latest package.',
+    )
+    keyword_export_parser.add_argument('--jsonl', default='', help='Relative output JSONL path inside the package.')
+    keyword_export_parser.add_argument('--markdown', default='', help='Relative output Markdown path inside the package.')
+
     split_parser = subparsers.add_parser('split', help='Split an existing batch package into smaller local packages.')
     split_parser.add_argument(
         'target',
@@ -3705,6 +4251,15 @@ def main(argv=None):
         )
         return
 
+    if command == 'build-keywords':
+        create_keyword_package(
+            display_name_override=args.display_name,
+            skip_prepare=args.skip_prepare,
+            chunk_size=args.chunk_size,
+            max_candidates_per_chunk=args.max_candidates_per_chunk,
+        )
+        return
+
     if command == 'bootstrap-rag':
         bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)
         return
@@ -3740,6 +4295,14 @@ def main(argv=None):
 
     if command == 'apply':
         apply_results(args.target or None, force=args.force)
+        return
+
+    if command == 'export-keywords':
+        export_keyword_candidates(
+            target=args.target or None,
+            output_jsonl=args.jsonl,
+            output_markdown=args.markdown,
+        )
         return
 
     if command == 'split':

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1969,6 +1969,148 @@ class BatchRepairRegressionTests(unittest.TestCase):
             self.assertEqual(first_child['story_memory_summary']['truncated_story_blocks'], 0)
             self.assertGreater(first_child['story_memory_summary']['formatted_char_count'], 0)
 
+    def test_create_keyword_package_uses_keyword_mode_manifest(self):
+        old_values = {
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'log_dir': batch_mod.LOG_DIR,
+            'jobs_dir': batch_mod.BATCH_JOBS_DIR,
+            'repair_dir': batch_mod.REPAIR_RUNS_DIR,
+            'latest': batch_mod.LATEST_MANIFEST_FILE,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / 'tl'
+                jobs_dir = root / 'batch_jobs'
+                tl_dir.mkdir()
+                target_file = tl_dir / 'script.rpy'
+                target_file.write_text(
+                    'translate schinese start:\n'
+                    '    old "Void Gate"\n'
+                    '    new "虚空门"\n'
+                    'label demo:\n'
+                    '    e "Aether Compass"\n',
+                    encoding='utf-8',
+                )
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.LOG_DIR = str(root / 'logs')
+                batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+                batch_mod.REPAIR_RUNS_DIR = str(root / 'repair_runs')
+                batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
+
+                manifest_path = batch_mod.create_keyword_package(
+                    skip_prepare=True,
+                    chunk_size=1,
+                    max_candidates_per_chunk=3,
+                )
+                manifest = json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+                request_rows = [
+                    json.loads(line)
+                    for line in Path(manifest['input_jsonl_path']).read_text(encoding='utf-8').splitlines()
+                ]
+        finally:
+            batch_mod.legacy.TL_DIR = old_values['tl_dir']
+            batch_mod.LOG_DIR = old_values['log_dir']
+            batch_mod.BATCH_JOBS_DIR = old_values['jobs_dir']
+            batch_mod.REPAIR_RUNS_DIR = old_values['repair_dir']
+            batch_mod.LATEST_MANIFEST_FILE = old_values['latest']
+
+        self.assertEqual(manifest['mode'], batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION)
+        self.assertEqual(manifest['summary']['item_count'], 2)
+        self.assertEqual(manifest['summary']['chunk_count'], 2)
+        self.assertEqual(request_rows[0]['request']['generation_config']['response_json_schema']['maxItems'], 3)
+        self.assertIn('source', request_rows[0]['request']['generation_config']['response_json_schema']['items']['required'])
+
+    def test_export_keyword_candidates_dedupes_jsonl_and_markdown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [
+                    {
+                        'source': 'Void Gate',
+                        'suggested_target': '虚空门',
+                        'category': 'term',
+                        'confidence': 0.7,
+                        'evidence': 'script.rpy:2',
+                    },
+                    {
+                        'source': 'Void Gate',
+                        'suggested_target': '虚空门',
+                        'category': 'term',
+                        'confidence': 0.9,
+                        'evidence': 'script.rpy:3',
+                    },
+                ],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'kw-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'mode': batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION,
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'kw-1',
+                                'file_rel_path': 'script.rpy',
+                                'line_numbers': [2, 3],
+                                'items': [
+                                    {'id': 'script.rpy:2:keyword:0'},
+                                    {'id': 'script.rpy:3:keyword:1'},
+                                ],
+                            },
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            export = batch_mod.export_keyword_candidates(str(manifest_path))
+            jsonl_path = Path(export['jsonl_path'])
+            markdown_path = Path(export['markdown_path'])
+            rows = [
+                json.loads(line)
+                for line in jsonl_path.read_text(encoding='utf-8').splitlines()
+            ]
+            markdown_text = markdown_path.read_text(encoding='utf-8')
+
+        self.assertEqual(export['summary']['candidate_count_raw'], 2)
+        self.assertEqual(export['summary']['candidate_count_deduped'], 1)
+        self.assertEqual(rows[0]['source'], 'Void Gate')
+        self.assertEqual(rows[0]['confidence'], 0.9)
+        self.assertEqual(rows[0]['occurrences'], 2)
+        self.assertIn('Void Gate', markdown_text)
+
+    def test_check_and_apply_reject_keyword_manifests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / 'manifest.json'
+            manifest_path.write_text(
+                json.dumps({'mode': batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION}),
+                encoding='utf-8',
+            )
+
+            with self.assertRaisesRegex(SystemExit, 'check only supports translation manifests'):
+                batch_mod.check_results(str(manifest_path))
+            with self.assertRaisesRegex(SystemExit, 'apply only supports translation manifests'):
+                batch_mod.apply_results(str(manifest_path))
+
     def test_collect_result_actions_ignores_duplicate_result_ids(self):
         with tempfile.TemporaryDirectory() as tmp:
             package_dir = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1998,11 +1998,11 @@ class BatchRepairRegressionTests(unittest.TestCase):
                 batch_mod.REPAIR_RUNS_DIR = str(root / 'repair_runs')
                 batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
 
-                manifest_path = batch_mod.create_keyword_package(
-                    skip_prepare=True,
-                    chunk_size=1,
-                    max_candidates_per_chunk=3,
-                )
+                with mock.patch.object(batch_mod.legacy, 'run_prepare_steps') as prepare_mock:
+                    manifest_path = batch_mod.create_keyword_package(
+                        chunk_size=1,
+                        max_candidates_per_chunk=3,
+                    )
                 manifest = json.loads(Path(manifest_path).read_text(encoding='utf-8'))
                 request_rows = [
                     json.loads(line)
@@ -2018,8 +2018,12 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(manifest['mode'], batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION)
         self.assertEqual(manifest['summary']['item_count'], 2)
         self.assertEqual(manifest['summary']['chunk_count'], 2)
+        self.assertEqual(manifest['chunks'][0]['items'][0]['line_number'], 2)
+        prepare_mock.assert_not_called()
         self.assertEqual(request_rows[0]['request']['generation_config']['response_json_schema']['maxItems'], 3)
         self.assertIn('source', request_rows[0]['request']['generation_config']['response_json_schema']['items']['required'])
+        self.assertIn('source_item_ids', request_rows[0]['request']['generation_config']['response_json_schema']['items']['properties'])
+        self.assertIn('Existing glossary entries', request_rows[0]['request']['system_instruction']['parts'][0]['text'])
 
     def test_export_keyword_candidates_dedupes_jsonl_and_markdown(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2034,6 +2038,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
                         'category': 'term',
                         'confidence': 0.7,
                         'evidence': 'script.rpy:2',
+                        'source_item_ids': ['script.rpy:2:keyword:0'],
                     },
                     {
                         'source': 'Void Gate',
@@ -2071,8 +2076,28 @@ class BatchRepairRegressionTests(unittest.TestCase):
                                 'file_rel_path': 'script.rpy',
                                 'line_numbers': [2, 3],
                                 'items': [
-                                    {'id': 'script.rpy:2:keyword:0'},
-                                    {'id': 'script.rpy:3:keyword:1'},
+                                    {
+                                        'id': 'script.rpy:2:keyword:0',
+                                        'line_number': 2,
+                                        'text': 'Void Gate',
+                                    },
+                                    {
+                                        'id': 'script.rpy:3:keyword:1',
+                                        'line_number': 3,
+                                        'text': 'Other Term',
+                                    },
+                                ],
+                            },
+                            {
+                                'key': 'kw-2',
+                                'file_rel_path': 'script.rpy',
+                                'line_numbers': [4],
+                                'items': [
+                                    {
+                                        'id': 'script.rpy:4:keyword:2',
+                                        'line_number': 4,
+                                        'text': 'Missing Term',
+                                    },
                                 ],
                             },
                         ],
@@ -2096,7 +2121,65 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(rows[0]['source'], 'Void Gate')
         self.assertEqual(rows[0]['confidence'], 0.9)
         self.assertEqual(rows[0]['occurrences'], 2)
+        self.assertEqual(rows[0]['source_lines'], [2])
+        self.assertEqual(rows[0]['source_item_ids'], ['script.rpy:2:keyword:0'])
+        self.assertEqual(export['summary']['missing_chunk_rows'], 1)
         self.assertIn('Void Gate', markdown_text)
+
+    def test_export_keyword_candidates_rejects_reserved_output_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'kw-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': '[]'}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'mode': batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION,
+                        'input_jsonl_path': str(package_dir / 'requests.jsonl'),
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [{'key': 'kw-1', 'file_rel_path': 'script.rpy', 'items': []}],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with self.assertRaisesRegex(SystemExit, 'reserved package file'):
+                batch_mod.export_keyword_candidates(str(manifest_path), output_jsonl='results.jsonl')
+            with self.assertRaisesRegex(SystemExit, 'must be different files'):
+                batch_mod.export_keyword_candidates(
+                    str(manifest_path),
+                    output_jsonl='same.jsonl',
+                    output_markdown='same.jsonl',
+                )
+
+    def test_create_batch_package_dir_avoids_existing_directory(self):
+        old_jobs_dir = batch_mod.BATCH_JOBS_DIR
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                batch_mod.BATCH_JOBS_DIR = tmp
+                first = batch_mod.create_batch_package_dir('same_package')
+                second = batch_mod.create_batch_package_dir('same_package')
+                self.assertNotEqual(first, second)
+                self.assertTrue(Path(first).is_dir())
+                self.assertTrue(Path(second).is_dir())
+        finally:
+            batch_mod.BATCH_JOBS_DIR = old_jobs_dir
 
     def test_check_and_apply_reject_keyword_manifests(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Adds a narrow keyword extraction MVP for issue #26 without changing the default translation flow.

- adds `build-keywords` to create a `keyword_extraction` Batch manifest from existing TL text
- adds `export-keywords` to dedupe downloaded candidates into JSONL and Markdown review files
- tags normal translation manifests with `mode=translation` and rejects keyword manifests in `check` / `apply`
- documents the keyword workflow and keeps it report-only: it does not write to `.rpy`, `glossary.json`, or `story_graph.json`

This intentionally does not implement the revision mode portion of #26 yet, so the issue should stay open.

## Validation

- `python -m py_compile gemini_translate_batch.py`
- `python -m unittest tests.test_regressions -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`
- `git diff --cached --check`