### PR TITLE
[codex] Add speaker-aware translation prompts

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -560,10 +560,24 @@ def compact_text(text):
     return re.sub(r'\s+', ' ', text or '').strip()
 
 
+def item_text(item):
+    if isinstance(item, dict):
+        return item.get('text') or item.get('source') or ''
+    return item
+
+
 def build_rag_query_text(target_items, context_past):
     parts = []
-    local_past = [compact_text(text) for text in context_past[-2:] if compact_text(text)]
-    target_lines = [compact_text(item.get('text', '')) for item in target_items if compact_text(item.get('text', ''))]
+    local_past = [
+        compact_text(item_text(item))
+        for item in context_past[-2:]
+        if compact_text(item_text(item))
+    ]
+    target_lines = [
+        compact_text(item_text(item))
+        for item in target_items
+        if compact_text(item_text(item))
+    ]
     if local_past:
         parts.append('Context before:\n' + '\n'.join(f'- {text}' for text in local_past))
     if target_lines:
@@ -1153,8 +1167,24 @@ def build_chunks(file_jobs):
                 file_rel_path=job['file_rel_path'],
                 file_path=job['file_path'],
             )
-            context_past = [item['text'] for item in tasks[max(0, start - BATCH_CONTEXT_BEFORE):start]]
-            context_future = [item['text'] for item in tasks[end:min(total, end + BATCH_CONTEXT_AFTER)]]
+            context_past = [
+                translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
+                for unit in translation_core.units_from_items(
+                    tasks[max(0, start - BATCH_CONTEXT_BEFORE):start],
+                    translation_core.MODE_TRANSLATION,
+                    file_rel_path=job['file_rel_path'],
+                    file_path=job['file_path'],
+                )
+            ]
+            context_future = [
+                translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
+                for unit in translation_core.units_from_items(
+                    tasks[end:min(total, end + BATCH_CONTEXT_AFTER)],
+                    translation_core.MODE_TRANSLATION,
+                    file_rel_path=job['file_rel_path'],
+                    file_path=job['file_path'],
+                )
+            ]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
             history_hits, rag_stats = retrieve_history_hits(target_items, context_past) if RAG_ENABLED else ([], {})
             story_hits = retrieve_batch_story_hits(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -566,18 +566,19 @@ def item_text(item):
     return item
 
 
+def compact_item_texts(items):
+    compacted = []
+    for item in items or []:
+        text = compact_text(item_text(item))
+        if text:
+            compacted.append(text)
+    return compacted
+
+
 def build_rag_query_text(target_items, context_past):
     parts = []
-    local_past = [
-        compact_text(item_text(item))
-        for item in context_past[-2:]
-        if compact_text(item_text(item))
-    ]
-    target_lines = [
-        compact_text(item_text(item))
-        for item in target_items
-        if compact_text(item_text(item))
-    ]
+    local_past = compact_item_texts(context_past[-2:])
+    target_lines = compact_item_texts(target_items)
     if local_past:
         parts.append('Context before:\n' + '\n'.join(f'- {text}' for text in local_past))
     if target_lines:
@@ -1167,24 +1168,8 @@ def build_chunks(file_jobs):
                 file_rel_path=job['file_rel_path'],
                 file_path=job['file_path'],
             )
-            context_past = [
-                translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
-                for unit in translation_core.units_from_items(
-                    tasks[max(0, start - BATCH_CONTEXT_BEFORE):start],
-                    translation_core.MODE_TRANSLATION,
-                    file_rel_path=job['file_rel_path'],
-                    file_path=job['file_path'],
-                )
-            ]
-            context_future = [
-                translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
-                for unit in translation_core.units_from_items(
-                    tasks[end:min(total, end + BATCH_CONTEXT_AFTER)],
-                    translation_core.MODE_TRANSLATION,
-                    file_rel_path=job['file_rel_path'],
-                    file_path=job['file_path'],
-                )
-            ]
+            context_past = tasks[max(0, start - BATCH_CONTEXT_BEFORE):start]
+            context_future = tasks[end:min(total, end + BATCH_CONTEXT_AFTER)]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
             history_hits, rag_stats = retrieve_history_hits(target_items, context_past) if RAG_ENABLED else ([], {})
             story_hits = retrieve_batch_story_hits(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -31,6 +31,7 @@ class TranslationCoreRegressionTests(unittest.TestCase):
             'prefix': '',
             'quote': '"',
             'speaker_id': 'e',
+            'speaker_name': 'Eileen',
             'progress_entry': 'task:0:4',
         }
         sync_unit = translation_core.unit_from_sync_task(sync_task, file_rel_path='script.rpy')
@@ -51,6 +52,7 @@ class TranslationCoreRegressionTests(unittest.TestCase):
                 'quote': '"',
                 'speaker_id': 'e',
                 'speaker': 'e',
+                'speaker_name': 'Eileen',
             },
         )
 
@@ -88,8 +90,8 @@ class TranslationCoreRegressionTests(unittest.TestCase):
 
     def test_prompt_wrappers_use_core_schema_for_all_modes(self):
         translation_prompt = batch_mod.build_user_prompt(
-            ['Before line'],
-            [{'id': 'script.rpy:0:4', 'text': 'Hello Alice'}],
+            [{'id': 'script.rpy:0:0', 'text': 'Before line', 'speaker_id': 'n', 'speaker_name': 'Noah'}],
+            [{'id': 'script.rpy:0:4', 'text': 'Hello Alice', 'speaker_id': 'e', 'speaker_name': 'Eileen'}],
             ['After line'],
             glossary_hits=[{'source': 'Alice', 'target': 'Alice'}],
         )
@@ -99,6 +101,9 @@ class TranslationCoreRegressionTests(unittest.TestCase):
         self.assertIn('LOCKED TERMS', translation_prompt)
         self.assertIn('TARGET', translation_prompt)
         self.assertIn('script.rpy:0:4', translation_prompt)
+        self.assertIn('Noah (n): Before line', translation_prompt)
+        self.assertIn('"speaker_id":"e"', translation_prompt)
+        self.assertIn('"speaker_name":"Eileen"', translation_prompt)
         self.assertEqual(translation_schema['items']['required'], ['id', 'translation'])
 
         revision_chunk = {
@@ -314,6 +319,22 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(by_text['Hello Noah'].get('speaker_id'), 'e')
         self.assertEqual(by_text['Hello Noah'].get('speaker'), 'e')
         self.assertNotIn('speaker_id', by_text['Start Game'])
+
+    def test_collect_tasks_uses_character_defines_for_speaker_name(self):
+        tasks = runtime.collect_tasks([
+            'define e = Character("Eileen")\n',
+            'define n = Character(_("Noah"), color="#fff")\n',
+            'e "Hello Noah"\n',
+            'n "Hi Eileen"\n',
+        ])
+        by_text = {task['text']: task for task in tasks}
+
+        self.assertNotIn('Eileen', by_text)
+        self.assertNotIn('Noah', by_text)
+        self.assertEqual(by_text['Hello Noah'].get('speaker_id'), 'e')
+        self.assertEqual(by_text['Hello Noah'].get('speaker_name'), 'Eileen')
+        self.assertEqual(by_text['Hi Eileen'].get('speaker_id'), 'n')
+        self.assertEqual(by_text['Hi Eileen'].get('speaker_name'), 'Noah')
 
     def test_collect_tasks_allows_new_as_dialogue_speaker_id(self):
         tasks = runtime.collect_tasks(['new "Hello Noah"\n'])

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import pickle
+import subprocess
 import sys
 import tempfile
 import time
@@ -372,6 +373,25 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertNotIn('Eileen', by_text)
         self.assertIn(' says ', by_text)
         self.assertEqual(by_text['Hello Noah'].get('speaker_name'), 'Eileen')
+
+    def test_runtime_import_does_not_load_relation_analyzer_common(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                (
+                    'import sys\n'
+                    'import translator_runtime\n'
+                    'print("COMMON_IMPORTED=%s" % ("relation_analyzer.common" in sys.modules))\n'
+                ),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        self.assertIn('COMMON_IMPORTED=False', result.stdout)
 
     def test_collect_tasks_allows_new_as_dialogue_speaker_id(self):
         tasks = runtime.collect_tasks(['new "Hello Noah"\n'])

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -336,6 +336,43 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(by_text['Hi Eileen'].get('speaker_id'), 'n')
         self.assertEqual(by_text['Hi Eileen'].get('speaker_name'), 'Noah')
 
+    def test_collect_tasks_keeps_character_kwargs_after_display_name(self):
+        tasks = runtime.collect_tasks([
+            'define e = Character("Eileen", what_prefix=" says ")\n',
+            'e "Hello Noah"\n',
+        ])
+        by_text = {task['text']: task for task in tasks}
+
+        self.assertNotIn('Eileen', by_text)
+        self.assertIn(' says ', by_text)
+        self.assertEqual(by_text['Hello Noah'].get('speaker_name'), 'Eileen')
+
+    def test_collect_tasks_resolves_character_defines_in_file_order(self):
+        tasks = runtime.collect_tasks([
+            'define e = Character("Eileen")\n',
+            'e "Before"\n',
+            'define e = Character("Echo")\n',
+            'e "After"\n',
+        ])
+        by_text = {task['text']: task for task in tasks}
+
+        self.assertEqual(by_text['Before'].get('speaker_name'), 'Eileen')
+        self.assertEqual(by_text['After'].get('speaker_name'), 'Echo')
+
+    def test_collect_tasks_skips_multiline_character_display_name(self):
+        tasks = runtime.collect_tasks([
+            'define e = Character(\n',
+            '    _("Eileen"),\n',
+            '    what_prefix=" says ",\n',
+            ')\n',
+            'e "Hello Noah"\n',
+        ])
+        by_text = {task['text']: task for task in tasks}
+
+        self.assertNotIn('Eileen', by_text)
+        self.assertIn(' says ', by_text)
+        self.assertEqual(by_text['Hello Noah'].get('speaker_name'), 'Eileen')
+
     def test_collect_tasks_allows_new_as_dialogue_speaker_id(self):
         tasks = runtime.collect_tasks(['new "Hello Noah"\n'])
 
@@ -1600,6 +1637,70 @@ class RagMemoryStoreTests(unittest.TestCase):
 
 
 class BatchRagRegressionTests(unittest.TestCase):
+    def test_build_chunks_keeps_context_task_dicts(self):
+        old_values = {
+            'target_size': batch_mod.BATCH_TARGET_SIZE,
+            'context_before': batch_mod.BATCH_CONTEXT_BEFORE,
+            'context_after': batch_mod.BATCH_CONTEXT_AFTER,
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'story_enabled': batch_mod.STORY_MEMORY_ENABLED,
+        }
+        try:
+            batch_mod.BATCH_TARGET_SIZE = 1
+            batch_mod.BATCH_CONTEXT_BEFORE = 1
+            batch_mod.BATCH_CONTEXT_AFTER = 1
+            batch_mod.RAG_ENABLED = False
+            batch_mod.STORY_MEMORY_ENABLED = False
+
+            chunks = batch_mod.build_chunks([
+                {
+                    'file_rel_path': 'script.rpy',
+                    'file_path': 'script.rpy',
+                    'tasks': [
+                        {
+                            'id': 'script.rpy:1:0',
+                            'text': 'Before line',
+                            'line': 1,
+                            'start': 0,
+                            'end': 11,
+                            'speaker_id': 'e',
+                            'speaker_name': 'Eileen',
+                            'progress_entry': 'task:1:0',
+                        },
+                        {
+                            'id': 'script.rpy:2:0',
+                            'text': 'Target line',
+                            'line': 2,
+                            'start': 0,
+                            'end': 11,
+                            'speaker_id': 'n',
+                            'speaker_name': 'Noah',
+                            'progress_entry': 'task:2:0',
+                        },
+                        {
+                            'id': 'script.rpy:3:0',
+                            'text': 'After line',
+                            'line': 3,
+                            'start': 0,
+                            'end': 10,
+                            'speaker_id': 'e',
+                            'speaker_name': 'Eileen',
+                            'progress_entry': 'task:3:0',
+                        },
+                    ],
+                }
+            ])
+        finally:
+            batch_mod.BATCH_TARGET_SIZE = old_values['target_size']
+            batch_mod.BATCH_CONTEXT_BEFORE = old_values['context_before']
+            batch_mod.BATCH_CONTEXT_AFTER = old_values['context_after']
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.STORY_MEMORY_ENABLED = old_values['story_enabled']
+
+        self.assertEqual(chunks[1]['context_past'][0]['speaker_name'], 'Eileen')
+        self.assertEqual(chunks[1]['context_past'][0]['progress_entry'], 'task:1:0')
+        self.assertEqual(chunks[1]['context_future'][0]['speaker_name'], 'Eileen')
+
     def test_format_history_hits_block_shows_source_translation_pair(self):
         block = batch_mod.format_history_hits_block([
             {

--- a/translation_core.py
+++ b/translation_core.py
@@ -52,6 +52,7 @@ class TranslationUnit:
     quote: str = '"'
     speaker_id: str = ''
     speaker: str = ''
+    speaker_name: str = ''
     progress_entry: str = ''
     metadata: dict = field(default_factory=dict)
 
@@ -179,6 +180,7 @@ _TRANSLATION_KEYS = {
     'quote',
     'speaker_id',
     'speaker',
+    'speaker_name',
     'progress_entry',
 }
 
@@ -189,6 +191,12 @@ def unit_from_translation_item(item, file_rel_path='', file_path='', mode=MODE_T
     text = str(item.get('text') if item.get('text') is not None else item.get('source') or '')
     source = str(item.get('source') or text)
     speaker_id = str(item.get('speaker_id') or item.get('speaker') or '')
+    speaker_name = str(
+        item.get('speaker_name')
+        or item.get('speaker_display_name')
+        or item.get('character_name')
+        or ''
+    )
     return TranslationUnit(
         id=str(item.get('id') or ''),
         mode=mode or MODE_TRANSLATION,
@@ -205,6 +213,7 @@ def unit_from_translation_item(item, file_rel_path='', file_path='', mode=MODE_T
         quote=str(item.get('quote') or '"'),
         speaker_id=speaker_id,
         speaker=str(item.get('speaker') or speaker_id),
+        speaker_name=speaker_name,
         progress_entry=str(item.get('progress_entry') or ''),
         metadata=_metadata_for(item, _TRANSLATION_KEYS),
     )
@@ -291,6 +300,8 @@ def unit_to_translation_item(unit):
         'speaker_id': unit.speaker_id,
         'speaker': unit.speaker,
     }
+    if unit.speaker_name:
+        item['speaker_name'] = unit.speaker_name
     return item
 
 
@@ -310,6 +321,8 @@ def unit_to_revision_item(unit):
     }
     if unit.speaker_id:
         item['speaker_id'] = unit.speaker_id
+    if unit.speaker_name:
+        item['speaker_name'] = unit.speaker_name
     return item
 
 
@@ -325,6 +338,8 @@ def unit_to_keyword_item(unit):
         item['translation_line_number'] = translation_line_number
     if unit.speaker_id:
         item['speaker_id'] = unit.speaker_id
+    if unit.speaker_name:
+        item['speaker_name'] = unit.speaker_name
     return item
 
 
@@ -337,15 +352,44 @@ def legacy_item_from_unit(unit, mode=None):
     return unit_to_translation_item(unit)
 
 
+def _speaker_label(speaker_id='', speaker_name=''):
+    speaker_id = str(speaker_id or '').strip()
+    speaker_name = str(speaker_name or '').strip()
+    if speaker_id and speaker_name and speaker_id != speaker_name:
+        return f'{speaker_name} ({speaker_id})'
+    return speaker_name or speaker_id
+
+
+def _format_context_line(line):
+    speaker_id = ''
+    speaker_name = ''
+    if isinstance(line, TranslationUnit):
+        text = line.source_text
+        speaker_id = line.speaker_id
+        speaker_name = line.speaker_name
+    elif isinstance(line, dict):
+        text = line.get('text') or line.get('source') or ''
+        speaker_id = line.get('speaker_id') or line.get('speaker') or ''
+        speaker_name = (
+            line.get('speaker_name')
+            or line.get('speaker_display_name')
+            or line.get('character_name')
+            or ''
+        )
+    else:
+        text = str(line)
+    label = _speaker_label(speaker_id, speaker_name)
+    if label and text:
+        return f'{label}: {text}'
+    return text
+
+
 def format_context_block(lines, empty_label='(none)'):
     if not lines:
         return empty_label
     rendered = []
     for line in lines:
-        if isinstance(line, TranslationUnit):
-            rendered.append(line.source_text)
-        else:
-            rendered.append(str(line))
+        rendered.append(_format_context_line(line))
     return '\n'.join(f'- {line}' for line in rendered if line) or empty_label
 
 
@@ -395,6 +439,15 @@ def build_reference_blocks(
     )
 
 
+def translation_target_payload_item(unit):
+    item = {'id': unit.id, 'text': unit.text}
+    if unit.speaker_id:
+        item['speaker_id'] = unit.speaker_id
+    if unit.speaker_name:
+        item['speaker_name'] = unit.speaker_name
+    return item
+
+
 def build_translation_system_instruction(preserve_terms, macro_setting=''):
     glossary = ', '.join(str(term) for term in preserve_terms or [])
     return (
@@ -404,6 +457,7 @@ def build_translation_system_instruction(preserve_terms, macro_setting=''):
         'Translate only TARGET lines into Simplified Chinese. CONTEXT lines are reference only.\n'
         f'Keep these terms unchanged: {glossary}\n'
         "Keep names, Ren'Py tags, placeholders, variables, and format strings unchanged.\n"
+        'When TARGET items include speaker_id or speaker_name, use them only to identify the speaker and voice.\n'
         'Return JSON only. Preserve every id exactly. Item count must match. '
         'translation must contain only the translated Chinese text.'
     )
@@ -422,7 +476,7 @@ def build_translation_user_prompt(
     context_window = context_window or ContextWindow()
     units = units_from_items(units, MODE_TRANSLATION)
     target_payload = json.dumps(
-        [{'id': unit.id, 'text': unit.text} for unit in units],
+        [translation_target_payload_item(unit) for unit in units],
         ensure_ascii=False,
         separators=(',', ':'),
     )
@@ -455,7 +509,7 @@ def build_sync_translation_prompt(
     units = units_from_items(units, MODE_TRANSLATION)
     glossary = ', '.join(str(term) for term in preserve_terms or [])
     payload = json.dumps(
-        [{'id': unit.id, 'text': unit.text} for unit in units],
+        [translation_target_payload_item(unit) for unit in units],
         ensure_ascii=False,
     )
     reference_body = build_reference_blocks(
@@ -480,6 +534,7 @@ def build_sync_translation_prompt(
         f'1. Preserve these terms exactly (do not translate): {glossary}\n'
         '1.1 Keep all person names in English; do not translate names.\n'
         "2. Preserve Ren'Py tags like {i}, {/i}, {color=...}, [name], %s.\n"
+        '2.1 If an input item includes speaker_id or speaker_name, use it only to identify who is speaking and their voice.\n'
         '3. Output plain Chinese text. No markdown, no Pinyin, no explanations.\n'
         '4. Return ONLY a JSON array matching the requested id/translation structure.\n'
         f'{reference_blocks}'
@@ -513,18 +568,21 @@ def build_revision_user_prompt(
 ):
     context_window = context_window or ContextWindow()
     units = units_from_items(units, MODE_REVISION)
+    payload_items = []
+    for unit in units:
+        item = {
+            'id': unit.id,
+            'file': unit.file_rel_path,
+            'line': unit.display_line_number,
+            'speaker_id': unit.speaker_id,
+            'source': unit.source_text,
+            'current_translation': unit.current_translation,
+        }
+        if unit.speaker_name:
+            item['speaker_name'] = unit.speaker_name
+        payload_items.append(item)
     target_payload = json.dumps(
-        [
-            {
-                'id': unit.id,
-                'file': unit.file_rel_path,
-                'line': unit.display_line_number,
-                'speaker_id': unit.speaker_id,
-                'source': unit.source_text,
-                'current_translation': unit.current_translation,
-            }
-            for unit in units
-        ],
+        payload_items,
         ensure_ascii=False,
         separators=(',', ':'),
     )
@@ -588,17 +646,20 @@ def build_keyword_system_instruction(
 
 def build_keyword_user_prompt(units):
     units = units_from_items(units, MODE_KEYWORD_EXTRACTION)
+    payload_items = []
+    for unit in units:
+        item = {
+            'id': unit.id,
+            'file': unit.file_rel_path,
+            'line': unit.display_line_number,
+            'speaker_id': unit.speaker_id,
+            'text': unit.text,
+        }
+        if unit.speaker_name:
+            item['speaker_name'] = unit.speaker_name
+        payload_items.append(item)
     target_payload = json.dumps(
-        [
-            {
-                'id': unit.id,
-                'file': unit.file_rel_path,
-                'line': unit.display_line_number,
-                'speaker_id': unit.speaker_id,
-                'text': unit.text,
-            }
-            for unit in units
-        ],
+        payload_items,
         ensure_ascii=False,
         separators=(',', ':'),
     )

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -19,6 +19,7 @@ from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
 import translation_core
+from relation_analyzer.parsing import CHARACTER_DEFINE_RE, extract_character_definitions
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -2398,6 +2399,7 @@ def collect_tasks(lines, skip_translated=True):
         line.lstrip().startswith("translate ")
         for line in lines
     )
+    speaker_names = extract_character_definitions(lines)
 
     # Simple parser for Ren'Py strings
     for idx, line in enumerate(lines):
@@ -2407,6 +2409,7 @@ def collect_tasks(lines, skip_translated=True):
             not sline
             or sline.startswith("#")
             or sline.startswith("translate ")
+            or CHARACTER_DEFINE_RE.match(line)
             or (is_translation_file and sline.startswith("old "))
         ):
             continue
@@ -2455,6 +2458,9 @@ def collect_tasks(lines, skip_translated=True):
                         if speaker_id:
                             task["speaker_id"] = speaker_id
                             task["speaker"] = speaker_id
+                            speaker_name = speaker_names.get(speaker_id)
+                            if speaker_name:
+                                task["speaker_name"] = speaker_name
                         tasks.append(task)
         except Exception:
             continue

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -19,7 +19,7 @@ from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
 import translation_core
-from relation_analyzer.parsing import CHARACTER_DEFINE_RE, extract_character_definitions
+from relation_analyzer.parsing import CHARACTER_DEFINE_RE, normalize_character_display_name
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -2389,6 +2389,122 @@ def infer_dialogue_speaker_id(line, string_start_col):
     return ""
 
 
+def _character_display_value_node(expr):
+    if isinstance(expr, ast.Constant):
+        if isinstance(expr.value, str):
+            return expr
+        return None
+    if (
+        isinstance(expr, ast.Call)
+        and isinstance(expr.func, ast.Name)
+        and expr.func.id == "_"
+        and len(expr.args) == 1
+        and not expr.keywords
+    ):
+        return _character_display_value_node(expr.args[0])
+    return None
+
+
+def _character_display_arg(call):
+    if not isinstance(call, ast.Call):
+        return None
+    if not isinstance(call.func, ast.Name) or call.func.id != "Character":
+        return None
+    if call.args:
+        return call.args[0]
+    for keyword_arg in call.keywords:
+        if keyword_arg.arg == "name":
+            return keyword_arg.value
+    return None
+
+
+def _literal_character_display_name(node):
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return ""
+    return normalize_character_display_name(node.value)
+
+
+def _source_col_for_node(node, call_start_col):
+    col = getattr(node, "col_offset", None)
+    if col is None:
+        return None
+    if getattr(node, "lineno", 1) == 1:
+        return col + call_start_col
+    return col
+
+
+def _source_end_col_for_node(node, call_start_col):
+    col = getattr(node, "end_col_offset", None)
+    if col is None:
+        return None
+    if getattr(node, "end_lineno", 1) == 1:
+        return col + call_start_col
+    return col
+
+
+def _parse_character_definition(lines, start_idx, max_lines=80):
+    match = CHARACTER_DEFINE_RE.match(lines[start_idx])
+    if not match:
+        return None
+
+    call_start_col = match.start("call")
+    pieces = []
+    parsed_call = None
+    end_limit = min(len(lines), start_idx + max_lines)
+    for line_idx in range(start_idx, end_limit):
+        if line_idx == start_idx:
+            pieces.append(lines[line_idx][call_start_col:])
+        else:
+            pieces.append(lines[line_idx])
+        try:
+            parsed = ast.parse("".join(pieces), mode="eval")
+        except SyntaxError:
+            continue
+        parsed_call = parsed.body
+        break
+
+    if parsed_call is None:
+        return None
+
+    display_arg = _character_display_arg(parsed_call)
+    display_node = _character_display_value_node(display_arg)
+    display_spans = []
+    display_name = _literal_character_display_name(display_node)
+    if display_node is not None:
+        start_line = start_idx + getattr(display_node, "lineno", 1) - 1
+        end_line = start_idx + getattr(display_node, "end_lineno", getattr(display_node, "lineno", 1)) - 1
+        start_col = _source_col_for_node(display_node, call_start_col)
+        end_col = _source_end_col_for_node(display_node, call_start_col)
+        if start_col is not None and end_col is not None:
+            display_spans.append((start_line, end_line, start_col, end_col))
+
+    return {
+        "speaker_id": match.group("speaker"),
+        "speaker_name": display_name,
+        "display_spans": display_spans,
+    }
+
+
+def _token_matches_span(line_idx, token, span):
+    start_line, end_line, start_col, end_col = span
+    token_start_line = line_idx
+    token_end_line = line_idx + token.end[0] - token.start[0]
+    token_start_col = token.start[1]
+    token_end_col = token.end[1]
+
+    if token_start_line < start_line or token_end_line > end_line:
+        return False
+    if token_start_line == start_line and token_start_col < start_col:
+        return False
+    if token_end_line == end_line and token_end_col > end_col:
+        return False
+    return True
+
+
+def _is_character_display_token(line_idx, token, display_spans):
+    return any(_token_matches_span(line_idx, token, span) for span in display_spans)
+
+
 def collect_tasks(lines, skip_translated=True):
     # Logic to parse Ren'Py files
     # Note: caller handles filename lookup, this function just parses
@@ -2399,17 +2515,27 @@ def collect_tasks(lines, skip_translated=True):
         line.lstrip().startswith("translate ")
         for line in lines
     )
-    speaker_names = extract_character_definitions(lines)
+    speaker_names = {}
+    character_display_spans = []
 
     # Simple parser for Ren'Py strings
     for idx, line in enumerate(lines):
+        definition = _parse_character_definition(lines, idx)
+        if definition:
+            speaker_id = definition["speaker_id"]
+            speaker_name = definition["speaker_name"]
+            if speaker_name:
+                speaker_names[speaker_id] = speaker_name
+            else:
+                speaker_names.pop(speaker_id, None)
+            character_display_spans.extend(definition["display_spans"])
+
         sline = line.strip()
         # In translation templates, `old` is a lookup key and must never be edited.
         if (
             not sline
             or sline.startswith("#")
             or sline.startswith("translate ")
-            or CHARACTER_DEFINE_RE.match(line)
             or (is_translation_file and sline.startswith("old "))
         ):
             continue
@@ -2422,6 +2548,8 @@ def collect_tasks(lines, skip_translated=True):
             tokens = list(tokenize.generate_tokens(io.StringIO(line).readline))
             for token in tokens:
                 if token.type != tokenize.STRING:
+                    continue
+                if _is_character_display_token(idx, token, character_display_spans):
                     continue
                 try:
                     text_val = ast.literal_eval(token.string)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -19,7 +19,6 @@ from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
 import translation_core
-from relation_analyzer.parsing import CHARACTER_DEFINE_RE, normalize_character_display_name
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -183,6 +182,14 @@ STRING_LITERAL_PREFIX_RE = re.compile(r"(?is)^(?P<prefix>[rubf]*)(?P<quote>'''|\
 TL_COMMENT_SOURCE_RE = re.compile(r'^\s*#\s*(?P<prefix>[^\"]*?)"(?P<text>.*)"\s*$')
 TL_OLD_LINE_RE = re.compile(r'^\s*old\s+"(?P<text>.*)"\s*$')
 TL_NEW_LINE_RE = re.compile(r'^\s*new\s+"(?P<text>.*)"\s*$')
+CHARACTER_DEFINE_RE = re.compile(
+    r"^\s*define\s+(?P<speaker>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<call>Character\s*\(.*)"
+)
+CHARACTER_DISPLAY_ASSET_RE = re.compile(
+    r"^[\w./\\-]+\.(png|jpg|jpeg|bmp|gif|webp|ogg|mp3|wav|webm|mp4|avi|txt|json|rpy)$",
+    re.IGNORECASE,
+)
+CHARACTER_DISPLAY_SYMBOLS_RE = re.compile(r"^[\s\W_]+$", re.UNICODE)
 RENPY_NON_SPEAKER_NAMES = {
     "_",
     "call",
@@ -2416,6 +2423,17 @@ def _character_display_arg(call):
         if keyword_arg.arg == "name":
             return keyword_arg.value
     return None
+
+
+def normalize_character_display_name(text):
+    text = " ".join(str(text).split()).strip()
+    if not text:
+        return ""
+    if CHARACTER_DISPLAY_SYMBOLS_RE.match(text):
+        return ""
+    if CHARACTER_DISPLAY_ASSET_RE.match(text):
+        return ""
+    return text
 
 
 def _literal_character_display_name(node):


### PR DESCRIPTION
## Summary

- Parse Ren'Py `define ... = Character(...)` speaker definitions during task collection.
- Preserve `speaker_id` and `speaker_name` through translation units, manifests, and prompt payloads.
- Render context lines with readable speaker labels so the model can identify who is speaking without requiring extra response fields.
- Skip Character definition display names as translation targets.

## Why

The main translation prompt previously sent target lines mostly as bare `id/text` JSON. Even when the runtime inferred `speaker_id`, the model did not reliably receive a readable speaker mapping such as `e -> Eileen`. This makes tone and dialogue attribution weaker for Ren'Py scripts.

## Validation

- `python -m py_compile translator_runtime.py translation_core.py gemini_translate_batch.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`
- `git diff --cached --check`