### PR TITLE
[codex] Add SDK template preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - `python gemini_translate.py --help` 会显示同步脚本的最小 CLI 帮助
 - 同步 RAG 启用后，每个成功写回的小批次会更新本地 history store，后续同步批次会在请求前重新检索并注入相关历史
 - Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
-- 不带子命令直接运行 `gemini_translate_batch.py` 时，默认等价于 `submit`
+- `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出
 - Batch 产物默认会写到本地 `logs/` 目录
 - `doctor` 会检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，适合在正式翻译前确认项目是否已准备好
 - `bootstrap-rag` 会扫描当前允许处理的全部 TL `.rpy` 文件，把已有译文预先写入本地 history store；适合在正式 `build / submit` 前先暖库

--- a/README.md
+++ b/README.md
@@ -94,7 +94,33 @@ Game_Example/
 
 - 默认目标语言是 `schinese`
 - 可以通过 `translator_config.json` 里的 `tl_subdir` 和 `prepare.language` 调整
-- 如果启用了 `prepare`，脚本会尝试从 `original/game` 提取脚本并自动生成 `tl/schinese` 模板
+- 推荐先使用 Ren'Py SDK 生成标准 `tl/<language>` 模板；如果启用了 `prepare`，脚本会尝试从 `original/game` 提取脚本并自动调用 Ren'Py 生成或刷新 `tl/schinese` 模板
+- 自动模板生成需要 Ren'Py SDK 或目标游戏自带的 Ren'Py launcher；如果已经有可用 TL 文件，缺少 SDK 时仍可直接处理现有 TL
+- 不要用 Ren'Py 的 `--empty` 生成空模板。本工具的初译流程需要目标行保留原文，之后再把目标行或 `new` 行替换成中文
+
+可以通过 `translator_config.json` 或环境变量 `RENPY_SDK_DIR` 指定 SDK 位置；如果没有配置，脚本会尝试在 `game_root` 附近和工具工作区里自动查找 `renpy-*-sdk`：
+
+```json
+{
+  "game_root": "C:/games/Game_Example/work",
+  "tl_subdir": "game/tl/schinese",
+  "prepare": {
+    "enabled": true,
+    "generate_template": true,
+    "refresh_existing_template": true,
+    "language": "schinese",
+    "renpy_sdk_dir": "C:/RenPy/renpy-8.5.2-sdk"
+  }
+}
+```
+
+如果已有第三方汉化或非标准 TL 文件，建议先跑诊断：
+
+```bash
+python gemini_translate_batch.py doctor
+```
+
+`doctor` 只检查配置、SDK/launcher 和 TL 文件形态，不调用 Gemini，也不会写回 `.rpy`。
 
 ### 4. 运行
 
@@ -115,6 +141,7 @@ python gemini_translate.py
 Batch 模式：
 
 ```bash
+python gemini_translate_batch.py doctor
 python gemini_translate_batch.py bootstrap-rag
 python gemini_translate_batch.py build
 python gemini_translate_batch.py submit
@@ -166,6 +193,7 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
 - 不带子命令直接运行 `gemini_translate_batch.py` 时，默认等价于 `submit`
 - Batch 产物默认会写到本地 `logs/` 目录
+- `doctor` 会检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，适合在正式翻译前确认项目是否已准备好
 - `bootstrap-rag` 会扫描当前允许处理的全部 TL `.rpy` 文件，把已有译文预先写入本地 history store；适合在正式 `build / submit` 前先暖库
 - `probe` 会用同步请求做最小 smoke test
 - `check` 是干跑校验，不会修改 `.rpy`
@@ -407,6 +435,6 @@ python extract_relations.py /path/to/game/tl/schinese --mode semantic
 更适合下面这类使用者：
 
 - 已经熟悉 Ren'Py 项目目录结构
-- 能自行准备 `work/game/tl/schinese` 或理解 `prepare` 行为
+- 能自行准备 `work/game/tl/schinese`、安装 Ren'Py SDK，或理解 `prepare` 行为
 - 能阅读 Python 脚本并按需修改本地配置
 - 接受这是实验性工具，而不是稳定打包好的最终产品

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -5352,10 +5352,19 @@ def collect_doctor_report():
         warnings.append(
             'Dialogue translation blocks do not include source comments; revision/RAG source pairing may be limited.'
         )
+    template_reason = template_info.get('reason', '')
+    if not can_generate_template and template_info.get('kind') == 'custom':
+        warnings.append(f'Custom template command cannot be rendered: {template_reason or "unknown error"}.')
     if not can_generate_template and not has_tl_files:
-        warnings.append('No TL files and no Ren\'Py SDK/game launcher found; template generation is required.')
+        if template_info.get('kind') == 'custom':
+            warnings.append('No TL files and custom template command is unavailable; template generation is required.')
+        else:
+            warnings.append('No TL files and no Ren\'Py SDK/game launcher found; template generation is required.')
     elif not can_generate_template and has_tl_files:
-        warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
+        if template_info.get('kind') == 'custom':
+            warnings.append('Custom template command is unavailable; existing TL files can still be processed.')
+        else:
+            warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
 
     if can_generate_template:
         mode = 'can_generate_template'
@@ -5753,17 +5762,20 @@ def main(argv=None):
         parser.print_help()
         return
 
+    if command == 'doctor':
+        legacy.load_translator_settings()
+        legacy.load_glossary()
+        load_batch_settings()
+        print_banner()
+        print_doctor_report(collect_doctor_report())
+        return
+
     initialize_batch_logging()
-    if command != 'doctor':
-        legacy.load_config()
+    legacy.load_config()
     legacy.load_translator_settings()
     legacy.load_glossary()
     load_batch_settings()
     print_banner()
-
-    if command == 'doctor':
-        print_doctor_report(collect_doctor_report())
-        return
 
     if command == 'build':
         create_batch_package(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -5286,6 +5286,142 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
     return summary
 
 
+DOCTOR_TRANSLATE_BLOCK_RE = re.compile(r'^translate\s+\S+\s+(?!strings\b)(?!python\b)\S+\s*:')
+DOCTOR_STRING_BLOCK_RE = re.compile(r'^translate\s+\S+\s+strings\s*:')
+
+
+def _stringify_command(command):
+    if command is None:
+        return ''
+    if isinstance(command, list):
+        return ' '.join(str(part) for part in command)
+    return str(command)
+
+
+def collect_tl_doctor_counts():
+    counts = {
+        'rpy_files': 0,
+        'translate_blocks': 0,
+        'string_sections': 0,
+        'old_lines': 0,
+        'new_lines': 0,
+        'commented_original_lines': 0,
+    }
+    if not os.path.isdir(legacy.TL_DIR):
+        return counts
+
+    for root, _, files in os.walk(legacy.TL_DIR):
+        for file_name in files:
+            if not file_name.endswith('.rpy'):
+                continue
+            counts['rpy_files'] += 1
+            path = os.path.join(root, file_name)
+            try:
+                with open(path, 'r', encoding='utf-8-sig') as handle:
+                    lines = handle.readlines()
+            except Exception:
+                continue
+
+            for line in lines:
+                if DOCTOR_TRANSLATE_BLOCK_RE.match(line):
+                    counts['translate_blocks'] += 1
+                if DOCTOR_STRING_BLOCK_RE.match(line):
+                    counts['string_sections'] += 1
+                if legacy.TL_OLD_LINE_RE.match(line):
+                    counts['old_lines'] += 1
+                if legacy.TL_NEW_LINE_RE.match(line):
+                    counts['new_lines'] += 1
+                if legacy.TL_COMMENT_SOURCE_RE.match(line):
+                    counts['commented_original_lines'] += 1
+
+    return counts
+
+
+def collect_doctor_report():
+    source_game_dir = legacy._guess_source_game_dir()
+    template_info = legacy.get_prepare_template_command_info(source_game_dir)
+    counts = collect_tl_doctor_counts()
+    tl_exists = os.path.isdir(legacy.TL_DIR)
+    has_tl_files = counts['rpy_files'] > 0
+    can_generate_template = bool(template_info.get('available'))
+
+    warnings = []
+    if counts['old_lines'] != counts['new_lines']:
+        warnings.append('old/new line counts differ; string translation blocks may be malformed.')
+    if counts['translate_blocks'] and not counts['commented_original_lines']:
+        warnings.append(
+            'Dialogue translation blocks do not include source comments; revision/RAG source pairing may be limited.'
+        )
+    if not can_generate_template and not has_tl_files:
+        warnings.append('No TL files and no Ren\'Py SDK/game launcher found; template generation is required.')
+    elif not can_generate_template and has_tl_files:
+        warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
+
+    if can_generate_template:
+        mode = 'can_generate_template'
+    elif has_tl_files:
+        mode = 'existing_tl_only'
+    else:
+        mode = 'blocked_missing_template'
+
+    return {
+        'base_dir': legacy.BASE_DIR,
+        'tl_dir': legacy.TL_DIR,
+        'tl_subdir': legacy.TL_SUBDIR,
+        'language': legacy.PREP_LANGUAGE,
+        'source_game_dir': source_game_dir,
+        'prepare_enabled': legacy.PREP_ENABLED,
+        'generate_template': legacy.PREP_GENERATE_TEMPLATE,
+        'refresh_existing_template': legacy.PREP_REFRESH_EXISTING_TEMPLATE,
+        'renpy_sdk_dir': legacy.PREP_RENPY_SDK_DIR,
+        'tl_exists': tl_exists,
+        'can_generate_template': can_generate_template,
+        'template_command_kind': template_info.get('kind', ''),
+        'template_command': _stringify_command(template_info.get('command')),
+        'template_reason': template_info.get('reason', ''),
+        'python_exe': template_info.get('python_exe', ''),
+        'launcher_py': template_info.get('launcher_py', ''),
+        'mode': mode,
+        'counts': counts,
+        'warnings': warnings,
+    }
+
+
+def print_doctor_report(report):
+    counts = report['counts']
+    print('Doctor report:')
+    print(f"- Base dir: {report['base_dir']}")
+    print(f"- TL dir: {report['tl_dir']} (exists: {report['tl_exists']})")
+    print(f"- Language: {report['language']}")
+    print(
+        f"- Prepare: enabled={report['prepare_enabled']}, "
+        f"generate_template={report['generate_template']}, "
+        f"refresh_existing_template={report['refresh_existing_template']}"
+    )
+    print(f"- Ren'Py SDK dir: {report['renpy_sdk_dir'] or '(not configured)'}")
+    print(f"- Launcher: {report['launcher_py'] or '(not found)'}")
+    print(f"- Python: {report['python_exe'] or '(not resolved)'}")
+    if report['can_generate_template']:
+        print(f"- Template generation: available ({report['template_command_kind']})")
+        print(f"- Template command: {report['template_command']}")
+    else:
+        print(f"- Template generation: unavailable ({report['template_reason'] or 'no command resolved'})")
+    print(f"- Mode: {report['mode']}")
+    print(
+        '- TL scan: '
+        f"rpy_files={counts['rpy_files']}, "
+        f"translate_blocks={counts['translate_blocks']}, "
+        f"string_sections={counts['string_sections']}, "
+        f"old_lines={counts['old_lines']}, "
+        f"new_lines={counts['new_lines']}, "
+        f"commented_original_lines={counts['commented_original_lines']}"
+    )
+    if report['warnings']:
+        print('Warnings:')
+        for warning in report['warnings']:
+            print(f'- {warning}')
+
+
 def print_banner():
     print('=' * 60)
     print('Gemini Batch Translator (Ren\'Py)')
@@ -5301,7 +5437,11 @@ def print_banner():
     )
     print(f'Max output tokens: {BATCH_MAX_OUTPUT_TOKENS}')
     print(f'Thinking level: {BATCH_THINKING_LEVEL or "(default)"}')
-    print(f'Prepare enabled: {legacy.PREP_ENABLED}')
+    print(
+        f'Prepare: enabled={legacy.PREP_ENABLED}, language={legacy.PREP_LANGUAGE}, '
+        f'generate_template={legacy.PREP_GENERATE_TEMPLATE}, '
+        f'refresh_existing_template={legacy.PREP_REFRESH_EXISTING_TEMPLATE}'
+    )
     print('=' * 60)
 
 
@@ -5310,6 +5450,8 @@ def build_arg_parser():
         description='Batch translator for Ren\'Py tl files using Gemini Batch API.'
     )
     subparsers = parser.add_subparsers(dest='command')
+
+    subparsers.add_parser('doctor', help='Inspect prepare, SDK, and TL template compatibility without writing files.')
 
     build_parser = subparsers.add_parser('build', help='Build local batch package and JSONL only.')
     build_parser.add_argument('--display-name', default='', help='Override Batch display name.')
@@ -5612,11 +5754,16 @@ def main(argv=None):
         return
 
     initialize_batch_logging()
-    legacy.load_config()
+    if command != 'doctor':
+        legacy.load_config()
     legacy.load_translator_settings()
     legacy.load_glossary()
     load_batch_settings()
     print_banner()
+
+    if command == 'doctor':
+        print_doctor_report(collect_doctor_report())
+        return
 
     if command == 'build':
         create_batch_package(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -525,6 +525,24 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             ):
                 self.assertEqual(runtime._discover_renpy_sdk_dir(), str(sdk))
 
+    def test_prepare_discovers_newest_sdk_by_parsed_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            base = workspace / 'Game_Example' / 'work'
+            older = workspace / 'renpy-8.9-sdk'
+            newer = workspace / 'renpy-8.10-sdk'
+            for sdk in (older, newer):
+                sdk.mkdir(parents=True)
+                (sdk / 'renpy.py').write_text('import renpy.bootstrap\n', encoding='utf-8')
+            base.mkdir(parents=True)
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+            ):
+                self.assertEqual(runtime._discover_renpy_sdk_dir(), str(newer))
+
     def test_prepare_does_not_discover_sdk_when_base_dir_is_filesystem_root(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)
@@ -552,6 +570,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
 
             with (
+                mock.patch.object(runtime.sys, 'platform', 'win32'),
                 mock.patch.object(runtime, 'BASE_DIR', str(base)),
                 mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
                 mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
@@ -566,6 +585,48 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             self.assertTrue(info['available'])
             self.assertEqual(info['kind'], 'sdk')
             self.assertEqual(info['command'], [str(python_exe), str(launcher), str(base), 'translate', 'schinese'])
+
+    def test_prepare_template_command_uses_renpy_sh_on_non_windows_sdk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            sdk = root / 'renpy-sdk'
+            windows_python = sdk / 'lib' / 'py3-windows-x86_64' / 'python.exe'
+            windows_python.parent.mkdir(parents=True)
+            windows_python.write_text('', encoding='utf-8')
+            launcher = sdk / 'renpy.py'
+            launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
+            shell_launcher = sdk / 'renpy.sh'
+            shell_launcher.write_text('#!/bin/sh\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime.sys, 'platform', 'linux'),
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', str(sdk)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_PYTHON_EXE', ''),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', None),
+                mock.patch.object(runtime, 'PREP_LANGUAGE', 'schinese'),
+            ):
+                info = runtime.get_prepare_template_command_info(str(base / 'game'))
+
+            self.assertTrue(info['available'])
+            self.assertEqual(info['kind'], 'sdk')
+            self.assertEqual(info['command'], [str(shell_launcher), str(base), 'translate', 'schinese'])
+            self.assertEqual(info['cwd'], str(sdk))
+            self.assertEqual(info['python_exe'], '')
+
+    def test_find_bundled_python_ignores_windows_python_on_linux(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sdk = Path(tmp) / 'renpy-sdk'
+            windows_python = sdk / 'lib' / 'py3-windows-x86_64' / 'python.exe'
+            windows_python.parent.mkdir(parents=True)
+            windows_python.write_text('', encoding='utf-8')
+
+            with mock.patch.object(runtime.sys, 'platform', 'linux'):
+                self.assertEqual(runtime._find_bundled_python(str(sdk)), '')
 
     def test_prepare_existing_tl_without_launcher_continues(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -615,6 +676,31 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             ):
                 with self.assertRaises(SystemExit):
                     runtime.run_prepare_steps()
+
+    def test_prepare_missing_tl_custom_template_command_error_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', ['{missing_placeholder}']),
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    runtime.run_prepare_steps()
+
+            self.assertIn('Custom template command error', str(raised.exception))
+            self.assertIn('missing_placeholder', str(raised.exception))
 
     def test_prepare_existing_tl_refresh_runs_template_command(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2465,7 +2551,7 @@ class BatchRagRegressionTests(unittest.TestCase):
 
     def test_doctor_command_does_not_require_api_keys(self):
         with (
-            mock.patch.object(batch_mod, 'initialize_batch_logging'),
+            mock.patch.object(batch_mod, 'initialize_batch_logging') as logging_mock,
             mock.patch.object(batch_mod.legacy, 'load_translator_settings'),
             mock.patch.object(batch_mod.legacy, 'load_glossary'),
             mock.patch.object(batch_mod, 'load_batch_settings'),
@@ -2477,6 +2563,29 @@ class BatchRagRegressionTests(unittest.TestCase):
             batch_mod.main(['doctor'])
 
         load_config_mock.assert_not_called()
+        logging_mock.assert_not_called()
+
+    def test_doctor_report_explains_custom_template_command_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'BASE_DIR', str(base)),
+                mock.patch.object(batch_mod.legacy, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(batch_mod.legacy, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_TEMPLATE_COMMAND', ['{missing_placeholder}']),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+        joined_warnings = ' '.join(report['warnings'])
+        self.assertFalse(report['can_generate_template'])
+        self.assertEqual(report['template_command_kind'], 'custom')
+        self.assertIn('missing_placeholder', report['template_reason'])
+        self.assertIn('Custom template command cannot be rendered', joined_warnings)
 
     def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
         summary = batch_mod.summarize_batch_rag(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -730,6 +730,35 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             self.assertIn('Custom template command error', str(raised.exception))
             self.assertIn('missing_placeholder', str(raised.exception))
 
+    def test_prepare_first_time_template_failure_blocks_even_with_partial_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+
+            def fail_after_partial_file(*_args):
+                tl_dir.mkdir(parents=True)
+                (tl_dir / 'partial.rpy').write_text('translate schinese strings:\n', encoding='utf-8')
+                return False
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', ['generate-template']),
+                mock.patch.object(runtime, '_run_prepare_command', side_effect=fail_after_partial_file),
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    runtime.run_prepare_steps()
+
+            self.assertIn('Translation template generation failed', str(raised.exception))
+
     def test_prepare_existing_tl_refresh_runs_template_command(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -494,6 +494,190 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             ):
                 self.assertEqual(runtime._resolve_prepare_launcher(), str(launcher))
 
+    def test_prepare_launcher_uses_configured_renpy_sdk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sdk = root / 'renpy-sdk'
+            sdk.mkdir()
+            launcher = sdk / 'renpy.py'
+            launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(root / 'work')),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', str(sdk)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+            ):
+                self.assertEqual(runtime._resolve_prepare_launcher(), str(launcher))
+
+    def test_prepare_discovers_workspace_renpy_sdk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            base = workspace / 'Game_Example' / 'work'
+            sdk = workspace / 'renpy-8.5.2-sdk'
+            sdk.mkdir(parents=True)
+            (sdk / 'renpy.py').write_text('import renpy.bootstrap\n', encoding='utf-8')
+            base.mkdir(parents=True)
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+            ):
+                self.assertEqual(runtime._discover_renpy_sdk_dir(), str(sdk))
+
+    def test_prepare_does_not_discover_sdk_when_base_dir_is_filesystem_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            sdk = workspace / 'renpy-8.5.2-sdk'
+            sdk.mkdir()
+            (sdk / 'renpy.py').write_text('import renpy.bootstrap\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', os.path.abspath(os.sep)),
+                mock.patch.object(runtime, 'ROOT_DIR', str(workspace)),
+                mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+            ):
+                self.assertEqual(runtime._discover_renpy_sdk_dir(), '')
+
+    def test_prepare_template_command_uses_sdk_with_project_base(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            sdk = root / 'renpy-sdk'
+            python_dir = sdk / 'lib' / 'py3-windows-x86_64'
+            python_dir.mkdir(parents=True)
+            python_exe = python_dir / 'python.exe'
+            python_exe.write_text('', encoding='utf-8')
+            launcher = sdk / 'renpy.py'
+            launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', str(sdk)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_PYTHON_EXE', ''),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', None),
+                mock.patch.object(runtime, 'PREP_LANGUAGE', 'schinese'),
+            ):
+                info = runtime.get_prepare_template_command_info(str(base / 'game'))
+
+            self.assertTrue(info['available'])
+            self.assertEqual(info['kind'], 'sdk')
+            self.assertEqual(info['command'], [str(python_exe), str(launcher), str(base), 'translate', 'schinese'])
+
+    def test_prepare_existing_tl_without_launcher_continues(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text('translate schinese strings:\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', None),
+                mock.patch.object(runtime, '_run_prepare_command') as run_mock,
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                runtime.run_prepare_steps()
+
+            run_mock.assert_not_called()
+
+    def test_prepare_missing_tl_without_launcher_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', None),
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                with self.assertRaises(SystemExit):
+                    runtime.run_prepare_steps()
+
+    def test_prepare_existing_tl_refresh_runs_template_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text('translate schinese strings:\n', encoding='utf-8')
+            sdk = root / 'renpy-sdk'
+            sdk.mkdir()
+            launcher = sdk / 'renpy.py'
+            launcher.write_text('import renpy.bootstrap\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', str(sdk)),
+                mock.patch.object(runtime, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(runtime, 'PREP_PYTHON_EXE', sys.executable),
+                mock.patch.object(runtime, 'PREP_TEMPLATE_COMMAND', None),
+                mock.patch.object(runtime, '_run_prepare_command', return_value=True) as run_mock,
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                runtime.run_prepare_steps()
+
+            run_mock.assert_called_once()
+            command = run_mock.call_args.args[0]
+            self.assertEqual(command, [sys.executable, str(launcher), str(base), 'translate', 'schinese'])
+
+    def test_prepare_existing_tl_refresh_disabled_skips_template_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text('translate schinese strings:\n', encoding='utf-8')
+            sdk = root / 'renpy-sdk'
+            sdk.mkdir()
+            (sdk / 'renpy.py').write_text('import renpy.bootstrap\n', encoding='utf-8')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', False),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', True),
+                mock.patch.object(runtime, 'PREP_REFRESH_EXISTING_TEMPLATE', False),
+                mock.patch.object(runtime, 'PREP_RENPY_SDK_DIR', str(sdk)),
+                mock.patch.object(runtime, '_run_prepare_command') as run_mock,
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                runtime.run_prepare_steps()
+
+            run_mock.assert_not_called()
+
     def test_process_batch_returns_only_successful_progress_entries(self):
         batch = [
             {
@@ -2183,6 +2367,116 @@ class BatchRagRegressionTests(unittest.TestCase):
         parser.parse_args(['bootstrap-rag', '--seed-jsonl', 'first.jsonl'])
         parsed_without_seed = parser.parse_args(['bootstrap-rag'])
         self.assertIsNone(parsed_without_seed.seed_jsonl)
+
+    def test_build_arg_parser_accepts_doctor_command(self):
+        args = batch_mod.build_arg_parser().parse_args(['doctor'])
+
+        self.assertEqual(args.command, 'doctor')
+
+    def test_doctor_report_classifies_existing_tl_without_sdk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text(
+                'translate schinese start_123:\n'
+                '    # e "Hello"\n'
+                '    e "\u4f60\u597d"\n'
+                '\n'
+                'translate schinese strings:\n'
+                '    old "Start"\n'
+                '    new "\u5f00\u59cb"\n',
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'BASE_DIR', str(base)),
+                mock.patch.object(batch_mod.legacy, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod.legacy, 'TL_SUBDIR', 'game/tl/schinese'),
+                mock.patch.object(batch_mod.legacy, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+                mock.patch.object(batch_mod.legacy, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_TEMPLATE_COMMAND', None),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+        self.assertEqual(report['mode'], 'existing_tl_only')
+        self.assertFalse(report['can_generate_template'])
+        self.assertEqual(report['counts']['rpy_files'], 1)
+        self.assertEqual(report['counts']['translate_blocks'], 1)
+        self.assertEqual(report['counts']['string_sections'], 1)
+        self.assertEqual(report['counts']['old_lines'], 1)
+        self.assertEqual(report['counts']['new_lines'], 1)
+        self.assertEqual(report['counts']['commented_original_lines'], 1)
+
+    def test_doctor_report_warns_when_dialogue_comments_are_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text(
+                'translate schinese start_123:\n'
+                '    e "\u4f60\u597d"\n',
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'BASE_DIR', str(base)),
+                mock.patch.object(batch_mod.legacy, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod.legacy, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_TEMPLATE_COMMAND', None),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+        self.assertIn('Dialogue translation blocks do not include source comments', ' '.join(report['warnings']))
+
+    def test_doctor_report_does_not_treat_translate_python_as_dialogue(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'style.rpy').write_text(
+                'translate schinese python:\n'
+                '    gui.text_font = "SourceHanSansLite.ttf"\n',
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'BASE_DIR', str(base)),
+                mock.patch.object(batch_mod.legacy, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod.legacy, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_RENPY_SDK_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LAUNCHER_PY', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_TEMPLATE_COMMAND', None),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+        self.assertEqual(report['counts']['translate_blocks'], 0)
+        self.assertNotIn('Dialogue translation blocks do not include source comments', ' '.join(report['warnings']))
+
+    def test_doctor_command_does_not_require_api_keys(self):
+        with (
+            mock.patch.object(batch_mod, 'initialize_batch_logging'),
+            mock.patch.object(batch_mod.legacy, 'load_translator_settings'),
+            mock.patch.object(batch_mod.legacy, 'load_glossary'),
+            mock.patch.object(batch_mod, 'load_batch_settings'),
+            mock.patch.object(batch_mod, 'print_banner'),
+            mock.patch.object(batch_mod, 'collect_doctor_report', return_value={'counts': {}, 'warnings': []}),
+            mock.patch.object(batch_mod, 'print_doctor_report'),
+            mock.patch.object(batch_mod.legacy, 'load_config') as load_config_mock,
+        ):
+            batch_mod.main(['doctor'])
+
+        load_config_mock.assert_not_called()
 
     def test_summarize_batch_rag_reports_hit_count_rate_and_errors(self):
         summary = batch_mod.summarize_batch_rag(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -543,6 +543,34 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             ):
                 self.assertEqual(runtime._discover_renpy_sdk_dir(), str(newer))
 
+    def test_prepare_invalid_configured_sdk_falls_back_to_discovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            base = workspace / 'Game_Example' / 'work'
+            sdk = workspace / 'renpy-8.5.2-sdk'
+            sdk.mkdir(parents=True)
+            (sdk / 'renpy.py').write_text('import renpy.bootstrap\n', encoding='utf-8')
+            base.mkdir(parents=True)
+            config_path = workspace / 'translator_config.json'
+            config_path.write_text(
+                json.dumps(
+                    {
+                        'game_root': str(base),
+                        'prepare': {'renpy_sdk_dir': 'missing-sdk'},
+                    }
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+                mock.patch.dict(os.environ, {}, clear=True),
+            ):
+                runtime.load_translator_settings()
+                self.assertEqual(runtime.PREP_RENPY_SDK_DIR, str(sdk))
+
     def test_prepare_does_not_discover_sdk_when_base_dir_is_filesystem_root(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -7,7 +7,9 @@
     "source_game_dir": "../original/game",
     "unpack_rpa": true,
     "generate_template": true,
+    "refresh_existing_template": true,
     "language": "schinese",
+    "renpy_sdk_dir": "",
     "python_exe": ""
   },
   "sync": {

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1329,7 +1329,7 @@ def run_prepare_steps():
                     template_info["cwd"],
                     "Generate tl template",
                 )
-                if not ok and not templates_exist and not _has_translation_templates():
+                if not ok and not templates_exist:
                     raise SystemExit(
                         "[Prepare] Translation template generation failed and no TL files exist. "
                         "Install Ren'Py SDK, set RENPY_SDK_DIR, or prepare game/tl/<language> manually."

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -420,6 +420,14 @@ def _renpy_sdk_sort_key(path):
     )
 
 
+def _is_renpy_sdk_dir(path):
+    return bool(
+        path
+        and os.path.isdir(path)
+        and os.path.isfile(os.path.join(path, "renpy.py"))
+    )
+
+
 def _discover_renpy_sdk_dir():
     if _is_filesystem_root(BASE_DIR):
         return ""
@@ -447,7 +455,7 @@ def _discover_renpy_sdk_dir():
         {
             os.path.abspath(candidate)
             for candidate in candidates
-            if os.path.isdir(candidate) and os.path.isfile(os.path.join(candidate, "renpy.py"))
+            if _is_renpy_sdk_dir(candidate)
         },
         key=_renpy_sdk_sort_key,
         reverse=True,
@@ -669,10 +677,14 @@ def load_translator_settings():
     renpy_sdk_dir = prepare.get("renpy_sdk_dir")
     if not (isinstance(renpy_sdk_dir, str) and renpy_sdk_dir.strip()):
         renpy_sdk_dir = os.environ.get("RENPY_SDK_DIR")
-    PREP_RENPY_SDK_DIR = _resolve_preferred_path_from_bases(
+    resolved_renpy_sdk_dir = _resolve_preferred_path_from_bases(
         renpy_sdk_dir,
         (BASE_DIR, ROOT_DIR, TOOL_DIR),
-    ) or _discover_renpy_sdk_dir()
+    )
+    if _is_renpy_sdk_dir(resolved_renpy_sdk_dir):
+        PREP_RENPY_SDK_DIR = resolved_renpy_sdk_dir
+    else:
+        PREP_RENPY_SDK_DIR = _discover_renpy_sdk_dir()
 
     source_game_dir = prepare.get("source_game_dir")
     if source_game_dir is not None:

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -45,7 +45,9 @@ SOURCE_GAME_DIR = ""
 PREP_ENABLED = True
 PREP_UNPACK_RPA = True
 PREP_GENERATE_TEMPLATE = True
+PREP_REFRESH_EXISTING_TEMPLATE = True
 PREP_LANGUAGE = "schinese"
+PREP_RENPY_SDK_DIR = ""
 PREP_LAUNCHER_PY = ""
 PREP_PYTHON_EXE = ""
 PREP_UNPACK_COMMAND = None
@@ -393,6 +395,48 @@ def _resolve_preferred_path(primary_base_dir, secondary_base_dir, value):
     return _resolve_preferred_path_from_bases(value, (primary_base_dir, secondary_base_dir))
 
 
+def _is_filesystem_root(path):
+    if not path:
+        return False
+    normalized = os.path.abspath(path)
+    parent = os.path.dirname(normalized)
+    return normalized == parent
+
+
+def _discover_renpy_sdk_dir():
+    if _is_filesystem_root(BASE_DIR):
+        return ""
+
+    base_dirs = _dedupe_keep_order(
+        [
+            BASE_DIR,
+            os.path.dirname(BASE_DIR),
+            os.path.dirname(os.path.dirname(BASE_DIR)),
+            ROOT_DIR,
+            os.path.dirname(ROOT_DIR),
+            TOOL_DIR,
+        ]
+    )
+    candidates = []
+    for base_dir in base_dirs:
+        if not base_dir or not os.path.isdir(base_dir):
+            continue
+        if os.path.isfile(os.path.join(base_dir, "renpy.py")):
+            candidates.append(base_dir)
+        for pattern in ("renpy-*-sdk", "renpy-*sdk", "renpy-sdk"):
+            candidates.extend(glob.glob(os.path.join(base_dir, pattern)))
+
+    candidates = sorted(
+        {
+            os.path.abspath(candidate)
+            for candidate in candidates
+            if os.path.isdir(candidate) and os.path.isfile(os.path.join(candidate, "renpy.py"))
+        },
+        reverse=True,
+    )
+    return candidates[0] if candidates else ""
+
+
 def resolve_story_memory_graph_path(value):
     return _resolve_preferred_path_from_bases(value, (ROOT_DIR, BASE_DIR, TOOL_DIR))
 
@@ -553,8 +597,8 @@ def load_sync_story_memory_settings(config):
 def load_translator_settings():
     """Loads per-game settings (game root, tl subdir) from translator_config.json or env."""
     global BASE_DIR, TL_DIR, TL_SUBDIR, ENV_GAME_ROOT, WORK_GAME_DIR, SOURCE_GAME_DIR, GLOSSARY_FILE
-    global PREP_ENABLED, PREP_UNPACK_RPA, PREP_GENERATE_TEMPLATE, PREP_LANGUAGE
-    global PREP_LAUNCHER_PY, PREP_PYTHON_EXE, PREP_UNPACK_COMMAND, PREP_TEMPLATE_COMMAND
+    global PREP_ENABLED, PREP_UNPACK_RPA, PREP_GENERATE_TEMPLATE, PREP_REFRESH_EXISTING_TEMPLATE, PREP_LANGUAGE
+    global PREP_RENPY_SDK_DIR, PREP_LAUNCHER_PY, PREP_PYTHON_EXE, PREP_UNPACK_COMMAND, PREP_TEMPLATE_COMMAND
 
     config = {}
     if os.path.exists(TRANSLATOR_CONFIG):
@@ -598,10 +642,19 @@ def load_translator_settings():
     PREP_ENABLED = _coerce_bool(prepare.get("enabled"), True)
     PREP_UNPACK_RPA = _coerce_bool(prepare.get("unpack_rpa"), True)
     PREP_GENERATE_TEMPLATE = _coerce_bool(prepare.get("generate_template"), True)
+    PREP_REFRESH_EXISTING_TEMPLATE = _coerce_bool(prepare.get("refresh_existing_template"), True)
 
     prep_language = prepare.get("language")
     if isinstance(prep_language, str) and prep_language.strip():
         PREP_LANGUAGE = prep_language.strip()
+
+    renpy_sdk_dir = prepare.get("renpy_sdk_dir")
+    if not (isinstance(renpy_sdk_dir, str) and renpy_sdk_dir.strip()):
+        renpy_sdk_dir = os.environ.get("RENPY_SDK_DIR")
+    PREP_RENPY_SDK_DIR = _resolve_preferred_path_from_bases(
+        renpy_sdk_dir,
+        (BASE_DIR, ROOT_DIR, TOOL_DIR),
+    ) or _discover_renpy_sdk_dir()
 
     source_game_dir = prepare.get("source_game_dir")
     if source_game_dir is not None:
@@ -929,24 +982,59 @@ def _extract_rpa_scripts(archive_path, target_game_dir):
     return extracted
 
 
-def _resolve_prepare_python():
-    if PREP_PYTHON_EXE and os.path.isfile(PREP_PYTHON_EXE):
-        return PREP_PYTHON_EXE
+def _find_bundled_python(base_dir):
+    if not base_dir:
+        return ""
 
-    bundled = os.path.join(BASE_DIR, "lib", "py3-windows-x86_64", "python.exe")
+    bundled = os.path.join(base_dir, "lib", "py3-windows-x86_64", "python.exe")
     if os.path.isfile(bundled):
         return bundled
 
-    for candidate in glob.glob(os.path.join(BASE_DIR, "lib", "py*", "python.exe")):
+    for candidate in glob.glob(os.path.join(base_dir, "lib", "py*", "python.exe")):
         if os.path.isfile(candidate):
             return candidate
 
+    return ""
+
+
+def _resolve_prepare_python(runtime_root=""):
+    if PREP_PYTHON_EXE and os.path.isfile(PREP_PYTHON_EXE):
+        return PREP_PYTHON_EXE
+
+    for base_dir in (runtime_root, PREP_RENPY_SDK_DIR, BASE_DIR):
+        bundled = _find_bundled_python(base_dir)
+        if bundled:
+            return bundled
+
     return sys.executable
+
+
+def _resolve_sdk_launcher(sdk_dir):
+    if not sdk_dir:
+        return ""
+    launcher = os.path.join(sdk_dir, "renpy.py")
+    if os.path.isfile(launcher):
+        return launcher
+    return ""
+
+
+def _is_sdk_launcher(launcher_py):
+    return bool(launcher_py) and os.path.basename(launcher_py).lower() == "renpy.py"
+
+
+def _prepare_launcher_root(launcher_py):
+    if not launcher_py:
+        return ""
+    return os.path.dirname(os.path.abspath(launcher_py))
 
 
 def _resolve_prepare_launcher():
     if PREP_LAUNCHER_PY and os.path.isfile(PREP_LAUNCHER_PY):
         return PREP_LAUNCHER_PY
+
+    sdk_launcher = _resolve_sdk_launcher(PREP_RENPY_SDK_DIR)
+    if sdk_launcher:
+        return sdk_launcher
 
     py_files = sorted(glob.glob(os.path.join(BASE_DIR, "*.py")))
     if not py_files:
@@ -1007,6 +1095,74 @@ def _run_prepare_command(command, cwd, step_name):
         return False
 
     return True
+
+
+def get_prepare_template_command_info(source_game_dir=""):
+    if not source_game_dir:
+        source_game_dir = _guess_source_game_dir()
+
+    launcher_py = _resolve_prepare_launcher()
+    python_exe = _resolve_prepare_python(_prepare_launcher_root(launcher_py))
+    variables = {
+        "python_exe": python_exe,
+        "launcher_py": launcher_py,
+        "language": PREP_LANGUAGE,
+        "base_dir": BASE_DIR,
+        "tl_dir": TL_DIR,
+        "work_game_dir": WORK_GAME_DIR,
+        "source_game_dir": source_game_dir,
+    }
+
+    if PREP_TEMPLATE_COMMAND:
+        try:
+            rendered, _ = _render_prepare_command(PREP_TEMPLATE_COMMAND, variables)
+        except Exception as e:
+            return {
+                "available": False,
+                "kind": "custom",
+                "reason": str(e),
+                "command": None,
+                "cwd": BASE_DIR,
+                "python_exe": python_exe,
+                "launcher_py": launcher_py,
+            }
+        return {
+            "available": True,
+            "kind": "custom",
+            "reason": "",
+            "command": rendered,
+            "cwd": BASE_DIR,
+            "python_exe": python_exe,
+            "launcher_py": launcher_py,
+        }
+
+    if not launcher_py:
+        return {
+            "available": False,
+            "kind": "auto",
+            "reason": "Ren'Py SDK or game launcher was not found.",
+            "command": None,
+            "cwd": BASE_DIR,
+            "python_exe": python_exe,
+            "launcher_py": "",
+        }
+
+    if _is_sdk_launcher(launcher_py):
+        command = [python_exe, launcher_py, BASE_DIR, "translate", PREP_LANGUAGE]
+        kind = "sdk"
+    else:
+        command = [python_exe, launcher_py, "translate", PREP_LANGUAGE]
+        kind = "game-launcher"
+
+    return {
+        "available": True,
+        "kind": kind,
+        "reason": "",
+        "command": command,
+        "cwd": BASE_DIR,
+        "python_exe": python_exe,
+        "launcher_py": launcher_py,
+    }
 
 
 def _run_unpack_command(command, archives, source_game_dir):
@@ -1092,31 +1248,37 @@ def run_prepare_steps():
         print("[Prepare] RPA unpack disabled.")
 
     if PREP_GENERATE_TEMPLATE:
-        if _has_translation_templates():
+        templates_exist = _has_translation_templates()
+        if templates_exist and not PREP_REFRESH_EXISTING_TEMPLATE:
             print("[Prepare] Translation template already exists; skipping generation.")
         else:
-            launcher_py = _resolve_prepare_launcher()
-            python_exe = _resolve_prepare_python()
-            if PREP_TEMPLATE_COMMAND:
-                variables = {
-                    "python_exe": python_exe,
-                    "launcher_py": launcher_py,
-                    "language": PREP_LANGUAGE,
-                    "base_dir": BASE_DIR,
-                    "tl_dir": TL_DIR,
-                    "work_game_dir": WORK_GAME_DIR,
-                    "source_game_dir": source_game_dir,
-                }
-                try:
-                    rendered, _ = _render_prepare_command(PREP_TEMPLATE_COMMAND, variables)
-                    _run_prepare_command(rendered, BASE_DIR, "Generate tl template")
-                except Exception as e:
-                    print(f"[Prepare] Template command error: {e}")
-            elif launcher_py:
-                command = [python_exe, launcher_py, "translate", PREP_LANGUAGE]
-                _run_prepare_command(command, BASE_DIR, "Generate tl template")
+            if templates_exist:
+                print("[Prepare] Translation template exists; refreshing missing entries.")
+            template_info = get_prepare_template_command_info(source_game_dir)
+            if template_info["available"]:
+                ok = _run_prepare_command(
+                    template_info["command"],
+                    template_info["cwd"],
+                    "Generate tl template",
+                )
+                if not ok and not templates_exist and not _has_translation_templates():
+                    raise SystemExit(
+                        "[Prepare] Translation template generation failed and no TL files exist. "
+                        "Install Ren'Py SDK, set RENPY_SDK_DIR, or prepare game/tl/<language> manually."
+                    )
+                if not ok and templates_exist:
+                    print("[Prepare] Template refresh failed; continuing with existing TL files.")
+            elif templates_exist:
+                print(
+                    "[Prepare] Could not locate Ren'Py SDK or game launcher; "
+                    "continuing with existing TL files."
+                )
             else:
-                print("[Prepare] Could not locate <Game>.py launcher; skip template generation.")
+                raise SystemExit(
+                    "[Prepare] Cannot generate translation template because Ren'Py SDK or game launcher "
+                    "was not found. Install Ren'Py SDK and set RENPY_SDK_DIR or prepare.renpy_sdk_dir, "
+                    "or create the TL template manually."
+                )
     else:
         print("[Prepare] Template generation disabled.")
 
@@ -2629,6 +2791,9 @@ def run_translation():
     print(f"Prepare enabled: {PREP_ENABLED}")
     print(f"Prepare source game dir: {SOURCE_GAME_DIR or '(auto)'}")
     print(f"Prepare language: {PREP_LANGUAGE}")
+    print(f"Prepare generate template: {PREP_GENERATE_TEMPLATE}")
+    print(f"Prepare refresh existing template: {PREP_REFRESH_EXISTING_TEMPLATE}")
+    print(f"Prepare Ren'Py SDK dir: {PREP_RENPY_SDK_DIR or '(not configured)'}")
     print("="*60)
 
     run_prepare_steps()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -403,6 +403,23 @@ def _is_filesystem_root(path):
     return normalized == parent
 
 
+def _parse_renpy_sdk_version(path):
+    name = os.path.basename(os.path.abspath(path)).lower()
+    match = re.search(r"renpy[-_](\d+(?:\.\d+)*)", name)
+    if not match:
+        return ()
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _renpy_sdk_sort_key(path):
+    normalized = os.path.abspath(path)
+    return (
+        _parse_renpy_sdk_version(normalized),
+        os.path.basename(normalized).lower(),
+        normalized.lower(),
+    )
+
+
 def _discover_renpy_sdk_dir():
     if _is_filesystem_root(BASE_DIR):
         return ""
@@ -432,6 +449,7 @@ def _discover_renpy_sdk_dir():
             for candidate in candidates
             if os.path.isdir(candidate) and os.path.isfile(os.path.join(candidate, "renpy.py"))
         },
+        key=_renpy_sdk_sort_key,
         reverse=True,
     )
     return candidates[0] if candidates else ""
@@ -986,13 +1004,26 @@ def _find_bundled_python(base_dir):
     if not base_dir:
         return ""
 
-    bundled = os.path.join(base_dir, "lib", "py3-windows-x86_64", "python.exe")
-    if os.path.isfile(bundled):
-        return bundled
+    if sys.platform.startswith("win"):
+        patterns = [
+            os.path.join(base_dir, "lib", "py3-windows-x86_64", "python.exe"),
+            os.path.join(base_dir, "lib", "py3-windows-*", "python.exe"),
+        ]
+    elif sys.platform == "darwin":
+        patterns = [
+            os.path.join(base_dir, "lib", "py3-mac*", "python"),
+            os.path.join(base_dir, "lib", "py3-macos*", "python"),
+            os.path.join(base_dir, "lib", "py3-darwin*", "python"),
+        ]
+    else:
+        patterns = [
+            os.path.join(base_dir, "lib", "py3-linux*", "python"),
+        ]
 
-    for candidate in glob.glob(os.path.join(base_dir, "lib", "py*", "python.exe")):
-        if os.path.isfile(candidate):
-            return candidate
+    for pattern in patterns:
+        for candidate in sorted(glob.glob(pattern)):
+            if os.path.isfile(candidate):
+                return candidate
 
     return ""
 
@@ -1013,6 +1044,15 @@ def _resolve_sdk_launcher(sdk_dir):
     if not sdk_dir:
         return ""
     launcher = os.path.join(sdk_dir, "renpy.py")
+    if os.path.isfile(launcher):
+        return launcher
+    return ""
+
+
+def _resolve_sdk_shell_launcher(sdk_dir):
+    if not sdk_dir or sys.platform.startswith("win"):
+        return ""
+    launcher = os.path.join(sdk_dir, "renpy.sh")
     if os.path.isfile(launcher):
         return launcher
     return ""
@@ -1148,10 +1188,19 @@ def get_prepare_template_command_info(source_game_dir=""):
         }
 
     if _is_sdk_launcher(launcher_py):
-        command = [python_exe, launcher_py, BASE_DIR, "translate", PREP_LANGUAGE]
+        sdk_dir = _prepare_launcher_root(launcher_py)
+        shell_launcher = _resolve_sdk_shell_launcher(sdk_dir)
+        if shell_launcher and not PREP_PYTHON_EXE:
+            command = [shell_launcher, BASE_DIR, "translate", PREP_LANGUAGE]
+            cwd = sdk_dir
+            python_exe = ""
+        else:
+            command = [python_exe, launcher_py, BASE_DIR, "translate", PREP_LANGUAGE]
+            cwd = BASE_DIR
         kind = "sdk"
     else:
         command = [python_exe, launcher_py, "translate", PREP_LANGUAGE]
+        cwd = BASE_DIR
         kind = "game-launcher"
 
     return {
@@ -1159,7 +1208,7 @@ def get_prepare_template_command_info(source_game_dir=""):
         "kind": kind,
         "reason": "",
         "command": command,
-        "cwd": BASE_DIR,
+        "cwd": cwd,
         "python_exe": python_exe,
         "launcher_py": launcher_py,
     }
@@ -1208,6 +1257,13 @@ def _run_unpack_command(command, archives, source_game_dir):
 
 def _has_translation_templates():
     return _has_files_with_extensions(TL_DIR, {".rpy"})
+
+
+def _describe_template_unavailable(template_info):
+    reason = template_info.get("reason") or "no command resolved"
+    if template_info.get("kind") == "custom":
+        return f"Custom template command error: {reason}"
+    return reason
 
 
 def run_prepare_steps():
@@ -1270,14 +1326,15 @@ def run_prepare_steps():
                     print("[Prepare] Template refresh failed; continuing with existing TL files.")
             elif templates_exist:
                 print(
-                    "[Prepare] Could not locate Ren'Py SDK or game launcher; "
+                    f"[Prepare] {_describe_template_unavailable(template_info)}; "
                     "continuing with existing TL files."
                 )
             else:
+                reason = _describe_template_unavailable(template_info)
                 raise SystemExit(
-                    "[Prepare] Cannot generate translation template because Ren'Py SDK or game launcher "
-                    "was not found. Install Ren'Py SDK and set RENPY_SDK_DIR or prepare.renpy_sdk_dir, "
-                    "or create the TL template manually."
+                    f"[Prepare] Cannot generate translation template: {reason}. "
+                    "Install Ren'Py SDK and set RENPY_SDK_DIR or prepare.renpy_sdk_dir, "
+                    "fix prepare.template_command, or create the TL template manually."
                 )
     else:
         print("[Prepare] Template generation disabled.")


### PR DESCRIPTION
## Summary
- Enhance `prepare` so it can locate/use a Ren'Py SDK, refresh existing TL templates, and continue on existing TL files when SDK generation is unavailable.
- Add a `doctor` command that diagnoses SDK/launcher availability and TL file shape without requiring API keys.
- Document the SDK template workflow and new prepare config fields.

## Validation
- `python -B -m unittest -q tests.test_regressions.TranslatorRuntimeRegressionTests tests.test_regressions.BatchRagRegressionTests`
- `python -B gemini_translate_batch.py doctor`
- `git diff --check`
- `python -B -c "import translator_runtime, gemini_translate_batch, tests.test_regressions; print('imports ok')"`

## Notes
- A broader local `tests.test_regressions` run still hits the existing local `PermissionError` path when writing `C:\RenPy_Workspace\logs\batch_jobs\latest_manifest.txt`, so the PR validation uses the focused regression suites above.