### PR TITLE
[codex] Unify sync and batch translation core

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1076,7 +1076,7 @@ def build_user_prompt(
 ):
     return translation_core.build_translation_user_prompt(
         translation_core.ContextWindow(context_past, context_future),
-        translation_core.units_from_items(target_items, translation_core.MODE_TRANSLATION),
+        target_items,
         translation_core.build_context_bundle(
             glossary_hits=glossary_hits,
             history_hits=history_hits,
@@ -1092,7 +1092,7 @@ def build_user_prompt(
 
 def build_response_json_schema(target_items):
     return translation_core.build_response_json_schema(
-        translation_core.units_from_items(target_items, translation_core.MODE_TRANSLATION),
+        target_items,
         mode=translation_core.MODE_TRANSLATION,
     )
 
@@ -1530,7 +1530,7 @@ def build_revision_user_prompt(chunk):
 
 def build_revision_response_json_schema(target_items):
     return translation_core.build_response_json_schema(
-        translation_core.units_from_items(target_items, translation_core.MODE_REVISION),
+        target_items,
         mode=translation_core.MODE_REVISION,
     )
 
@@ -1785,12 +1785,7 @@ def build_keyword_system_instruction(max_candidates_per_chunk=None):
 
 
 def build_keyword_user_prompt(target_items):
-    return translation_core.build_keyword_user_prompt(
-        translation_core.units_from_items(
-            target_items,
-            translation_core.MODE_KEYWORD_EXTRACTION,
-        )
-    )
+    return translation_core.build_keyword_user_prompt(target_items)
 
 
 def build_keyword_response_json_schema(max_candidates_per_chunk=None):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -18,6 +18,7 @@ if SCRIPT_DIR not in sys.path:
 from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
+import translation_core
 import translator_runtime as runtime
 
 try:
@@ -1055,22 +1056,13 @@ def collect_pending_file_jobs():
 
 
 def format_context_block(lines, empty_label):
-    if not lines:
-        return empty_label
-    return '\n'.join(f'- {line}' for line in lines)
+    return translation_core.format_context_block(lines, empty_label)
 
 
 def build_system_instruction():
-    glossary = ', '.join(legacy.PRESERVE_TERMS)
-    return (
-        'Setting:\n'
-        f'{BATCH_MACRO_SETTING}\n\n'
-        'Task:\n'
-        'Translate only TARGET lines into Simplified Chinese. CONTEXT lines are reference only.\n'
-        f'Keep these terms unchanged: {glossary}\n'
-        "Keep names, Ren'Py tags, placeholders, variables, and format strings unchanged.\n"
-        'Return JSON only. Preserve every id exactly. Item count must match. '
-        'translation must contain only the translated Chinese text.'
+    return translation_core.build_translation_system_instruction(
+        legacy.PRESERVE_TERMS,
+        macro_setting=BATCH_MACRO_SETTING,
     )
 
 
@@ -1082,50 +1074,27 @@ def build_user_prompt(
     history_hits=None,
     story_hits=None,
 ):
-    target_payload = json.dumps(
-        [{'id': item['id'], 'text': item['text']} for item in target_items],
-        ensure_ascii=False,
-        separators=(',', ':'),
-    )
-    blocks = [
-        prompt_context.build_reference_blocks(
-            include_translation_memory=True,
-            glossary_hits=glossary_hits or [],
-            history_hits=history_hits or [],
+    return translation_core.build_translation_user_prompt(
+        translation_core.ContextWindow(context_past, context_future),
+        translation_core.units_from_items(target_items, translation_core.MODE_TRANSLATION),
+        translation_core.build_context_bundle(
+            glossary_hits=glossary_hits,
+            history_hits=history_hits,
             story_hits=story_hits,
-            history_char_limit=RAG_HISTORY_CHAR_LIMIT,
-            story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
-            include_source_text=True,
         ),
-    ]
-    blocks.extend(
-        [
-            f'CONTEXT BEFORE:\n{format_context_block(context_past, "(none)")}\n\n',
-            f'TARGET:\n{target_payload}\n\n',
-            f'CONTEXT AFTER:\n{format_context_block(context_future, "(none)")}\n\n',
-            'Return the result now.',
-        ]
+        history_char_limit=RAG_HISTORY_CHAR_LIMIT,
+        story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
+        include_translation_memory=True,
+        include_source_text=True,
     )
-    return ''.join(blocks)
 
 
 
 def build_response_json_schema(target_items):
-    target_ids = [item['id'] for item in target_items]
-    return {
-        'type': 'array',
-        'minItems': len(target_items),
-        'maxItems': len(target_items),
-        'items': {
-            'type': 'object',
-            'required': ['id', 'translation'],
-            'additionalProperties': False,
-            'properties': {
-                'id': {'type': 'string', 'enum': target_ids},
-                'translation': {'type': 'string'},
-            },
-        },
-    }
+    return translation_core.build_response_json_schema(
+        translation_core.units_from_items(target_items, translation_core.MODE_TRANSLATION),
+        mode=translation_core.MODE_TRANSLATION,
+    )
 
 
 def build_generation_config(target_items):
@@ -1178,6 +1147,12 @@ def build_chunks(file_jobs):
         for start in range(0, total, BATCH_TARGET_SIZE):
             end = min(start + BATCH_TARGET_SIZE, total)
             target_items = tasks[start:end]
+            target_units = translation_core.units_from_items(
+                target_items,
+                translation_core.MODE_TRANSLATION,
+                file_rel_path=job['file_rel_path'],
+                file_path=job['file_path'],
+            )
             context_past = [item['text'] for item in tasks[max(0, start - BATCH_CONTEXT_BEFORE):start]]
             context_future = [item['text'] for item in tasks[end:min(total, end + BATCH_CONTEXT_AFTER)]]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
@@ -1192,28 +1167,19 @@ def build_chunks(file_jobs):
             chunk_key = f"{hash_key(job['file_rel_path'])}-{chunk_number:05d}"
             chunk = {
                 'key': chunk_key,
+                'mode': MANIFEST_MODE_TRANSLATION,
                 'file_rel_path': job['file_rel_path'],
                 'file_path': job['file_path'],
                 'chunk_index': chunk_number,
-                'line_numbers': [item['line'] for item in target_items],
+                'line_numbers': [unit.line for unit in target_units],
                 'context_past': context_past,
                 'context_future': context_future,
                 'glossary_hits': glossary_hits,
                 'history_hits': history_hits,
                 'rag_stats': rag_stats,
                 'items': [
-                    {
-                        'id': item['id'],
-                        'text': item['text'],
-                        'line': item['line'],
-                        'start': item['start'],
-                        'end': item['end'],
-                        'prefix': item.get('prefix', ''),
-                        'quote': item['quote'],
-                        'speaker_id': item.get('speaker_id', ''),
-                        'speaker': item.get('speaker', ''),
-                    }
-                    for item in target_items
+                    translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
+                    for unit in target_units
                 ],
             }
             if STORY_MEMORY_ENABLED and story_memory.has_story_hits(story_hits):
@@ -1333,6 +1299,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
 
     manifest = {
         'version': 1,
+        'core_schema_version': translation_core.CORE_SCHEMA_VERSION,
         'mode': MANIFEST_MODE_TRANSLATION,
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
@@ -1463,15 +1430,7 @@ def collect_revision_file_jobs():
 
 
 def format_revision_context_block(items, empty_label):
-    if not items:
-        return empty_label
-    lines = []
-    for item in items:
-        source = compact_text(item.get('source', ''))
-        current = compact_text(item.get('current_translation', ''))
-        if source or current:
-            lines.append(f'- {source} => {current}')
-    return '\n'.join(lines) if lines else empty_label
+    return translation_core.format_revision_context_block(items, empty_label)
 
 
 def build_revision_chunks(file_jobs, chunk_size=None):
@@ -1483,6 +1442,12 @@ def build_revision_chunks(file_jobs, chunk_size=None):
         for start in range(0, total, chunk_size):
             end = min(start + chunk_size, total)
             target_items = items[start:end]
+            target_units = translation_core.units_from_items(
+                target_items,
+                translation_core.MODE_REVISION,
+                file_rel_path=job['file_rel_path'],
+                file_path=job['file_path'],
+            )
             context_past_items = items[max(0, start - BATCH_CONTEXT_BEFORE):start]
             context_future_items = items[end:min(total, end + BATCH_CONTEXT_AFTER)]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
@@ -1521,7 +1486,10 @@ def build_revision_chunks(file_jobs, chunk_size=None):
                 'glossary_hits': glossary_hits,
                 'history_hits': history_hits,
                 'rag_stats': rag_stats,
-                'items': target_items,
+                'items': [
+                    translation_core.legacy_item_from_unit(unit, translation_core.MODE_REVISION)
+                    for unit in target_units
+                ],
             }
             if STORY_MEMORY_ENABLED and story_memory.has_story_hits(story_hits):
                 chunk['story_hits'] = story_hits
@@ -1530,77 +1498,41 @@ def build_revision_chunks(file_jobs, chunk_size=None):
 
 
 def build_revision_system_instruction():
-    glossary = ', '.join(legacy.PRESERVE_TERMS)
-    return (
-        'Setting:\n'
-        f'{BATCH_MACRO_SETTING}\n\n'
-        'Task:\n'
-        'Review existing Simplified Chinese Ren\'Py TL translations. '
-        'For each TARGET item, decide whether the current translation should be revised. '
-        'Preserve meaning, tone, Ren\'Py tags, placeholders, variables, format strings, and locked terms. '
-        f'Keep these terms unchanged: {glossary}\n'
-        'If the current translation is already acceptable, set should_update=false and repeat it as revised_translation. '
-        'If it needs a change, set should_update=true and provide only the revised Chinese translation. '
-        'Return JSON only. Preserve every id exactly. Item count must match.'
+    return translation_core.build_revision_system_instruction(
+        legacy.PRESERVE_TERMS,
+        macro_setting=BATCH_MACRO_SETTING,
     )
 
 
 def build_revision_user_prompt(chunk):
-    target_payload = json.dumps(
-        [
-            {
-                'id': item['id'],
-                'file': item.get('file_rel_path', ''),
-                'line': item.get('line_number', 0),
-                'speaker_id': item.get('speaker_id', ''),
-                'source': item.get('source', ''),
-                'current_translation': item.get('current_translation', ''),
-            }
-            for item in chunk['items']
-        ],
-        ensure_ascii=False,
-        separators=(',', ':'),
-    )
-    blocks = [
-        prompt_context.build_reference_blocks(
-            include_translation_memory=True,
+    return translation_core.build_revision_user_prompt(
+        translation_core.ContextWindow(
+            chunk.get('context_past') or [],
+            chunk.get('context_future') or [],
+        ),
+        translation_core.units_from_items(
+            chunk['items'],
+            translation_core.MODE_REVISION,
+            file_rel_path=chunk.get('file_rel_path', ''),
+            file_path=chunk.get('file_path', ''),
+        ),
+        translation_core.build_context_bundle(
             glossary_hits=chunk.get('glossary_hits') or [],
             history_hits=chunk.get('history_hits') or [],
             story_hits=chunk.get('story_hits'),
-            history_char_limit=RAG_HISTORY_CHAR_LIMIT,
-            story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
-            include_source_text=True,
+            rag_stats=chunk.get('rag_stats') or {},
         ),
-    ]
-    blocks.extend(
-        [
-            f'CONTEXT BEFORE:\n{format_revision_context_block(chunk.get("context_past") or [], "(none)")}\n\n',
-            f'TARGET:\n{target_payload}\n\n',
-            f'CONTEXT AFTER:\n{format_revision_context_block(chunk.get("context_future") or [], "(none)")}\n\n',
-            'Return objects with id, should_update, revised_translation, and reason.',
-        ]
+        history_char_limit=RAG_HISTORY_CHAR_LIMIT,
+        story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
+        include_source_text=True,
     )
-    return ''.join(blocks)
 
 
 def build_revision_response_json_schema(target_items):
-    target_ids = [item['id'] for item in target_items]
-    return {
-        'type': 'array',
-        'minItems': len(target_items),
-        'maxItems': len(target_items),
-        'items': {
-            'type': 'object',
-            'required': ['id', 'should_update', 'revised_translation', 'reason'],
-            'additionalProperties': False,
-            'properties': {
-                'id': {'type': 'string', 'enum': target_ids},
-                'should_update': {'type': 'boolean'},
-                'revised_translation': {'type': 'string'},
-                'reason': {'type': 'string'},
-            },
-        },
-    }
+    return translation_core.build_response_json_schema(
+        translation_core.units_from_items(target_items, translation_core.MODE_REVISION),
+        mode=translation_core.MODE_REVISION,
+    )
 
 
 def build_revision_generation_config(target_items):
@@ -1667,6 +1599,7 @@ def create_revision_package(display_name_override='', skip_prepare=False, chunk_
     build_warnings = get_batch_risk_warnings()
     manifest = {
         'version': 1,
+        'core_schema_version': translation_core.CORE_SCHEMA_VERSION,
         'mode': MANIFEST_MODE_REVISION,
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
@@ -1806,6 +1739,12 @@ def build_keyword_chunks(file_jobs, chunk_size=None):
         items = job['items']
         for start in range(0, len(items), chunk_size):
             target_items = items[start:start + chunk_size]
+            target_units = translation_core.units_from_items(
+                target_items,
+                translation_core.MODE_KEYWORD_EXTRACTION,
+                file_rel_path=job['file_rel_path'],
+                file_path=job['file_path'],
+            )
             chunk_number = start // chunk_size + 1
             chunks.append(
                 {
@@ -1814,92 +1753,51 @@ def build_keyword_chunks(file_jobs, chunk_size=None):
                     'file_rel_path': job['file_rel_path'],
                     'file_path': job['file_path'],
                     'chunk_index': chunk_number,
-                    'line_numbers': [item.get('line_number', 0) for item in target_items],
-                    'items': target_items,
+                    'line_numbers': [unit.display_line_number for unit in target_units],
+                    'items': [
+                        translation_core.legacy_item_from_unit(
+                            unit,
+                            translation_core.MODE_KEYWORD_EXTRACTION,
+                        )
+                        for unit in target_units
+                    ],
                 }
             )
     return chunks
 
 
 def format_keyword_glossary_block():
-    lines = []
-    for term in legacy.PRESERVE_TERMS:
-        if isinstance(term, str) and term.strip():
-            lines.append(f'- Preserve: {term.strip()}')
-    for source, target in (legacy.NORMALIZE_TRANSLATION_MAP or {}).items():
-        if source:
-            lines.append(f'- Existing mapping: {source} -> {target}')
-    for term in sorted(getattr(legacy, 'NON_TRANSLATABLE_EXACT', set()) or []):
-        if isinstance(term, str) and term.strip():
-            lines.append(f'- Non-translatable: {term.strip()}')
-    return '\n'.join(lines) if lines else '(none)'
+    return translation_core.build_keyword_glossary_block(
+        legacy.PRESERVE_TERMS,
+        legacy.NORMALIZE_TRANSLATION_MAP,
+        getattr(legacy, 'NON_TRANSLATABLE_EXACT', set()),
+    )
 
 
 def build_keyword_system_instruction(max_candidates_per_chunk=None):
-    max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
-    return (
-        'Setting:\n'
-        f'{BATCH_MACRO_SETTING}\n\n'
-        'Existing glossary entries:\n'
-        f'{format_keyword_glossary_block()}\n\n'
-        'Task:\n'
-        'Extract glossary or story-memory keyword candidates from Ren\'Py TL source text. '
-        'Do not translate full lines. Return only high-value terms, names, places, items, concepts, abilities, '
-        'relationship labels, or recurring phrasing that a human may want to add to glossary.json or story_graph.json.\n'
-        f'Return at most {max_candidates} candidates for this chunk. '
-        'Avoid generic words, common function words, UI filler, and candidates already covered by existing glossary entries. '
-        'Set source_item_ids to the input id values that support the candidate. '
-        'Use concise evidence that cites the relevant input id or phrase. Return JSON only.'
+    return translation_core.build_keyword_system_instruction(
+        legacy.PRESERVE_TERMS,
+        legacy.NORMALIZE_TRANSLATION_MAP,
+        getattr(legacy, 'NON_TRANSLATABLE_EXACT', set()),
+        macro_setting=BATCH_MACRO_SETTING,
+        max_candidates_per_chunk=max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK,
     )
 
 
 def build_keyword_user_prompt(target_items):
-    target_payload = json.dumps(
-        [
-            {
-                'id': item['id'],
-                'file': item.get('file_rel_path', ''),
-                'line': item.get('line_number', 0),
-                'speaker_id': item.get('speaker_id', ''),
-                'text': item['text'],
-            }
-            for item in target_items
-        ],
-        ensure_ascii=False,
-        separators=(',', ':'),
-    )
-    return (
-        'TARGET LINES:\n'
-        f'{target_payload}\n\n'
-        'Return candidate objects with source, suggested_target, category, confidence, evidence, and source_item_ids.'
+    return translation_core.build_keyword_user_prompt(
+        translation_core.units_from_items(
+            target_items,
+            translation_core.MODE_KEYWORD_EXTRACTION,
+        )
     )
 
 
 def build_keyword_response_json_schema(max_candidates_per_chunk=None):
-    max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
-    return {
-        'type': 'array',
-        'maxItems': max_candidates,
-        'items': {
-            'type': 'object',
-            'required': ['source', 'suggested_target', 'category', 'confidence', 'evidence'],
-            'additionalProperties': False,
-            'properties': {
-                'source': {'type': 'string'},
-                'suggested_target': {'type': 'string'},
-                'category': {
-                    'type': 'string',
-                    'enum': ['term', 'character', 'place', 'item', 'ability', 'concept', 'relationship', 'style', 'other'],
-                },
-                'confidence': {'type': 'number'},
-                'evidence': {'type': 'string'},
-                'source_item_ids': {
-                    'type': 'array',
-                    'items': {'type': 'string'},
-                },
-            },
-        },
-    }
+    return translation_core.build_response_json_schema(
+        mode=translation_core.MODE_KEYWORD_EXTRACTION,
+        max_candidates_per_chunk=max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK,
+    )
 
 
 def build_keyword_generation_config(max_candidates_per_chunk=None):
@@ -1967,6 +1865,7 @@ def create_keyword_package(display_name_override='', skip_prepare=True, chunk_si
 
     manifest = {
         'version': 1,
+        'core_schema_version': translation_core.CORE_SCHEMA_VERSION,
         'mode': MANIFEST_MODE_KEYWORD_EXTRACTION,
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
@@ -2080,6 +1979,10 @@ def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix
         part_files = summarize_files_for_chunks(part_chunks)
         part_manifest = {
             'version': manifest.get('version', 1),
+            'core_schema_version': manifest.get(
+                'core_schema_version',
+                translation_core.CORE_SCHEMA_VERSION,
+            ),
             'mode': manifest_mode(manifest),
             'created_at': now,
             'display_name': f'{part_name_prefix}-part{index:02d}',
@@ -2413,77 +2316,24 @@ def parse_json_payload(text):
 
 
 def normalize_result_items(payload):
-    data = payload
-    if isinstance(data, dict):
-        if isinstance(data.get('items'), list):
-            data = data['items']
-        elif isinstance(data.get('translations'), list):
-            data = data['translations']
-
-    if not isinstance(data, list):
-        raise ValueError(f'Response JSON is not a list: {type(data)}')
-
-    normalized = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        item_id = item.get('id')
-        translation = item.get('translation')
-        if item_id is None or translation is None:
-            continue
-        normalized.append({'id': str(item_id), 'translation': str(translation)})
-    return normalized
+    return translation_core.normalize_model_results(
+        payload,
+        mode=translation_core.MODE_TRANSLATION,
+    )
 
 
-KEYWORD_CATEGORIES = {'term', 'character', 'place', 'item', 'ability', 'concept', 'relationship', 'style', 'other'}
+KEYWORD_CATEGORIES = translation_core.KEYWORD_CATEGORIES
 
 
 def coerce_keyword_confidence(value):
-    try:
-        confidence = float(value)
-    except (TypeError, ValueError):
-        return 0.0
-    if not confidence == confidence:
-        return 0.0
-    return max(0.0, min(confidence, 1.0))
+    return translation_core.coerce_keyword_confidence(value)
 
 
 def normalize_keyword_candidates(payload):
-    data = payload
-    if isinstance(data, dict):
-        if isinstance(data.get('candidates'), list):
-            data = data['candidates']
-        elif isinstance(data.get('items'), list):
-            data = data['items']
-        elif isinstance(data.get('keywords'), list):
-            data = data['keywords']
-    if not isinstance(data, list):
-        raise ValueError(f'Response JSON is not a candidate list: {type(data)}')
-
-    normalized = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        source = compact_text(str(item.get('source') or ''))
-        if not source:
-            continue
-        category = compact_text(str(item.get('category') or 'other')).lower()
-        if category not in KEYWORD_CATEGORIES:
-            category = 'other'
-        raw_source_item_ids = item.get('source_item_ids')
-        if not isinstance(raw_source_item_ids, list):
-            raw_source_item_ids = []
-        normalized.append(
-            {
-                'source': source,
-                'suggested_target': compact_text(str(item.get('suggested_target') or '')),
-                'category': category,
-                'confidence': coerce_keyword_confidence(item.get('confidence')),
-                'evidence': compact_text(str(item.get('evidence') or '')),
-                'source_item_ids': [str(value) for value in raw_source_item_ids if str(value).strip()],
-            }
-        )
-    return normalized
+    return translation_core.normalize_model_results(
+        payload,
+        mode=translation_core.MODE_KEYWORD_EXTRACTION,
+    )
 
 
 def keyword_candidate_key(candidate):
@@ -2939,46 +2789,14 @@ def summarize_pending_replacements(replacements_by_file, translated_lines_by_fil
 
 
 def coerce_revision_should_update(value):
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {'1', 'true', 'yes', 'y', 'update', 'revise', 'change', 'changed'}
-    return False
+    return translation_core.coerce_revision_should_update(value)
 
 
 def normalize_revision_items(payload):
-    data = payload
-    if isinstance(data, dict):
-        for key in ('revisions', 'items', 'results'):
-            if isinstance(data.get(key), list):
-                data = data[key]
-                break
-    if not isinstance(data, list):
-        raise ValueError(f'Response JSON is not a revision list: {type(data)}')
-
-    normalized = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        item_id = item.get('id')
-        if item_id is None:
-            continue
-        revised = item.get('revised_translation')
-        if revised is None:
-            revised = item.get('translation')
-        if revised is None:
-            revised = item.get('revised')
-        normalized.append(
-            {
-                'id': str(item_id),
-                'should_update': coerce_revision_should_update(item.get('should_update')),
-                'revised_translation': str(revised or ''),
-                'reason': compact_text(str(item.get('reason') or '')),
-            }
-        )
-    return normalized
+    return translation_core.normalize_model_results(
+        payload,
+        mode=translation_core.MODE_REVISION,
+    )
 
 
 def make_revision_preview_entry(target_item, result_item, status, error=''):
@@ -3153,7 +2971,12 @@ def collect_revision_actions(manifest, validate_sources=False):
                 seen_ids.add(result_id)
                 summary['parsed_items'] += 1
 
-                current_translation = target_item.get('current_translation', '')
+                target_unit = translation_core.unit_from_manifest_item(
+                    target_item,
+                    mode=translation_core.MODE_REVISION,
+                    chunk=chunk,
+                )
+                current_translation = target_unit.current_translation
                 revised_translation = result_item.get('revised_translation', '')
                 if not revised_translation and not result_item.get('should_update'):
                     revised_translation = current_translation
@@ -3164,14 +2987,12 @@ def collect_revision_actions(manifest, validate_sources=False):
                     preview_entries.append(make_revision_preview_entry(target_item, result_item, 'unchanged'))
                     continue
 
-                valid, reason = legacy.validate_translation(
-                    target_item.get('source', target_item.get('text', '')),
-                    revised_translation,
-                )
+                source_text = target_unit.source_text
+                valid, reason = legacy.validate_translation(source_text, revised_translation)
                 if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
                     manifest,
                     chunk,
-                    target_item.get('source', target_item.get('text', '')),
+                    source_text,
                     revised_translation,
                 ):
                     valid = True
@@ -3184,7 +3005,7 @@ def collect_revision_actions(manifest, validate_sources=False):
                         file_rel_path=chunk['file_rel_path'],
                         item_id=target_item['id'],
                         line=target_item['line'],
-                        text=target_item.get('source', target_item.get('text', '')),
+                        text=source_text,
                         key=key,
                         translation=revised_translation,
                         finish_reason=finish_reason,
@@ -3196,18 +3017,14 @@ def collect_revision_actions(manifest, validate_sources=False):
                 summary['valid_items'] += 1
                 summary['revision_candidate_items'] += 1
                 preview_entries.append(make_revision_preview_entry(target_item, result_item, 'pending'))
+                action = translation_core.revision_writeback_action(
+                    target_unit,
+                    result_item,
+                    chunk_key=key,
+                )
                 file_key = chunk['file_rel_path']
                 replacements_by_file.setdefault(file_key, {}).setdefault(target_item['line'], []).append(
-                    (
-                        target_item['start'],
-                        target_item['end'],
-                        revised_translation,
-                        target_item.get('prefix', ''),
-                        target_item['quote'],
-                        current_translation,
-                        target_item['id'],
-                        key,
-                    )
+                    translation_core.writeback_tuple(action, include_expected=True)
                 )
                 revised_lines_by_file.setdefault(file_key, set()).add(target_item['line'])
 
@@ -3527,11 +3344,16 @@ def collect_result_actions(manifest, validate_sources=False):
                     continue
                 seen_ids.add(result_id)
 
-                valid, reason = legacy.validate_translation(target_item['text'], result_item['translation'])
+                target_unit = translation_core.unit_from_manifest_item(
+                    target_item,
+                    mode=translation_core.MODE_TRANSLATION,
+                    chunk=chunk,
+                )
+                valid, reason = legacy.validate_translation(target_unit.text, result_item['translation'])
                 if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
                     manifest,
                     chunk,
-                    target_item['text'],
+                    target_unit.text,
                     result_item['translation'],
                 ):
                     valid = True
@@ -3546,7 +3368,7 @@ def collect_result_actions(manifest, validate_sources=False):
                             'file_rel_path': chunk['file_rel_path'],
                             'id': target_item['id'],
                             'line': target_item['line'],
-                            'text': target_item['text'],
+                            'text': target_unit.text,
                             'error': f'Validation failed: {reason}',
                             'translation': result_item['translation'],
                             'finish_reason': finish_reason,
@@ -3556,18 +3378,14 @@ def collect_result_actions(manifest, validate_sources=False):
                     continue
 
                 summary['valid_items'] += 1
+                action = translation_core.translation_writeback_action(
+                    target_unit,
+                    result_item,
+                    chunk_key=key,
+                )
                 file_key = chunk['file_rel_path']
                 replacements_by_file.setdefault(file_key, {}).setdefault(target_item['line'], []).append(
-                    (
-                        target_item['start'],
-                        target_item['end'],
-                        result_item['translation'],
-                        target_item.get('prefix', ''),
-                        target_item['quote'],
-                        target_item['text'],
-                        target_item['id'],
-                        key,
-                    )
+                    translation_core.writeback_tuple(action, include_expected=True)
                 )
                 translated_lines_by_file.setdefault(file_key, set()).add(target_item['line'])
 
@@ -4844,6 +4662,7 @@ def make_sync_manifest(
     write_request_rows(input_jsonl_path, request_rows)
     manifest = {
         'version': 1,
+        'core_schema_version': translation_core.CORE_SCHEMA_VERSION,
         'mode': mode,
         'execution': 'sync',
         'created_at': datetime.now().isoformat(timespec='seconds'),

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -36,6 +36,8 @@ class TranslationCoreRegressionTests(unittest.TestCase):
         sync_unit = translation_core.unit_from_sync_task(sync_task, file_rel_path='script.rpy')
         self.assertEqual(sync_unit.mode, translation_core.MODE_TRANSLATION)
         self.assertEqual(sync_unit.source_text, 'Hello Alice')
+        self.assertEqual(sync_unit.line_number, 0)
+        self.assertEqual(sync_unit.display_line_number, 1)
         self.assertEqual(sync_unit.progress_entry, 'task:0:4')
         self.assertEqual(
             translation_core.unit_to_translation_item(sync_unit),

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -16,7 +16,158 @@ import gemini_translate_batch as batch_mod
 import prompt_context
 import rag_memory
 import story_memory
+import translation_core
 import translator_runtime as runtime
+
+
+class TranslationCoreRegressionTests(unittest.TestCase):
+    def test_legacy_items_round_trip_through_translation_unit(self):
+        sync_task = {
+            'id': 'script.rpy:0:4',
+            'text': 'Hello Alice',
+            'line': 0,
+            'start': 4,
+            'end': 17,
+            'prefix': '',
+            'quote': '"',
+            'speaker_id': 'e',
+            'progress_entry': 'task:0:4',
+        }
+        sync_unit = translation_core.unit_from_sync_task(sync_task, file_rel_path='script.rpy')
+        self.assertEqual(sync_unit.mode, translation_core.MODE_TRANSLATION)
+        self.assertEqual(sync_unit.source_text, 'Hello Alice')
+        self.assertEqual(sync_unit.progress_entry, 'task:0:4')
+        self.assertEqual(
+            translation_core.unit_to_translation_item(sync_unit),
+            {
+                'id': 'script.rpy:0:4',
+                'text': 'Hello Alice',
+                'line': 0,
+                'start': 4,
+                'end': 17,
+                'prefix': '',
+                'quote': '"',
+                'speaker_id': 'e',
+                'speaker': 'e',
+            },
+        )
+
+        revision_item = {
+            'id': 'script.rpy:1:4:revision:0',
+            'source': 'Open the Void Gate',
+            'current_translation': '\u6253\u5f00\u95e8',
+            'file_rel_path': 'script.rpy',
+            'line': 1,
+            'line_number': 2,
+            'start': 8,
+            'end': 14,
+            'prefix': '',
+            'quote': '"',
+        }
+        revision_unit = translation_core.unit_from_revision_item(revision_item)
+        self.assertEqual(revision_unit.mode, translation_core.MODE_REVISION)
+        self.assertEqual(revision_unit.source_text, 'Open the Void Gate')
+        self.assertEqual(
+            translation_core.unit_to_revision_item(revision_unit)['current_translation'],
+            '\u6253\u5f00\u95e8',
+        )
+
+        keyword_item = {
+            'id': 'script.rpy:2:keyword:0',
+            'text': 'Void Gate',
+            'file_rel_path': 'script.rpy',
+            'line_number': 2,
+            'translation_line_number': 3,
+        }
+        keyword_unit = translation_core.unit_from_keyword_item(keyword_item)
+        keyword_legacy = translation_core.unit_to_keyword_item(keyword_unit)
+        self.assertEqual(keyword_unit.mode, translation_core.MODE_KEYWORD_EXTRACTION)
+        self.assertEqual(keyword_legacy['translation_line_number'], 3)
+
+    def test_prompt_wrappers_use_core_schema_for_all_modes(self):
+        translation_prompt = batch_mod.build_user_prompt(
+            ['Before line'],
+            [{'id': 'script.rpy:0:4', 'text': 'Hello Alice'}],
+            ['After line'],
+            glossary_hits=[{'source': 'Alice', 'target': 'Alice'}],
+        )
+        translation_schema = batch_mod.build_response_json_schema(
+            [{'id': 'script.rpy:0:4', 'text': 'Hello Alice'}]
+        )
+        self.assertIn('LOCKED TERMS', translation_prompt)
+        self.assertIn('TARGET', translation_prompt)
+        self.assertIn('script.rpy:0:4', translation_prompt)
+        self.assertEqual(translation_schema['items']['required'], ['id', 'translation'])
+
+        revision_chunk = {
+            'file_rel_path': 'script.rpy',
+            'items': [
+                {
+                    'id': 'script.rpy:1:4:revision:0',
+                    'source': 'Open the Void Gate',
+                    'current_translation': '\u6253\u5f00\u95e8',
+                    'file_rel_path': 'script.rpy',
+                    'line': 1,
+                    'line_number': 2,
+                    'start': 8,
+                    'end': 14,
+                    'prefix': '',
+                    'quote': '"',
+                }
+            ],
+        }
+        revision_prompt = batch_mod.build_revision_user_prompt(revision_chunk)
+        revision_schema = batch_mod.build_revision_response_json_schema(revision_chunk['items'])
+        self.assertIn('current_translation', revision_prompt)
+        self.assertIn('should_update', revision_prompt)
+        self.assertEqual(
+            revision_schema['items']['required'],
+            ['id', 'should_update', 'revised_translation', 'reason'],
+        )
+
+        keyword_prompt = batch_mod.build_keyword_user_prompt(
+            [{'id': 'script.rpy:2:keyword:0', 'text': 'Void Gate', 'line_number': 2}]
+        )
+        keyword_schema = batch_mod.build_keyword_response_json_schema(5)
+        self.assertIn('source_item_ids', keyword_prompt)
+        self.assertEqual(keyword_schema['maxItems'], 5)
+
+    def test_core_result_parsers_and_writeback_actions_are_mode_aware(self):
+        translation_results = translation_core.normalize_model_results(
+            {'translations': [{'id': 'a', 'translation': '\u4f60\u597d'}]},
+            mode=translation_core.MODE_TRANSLATION,
+        )
+        revision_results = translation_core.normalize_model_results(
+            {'revisions': [{'id': 'b', 'should_update': 'yes', 'translation': '\u65b0\u8bd1'}]},
+            mode=translation_core.MODE_REVISION,
+        )
+        keyword_results = translation_core.normalize_model_results(
+            {'keywords': [{'source': 'Void Gate', 'category': 'unknown', 'confidence': 2}]},
+            mode=translation_core.MODE_KEYWORD_EXTRACTION,
+        )
+
+        self.assertEqual(translation_results, [{'id': 'a', 'translation': '\u4f60\u597d'}])
+        self.assertTrue(revision_results[0]['should_update'])
+        self.assertEqual(revision_results[0]['revised_translation'], '\u65b0\u8bd1')
+        self.assertEqual(keyword_results[0]['category'], 'other')
+        self.assertEqual(keyword_results[0]['confidence'], 1.0)
+
+        unit = translation_core.unit_from_translation_item(
+            {
+                'id': 'script.rpy:0:4',
+                'text': 'Hello',
+                'line': 0,
+                'start': 4,
+                'end': 11,
+                'quote': '"',
+            },
+            file_rel_path='script.rpy',
+        )
+        action = translation_core.translation_writeback_action(unit, translation_results[0], chunk_key='chunk-1')
+        self.assertEqual(
+            translation_core.writeback_tuple(action),
+            (4, 11, '\u4f60\u597d', '', '"', 'Hello', 'script.rpy:0:4', 'chunk-1'),
+        )
 
 
 class TranslatorRuntimeRegressionTests(unittest.TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -168,6 +168,59 @@ class TranslationCoreRegressionTests(unittest.TestCase):
             translation_core.writeback_tuple(action),
             (4, 11, '\u4f60\u597d', '', '"', 'Hello', 'script.rpy:0:4', 'chunk-1'),
         )
+        keyword_unit = translation_core.unit_from_keyword_item(
+            {'id': 'kw-1', 'text': 'Void Gate'},
+            file_rel_path='script.rpy',
+        )
+        self.assertIsNone(
+            translation_core.build_writeback_action(
+                keyword_unit,
+                keyword_results[0],
+                mode=translation_core.MODE_KEYWORD_EXTRACTION,
+            )
+        )
+
+    def test_manifest_item_dispatches_by_mode_with_chunk_defaults(self):
+        revision_unit = translation_core.unit_from_manifest_item(
+            {
+                'id': 'script.rpy:2:4',
+                'text': '',
+                'source': 'Hello Alice',
+                'current_translation': None,
+                'line_number': 3,
+            },
+            mode=translation_core.MODE_REVISION,
+            chunk={'file_rel_path': 'script.rpy', 'file_path': '/tmp/script.rpy'},
+        )
+        self.assertEqual(revision_unit.mode, translation_core.MODE_REVISION)
+        self.assertEqual(revision_unit.file_rel_path, 'script.rpy')
+        self.assertEqual(revision_unit.text, 'Hello Alice')
+        self.assertEqual(revision_unit.current_translation, '')
+        self.assertEqual(revision_unit.line, 2)
+
+        keyword_unit = translation_core.unit_from_manifest_item(
+            {'id': 'kw-1', 'text': 'Void Gate', 'translation_line_number': 8},
+            mode=translation_core.MODE_KEYWORD_EXTRACTION,
+            chunk={'file_rel_path': 'script.rpy'},
+        )
+        self.assertEqual(keyword_unit.mode, translation_core.MODE_KEYWORD_EXTRACTION)
+        self.assertEqual(keyword_unit.file_rel_path, 'script.rpy')
+        self.assertEqual(keyword_unit.metadata['translation_line_number'], 8)
+
+    def test_revision_context_block_accepts_units_and_dicts(self):
+        block = translation_core.format_revision_context_block(
+            [
+                translation_core.TranslationUnit(
+                    id='unit-1',
+                    source='Hello Alice',
+                    current_translation='\u4f60\u597d Alice',
+                ),
+                {'source': 'Goodbye', 'current_translation': '\u518d\u89c1'},
+            ]
+        )
+
+        self.assertIn('- Hello Alice => \u4f60\u597d Alice', block)
+        self.assertIn('- Goodbye => \u518d\u89c1', block)
 
 
 class TranslatorRuntimeRegressionTests(unittest.TestCase):
@@ -410,15 +463,33 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         try:
             runtime.NORMALIZE_TRANSLATION_MAP = {'\u65e7\u79f0': '\u65b0\u79f0'}
             runtime.USE_TRANSLATION_MEMORY = True
+            replacements = {}
             with mock.patch.object(runtime, 'call_gemini_sdk', return_value=[
                 {'id': 'file:0:1', 'translation': '\u65e7\u79f0\u4f60\u597d'},
             ]):
-                runtime.process_batch(batch, {})
+                runtime.process_batch(batch, replacements)
+            with tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / 'script.rpy'
+                lines = ['x"Hello"\n']
+                runtime.commit_replacements(str(path), lines, replacements)
+                committed_text = path.read_text(encoding='utf-8')
         finally:
             runtime.NORMALIZE_TRANSLATION_MAP = old_normalize_map
             runtime.USE_TRANSLATION_MEMORY = old_use_memory
 
         self.assertEqual(batch[0]['translated_text'], '\u65b0\u79f0\u4f60\u597d')
+        self.assertEqual(replacements[0][0], (1, 8, '\u65e7\u79f0\u4f60\u597d', '', '"'))
+        self.assertEqual(committed_text, 'x"\u65b0\u79f0\u4f60\u597d"\n')
+
+    def test_sync_prompt_preserves_legacy_wrapper(self):
+        prompt = runtime.build_prompt(
+            [{'id': 'file:0:1', 'text': 'Hello Alice'}],
+        )
+
+        self.assertIn("You are translating a Ren'Py visual novel", prompt)
+        self.assertIn('1.1 Keep all person names in English; do not translate names.', prompt)
+        self.assertIn('Input JSON:', prompt)
+        self.assertNotIn('CONTEXT BEFORE:', prompt)
 
     def test_sync_rag_prompt_includes_retrieved_memory_when_enabled(self):
         old_enabled = runtime.SYNC_RAG_ENABLED

--- a/translation_core.py
+++ b/translation_core.py
@@ -156,7 +156,7 @@ def _coerce_line(item):
 def _coerce_line_number(item, line):
     if 'line_number' in item:
         return max(0, _coerce_int(item.get('line_number'), 0))
-    return line + 1 if line >= 0 else 0
+    return 0
 
 
 def _metadata_for(item, known_keys):

--- a/translation_core.py
+++ b/translation_core.py
@@ -61,6 +61,8 @@ class TranslationUnit:
 
     @property
     def display_line_number(self):
+        # ``line_number`` is 1-indexed. A zero value means "not supplied", so
+        # display falls back to the internal 0-indexed ``line`` value.
         if self.line_number:
             return self.line_number
         return self.line + 1 if self.line >= 0 else 0
@@ -96,6 +98,25 @@ class ModelResult:
     source_item_ids: list = field(default_factory=list)
     metadata: dict = field(default_factory=dict)
 
+    def to_legacy_dict(self):
+        if self.mode == MODE_REVISION:
+            return {
+                'id': self.id,
+                'should_update': self.should_update,
+                'revised_translation': self.revised_translation,
+                'reason': self.reason,
+            }
+        if self.mode == MODE_KEYWORD_EXTRACTION:
+            return {
+                'source': self.source,
+                'suggested_target': self.suggested_target,
+                'category': self.category,
+                'confidence': self.confidence,
+                'evidence': self.evidence,
+                'source_item_ids': list(self.source_item_ids),
+            }
+        return {'id': self.id, 'translation': self.translation}
+
 
 @dataclass
 class WritebackAction:
@@ -124,6 +145,7 @@ def _coerce_int(value, default=0):
 
 
 def _coerce_line(item):
+    """Return the internal 0-indexed line; legacy line_number is 1-indexed."""
     if 'line' in item:
         return max(0, _coerce_int(item.get('line'), 0))
     if 'line_number' in item:
@@ -193,17 +215,19 @@ def unit_from_sync_task(task, file_rel_path='', file_path=''):
 
 
 def unit_from_revision_item(item, file_rel_path='', file_path=''):
+    item = dict(item or {})
     unit = unit_from_translation_item(
         item,
         file_rel_path=file_rel_path,
         file_path=file_path,
         mode=MODE_REVISION,
     )
-    source = str(item.get('source') if isinstance(item, dict) else '')
+    source = str(item.get('source') or '')
     if source:
+        # Revision manifests may carry an empty text field; reviewers should
+        # still see the original source string in that case.
         unit.source = source
         unit.text = str(item.get('text') or source)
-    unit.current_translation = str((item or {}).get('current_translation') or '')
     return unit
 
 
@@ -350,7 +374,7 @@ def build_context_bundle(glossary_hits=None, history_hits=None, story_hits=None,
     )
 
 
-def _reference_blocks(
+def build_reference_blocks(
     context_bundle,
     history_char_limit=220,
     story_char_limit=1200,
@@ -404,7 +428,7 @@ def build_translation_user_prompt(
     )
     return ''.join(
         [
-            _reference_blocks(
+            build_reference_blocks(
                 context_bundle,
                 history_char_limit=history_char_limit,
                 story_char_limit=story_char_limit,
@@ -417,6 +441,49 @@ def build_translation_user_prompt(
             f'CONTEXT AFTER:\n{format_context_block(context_window.after, "(none)")}\n\n',
             'Return the result now.',
         ]
+    )
+
+
+def build_sync_translation_prompt(
+    units,
+    preserve_terms,
+    context_bundle=None,
+    history_char_limit=220,
+    story_char_limit=1200,
+    include_translation_memory=True,
+):
+    units = units_from_items(units, MODE_TRANSLATION)
+    glossary = ', '.join(str(term) for term in preserve_terms or [])
+    payload = json.dumps(
+        [{'id': unit.id, 'text': unit.text} for unit in units],
+        ensure_ascii=False,
+    )
+    reference_body = build_reference_blocks(
+        context_bundle,
+        history_char_limit=history_char_limit,
+        story_char_limit=story_char_limit,
+        include_translation_memory=include_translation_memory,
+        include_source_text=False,
+        story_block_suffix='\n',
+    )
+    reference_blocks = ''
+    if reference_body:
+        reference_blocks = (
+            '\nReference blocks:\n'
+            f'{reference_body}'
+            'Use reference blocks only as style, terminology, and continuity reference; '
+            'ignore them when unrelated.\n'
+        )
+    return (
+        "You are translating a Ren'Py visual novel into Simplified Chinese (zh-CN).\n"
+        'Rules:\n'
+        f'1. Preserve these terms exactly (do not translate): {glossary}\n'
+        '1.1 Keep all person names in English; do not translate names.\n'
+        "2. Preserve Ren'Py tags like {i}, {/i}, {color=...}, [name], %s.\n"
+        '3. Output plain Chinese text. No markdown, no Pinyin, no explanations.\n'
+        '4. Return ONLY a JSON array matching the requested id/translation structure.\n'
+        f'{reference_blocks}'
+        f'Input JSON:\n{payload}'
     )
 
 
@@ -463,7 +530,7 @@ def build_revision_user_prompt(
     )
     return ''.join(
         [
-            _reference_blocks(
+            build_reference_blocks(
                 context_bundle,
                 history_char_limit=history_char_limit,
                 story_char_limit=story_char_limit,
@@ -633,7 +700,13 @@ def normalize_translation_results(payload):
         translation = item.get('translation')
         if item_id is None or translation is None:
             continue
-        normalized.append({'id': str(item_id), 'translation': str(translation)})
+        normalized.append(
+            ModelResult(
+                id=str(item_id),
+                mode=MODE_TRANSLATION,
+                translation=str(translation),
+            ).to_legacy_dict()
+        )
     return normalized
 
 
@@ -670,12 +743,13 @@ def normalize_revision_results(payload):
         if revised is None:
             revised = item.get('revised')
         normalized.append(
-            {
-                'id': str(item_id),
-                'should_update': coerce_revision_should_update(item.get('should_update')),
-                'revised_translation': str(revised or ''),
-                'reason': compact_text(str(item.get('reason') or '')),
-            }
+            ModelResult(
+                id=str(item_id),
+                mode=MODE_REVISION,
+                should_update=coerce_revision_should_update(item.get('should_update')),
+                revised_translation=str(revised or ''),
+                reason=compact_text(str(item.get('reason') or '')),
+            ).to_legacy_dict()
         )
     return normalized
 
@@ -716,14 +790,15 @@ def normalize_keyword_results(payload):
         if not isinstance(raw_source_item_ids, list):
             raw_source_item_ids = []
         normalized.append(
-            {
-                'source': source,
-                'suggested_target': compact_text(str(item.get('suggested_target') or '')),
-                'category': category,
-                'confidence': coerce_keyword_confidence(item.get('confidence')),
-                'evidence': compact_text(str(item.get('evidence') or '')),
-                'source_item_ids': [str(value) for value in raw_source_item_ids if str(value).strip()],
-            }
+            ModelResult(
+                mode=MODE_KEYWORD_EXTRACTION,
+                source=source,
+                suggested_target=compact_text(str(item.get('suggested_target') or '')),
+                category=category,
+                confidence=coerce_keyword_confidence(item.get('confidence')),
+                evidence=compact_text(str(item.get('evidence') or '')),
+                source_item_ids=[str(value) for value in raw_source_item_ids if str(value).strip()],
+            ).to_legacy_dict()
         )
     return normalized
 
@@ -771,6 +846,7 @@ def revision_writeback_action(unit, result, chunk_key=''):
 
 
 def keyword_writeback_action(unit, result, chunk_key=''):
+    """Keyword extraction produces glossary candidates and never edits scripts."""
     return None
 
 

--- a/translation_core.py
+++ b/translation_core.py
@@ -1,0 +1,796 @@
+# -*- coding: utf-8 -*-
+"""Shared translation pipeline primitives for sync and batch workflows.
+
+This module deliberately keeps public CLI and manifest shapes out at the edge:
+callers adapt their legacy task/chunk/result dictionaries into these internal
+objects, then serialize back to the same dictionaries when writing manifests or
+applying replacements.
+"""
+
+from dataclasses import dataclass, field
+import json
+import math
+import re
+
+import prompt_context
+
+
+CORE_SCHEMA_VERSION = 1
+
+MODE_TRANSLATION = 'translation'
+MODE_KEYWORD_EXTRACTION = 'keyword_extraction'
+MODE_REVISION = 'revision'
+
+KEYWORD_CATEGORY_ORDER = [
+    'term',
+    'character',
+    'place',
+    'item',
+    'ability',
+    'concept',
+    'relationship',
+    'style',
+    'other',
+]
+KEYWORD_CATEGORIES = set(KEYWORD_CATEGORY_ORDER)
+
+
+@dataclass
+class TranslationUnit:
+    id: str
+    mode: str = MODE_TRANSLATION
+    text: str = ''
+    source: str = ''
+    current_translation: str = ''
+    file_rel_path: str = ''
+    file_path: str = ''
+    line: int = 0
+    line_number: int = 0
+    start: int = 0
+    end: int = 0
+    prefix: str = ''
+    quote: str = '"'
+    speaker_id: str = ''
+    speaker: str = ''
+    progress_entry: str = ''
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def source_text(self):
+        return self.source or self.text
+
+    @property
+    def display_line_number(self):
+        if self.line_number:
+            return self.line_number
+        return self.line + 1 if self.line >= 0 else 0
+
+
+@dataclass
+class ContextWindow:
+    before: list = field(default_factory=list)
+    after: list = field(default_factory=list)
+
+
+@dataclass
+class ContextBundle:
+    glossary_hits: list = field(default_factory=list)
+    history_hits: list = field(default_factory=list)
+    story_hits: object = None
+    rag_stats: dict = field(default_factory=dict)
+
+
+@dataclass
+class ModelResult:
+    id: str = ''
+    mode: str = MODE_TRANSLATION
+    translation: str = ''
+    should_update: bool = False
+    revised_translation: str = ''
+    reason: str = ''
+    source: str = ''
+    suggested_target: str = ''
+    category: str = 'other'
+    confidence: float = 0.0
+    evidence: str = ''
+    source_item_ids: list = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class WritebackAction:
+    mode: str
+    file_rel_path: str
+    line: int
+    start: int
+    end: int
+    replacement: str
+    prefix: str = ''
+    quote: str = '"'
+    expected_text: str = ''
+    item_id: str = ''
+    chunk_key: str = ''
+
+
+def compact_text(text):
+    return re.sub(r'\s+', ' ', str(text or '')).strip()
+
+
+def _coerce_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_line(item):
+    if 'line' in item:
+        return max(0, _coerce_int(item.get('line'), 0))
+    if 'line_number' in item:
+        return max(0, _coerce_int(item.get('line_number'), 1) - 1)
+    return 0
+
+
+def _coerce_line_number(item, line):
+    if 'line_number' in item:
+        return max(0, _coerce_int(item.get('line_number'), 0))
+    return line + 1 if line >= 0 else 0
+
+
+def _metadata_for(item, known_keys):
+    return {key: value for key, value in dict(item).items() if key not in known_keys}
+
+
+_TRANSLATION_KEYS = {
+    'id',
+    'mode',
+    'text',
+    'source',
+    'current_translation',
+    'file_rel_path',
+    'file_path',
+    'line',
+    'line_number',
+    'start',
+    'end',
+    'prefix',
+    'quote',
+    'speaker_id',
+    'speaker',
+    'progress_entry',
+}
+
+
+def unit_from_translation_item(item, file_rel_path='', file_path='', mode=MODE_TRANSLATION):
+    item = dict(item or {})
+    line = _coerce_line(item)
+    text = str(item.get('text') if item.get('text') is not None else item.get('source') or '')
+    source = str(item.get('source') or text)
+    speaker_id = str(item.get('speaker_id') or item.get('speaker') or '')
+    return TranslationUnit(
+        id=str(item.get('id') or ''),
+        mode=mode or MODE_TRANSLATION,
+        text=text,
+        source=source,
+        current_translation=str(item.get('current_translation') or ''),
+        file_rel_path=str(item.get('file_rel_path') or file_rel_path or ''),
+        file_path=str(item.get('file_path') or file_path or ''),
+        line=line,
+        line_number=_coerce_line_number(item, line),
+        start=_coerce_int(item.get('start'), 0),
+        end=_coerce_int(item.get('end'), 0),
+        prefix=str(item.get('prefix') or ''),
+        quote=str(item.get('quote') or '"'),
+        speaker_id=speaker_id,
+        speaker=str(item.get('speaker') or speaker_id),
+        progress_entry=str(item.get('progress_entry') or ''),
+        metadata=_metadata_for(item, _TRANSLATION_KEYS),
+    )
+
+
+def unit_from_sync_task(task, file_rel_path='', file_path=''):
+    return unit_from_translation_item(task, file_rel_path=file_rel_path, file_path=file_path)
+
+
+def unit_from_revision_item(item, file_rel_path='', file_path=''):
+    unit = unit_from_translation_item(
+        item,
+        file_rel_path=file_rel_path,
+        file_path=file_path,
+        mode=MODE_REVISION,
+    )
+    source = str(item.get('source') if isinstance(item, dict) else '')
+    if source:
+        unit.source = source
+        unit.text = str(item.get('text') or source)
+    unit.current_translation = str((item or {}).get('current_translation') or '')
+    return unit
+
+
+def unit_from_keyword_item(item, file_rel_path='', file_path=''):
+    unit = unit_from_translation_item(
+        item,
+        file_rel_path=file_rel_path,
+        file_path=file_path,
+        mode=MODE_KEYWORD_EXTRACTION,
+    )
+    if isinstance(item, dict) and 'translation_line_number' in item:
+        unit.metadata['translation_line_number'] = item.get('translation_line_number')
+    return unit
+
+
+def unit_from_manifest_item(item, mode=MODE_TRANSLATION, chunk=None):
+    chunk = chunk or {}
+    actual_mode = mode or chunk.get('mode') or MODE_TRANSLATION
+    if actual_mode == MODE_REVISION:
+        return unit_from_revision_item(
+            item,
+            file_rel_path=chunk.get('file_rel_path', ''),
+            file_path=chunk.get('file_path', ''),
+        )
+    if actual_mode == MODE_KEYWORD_EXTRACTION:
+        return unit_from_keyword_item(
+            item,
+            file_rel_path=chunk.get('file_rel_path', ''),
+            file_path=chunk.get('file_path', ''),
+        )
+    return unit_from_translation_item(
+        item,
+        file_rel_path=chunk.get('file_rel_path', ''),
+        file_path=chunk.get('file_path', ''),
+    )
+
+
+def units_from_items(items, mode=MODE_TRANSLATION, file_rel_path='', file_path=''):
+    units = []
+    for item in items or []:
+        if isinstance(item, TranslationUnit):
+            units.append(item)
+        elif mode == MODE_REVISION:
+            units.append(unit_from_revision_item(item, file_rel_path=file_rel_path, file_path=file_path))
+        elif mode == MODE_KEYWORD_EXTRACTION:
+            units.append(unit_from_keyword_item(item, file_rel_path=file_rel_path, file_path=file_path))
+        else:
+            units.append(unit_from_translation_item(item, file_rel_path=file_rel_path, file_path=file_path))
+    return units
+
+
+def unit_to_translation_item(unit):
+    item = {
+        'id': unit.id,
+        'text': unit.text,
+        'line': unit.line,
+        'start': unit.start,
+        'end': unit.end,
+        'prefix': unit.prefix,
+        'quote': unit.quote,
+        'speaker_id': unit.speaker_id,
+        'speaker': unit.speaker,
+    }
+    return item
+
+
+def unit_to_revision_item(unit):
+    item = {
+        'id': unit.id,
+        'text': unit.source_text,
+        'source': unit.source_text,
+        'current_translation': unit.current_translation,
+        'file_rel_path': unit.file_rel_path,
+        'line': unit.line,
+        'line_number': unit.display_line_number,
+        'start': unit.start,
+        'end': unit.end,
+        'prefix': unit.prefix,
+        'quote': unit.quote,
+    }
+    if unit.speaker_id:
+        item['speaker_id'] = unit.speaker_id
+    return item
+
+
+def unit_to_keyword_item(unit):
+    item = {
+        'id': unit.id,
+        'text': unit.text,
+        'file_rel_path': unit.file_rel_path,
+        'line_number': unit.display_line_number,
+    }
+    translation_line_number = unit.metadata.get('translation_line_number')
+    if translation_line_number is not None:
+        item['translation_line_number'] = translation_line_number
+    if unit.speaker_id:
+        item['speaker_id'] = unit.speaker_id
+    return item
+
+
+def legacy_item_from_unit(unit, mode=None):
+    actual_mode = mode or unit.mode
+    if actual_mode == MODE_REVISION:
+        return unit_to_revision_item(unit)
+    if actual_mode == MODE_KEYWORD_EXTRACTION:
+        return unit_to_keyword_item(unit)
+    return unit_to_translation_item(unit)
+
+
+def format_context_block(lines, empty_label='(none)'):
+    if not lines:
+        return empty_label
+    rendered = []
+    for line in lines:
+        if isinstance(line, TranslationUnit):
+            rendered.append(line.source_text)
+        else:
+            rendered.append(str(line))
+    return '\n'.join(f'- {line}' for line in rendered if line) or empty_label
+
+
+def format_revision_context_block(items, empty_label='(none)'):
+    if not items:
+        return empty_label
+    lines = []
+    for item in items:
+        if isinstance(item, TranslationUnit):
+            source = compact_text(item.source_text)
+            current = compact_text(item.current_translation)
+        else:
+            source = compact_text((item or {}).get('source', ''))
+            current = compact_text((item or {}).get('current_translation', ''))
+        if source or current:
+            lines.append(f'- {source} => {current}')
+    return '\n'.join(lines) if lines else empty_label
+
+
+def build_context_bundle(glossary_hits=None, history_hits=None, story_hits=None, rag_stats=None):
+    return ContextBundle(
+        glossary_hits=list(glossary_hits or []),
+        history_hits=list(history_hits or []),
+        story_hits=story_hits,
+        rag_stats=dict(rag_stats or {}),
+    )
+
+
+def _reference_blocks(
+    context_bundle,
+    history_char_limit=220,
+    story_char_limit=1200,
+    include_translation_memory=True,
+    include_source_text=True,
+    story_block_suffix='\n\n',
+):
+    context_bundle = context_bundle or ContextBundle()
+    return prompt_context.build_reference_blocks(
+        include_translation_memory=include_translation_memory,
+        glossary_hits=context_bundle.glossary_hits,
+        history_hits=context_bundle.history_hits,
+        story_hits=context_bundle.story_hits,
+        history_char_limit=history_char_limit,
+        story_char_limit=story_char_limit,
+        include_source_text=include_source_text,
+        story_block_suffix=story_block_suffix,
+    )
+
+
+def build_translation_system_instruction(preserve_terms, macro_setting=''):
+    glossary = ', '.join(str(term) for term in preserve_terms or [])
+    return (
+        'Setting:\n'
+        f'{macro_setting or ""}\n\n'
+        'Task:\n'
+        'Translate only TARGET lines into Simplified Chinese. CONTEXT lines are reference only.\n'
+        f'Keep these terms unchanged: {glossary}\n'
+        "Keep names, Ren'Py tags, placeholders, variables, and format strings unchanged.\n"
+        'Return JSON only. Preserve every id exactly. Item count must match. '
+        'translation must contain only the translated Chinese text.'
+    )
+
+
+def build_translation_user_prompt(
+    context_window,
+    units,
+    context_bundle=None,
+    history_char_limit=220,
+    story_char_limit=1200,
+    include_translation_memory=True,
+    include_source_text=True,
+    story_block_suffix='\n\n',
+):
+    context_window = context_window or ContextWindow()
+    units = units_from_items(units, MODE_TRANSLATION)
+    target_payload = json.dumps(
+        [{'id': unit.id, 'text': unit.text} for unit in units],
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+    return ''.join(
+        [
+            _reference_blocks(
+                context_bundle,
+                history_char_limit=history_char_limit,
+                story_char_limit=story_char_limit,
+                include_translation_memory=include_translation_memory,
+                include_source_text=include_source_text,
+                story_block_suffix=story_block_suffix,
+            ),
+            f'CONTEXT BEFORE:\n{format_context_block(context_window.before, "(none)")}\n\n',
+            f'TARGET:\n{target_payload}\n\n',
+            f'CONTEXT AFTER:\n{format_context_block(context_window.after, "(none)")}\n\n',
+            'Return the result now.',
+        ]
+    )
+
+
+def build_revision_system_instruction(preserve_terms, macro_setting=''):
+    glossary = ', '.join(str(term) for term in preserve_terms or [])
+    return (
+        'Setting:\n'
+        f'{macro_setting or ""}\n\n'
+        'Task:\n'
+        "Review existing Simplified Chinese Ren'Py TL translations. "
+        'For each TARGET item, decide whether the current translation should be revised. '
+        "Preserve meaning, tone, Ren'Py tags, placeholders, variables, format strings, and locked terms. "
+        f'Keep these terms unchanged: {glossary}\n'
+        'If the current translation is already acceptable, set should_update=false and repeat it as revised_translation. '
+        'If it needs a change, set should_update=true and provide only the revised Chinese translation. '
+        'Return JSON only. Preserve every id exactly. Item count must match.'
+    )
+
+
+def build_revision_user_prompt(
+    context_window,
+    units,
+    context_bundle=None,
+    history_char_limit=220,
+    story_char_limit=1200,
+    include_source_text=True,
+):
+    context_window = context_window or ContextWindow()
+    units = units_from_items(units, MODE_REVISION)
+    target_payload = json.dumps(
+        [
+            {
+                'id': unit.id,
+                'file': unit.file_rel_path,
+                'line': unit.display_line_number,
+                'speaker_id': unit.speaker_id,
+                'source': unit.source_text,
+                'current_translation': unit.current_translation,
+            }
+            for unit in units
+        ],
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+    return ''.join(
+        [
+            _reference_blocks(
+                context_bundle,
+                history_char_limit=history_char_limit,
+                story_char_limit=story_char_limit,
+                include_translation_memory=True,
+                include_source_text=include_source_text,
+            ),
+            f'CONTEXT BEFORE:\n{format_revision_context_block(context_window.before, "(none)")}\n\n',
+            f'TARGET:\n{target_payload}\n\n',
+            f'CONTEXT AFTER:\n{format_revision_context_block(context_window.after, "(none)")}\n\n',
+            'Return objects with id, should_update, revised_translation, and reason.',
+        ]
+    )
+
+
+def build_keyword_glossary_block(preserve_terms=None, normalize_map=None, non_translatable_terms=None):
+    lines = []
+    for term in preserve_terms or []:
+        if isinstance(term, str) and term.strip():
+            lines.append(f'- Preserve: {term.strip()}')
+    for source, target in (normalize_map or {}).items():
+        if source:
+            lines.append(f'- Existing mapping: {source} -> {target}')
+    for term in sorted(non_translatable_terms or []):
+        if isinstance(term, str) and term.strip():
+            lines.append(f'- Non-translatable: {term.strip()}')
+    return '\n'.join(lines) if lines else '(none)'
+
+
+def build_keyword_system_instruction(
+    preserve_terms=None,
+    normalize_map=None,
+    non_translatable_terms=None,
+    macro_setting='',
+    max_candidates_per_chunk=12,
+):
+    max_candidates = max(1, _coerce_int(max_candidates_per_chunk, 12))
+    return (
+        'Setting:\n'
+        f'{macro_setting or ""}\n\n'
+        'Existing glossary entries:\n'
+        f'{build_keyword_glossary_block(preserve_terms, normalize_map, non_translatable_terms)}\n\n'
+        'Task:\n'
+        "Extract glossary or story-memory keyword candidates from Ren'Py TL source text. "
+        'Do not translate full lines. Return only high-value terms, names, places, items, concepts, abilities, '
+        'relationship labels, or recurring phrasing that a human may want to add to glossary.json or story_graph.json.\n'
+        f'Return at most {max_candidates} candidates for this chunk. '
+        'Avoid generic words, common function words, UI filler, and candidates already covered by existing glossary entries. '
+        'Set source_item_ids to the input id values that support the candidate. '
+        'Use concise evidence that cites the relevant input id or phrase. Return JSON only.'
+    )
+
+
+def build_keyword_user_prompt(units):
+    units = units_from_items(units, MODE_KEYWORD_EXTRACTION)
+    target_payload = json.dumps(
+        [
+            {
+                'id': unit.id,
+                'file': unit.file_rel_path,
+                'line': unit.display_line_number,
+                'speaker_id': unit.speaker_id,
+                'text': unit.text,
+            }
+            for unit in units
+        ],
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+    return (
+        'TARGET LINES:\n'
+        f'{target_payload}\n\n'
+        'Return candidate objects with source, suggested_target, category, confidence, evidence, and source_item_ids.'
+    )
+
+
+def build_translation_schema(units):
+    units = units_from_items(units, MODE_TRANSLATION)
+    target_ids = [unit.id for unit in units]
+    return {
+        'type': 'array',
+        'minItems': len(units),
+        'maxItems': len(units),
+        'items': {
+            'type': 'object',
+            'required': ['id', 'translation'],
+            'additionalProperties': False,
+            'properties': {
+                'id': {'type': 'string', 'enum': target_ids},
+                'translation': {'type': 'string'},
+            },
+        },
+    }
+
+
+def build_revision_schema(units):
+    units = units_from_items(units, MODE_REVISION)
+    target_ids = [unit.id for unit in units]
+    return {
+        'type': 'array',
+        'minItems': len(units),
+        'maxItems': len(units),
+        'items': {
+            'type': 'object',
+            'required': ['id', 'should_update', 'revised_translation', 'reason'],
+            'additionalProperties': False,
+            'properties': {
+                'id': {'type': 'string', 'enum': target_ids},
+                'should_update': {'type': 'boolean'},
+                'revised_translation': {'type': 'string'},
+                'reason': {'type': 'string'},
+            },
+        },
+    }
+
+
+def build_keyword_schema(max_candidates_per_chunk=12):
+    max_candidates = max(1, _coerce_int(max_candidates_per_chunk, 12))
+    return {
+        'type': 'array',
+        'maxItems': max_candidates,
+        'items': {
+            'type': 'object',
+            'required': ['source', 'suggested_target', 'category', 'confidence', 'evidence'],
+            'additionalProperties': False,
+            'properties': {
+                'source': {'type': 'string'},
+                'suggested_target': {'type': 'string'},
+                'category': {
+                    'type': 'string',
+                    'enum': KEYWORD_CATEGORY_ORDER,
+                },
+                'confidence': {'type': 'number'},
+                'evidence': {'type': 'string'},
+                'source_item_ids': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                },
+            },
+        },
+    }
+
+
+def build_response_json_schema(units=None, mode=MODE_TRANSLATION, max_candidates_per_chunk=12):
+    if mode == MODE_REVISION:
+        return build_revision_schema(units or [])
+    if mode == MODE_KEYWORD_EXTRACTION:
+        return build_keyword_schema(max_candidates_per_chunk)
+    return build_translation_schema(units or [])
+
+
+def normalize_translation_results(payload):
+    data = payload
+    if isinstance(data, dict):
+        if isinstance(data.get('items'), list):
+            data = data['items']
+        elif isinstance(data.get('translations'), list):
+            data = data['translations']
+
+    if not isinstance(data, list):
+        raise ValueError(f'Response JSON is not a list: {type(data)}')
+
+    normalized = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get('id')
+        translation = item.get('translation')
+        if item_id is None or translation is None:
+            continue
+        normalized.append({'id': str(item_id), 'translation': str(translation)})
+    return normalized
+
+
+def coerce_revision_should_update(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'y', 'update', 'revise', 'change', 'changed'}
+    return False
+
+
+def normalize_revision_results(payload):
+    data = payload
+    if isinstance(data, dict):
+        for key in ('revisions', 'items', 'results'):
+            if isinstance(data.get(key), list):
+                data = data[key]
+                break
+    if not isinstance(data, list):
+        raise ValueError(f'Response JSON is not a revision list: {type(data)}')
+
+    normalized = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get('id')
+        if item_id is None:
+            continue
+        revised = item.get('revised_translation')
+        if revised is None:
+            revised = item.get('translation')
+        if revised is None:
+            revised = item.get('revised')
+        normalized.append(
+            {
+                'id': str(item_id),
+                'should_update': coerce_revision_should_update(item.get('should_update')),
+                'revised_translation': str(revised or ''),
+                'reason': compact_text(str(item.get('reason') or '')),
+            }
+        )
+    return normalized
+
+
+def coerce_keyword_confidence(value):
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(confidence):
+        return 0.0
+    return max(0.0, min(confidence, 1.0))
+
+
+def normalize_keyword_results(payload):
+    data = payload
+    if isinstance(data, dict):
+        if isinstance(data.get('candidates'), list):
+            data = data['candidates']
+        elif isinstance(data.get('items'), list):
+            data = data['items']
+        elif isinstance(data.get('keywords'), list):
+            data = data['keywords']
+    if not isinstance(data, list):
+        raise ValueError(f'Response JSON is not a candidate list: {type(data)}')
+
+    normalized = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        source = compact_text(str(item.get('source') or ''))
+        if not source:
+            continue
+        category = compact_text(str(item.get('category') or 'other')).lower()
+        if category not in KEYWORD_CATEGORIES:
+            category = 'other'
+        raw_source_item_ids = item.get('source_item_ids')
+        if not isinstance(raw_source_item_ids, list):
+            raw_source_item_ids = []
+        normalized.append(
+            {
+                'source': source,
+                'suggested_target': compact_text(str(item.get('suggested_target') or '')),
+                'category': category,
+                'confidence': coerce_keyword_confidence(item.get('confidence')),
+                'evidence': compact_text(str(item.get('evidence') or '')),
+                'source_item_ids': [str(value) for value in raw_source_item_ids if str(value).strip()],
+            }
+        )
+    return normalized
+
+
+def normalize_model_results(payload, mode=MODE_TRANSLATION):
+    if mode == MODE_REVISION:
+        return normalize_revision_results(payload)
+    if mode == MODE_KEYWORD_EXTRACTION:
+        return normalize_keyword_results(payload)
+    return normalize_translation_results(payload)
+
+
+def translation_writeback_action(unit, result, chunk_key=''):
+    result = result or {}
+    return WritebackAction(
+        mode=MODE_TRANSLATION,
+        file_rel_path=unit.file_rel_path,
+        line=unit.line,
+        start=unit.start,
+        end=unit.end,
+        replacement=str(result.get('translation') or ''),
+        prefix=unit.prefix,
+        quote=unit.quote,
+        expected_text=unit.text,
+        item_id=unit.id,
+        chunk_key=chunk_key,
+    )
+
+
+def revision_writeback_action(unit, result, chunk_key=''):
+    result = result or {}
+    return WritebackAction(
+        mode=MODE_REVISION,
+        file_rel_path=unit.file_rel_path,
+        line=unit.line,
+        start=unit.start,
+        end=unit.end,
+        replacement=str(result.get('revised_translation') or ''),
+        prefix=unit.prefix,
+        quote=unit.quote,
+        expected_text=unit.current_translation,
+        item_id=unit.id,
+        chunk_key=chunk_key,
+    )
+
+
+def keyword_writeback_action(unit, result, chunk_key=''):
+    return None
+
+
+def build_writeback_action(unit, result, mode=None, chunk_key=''):
+    actual_mode = mode or unit.mode
+    if actual_mode == MODE_REVISION:
+        return revision_writeback_action(unit, result, chunk_key=chunk_key)
+    if actual_mode == MODE_KEYWORD_EXTRACTION:
+        return keyword_writeback_action(unit, result, chunk_key=chunk_key)
+    return translation_writeback_action(unit, result, chunk_key=chunk_key)
+
+
+def writeback_tuple(action, include_expected=True):
+    base = (
+        action.start,
+        action.end,
+        action.replacement,
+        action.prefix,
+        action.quote,
+    )
+    if not include_expected:
+        return base
+    return base + (action.expected_text, action.item_id, action.chunk_key)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2073,19 +2073,13 @@ def build_prompt(items, glossary_hits=None, history_hits=None, story_hits=None):
         history_hits=history_hits or [],
         story_hits=story_hits,
     )
-    return (
-        translation_core.build_translation_system_instruction(PRESERVE_TERMS)
-        + "\n\n"
-        + translation_core.build_translation_user_prompt(
-            translation_core.ContextWindow([], []),
-            units,
-            context_bundle,
-            history_char_limit=SYNC_RAG_HISTORY_CHAR_LIMIT,
-            story_char_limit=SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS,
-            include_translation_memory=SYNC_RAG_ENABLED,
-            include_source_text=False,
-            story_block_suffix="\n",
-        )
+    return translation_core.build_sync_translation_prompt(
+        units,
+        PRESERVE_TERMS,
+        context_bundle,
+        history_char_limit=SYNC_RAG_HISTORY_CHAR_LIMIT,
+        story_char_limit=SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS,
+        include_translation_memory=SYNC_RAG_ENABLED,
     )
 
 def get_nested(source, *candidates):
@@ -2171,7 +2165,7 @@ def extract_prompt_feedback(response_payload):
 
 def build_response_json_schema(items):
     return translation_core.build_response_json_schema(
-        translation_core.units_from_items(items, translation_core.MODE_TRANSLATION),
+        items,
         mode=translation_core.MODE_TRANSLATION,
     )
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
+import translation_core
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -2063,42 +2064,28 @@ def log_failure(batch, error):
 
 
 def build_prompt(items, glossary_hits=None, history_hits=None, story_hits=None):
-    glossary = ", ".join(PRESERVE_TERMS)
-    payload = json.dumps(
-        [{"id": item["id"], "text": item["text"]} for item in items],
-        ensure_ascii=False,
+    units = translation_core.units_from_items(
+        items,
+        translation_core.MODE_TRANSLATION,
     )
-    reference_blocks = ""
-    has_story_hits = story_memory.has_story_hits(story_hits)
-    if SYNC_RAG_ENABLED or has_story_hits:
-        parts = ["\nReference blocks:\n"]
-        parts.append(
-            prompt_context.build_reference_blocks(
-                include_translation_memory=SYNC_RAG_ENABLED,
-                glossary_hits=glossary_hits or [],
-                history_hits=history_hits or [],
-                story_hits=story_hits,
-                history_char_limit=SYNC_RAG_HISTORY_CHAR_LIMIT,
-                story_char_limit=SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS,
-                include_source_text=False,
-                story_block_suffix="\n",
-            )
-        )
-        parts.append(
-            "Use reference blocks only as style, terminology, and continuity reference; "
-            "ignore them when unrelated.\n"
-        )
-        reference_blocks = "".join(parts)
+    context_bundle = translation_core.build_context_bundle(
+        glossary_hits=glossary_hits or [],
+        history_hits=history_hits or [],
+        story_hits=story_hits,
+    )
     return (
-        "You are translating a Ren'Py visual novel into Simplified Chinese (zh-CN).\n"
-        "Rules:\n"
-        f"1. Preserve these terms exactly (do not translate): {glossary}\n"
-        "1.1 Keep all person names in English; do not translate names.\n"
-        "2. Preserve Ren'Py tags like {i}, {/i}, {color=...}, [name], %s.\n"
-        "3. Output plain Chinese text. No markdown, no Pinyin, no explanations.\n"
-        "4. Return ONLY a JSON array matching the requested id/translation structure.\n"
-        f"{reference_blocks}"
-        f"Input JSON:\n{payload}"
+        translation_core.build_translation_system_instruction(PRESERVE_TERMS)
+        + "\n\n"
+        + translation_core.build_translation_user_prompt(
+            translation_core.ContextWindow([], []),
+            units,
+            context_bundle,
+            history_char_limit=SYNC_RAG_HISTORY_CHAR_LIMIT,
+            story_char_limit=SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS,
+            include_translation_memory=SYNC_RAG_ENABLED,
+            include_source_text=False,
+            story_block_suffix="\n",
+        )
     )
 
 def get_nested(source, *candidates):
@@ -2183,21 +2170,10 @@ def extract_prompt_feedback(response_payload):
 
 
 def build_response_json_schema(items):
-    target_ids = [item["id"] for item in items]
-    return {
-        "type": "array",
-        "minItems": len(items),
-        "maxItems": len(items),
-        "items": {
-            "type": "object",
-            "required": ["id", "translation"],
-            "additionalProperties": False,
-            "properties": {
-                "id": {"type": "string", "enum": target_ids},
-                "translation": {"type": "string"},
-            },
-        },
-    }
+    return translation_core.build_response_json_schema(
+        translation_core.units_from_items(items, translation_core.MODE_TRANSLATION),
+        mode=translation_core.MODE_TRANSLATION,
+    )
 
 
 def parse_json_payload(text):
@@ -2220,26 +2196,10 @@ def parse_json_payload(text):
 
 
 def normalize_result_items(payload):
-    data = payload
-    if isinstance(data, dict):
-        if isinstance(data.get("items"), list):
-            data = data["items"]
-        elif isinstance(data.get("translations"), list):
-            data = data["translations"]
-
-    if not isinstance(data, list):
-        raise ValueError(f"Response JSON is not a list: {type(data)}")
-
-    normalized = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        item_id = item.get("id")
-        translation = item.get("translation")
-        if item_id is None or translation is None:
-            continue
-        normalized.append({"id": str(item_id), "translation": str(translation)})
-    return normalized
+    return translation_core.normalize_model_results(
+        payload,
+        mode=translation_core.MODE_TRANSLATION,
+    )
 
 
 def call_gemini_sdk(prompt, items):
@@ -2329,9 +2289,10 @@ def process_batch(batch, replacements):
 
         valid_progress_entries.append(entry["progress_entry"])
         entry["translated_text"] = memory_translation
-        line_idx = entry["line"]
-        replacements.setdefault(line_idx, []).append(
-            (entry["start"], entry["end"], translated, entry.get("prefix", ""), entry["quote"])
+        unit = translation_core.unit_from_sync_task(entry)
+        action = translation_core.translation_writeback_action(unit, item)
+        replacements.setdefault(action.line, []).append(
+            translation_core.writeback_tuple(action, include_expected=False)
         )
 
     if not valid_progress_entries:


### PR DESCRIPTION
## Summary

- Add `translation_core.py` as the shared internal core for sync and batch translation units, context bundles, prompt/schema builders, model result normalization, and writeback actions.
- Refactor sync and batch translation/revision/keyword wrappers to use the shared core while keeping existing CLI commands and manifest fields compatible.
- Add `core_schema_version: 1` to new manifests and preserve old manifest read/apply/export/preview behavior through adapters.

Closes #30

## Validation

- `python -m py_compile translation_core.py prompt_context.py translator_runtime.py gemini_translate_batch.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`
- `python gemini_translate_batch.py --help`
- `python gemini_translate_batch.py sync-keywords --help`
- `python gemini_translate_batch.py sync-revisions --help`