### PR TITLE
[codex] Add keyword chunk summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - `apply` 只会写回通过校验的结果
 - `build-revisions` 会复用 include 过滤、glossary、macro setting、可选 RAG / Story Memory，把已有原文和当前译文送入 Batch；`preview-revisions` 导出 `revision_preview.jsonl` 和 `revision_preview.md`，`apply-revisions` 会在写回前重新校验当前文件中的旧译文快照
 - `sync-revisions` 复用订正 prompt、schema、RAG / Story Memory 注入、预览报告和写回前源快照校验；默认只预览，传 `--apply` 才调用 `apply-revisions` 写回
-- `build-keywords` 会复用 include 过滤和 Batch manifest，默认不运行 prepare，按较大 chunk 扫描 TL 文本并要求模型输出 `source`、`suggested_target`、`category`、`confidence`、`evidence`、`source_item_ids`；如果确实要先刷新 TL 模板，可显式传 `--prepare`
-- `export-keywords` 会导出去重后的 `keyword_candidates.jsonl` 和 `keyword_candidates.md`，并在报告里标出缺失 chunk row 或无法精确定位的候选来源
-- `sync-keywords` 复用关键词 prompt、schema、候选去重和 JSONL / Markdown 导出逻辑，适合小范围即时跑报告
+- `build-keywords` 会复用 include 过滤和 Batch manifest，默认不运行 prepare，按较大 chunk 扫描 TL 文本并要求模型输出 `candidates`、`chunk_summary`、`summary_evidence_item_ids`；候选项里包含 `source`、`suggested_target`、`category`、`confidence`、`evidence`、`source_item_ids`。如果确实要先刷新 TL 模板，可显式传 `--prepare`
+- `export-keywords` 会导出去重后的 `keyword_candidates.jsonl` / `keyword_candidates.md`，并额外导出 chunk 级剧情概要 `keyword_chunk_summaries.jsonl` / `keyword_chunk_summaries.md`；报告会标出缺失 chunk row 或无法精确定位的候选 / 概要来源
+- `sync-keywords` 复用关键词 prompt、schema、候选去重、chunk 概要和 JSONL / Markdown 导出逻辑，适合小范围即时跑报告
 - 订正 manifest 的 `mode=revision`，关键词 manifest 的 `mode=keyword_extraction`，普通 `check/apply` 会拒绝处理，避免把非翻译结果误写回 `.rpy`
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包
 - 本地 RAG store 写入会使用 `.rag_store.lock` 和临时文件 + 原子替换保护 `history.jsonl` / `metadata.json`；如果另一个进程正在写同一个 store，后启动的进程会明确失败并显示锁持有者信息；同机写入进程崩溃后留下的 stale lock 会在确认 PID 已退出时自动回收

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2298,12 +2298,17 @@ def parse_json_payload(text):
         return json.loads(cleaned)
     except json.JSONDecodeError:
         decoder = json.JSONDecoder()
-        for start, char in sorted((index, char) for index, char in enumerate(cleaned) if char in '[{'):
+        embedded_payloads = []
+        for start, char in enumerate(cleaned):
+            if char not in '[{':
+                continue
             try:
-                payload, _end = decoder.raw_decode(cleaned[start:])
-                return payload
+                payload, end = decoder.raw_decode(cleaned[start:])
+                embedded_payloads.append((start + end, -start, payload))
             except json.JSONDecodeError:
                 continue
+        if embedded_payloads:
+            return max(embedded_payloads, key=lambda item: (item[0], item[1]))[2]
 
         start = cleaned.find('[')
         end = cleaned.rfind(']')
@@ -2513,8 +2518,8 @@ def write_keyword_summary_markdown(path, summaries, summary):
         f"- Parsed chunks: {summary.get('parsed_chunks', 0)}/{summary.get('expected_chunks', summary.get('result_rows', 0))}",
         f"- Ambiguous summary provenance chunks: {summary.get('ambiguous_summary_chunks', 0)}",
         '',
-        '| File | Lines | Summary | Evidence item ids |',
-        '| --- | ---: | --- | --- |',
+        '| File | Chunk lines | Evidence lines | Summary | Evidence item ids |',
+        '| --- | ---: | ---: | --- | --- |',
     ]
     for item in summaries:
         lines.append(
@@ -2522,6 +2527,7 @@ def write_keyword_summary_markdown(path, summaries, summary):
             + ' | '.join(
                 [
                     markdown_escape_cell(item.get('file_rel_path')),
+                    markdown_escape_cell(', '.join(str(value) for value in item.get('line_numbers') or [])),
                     markdown_escape_cell(', '.join(str(value) for value in item.get('source_lines') or [])),
                     markdown_escape_cell(item.get('chunk_summary')),
                     markdown_escape_cell(', '.join(item.get('summary_evidence_item_ids') or [])),

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1849,7 +1849,10 @@ def build_keyword_system_instruction(max_candidates_per_chunk=None):
         f'Return at most {max_candidates} candidates for this chunk. '
         'Avoid generic words, common function words, UI filler, and candidates already covered by existing glossary entries. '
         'Set source_item_ids to the input id values that support the candidate. '
-        'Use concise evidence that cites the relevant input id or phrase. Return JSON only.'
+        'Use concise evidence that cites the relevant input id or phrase.\n'
+        'Also write a compact chunk_summary in Chinese that summarizes only the visible story events in this chunk. '
+        'Use 1-3 sentences, avoid invented continuity, and leave chunk_summary empty if the lines do not contain usable story content. '
+        'Set summary_evidence_item_ids to the input ids that support the summary. Return JSON only.'
     )
 
 
@@ -1871,13 +1874,14 @@ def build_keyword_user_prompt(target_items):
     return (
         'TARGET LINES:\n'
         f'{target_payload}\n\n'
-        'Return candidate objects with source, suggested_target, category, confidence, evidence, and source_item_ids.'
+        'Return a JSON object with candidates, chunk_summary, and summary_evidence_item_ids. '
+        'Each candidate must include source, suggested_target, category, confidence, evidence, and source_item_ids.'
     )
 
 
 def build_keyword_response_json_schema(max_candidates_per_chunk=None):
     max_candidates = max(1, int(max_candidates_per_chunk or KEYWORD_MAX_CANDIDATES_PER_CHUNK))
-    return {
+    candidate_schema = {
         'type': 'array',
         'maxItems': max_candidates,
         'items': {
@@ -1897,6 +1901,19 @@ def build_keyword_response_json_schema(max_candidates_per_chunk=None):
                     'type': 'array',
                     'items': {'type': 'string'},
                 },
+            },
+        },
+    }
+    return {
+        'type': 'object',
+        'required': ['candidates', 'chunk_summary', 'summary_evidence_item_ids'],
+        'additionalProperties': False,
+        'properties': {
+            'candidates': candidate_schema,
+            'chunk_summary': {'type': 'string'},
+            'summary_evidence_item_ids': {
+                'type': 'array',
+                'items': {'type': 'string'},
             },
         },
     }
@@ -2486,6 +2503,38 @@ def normalize_keyword_candidates(payload):
     return normalized
 
 
+def normalize_keyword_summary(payload):
+    if not isinstance(payload, dict):
+        return {'chunk_summary': '', 'summary_evidence_item_ids': []}
+
+    summary_text = ''
+    for key in ('chunk_summary', 'plot_summary', 'scene_summary', 'summary'):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            summary_text = value
+            break
+
+    raw_source_item_ids = payload.get('summary_evidence_item_ids')
+    if not isinstance(raw_source_item_ids, list):
+        raw_source_item_ids = payload.get('summary_source_item_ids')
+    if not isinstance(raw_source_item_ids, list):
+        raw_source_item_ids = []
+
+    return {
+        'chunk_summary': compact_text(str(summary_text or '')),
+        'summary_evidence_item_ids': [
+            str(value) for value in raw_source_item_ids if str(value).strip()
+        ],
+    }
+
+
+def normalize_keyword_extraction_payload(payload):
+    return {
+        'candidates': normalize_keyword_candidates(payload),
+        **normalize_keyword_summary(payload),
+    }
+
+
 def keyword_candidate_key(candidate):
     return (
         compact_text(candidate.get('source', '')).lower(),
@@ -2520,11 +2569,10 @@ def resolve_keyword_export_path(manifest, value, default_name, field_name):
     return os.path.join(package_dir, default_name)
 
 
-def validate_keyword_export_paths(manifest, jsonl_path, markdown_path):
-    normalized_jsonl = _normalized_abs_path(jsonl_path)
-    normalized_markdown = _normalized_abs_path(markdown_path)
-    if normalized_jsonl == normalized_markdown:
-        raise SystemExit('Keyword export JSONL and Markdown outputs must be different files.')
+def validate_keyword_export_paths(manifest, *output_paths):
+    normalized_outputs = [_normalized_abs_path(path) for path in output_paths if path]
+    if len(normalized_outputs) != len(set(normalized_outputs)):
+        raise SystemExit('Keyword export outputs must be different files.')
 
     reserved_paths = {
         os.path.join(manifest.get('_package_dir', ''), 'manifest.json'),
@@ -2537,9 +2585,21 @@ def validate_keyword_export_paths(manifest, jsonl_path, markdown_path):
         if value:
             reserved_paths.add(value)
     normalized_reserved = {_normalized_abs_path(path) for path in reserved_paths if path}
-    for output_path in (jsonl_path, markdown_path):
+    for output_path in output_paths:
         if _normalized_abs_path(output_path) in normalized_reserved:
             raise SystemExit(f'Keyword export output would overwrite reserved package file: {output_path}')
+
+
+def match_keyword_items_by_ids(source_item_ids, chunk):
+    requested_ids = {str(value) for value in source_item_ids or [] if str(value).strip()}
+    if not requested_ids:
+        return []
+
+    matched = []
+    for item in chunk.get('items') or []:
+        if str(item.get('id') or '') in requested_ids:
+            matched.append(item)
+    return matched
 
 
 def match_keyword_candidate_items(candidate, chunk):
@@ -2609,7 +2669,41 @@ def write_keyword_markdown(path, candidates, summary):
         handle.write('\n'.join(lines) + '\n')
 
 
-def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
+def write_keyword_summary_markdown(path, summaries, summary):
+    lines = [
+        '# Keyword Chunk Summaries',
+        '',
+        f"- Summary count: {len(summaries)}",
+        f"- Parsed chunks: {summary.get('parsed_chunks', 0)}/{summary.get('expected_chunks', summary.get('result_rows', 0))}",
+        f"- Ambiguous summary provenance chunks: {summary.get('ambiguous_summary_chunks', 0)}",
+        '',
+        '| File | Lines | Summary | Evidence item ids |',
+        '| --- | ---: | --- | --- |',
+    ]
+    for item in summaries:
+        lines.append(
+            '| '
+            + ' | '.join(
+                [
+                    markdown_escape_cell(item.get('file_rel_path')),
+                    markdown_escape_cell(', '.join(str(value) for value in item.get('source_lines') or [])),
+                    markdown_escape_cell(item.get('chunk_summary')),
+                    markdown_escape_cell(', '.join(item.get('summary_evidence_item_ids') or [])),
+                ]
+            )
+            + ' |'
+        )
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write('\n'.join(lines) + '\n')
+
+
+def export_keyword_candidates(
+    target=None,
+    output_jsonl='',
+    output_markdown='',
+    output_summary_jsonl='',
+    output_summary_markdown='',
+):
     manifest = load_manifest(target)
     require_manifest_mode(manifest, MANIFEST_MODE_KEYWORD_EXTRACTION, 'export-keywords')
     result_path = resolve_manifest_result_path(manifest)
@@ -2631,9 +2725,12 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
         'missing_response_chunks': 0,
         'missing_chunk_rows': 0,
         'ambiguous_provenance_candidates': 0,
+        'chunk_summary_count': 0,
+        'ambiguous_summary_chunks': 0,
         'parse_errors': 0,
         'reason_counts': {},
     }
+    chunk_summaries = []
 
     with open(result_path, 'r', encoding='utf-8') as handle:
         for raw_line in handle:
@@ -2665,13 +2762,39 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
                 bump_counter(summary['reason_counts'], 'missing_response_text')
                 continue
             try:
-                candidates = normalize_keyword_candidates(parse_json_payload(response_text))
+                keyword_payload = normalize_keyword_extraction_payload(parse_json_payload(response_text))
+                candidates = keyword_payload['candidates']
             except Exception:
                 summary['parse_errors'] += 1
                 bump_counter(summary['reason_counts'], 'failed_to_parse_keyword_json')
                 continue
 
             summary['parsed_chunks'] += 1
+            chunk_summary = keyword_payload.get('chunk_summary', '')
+            if chunk_summary:
+                matched_summary_items = match_keyword_items_by_ids(
+                    keyword_payload.get('summary_evidence_item_ids'),
+                    chunk,
+                )
+                if not matched_summary_items:
+                    summary['ambiguous_summary_chunks'] += 1
+                    bump_counter(summary['reason_counts'], 'ambiguous_summary_provenance')
+                summary['chunk_summary_count'] += 1
+                chunk_summaries.append(
+                    {
+                        'key': key,
+                        'file_rel_path': chunk.get('file_rel_path', ''),
+                        'chunk_index': chunk.get('chunk_index', 0),
+                        'line_numbers': chunk.get('line_numbers') or [],
+                        'chunk_summary': chunk_summary,
+                        'summary_evidence_item_ids': [
+                            item.get('id') for item in matched_summary_items if item.get('id')
+                        ],
+                        'source_lines': sorted(
+                            {item.get('line_number', 0) for item in matched_summary_items if item.get('line_number')}
+                        ),
+                    }
+                )
             summary['candidate_count_raw'] += len(candidates)
             for candidate in candidates:
                 matched_items = match_keyword_candidate_items(candidate, chunk)
@@ -2708,27 +2831,50 @@ def export_keyword_candidates(target=None, output_jsonl='', output_markdown=''):
 
     jsonl_path = resolve_keyword_export_path(manifest, output_jsonl, 'keyword_candidates.jsonl', 'keyword JSONL output')
     markdown_path = resolve_keyword_export_path(manifest, output_markdown, 'keyword_candidates.md', 'keyword Markdown output')
-    validate_keyword_export_paths(manifest, jsonl_path, markdown_path)
+    summary_jsonl_path = resolve_keyword_export_path(
+        manifest,
+        output_summary_jsonl,
+        'keyword_chunk_summaries.jsonl',
+        'keyword summary JSONL output',
+    )
+    summary_markdown_path = resolve_keyword_export_path(
+        manifest,
+        output_summary_markdown,
+        'keyword_chunk_summaries.md',
+        'keyword summary Markdown output',
+    )
+    validate_keyword_export_paths(manifest, jsonl_path, markdown_path, summary_jsonl_path, summary_markdown_path)
     os.makedirs(os.path.dirname(jsonl_path), exist_ok=True)
     os.makedirs(os.path.dirname(markdown_path), exist_ok=True)
+    os.makedirs(os.path.dirname(summary_jsonl_path), exist_ok=True)
+    os.makedirs(os.path.dirname(summary_markdown_path), exist_ok=True)
     with open(jsonl_path, 'w', encoding='utf-8') as handle:
         for candidate in candidates:
             serializable = dict(candidate)
             serializable.pop('evidence_items', None)
             handle.write(json.dumps(serializable, ensure_ascii=False) + '\n')
+    with open(summary_jsonl_path, 'w', encoding='utf-8') as handle:
+        for item in chunk_summaries:
+            handle.write(json.dumps(item, ensure_ascii=False) + '\n')
     write_keyword_markdown(markdown_path, candidates, summary)
+    write_keyword_summary_markdown(summary_markdown_path, chunk_summaries, summary)
 
     manifest['keyword_exported_at'] = datetime.now().isoformat(timespec='seconds')
     manifest['keyword_export'] = {
         'jsonl_path': jsonl_path,
         'markdown_path': markdown_path,
+        'summary_jsonl_path': summary_jsonl_path,
+        'summary_markdown_path': summary_markdown_path,
         'summary': summary,
     }
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
 
     print(f'Keyword candidates: {summary["candidate_count_deduped"]} deduped from {summary["candidate_count_raw"]} raw')
+    print(f'Chunk summaries: {summary["chunk_summary_count"]}')
     print(f'JSONL: {jsonl_path}')
     print(f'Markdown: {markdown_path}')
+    print(f'Summary JSONL: {summary_jsonl_path}')
+    print(f'Summary Markdown: {summary_markdown_path}')
     if summary.get('reason_counts'):
         print('Warnings:')
         for name in sorted(summary['reason_counts']):
@@ -4881,6 +5027,8 @@ def sync_keyword_candidates(
     offset=0,
     output_jsonl='',
     output_markdown='',
+    output_summary_jsonl='',
+    output_summary_markdown='',
     api_key_index=None,
 ):
     if not skip_prepare:
@@ -4931,6 +5079,8 @@ def sync_keyword_candidates(
         target=manifest['_manifest_path'],
         output_jsonl=output_jsonl,
         output_markdown=output_markdown,
+        output_summary_jsonl=output_summary_jsonl,
+        output_summary_markdown=output_summary_markdown,
     )
 
 
@@ -5463,6 +5613,16 @@ def build_arg_parser():
     )
     keyword_export_parser.add_argument('--jsonl', default='', help='Relative output JSONL path inside the package.')
     keyword_export_parser.add_argument('--markdown', default='', help='Relative output Markdown path inside the package.')
+    keyword_export_parser.add_argument(
+        '--summary-jsonl',
+        default='',
+        help='Relative chunk summary JSONL path inside the package.',
+    )
+    keyword_export_parser.add_argument(
+        '--summary-markdown',
+        default='',
+        help='Relative chunk summary Markdown path inside the package.',
+    )
 
     revision_preview_parser = subparsers.add_parser(
         'preview-revisions',
@@ -5524,6 +5684,16 @@ def build_arg_parser():
     sync_keyword_parser.add_argument('--offset', type=int, default=0, help='Start offset within built keyword chunks.')
     sync_keyword_parser.add_argument('--jsonl', default='', help='Relative output JSONL path inside the sync run dir.')
     sync_keyword_parser.add_argument('--markdown', default='', help='Relative output Markdown path inside the sync run dir.')
+    sync_keyword_parser.add_argument(
+        '--summary-jsonl',
+        default='',
+        help='Relative chunk summary JSONL path inside the sync run dir.',
+    )
+    sync_keyword_parser.add_argument(
+        '--summary-markdown',
+        default='',
+        help='Relative chunk summary Markdown path inside the sync run dir.',
+    )
     sync_keyword_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
 
     sync_revision_parser = subparsers.add_parser(
@@ -5676,6 +5846,8 @@ def main(argv=None):
             target=args.target or None,
             output_jsonl=args.jsonl,
             output_markdown=args.markdown,
+            output_summary_jsonl=args.summary_jsonl,
+            output_summary_markdown=args.summary_markdown,
         )
         return
 
@@ -5701,6 +5873,8 @@ def main(argv=None):
             offset=args.offset,
             output_jsonl=args.jsonl,
             output_markdown=args.markdown,
+            output_summary_jsonl=args.summary_jsonl,
+            output_summary_markdown=args.summary_markdown,
             api_key_index=args.api_key_index,
         )
         return

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2308,7 +2308,19 @@ def parse_json_payload(text):
             except json.JSONDecodeError:
                 continue
         if embedded_payloads:
-            return max(embedded_payloads, key=lambda item: (item[0], item[1]))[2]
+            _end, neg_start, payload = max(embedded_payloads, key=lambda item: (item[0], item[1]))
+            start = -neg_start
+            previous_index = start - 1
+            while previous_index >= 0 and cleaned[previous_index].isspace():
+                previous_index -= 1
+            salvaged = salvage_partial_json_array(cleaned)
+            if (
+                salvaged
+                and previous_index >= 0
+                and cleaned[previous_index] in '[,'
+            ):
+                return salvaged
+            return payload
 
         start = cleaned.find('[')
         end = cleaned.rfind(']')

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2189,6 +2189,14 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(payload['chunk_summary'], '片段概要')
         self.assertEqual(payload['summary_evidence_item_ids'], ['line-1'])
 
+    def test_parse_json_payload_preserves_partial_array_salvage(self):
+        payload = batch_mod.parse_json_payload(
+            '[{"id":"line-1","translation":"第一行"},{"id":"line-2","translation":"第二行"'
+        )
+
+        self.assertIsInstance(payload, list)
+        self.assertEqual(payload, [{'id': 'line-1', 'translation': '第一行'}])
+
     def test_split_manifest_keeps_first_child_latest_and_context_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2093,10 +2093,18 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(manifest['summary']['chunk_count'], 2)
         self.assertEqual(manifest['chunks'][0]['items'][0]['line_number'], 2)
         prepare_mock.assert_not_called()
-        self.assertEqual(request_rows[0]['request']['generation_config']['response_json_schema']['maxItems'], 3)
-        self.assertIn('source', request_rows[0]['request']['generation_config']['response_json_schema']['items']['required'])
-        self.assertIn('source_item_ids', request_rows[0]['request']['generation_config']['response_json_schema']['items']['properties'])
-        self.assertIn('Existing glossary entries', request_rows[0]['request']['system_instruction']['parts'][0]['text'])
+        schema = request_rows[0]['request']['generation_config']['response_json_schema']
+        candidate_schema = schema['properties']['candidates']
+        self.assertEqual(schema['type'], 'object')
+        self.assertIn('candidates', schema['required'])
+        self.assertIn('chunk_summary', schema['required'])
+        self.assertIn('summary_evidence_item_ids', schema['required'])
+        self.assertEqual(candidate_schema['maxItems'], 3)
+        self.assertIn('source', candidate_schema['items']['required'])
+        self.assertIn('source_item_ids', candidate_schema['items']['properties'])
+        system_text = request_rows[0]['request']['system_instruction']['parts'][0]['text']
+        self.assertIn('Existing glossary entries', system_text)
+        self.assertIn('chunk_summary', system_text)
 
     def test_export_keyword_candidates_dedupes_jsonl_and_markdown(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2104,23 +2112,27 @@ class BatchRepairRegressionTests(unittest.TestCase):
             result_path = package_dir / 'results.jsonl'
             manifest_path = package_dir / 'manifest.json'
             response_text = json.dumps(
-                [
-                    {
-                        'source': 'Void Gate',
-                        'suggested_target': '虚空门',
-                        'category': 'term',
-                        'confidence': 0.7,
-                        'evidence': 'script.rpy:2',
-                        'source_item_ids': ['script.rpy:2:keyword:0'],
-                    },
-                    {
-                        'source': 'Void Gate',
-                        'suggested_target': '虚空门',
-                        'category': 'term',
-                        'confidence': 0.9,
-                        'evidence': 'script.rpy:3',
-                    },
-                ],
+                {
+                    'candidates': [
+                        {
+                            'source': 'Void Gate',
+                            'suggested_target': '虚空门',
+                            'category': 'term',
+                            'confidence': 0.7,
+                            'evidence': 'script.rpy:2',
+                            'source_item_ids': ['script.rpy:2:keyword:0'],
+                        },
+                        {
+                            'source': 'Void Gate',
+                            'suggested_target': '虚空门',
+                            'category': 'term',
+                            'confidence': 0.9,
+                            'evidence': 'script.rpy:3',
+                        },
+                    ],
+                    'chunk_summary': '一行提到虚空门，另一行提到其他术语。',
+                    'summary_evidence_item_ids': ['script.rpy:2:keyword:0', 'script.rpy:3:keyword:1'],
+                },
                 ensure_ascii=False,
             )
             result_path.write_text(
@@ -2183,21 +2195,102 @@ class BatchRepairRegressionTests(unittest.TestCase):
             export = batch_mod.export_keyword_candidates(str(manifest_path))
             jsonl_path = Path(export['jsonl_path'])
             markdown_path = Path(export['markdown_path'])
+            summary_jsonl_path = Path(export['summary_jsonl_path'])
+            summary_markdown_path = Path(export['summary_markdown_path'])
             rows = [
                 json.loads(line)
                 for line in jsonl_path.read_text(encoding='utf-8').splitlines()
             ]
+            summary_rows = [
+                json.loads(line)
+                for line in summary_jsonl_path.read_text(encoding='utf-8').splitlines()
+            ]
             markdown_text = markdown_path.read_text(encoding='utf-8')
+            summary_markdown_text = summary_markdown_path.read_text(encoding='utf-8')
 
         self.assertEqual(export['summary']['candidate_count_raw'], 2)
         self.assertEqual(export['summary']['candidate_count_deduped'], 1)
+        self.assertEqual(export['summary']['chunk_summary_count'], 1)
         self.assertEqual(rows[0]['source'], 'Void Gate')
         self.assertEqual(rows[0]['confidence'], 0.9)
         self.assertEqual(rows[0]['occurrences'], 2)
         self.assertEqual(rows[0]['source_lines'], [2])
         self.assertEqual(rows[0]['source_item_ids'], ['script.rpy:2:keyword:0'])
+        self.assertEqual(summary_rows[0]['chunk_summary'], '一行提到虚空门，另一行提到其他术语。')
+        self.assertEqual(summary_rows[0]['source_lines'], [2, 3])
         self.assertEqual(export['summary']['missing_chunk_rows'], 1)
         self.assertIn('Void Gate', markdown_text)
+        self.assertIn('虚空门', summary_markdown_text)
+
+    def test_export_keyword_candidates_accepts_legacy_candidate_array(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            response_text = json.dumps(
+                [
+                    {
+                        'source': 'Legacy Term',
+                        'suggested_target': '旧术语',
+                        'category': 'term',
+                        'confidence': 0.8,
+                        'evidence': 'script.rpy:2',
+                        'source_item_ids': ['script.rpy:2:keyword:0'],
+                    }
+                ],
+                ensure_ascii=False,
+            )
+            result_path.write_text(
+                json.dumps(
+                    {
+                        'key': 'kw-1',
+                        'response': {
+                            'candidates': [
+                                {'content': {'parts': [{'text': response_text}]}}
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'mode': batch_mod.MANIFEST_MODE_KEYWORD_EXTRACTION,
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'kw-1',
+                                'file_rel_path': 'script.rpy',
+                                'line_numbers': [2],
+                                'items': [
+                                    {
+                                        'id': 'script.rpy:2:keyword:0',
+                                        'line_number': 2,
+                                        'text': 'Legacy Term',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            export = batch_mod.export_keyword_candidates(str(manifest_path))
+            rows = [
+                json.loads(line)
+                for line in Path(export['jsonl_path']).read_text(encoding='utf-8').splitlines()
+            ]
+            summary_jsonl_text = Path(export['summary_jsonl_path']).read_text(encoding='utf-8')
+
+        self.assertEqual(rows[0]['source'], 'Legacy Term')
+        self.assertEqual(export['summary']['candidate_count_deduped'], 1)
+        self.assertEqual(export['summary']['chunk_summary_count'], 0)
+        self.assertEqual(summary_jsonl_text, '')
 
     def test_export_keyword_candidates_rejects_reserved_output_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2352,16 +2445,20 @@ class BatchRepairRegressionTests(unittest.TestCase):
                 batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
                 Path(batch_mod.LATEST_MANIFEST_FILE).write_text(str(previous_latest), encoding='utf-8')
                 response_text = json.dumps(
-                    [
-                        {
-                            'source': 'Void Gate',
-                            'suggested_target': '虚空门',
-                            'category': 'term',
-                            'confidence': 0.9,
-                            'evidence': 'script.rpy:2:keyword:0',
-                            'source_item_ids': ['script.rpy:2:keyword:0'],
-                        }
-                    ],
+                    {
+                        'candidates': [
+                            {
+                                'source': 'Void Gate',
+                                'suggested_target': '虚空门',
+                                'category': 'term',
+                                'confidence': 0.9,
+                                'evidence': 'script.rpy:2:keyword:0',
+                                'source_item_ids': ['script.rpy:2:keyword:0'],
+                            }
+                        ],
+                        'chunk_summary': '这里提到了虚空门。',
+                        'summary_evidence_item_ids': ['script.rpy:2:keyword:0'],
+                    },
                     ensure_ascii=False,
                 )
 
@@ -2384,6 +2481,10 @@ class BatchRepairRegressionTests(unittest.TestCase):
                     json.loads(line)
                     for line in jsonl_path.read_text(encoding='utf-8').splitlines()
                 ]
+                summary_rows = [
+                    json.loads(line)
+                    for line in Path(export['summary_jsonl_path']).read_text(encoding='utf-8').splitlines()
+                ]
                 latest_after = Path(batch_mod.LATEST_MANIFEST_FILE).read_text(encoding='utf-8')
         finally:
             batch_mod.legacy.TL_DIR = old_values['tl_dir']
@@ -2395,8 +2496,10 @@ class BatchRepairRegressionTests(unittest.TestCase):
 
         sync_request.assert_called_once()
         self.assertEqual(export['summary']['candidate_count_deduped'], 1)
+        self.assertEqual(export['summary']['chunk_summary_count'], 1)
         self.assertEqual(rows[0]['source'], 'Void Gate')
         self.assertEqual(rows[0]['suggested_target'], '虚空门')
+        self.assertEqual(summary_rows[0]['chunk_summary'], '这里提到了虚空门。')
         self.assertEqual(latest_after, str(previous_latest))
 
     def test_sync_revisions_previews_and_optionally_applies(self):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2181,7 +2181,9 @@ class BatchRagRegressionTests(unittest.TestCase):
 class BatchRepairRegressionTests(unittest.TestCase):
     def test_parse_json_payload_recovers_prefixed_keyword_object(self):
         payload = batch_mod.parse_json_payload(
-            'Here is the JSON: {"candidates":[],"chunk_summary":"片段概要","summary_evidence_item_ids":["line-1"]}'
+            'Earlier attempt: []\n'
+            'Here is the JSON: {"candidates":[],"chunk_summary":"片段概要","summary_evidence_item_ids":["line-1"]}\n'
+            'Done.'
         )
 
         self.assertEqual(payload['chunk_summary'], '片段概要')
@@ -2335,6 +2337,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertIn('summary_evidence_item_ids', schema['required'])
         self.assertEqual(candidate_schema['maxItems'], 3)
         self.assertIn('source', candidate_schema['items']['required'])
+        self.assertIn('source_item_ids', candidate_schema['items']['required'])
         self.assertIn('source_item_ids', candidate_schema['items']['properties'])
         system_text = request_rows[0]['request']['system_instruction']['parts'][0]['text']
         self.assertIn('Existing glossary entries', system_text)
@@ -2455,6 +2458,8 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(export['summary']['missing_chunk_rows'], 1)
         self.assertIn('Void Gate', markdown_text)
         self.assertIn('虚空门', summary_markdown_text)
+        self.assertIn('Chunk lines', summary_markdown_text)
+        self.assertIn('Evidence lines', summary_markdown_text)
 
     def test_export_keyword_candidates_accepts_legacy_candidate_array(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/translation_core.py
+++ b/translation_core.py
@@ -657,7 +657,7 @@ def build_keyword_schema(max_candidates_per_chunk=12):
         'maxItems': max_candidates,
         'items': {
             'type': 'object',
-            'required': ['source', 'suggested_target', 'category', 'confidence', 'evidence'],
+            'required': ['source', 'suggested_target', 'category', 'confidence', 'evidence', 'source_item_ids'],
             'additionalProperties': False,
             'properties': {
                 'source': {'type': 'string'},


### PR DESCRIPTION
## Summary

- Extend keyword extraction requests to return a structured object with `candidates`, `chunk_summary`, and `summary_evidence_item_ids`.
- Export chunk-level story summaries alongside keyword candidate JSONL/Markdown reports.
- Keep export compatibility with legacy keyword result payloads that are plain candidate arrays.

## Validation

- `python -m py_compile .\gemini_translate_batch.py`
- `python -m unittest -q tests.test_regressions`
- `python -m unittest discover -s tests -q`
- `git diff --cached --check`