### PR TITLE
[codex] Use Gemini 3.1 Flash-Lite by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Game_Example/
 
 当前模型建议：
 
-- 正式 Batch 默认优先使用 `gemini-2.5-flash`
-- `gemini-3-flash-preview` 仍是目标模型，但 Batch 通道仍建议继续做小包稳定性验证
+- 正式 Batch 默认优先使用 `gemini-3.1-flash-lite`
+- 该模型支持 Batch API、结构化输出和 Thinking，定位更适合高频、低延迟、低成本翻译任务
 - RAG 当前默认搭配 `gemini-embedding-001`
 
 同步模式：

--- a/api_keys.example.json
+++ b/api_keys.example.json
@@ -3,7 +3,7 @@
     "your-key-here"
   ],
   "models": [
-    "gemini-3-flash-preview"
+    "gemini-3.1-flash-lite"
   ],
   "batch_size": 10,
   "max_chars": 4000,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -64,7 +64,7 @@ def initialize_batch_logging():
     ensure_batch_dirs()
     sys.stdout = DualLogger(CONSOLE_LOG)
 
-BATCH_MODEL = 'gemini-3-flash-preview'
+BATCH_MODEL = 'gemini-3.1-flash-lite'
 BATCH_TARGET_SIZE = 4
 BATCH_CONTEXT_BEFORE = 8
 BATCH_CONTEXT_AFTER = 4

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -35,7 +35,7 @@
     }
   },
   "batch": {
-    "model": "gemini-2.5-flash",
+    "model": "gemini-3.1-flash-lite",
     "chunk_size": 10,
     "context_before": 30,
     "context_after": 10,

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -71,6 +71,7 @@ class DualLogger(object):
 
 # Model definitions (Priority Order)
 MODELS = [
+    "gemini-3.1-flash-lite",
     "gemini-3-flash-preview",
     "gemini-3-pro-preview",
     "gemini-2.5-pro"


### PR DESCRIPTION
## Summary
- Make `gemini-3.1-flash-lite` the default Batch translation model.
- Put `gemini-3.1-flash-lite` first in the sync translation model fallback list.
- Update example configuration and README model guidance to match the new default.

## Why
Gemini 3.1 Flash-Lite is positioned for low-latency, low-cost high-volume tasks such as translation, and it supports Batch API plus structured JSON output, which fits this project's translation workflow.

## Validation
- `python -m py_compile translator_runtime.py gemini_translate_batch.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`