### PR TITLE
[codex] Unify translation chunk settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ pip install -r requirements.txt
 
 说明：
 
-- `api_keys.json` 保存 Gemini API Key，不要提交到公开仓库
-- `translator_config.json` 保存本地游戏路径与批处理参数，不要提交到公开仓库
+- `api_keys.json` 保存 Gemini API Key，不要提交到公开仓库；旧的 `batch_size/max_chars` 等字段仍兼容，但不再推荐写在这里
+- `translator_config.json` 保存本地游戏路径、模型、include 过滤和同步/Batch 分块参数，不要提交到公开仓库
 - `glossary.json` 通常包含项目私有术语，也建议本地维护
 - `macro_setting.md` 往往包含剧情、角色口吻、世界观约束，也建议本地维护
 - 如果你不想使用 `api_keys.json`，也可以改用环境变量 `GEMINI_API_KEY`、`GEMINI_API_KEY_2`、`GEMINI_API_KEY_3`
@@ -124,7 +124,7 @@ python gemini_translate_batch.py doctor
 
 ### 4. 运行
 
-当前更推荐优先使用 Batch 模式；同步模式仍可用，并且现在与 Batch 一样统一基于 `google-genai` SDK。同步模式可以通过 `translator_config.json` 里的 `sync.rag.enabled=true` 启用可选 RAG 滚动记忆。
+当前更推荐优先使用 Batch 模式；同步模式仍可用，并且现在与 Batch 一样统一基于 `google-genai` SDK。同步模式的 `model/chunk_size/max_source_chars/max_output_tokens` 和可选 RAG 滚动记忆都通过 `translator_config.json` 的 `sync` 配置读取。
 
 当前模型建议：
 
@@ -193,6 +193,7 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
 - `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出
 - Batch 产物默认会写到本地 `logs/` 目录
+- 同步和普通 Batch 翻译默认每个 chunk 最多 20 条，同时受 `max_source_chars=6000` 保护；短句会合并，长句会自动提前切块，避免单个请求输出过长
 - `doctor` 会检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，适合在正式翻译前确认项目是否已准备好
 - `bootstrap-rag` 会扫描当前允许处理的全部 TL `.rpy` 文件，把已有译文预先写入本地 history store；适合在正式 `build / submit` 前先暖库
 - `probe` 会用同步请求做最小 smoke test

--- a/api_keys.example.json
+++ b/api_keys.example.json
@@ -1,12 +1,5 @@
 {
   "api_keys": [
     "your-key-here"
-  ],
-  "models": [
-    "gemini-3.1-flash-lite"
-  ],
-  "batch_size": 10,
-  "max_chars": 4000,
-  "include_files": [],
-  "include_prefixes": []
+  ]
 }

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -69,10 +69,11 @@ def initialize_batch_logging():
     sys.stdout = DualLogger(CONSOLE_LOG)
 
 BATCH_MODEL = 'gemini-3.1-flash-lite'
-BATCH_TARGET_SIZE = 4
+BATCH_TARGET_SIZE = 20
+BATCH_TARGET_CHARS = 6000
 BATCH_CONTEXT_BEFORE = 8
 BATCH_CONTEXT_AFTER = 4
-BATCH_MAX_OUTPUT_TOKENS = 4096
+BATCH_MAX_OUTPUT_TOKENS = 16384
 BATCH_TEMPERATURE = 0.2
 BATCH_THINKING_LEVEL = 'minimal'
 BATCH_DISPLAY_NAME_PREFIX = 'renpy-translate'
@@ -175,7 +176,7 @@ def normalize_task_type(value, default):
 
 def load_batch_settings():
     global BATCH_MODEL, BATCH_TARGET_SIZE, BATCH_CONTEXT_BEFORE, BATCH_CONTEXT_AFTER
-    global BATCH_MAX_OUTPUT_TOKENS, BATCH_TEMPERATURE, BATCH_THINKING_LEVEL
+    global BATCH_TARGET_CHARS, BATCH_MAX_OUTPUT_TOKENS, BATCH_TEMPERATURE, BATCH_THINKING_LEVEL
     global BATCH_DISPLAY_NAME_PREFIX, BATCH_MACRO_SETTING
     global KEYWORD_DISPLAY_NAME_PREFIX, KEYWORD_CHUNK_SIZE, KEYWORD_MAX_CANDIDATES_PER_CHUNK
     global REVISION_DISPLAY_NAME_PREFIX, REVISION_CHUNK_SIZE
@@ -197,6 +198,10 @@ def load_batch_settings():
     BATCH_TARGET_SIZE = coerce_positive_int(
         config.get('batch_target_size', config.get('batch_size')),
         BATCH_TARGET_SIZE,
+    )
+    BATCH_TARGET_CHARS = coerce_positive_int(
+        config.get('batch_target_chars', config.get('batch_max_source_chars')),
+        BATCH_TARGET_CHARS,
     )
     BATCH_CONTEXT_BEFORE = coerce_positive_int(config.get('batch_context_before'), BATCH_CONTEXT_BEFORE)
     BATCH_CONTEXT_AFTER = coerce_positive_int(config.get('batch_context_after'), BATCH_CONTEXT_AFTER)
@@ -230,6 +235,10 @@ def load_batch_settings():
         BATCH_DISPLAY_NAME_PREFIX = display_name_prefix.strip()
 
     BATCH_TARGET_SIZE = coerce_positive_int(batch.get('chunk_size'), BATCH_TARGET_SIZE)
+    BATCH_TARGET_CHARS = coerce_positive_int(
+        batch.get('max_source_chars', batch.get('target_chars')),
+        BATCH_TARGET_CHARS,
+    )
     BATCH_CONTEXT_BEFORE = coerce_positive_int(batch.get('context_before'), BATCH_CONTEXT_BEFORE)
     BATCH_CONTEXT_AFTER = coerce_positive_int(batch.get('context_after'), BATCH_CONTEXT_AFTER)
     BATCH_MAX_OUTPUT_TOKENS = coerce_positive_int(
@@ -1154,13 +1163,35 @@ def build_batch_request(chunk):
 
 
 
+def task_text_char_count(task):
+    text = task.get('text', '') if isinstance(task, dict) else ''
+    return len(text) if isinstance(text, str) else len(str(text))
+
+
+def iter_translation_chunk_ranges(tasks):
+    total = len(tasks)
+    start = 0
+    while start < total:
+        end = start
+        current_chars = 0
+        while end < total and (end - start) < BATCH_TARGET_SIZE:
+            item_chars = task_text_char_count(tasks[end])
+            if end > start and current_chars + item_chars > BATCH_TARGET_CHARS:
+                break
+            current_chars += item_chars
+            end += 1
+        if end == start:
+            end = start + 1
+        yield start, end
+        start = end
+
+
 def build_chunks(file_jobs):
     chunks = []
     for job in file_jobs:
         tasks = job['tasks']
         total = len(tasks)
-        for start in range(0, total, BATCH_TARGET_SIZE):
-            end = min(start + BATCH_TARGET_SIZE, total)
+        for chunk_number, (start, end) in enumerate(iter_translation_chunk_ranges(tasks), start=1):
             target_items = tasks[start:end]
             target_units = translation_core.units_from_items(
                 target_items,
@@ -1178,7 +1209,6 @@ def build_chunks(file_jobs):
                 context_past,
                 context_future,
             ) if STORY_MEMORY_ENABLED else None
-            chunk_number = start // BATCH_TARGET_SIZE + 1
             chunk_key = f"{hash_key(job['file_rel_path'])}-{chunk_number:05d}"
             chunk = {
                 'key': chunk_key,
@@ -1187,6 +1217,7 @@ def build_chunks(file_jobs):
                 'file_path': job['file_path'],
                 'chunk_index': chunk_number,
                 'line_numbers': [unit.line for unit in target_units],
+                'source_char_count': sum(task_text_char_count(item) for item in target_items),
                 'context_past': context_past,
                 'context_future': context_future,
                 'glossary_hits': glossary_hits,
@@ -1263,7 +1294,7 @@ def summarize_batch_story_memory(chunks, graph_file=None, max_context_chars=None
 
 def get_batch_risk_warnings():
     warnings_list = []
-    if BATCH_TARGET_SIZE > 4:
+    if BATCH_TARGET_SIZE > 20:
         warnings_list.append(f'chunk_size={BATCH_TARGET_SIZE} is aggressive for Gemini 3 Flash structured output.')
     if BATCH_CONTEXT_BEFORE > 12 or BATCH_CONTEXT_AFTER > 6:
         warnings_list.append(
@@ -1329,6 +1360,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
         'result_file_name': '',
         'settings': {
             'target_size': BATCH_TARGET_SIZE,
+            'target_chars': BATCH_TARGET_CHARS,
             'context_before': BATCH_CONTEXT_BEFORE,
             'context_after': BATCH_CONTEXT_AFTER,
             'max_output_tokens': BATCH_MAX_OUTPUT_TOKENS,
@@ -5442,6 +5474,7 @@ def print_banner():
     print(f'Batch model: {BATCH_MODEL}')
     print(
         f'Chunk settings: target={BATCH_TARGET_SIZE}, '
+        f'target_chars={BATCH_TARGET_CHARS}, '
         f'context_before={BATCH_CONTEXT_BEFORE}, context_after={BATCH_CONTEXT_AFTER}'
     )
     print(f'Max output tokens: {BATCH_MAX_OUTPUT_TOKENS}')

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -571,6 +571,101 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 runtime.load_translator_settings()
                 self.assertEqual(runtime.PREP_RENPY_SDK_DIR, str(sdk))
 
+    def test_translator_config_sync_settings_override_legacy_batch_defaults(self):
+        old_values = {
+            'models': runtime.MODELS,
+            'max_items': runtime.MAX_ITEMS,
+            'max_chars': runtime.MAX_CHARS,
+            'max_output_tokens': runtime.SYNC_MAX_OUTPUT_TOKENS,
+            'include_files': runtime.INCLUDE_FILES,
+            'include_prefixes': runtime.INCLUDE_PREFIXES,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                base = workspace / 'work'
+                base.mkdir()
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(
+                    json.dumps({
+                        'game_root': str(base),
+                        'include_files': ['game/tl/schinese/script.rpy'],
+                        'include_prefixes': ['game/tl/schinese/chapter1'],
+                        'sync': {
+                            'model': 'gemini-sync-test',
+                            'chunk_size': 7,
+                            'max_source_chars': 1234,
+                            'max_output_tokens': 5678,
+                        },
+                    }),
+                    encoding='utf-8',
+                )
+
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    runtime.MAX_ITEMS = 20
+                    runtime.MAX_CHARS = 6000
+                    runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
+                    runtime.INCLUDE_FILES = set()
+                    runtime.INCLUDE_PREFIXES = set()
+                    runtime.load_translator_settings()
+
+                self.assertEqual(runtime.MODELS, ['gemini-sync-test'])
+                self.assertEqual(runtime.MAX_ITEMS, 7)
+                self.assertEqual(runtime.MAX_CHARS, 1234)
+                self.assertEqual(runtime.SYNC_MAX_OUTPUT_TOKENS, 5678)
+                self.assertEqual(runtime.INCLUDE_FILES, {'game/tl/schinese/script.rpy'})
+                self.assertEqual(runtime.INCLUDE_PREFIXES, {'game/tl/schinese/chapter1'})
+        finally:
+            runtime.MODELS = old_values['models']
+            runtime.MAX_ITEMS = old_values['max_items']
+            runtime.MAX_CHARS = old_values['max_chars']
+            runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']
+            runtime.INCLUDE_FILES = old_values['include_files']
+            runtime.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_legacy_api_config_still_sets_sync_chunk_defaults(self):
+        old_values = {
+            'api_keys': runtime.API_KEYS,
+            'max_items': runtime.MAX_ITEMS,
+            'max_chars': runtime.MAX_CHARS,
+            'max_output_tokens': runtime.SYNC_MAX_OUTPUT_TOKENS,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                config_path = Path(tmp) / 'api_keys.json'
+                config_path.write_text(
+                    json.dumps({
+                        'api_keys': ['test-key'],
+                        'batch_size': 9,
+                        'max_chars': 2222,
+                        'sync_max_output_tokens': 3333,
+                    }),
+                    encoding='utf-8',
+                )
+
+                with (
+                    mock.patch.object(runtime, 'CONFIG_FILE', str(config_path)),
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    runtime.API_KEYS = []
+                    runtime.MAX_ITEMS = 20
+                    runtime.MAX_CHARS = 6000
+                    runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
+                    runtime.load_config()
+
+                self.assertEqual(runtime.MAX_ITEMS, 9)
+                self.assertEqual(runtime.MAX_CHARS, 2222)
+                self.assertEqual(runtime.SYNC_MAX_OUTPUT_TOKENS, 3333)
+        finally:
+            runtime.API_KEYS = old_values['api_keys']
+            runtime.MAX_ITEMS = old_values['max_items']
+            runtime.MAX_CHARS = old_values['max_chars']
+            runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']
+
     def test_prepare_does_not_discover_sdk_when_base_dir_is_filesystem_root(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)
@@ -1987,6 +2082,7 @@ class BatchRagRegressionTests(unittest.TestCase):
     def test_build_chunks_keeps_context_task_dicts(self):
         old_values = {
             'target_size': batch_mod.BATCH_TARGET_SIZE,
+            'target_chars': batch_mod.BATCH_TARGET_CHARS,
             'context_before': batch_mod.BATCH_CONTEXT_BEFORE,
             'context_after': batch_mod.BATCH_CONTEXT_AFTER,
             'rag_enabled': batch_mod.RAG_ENABLED,
@@ -2039,6 +2135,7 @@ class BatchRagRegressionTests(unittest.TestCase):
             ])
         finally:
             batch_mod.BATCH_TARGET_SIZE = old_values['target_size']
+            batch_mod.BATCH_TARGET_CHARS = old_values['target_chars']
             batch_mod.BATCH_CONTEXT_BEFORE = old_values['context_before']
             batch_mod.BATCH_CONTEXT_AFTER = old_values['context_after']
             batch_mod.RAG_ENABLED = old_values['rag_enabled']
@@ -2047,6 +2144,50 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(chunks[1]['context_past'][0]['speaker_name'], 'Eileen')
         self.assertEqual(chunks[1]['context_past'][0]['progress_entry'], 'task:1:0')
         self.assertEqual(chunks[1]['context_future'][0]['speaker_name'], 'Eileen')
+
+    def test_build_chunks_respects_source_char_limit(self):
+        old_values = {
+            'target_size': batch_mod.BATCH_TARGET_SIZE,
+            'target_chars': batch_mod.BATCH_TARGET_CHARS,
+            'context_before': batch_mod.BATCH_CONTEXT_BEFORE,
+            'context_after': batch_mod.BATCH_CONTEXT_AFTER,
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'story_enabled': batch_mod.STORY_MEMORY_ENABLED,
+        }
+        try:
+            batch_mod.BATCH_TARGET_SIZE = 20
+            batch_mod.BATCH_TARGET_CHARS = 10
+            batch_mod.BATCH_CONTEXT_BEFORE = 1
+            batch_mod.BATCH_CONTEXT_AFTER = 1
+            batch_mod.RAG_ENABLED = False
+            batch_mod.STORY_MEMORY_ENABLED = False
+
+            tasks = []
+            for index, text in enumerate(['x' * 12, 'short', 'small', 'tiny']):
+                tasks.append({
+                    'id': f'script.rpy:{index}:0',
+                    'text': text,
+                    'line': index,
+                    'start': 0,
+                    'end': len(text),
+                })
+
+            chunks = batch_mod.build_chunks([{
+                'file_rel_path': 'script.rpy',
+                'file_path': 'script.rpy',
+                'tasks': tasks,
+            }])
+        finally:
+            batch_mod.BATCH_TARGET_SIZE = old_values['target_size']
+            batch_mod.BATCH_TARGET_CHARS = old_values['target_chars']
+            batch_mod.BATCH_CONTEXT_BEFORE = old_values['context_before']
+            batch_mod.BATCH_CONTEXT_AFTER = old_values['context_after']
+            batch_mod.RAG_ENABLED = old_values['rag_enabled']
+            batch_mod.STORY_MEMORY_ENABLED = old_values['story_enabled']
+
+        self.assertEqual([len(chunk['items']) for chunk in chunks], [1, 2, 1])
+        self.assertEqual([chunk['source_char_count'] for chunk in chunks], [12, 10, 4])
+        self.assertEqual(chunks[0]['items'][0]['text'], 'x' * 12)
 
     def test_format_history_hits_block_shows_source_translation_pair(self):
         block = batch_mod.format_history_hits_block([

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -571,7 +571,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 runtime.load_translator_settings()
                 self.assertEqual(runtime.PREP_RENPY_SDK_DIR, str(sdk))
 
-    def test_translator_config_sync_settings_override_legacy_batch_defaults(self):
+    def test_translator_config_sync_settings_override_sync_defaults(self):
         old_values = {
             'models': runtime.MODELS,
             'max_items': runtime.MAX_ITEMS,
@@ -665,6 +665,75 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             runtime.MAX_ITEMS = old_values['max_items']
             runtime.MAX_CHARS = old_values['max_chars']
             runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']
+
+    def test_translator_config_empty_include_lists_clear_existing_filters(self):
+        old_values = {
+            'include_files': runtime.INCLUDE_FILES,
+            'include_prefixes': runtime.INCLUDE_PREFIXES,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                base = workspace / 'work'
+                base.mkdir()
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(
+                    json.dumps({
+                        'game_root': str(base),
+                        'include_files': [],
+                        'include_prefixes': [],
+                    }),
+                    encoding='utf-8',
+                )
+
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    runtime.INCLUDE_FILES = {'game/tl/schinese/old.rpy'}
+                    runtime.INCLUDE_PREFIXES = {'game/tl/schinese/old'}
+                    runtime.load_translator_settings()
+
+                self.assertEqual(runtime.INCLUDE_FILES, set())
+                self.assertEqual(runtime.INCLUDE_PREFIXES, set())
+        finally:
+            runtime.INCLUDE_FILES = old_values['include_files']
+            runtime.INCLUDE_PREFIXES = old_values['include_prefixes']
+
+    def test_legacy_api_config_empty_include_lists_clear_existing_filters(self):
+        old_values = {
+            'api_keys': runtime.API_KEYS,
+            'include_files': runtime.INCLUDE_FILES,
+            'include_prefixes': runtime.INCLUDE_PREFIXES,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                config_path = Path(tmp) / 'api_keys.json'
+                config_path.write_text(
+                    json.dumps({
+                        'api_keys': ['test-key'],
+                        'include_files': [],
+                        'include_prefixes': [],
+                    }),
+                    encoding='utf-8',
+                )
+
+                with (
+                    mock.patch.object(runtime, 'CONFIG_FILE', str(config_path)),
+                    mock.patch('sys.stdout', io.StringIO()),
+                ):
+                    runtime.API_KEYS = []
+                    runtime.INCLUDE_FILES = {'game/tl/schinese/old.rpy'}
+                    runtime.INCLUDE_PREFIXES = {'game/tl/schinese/old'}
+                    runtime.load_config()
+
+                self.assertEqual(runtime.INCLUDE_FILES, set())
+                self.assertEqual(runtime.INCLUDE_PREFIXES, set())
+        finally:
+            runtime.API_KEYS = old_values['api_keys']
+            runtime.INCLUDE_FILES = old_values['include_files']
+            runtime.INCLUDE_PREFIXES = old_values['include_prefixes']
 
     def test_prepare_does_not_discover_sdk_when_base_dir_is_filesystem_root(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -574,6 +574,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
     def test_translator_config_sync_settings_override_sync_defaults(self):
         old_values = {
             'models': runtime.MODELS,
+            'model_index': runtime.CURRENT_MODEL_INDEX,
             'max_items': runtime.MAX_ITEMS,
             'max_chars': runtime.MAX_CHARS,
             'max_output_tokens': runtime.SYNC_MAX_OUTPUT_TOKENS,
@@ -592,7 +593,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                         'include_files': ['game/tl/schinese/script.rpy'],
                         'include_prefixes': ['game/tl/schinese/chapter1'],
                         'sync': {
-                            'model': 'gemini-sync-test',
+                            'models': [' ', 'gemini-sync-test'],
                             'chunk_size': 7,
                             'max_source_chars': 1234,
                             'max_output_tokens': 5678,
@@ -606,6 +607,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     mock.patch.dict(os.environ, {}, clear=True),
                     mock.patch('sys.stdout', io.StringIO()),
                 ):
+                    runtime.CURRENT_MODEL_INDEX = 3
                     runtime.MAX_ITEMS = 20
                     runtime.MAX_CHARS = 6000
                     runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
@@ -614,6 +616,8 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     runtime.load_translator_settings()
 
                 self.assertEqual(runtime.MODELS, ['gemini-sync-test'])
+                self.assertEqual(runtime.CURRENT_MODEL_INDEX, 0)
+                self.assertEqual(runtime.get_current_model(), 'gemini-sync-test')
                 self.assertEqual(runtime.MAX_ITEMS, 7)
                 self.assertEqual(runtime.MAX_CHARS, 1234)
                 self.assertEqual(runtime.SYNC_MAX_OUTPUT_TOKENS, 5678)
@@ -621,6 +625,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 self.assertEqual(runtime.INCLUDE_PREFIXES, {'game/tl/schinese/chapter1'})
         finally:
             runtime.MODELS = old_values['models']
+            runtime.CURRENT_MODEL_INDEX = old_values['model_index']
             runtime.MAX_ITEMS = old_values['max_items']
             runtime.MAX_CHARS = old_values['max_chars']
             runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']
@@ -630,6 +635,8 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
     def test_legacy_api_config_still_sets_sync_chunk_defaults(self):
         old_values = {
             'api_keys': runtime.API_KEYS,
+            'models': runtime.MODELS,
+            'model_index': runtime.CURRENT_MODEL_INDEX,
             'max_items': runtime.MAX_ITEMS,
             'max_chars': runtime.MAX_CHARS,
             'max_output_tokens': runtime.SYNC_MAX_OUTPUT_TOKENS,
@@ -640,6 +647,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 config_path.write_text(
                     json.dumps({
                         'api_keys': ['test-key'],
+                        'models': [' ', 'gemini-legacy-test'],
                         'batch_size': 9,
                         'max_chars': 2222,
                         'sync_max_output_tokens': 3333,
@@ -652,16 +660,22 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     mock.patch('sys.stdout', io.StringIO()),
                 ):
                     runtime.API_KEYS = []
+                    runtime.CURRENT_MODEL_INDEX = 2
                     runtime.MAX_ITEMS = 20
                     runtime.MAX_CHARS = 6000
                     runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
                     runtime.load_config()
 
+                self.assertEqual(runtime.MODELS, ['gemini-legacy-test'])
+                self.assertEqual(runtime.CURRENT_MODEL_INDEX, 0)
+                self.assertEqual(runtime.get_current_model(), 'gemini-legacy-test')
                 self.assertEqual(runtime.MAX_ITEMS, 9)
                 self.assertEqual(runtime.MAX_CHARS, 2222)
                 self.assertEqual(runtime.SYNC_MAX_OUTPUT_TOKENS, 3333)
         finally:
             runtime.API_KEYS = old_values['api_keys']
+            runtime.MODELS = old_values['models']
+            runtime.CURRENT_MODEL_INDEX = old_values['model_index']
             runtime.MAX_ITEMS = old_values['max_items']
             runtime.MAX_CHARS = old_values['max_chars']
             runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -2,6 +2,8 @@
   "game_root": "C:/games/Game_Example/work",
   "glossary_file": "glossary.json",
   "tl_subdir": "game/tl/schinese",
+  "include_files": [],
+  "include_prefixes": [],
   "prepare": {
     "enabled": true,
     "source_game_dir": "../original/game",
@@ -13,6 +15,10 @@
     "python_exe": ""
   },
   "sync": {
+    "model": "gemini-3.1-flash-lite",
+    "chunk_size": 20,
+    "max_source_chars": 6000,
+    "max_output_tokens": 16384,
     "rag": {
       "enabled": false,
       "embedding_model": "gemini-embedding-001",
@@ -38,10 +44,11 @@
   },
   "batch": {
     "model": "gemini-3.1-flash-lite",
-    "chunk_size": 10,
+    "chunk_size": 20,
+    "max_source_chars": 6000,
     "context_before": 30,
     "context_after": 10,
-    "max_output_tokens": 1024,
+    "max_output_tokens": 16384,
     "temperature": 0.4,
     "display_name_prefix": "renpy-translate",
     "macro_setting_file": "macro_setting.md",

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -91,8 +91,9 @@ PRESERVE_TERMS = [
 ]
 
 # Config Defaults
-MAX_CHARS = 3000  # Reduced slightly to be safer
+MAX_CHARS = 6000
 MAX_ITEMS = 20    # Back to a safer batch size (50 was too aggressive)
+SYNC_MAX_OUTPUT_TOKENS = 16384
 MIN_DELAY = 1.0  # Reduced delay for SDK
 MAX_DELAY = 3.0
 BATCH_RETRIES = 3
@@ -620,6 +621,63 @@ def load_sync_story_memory_settings(config):
     _SYNC_STORY_GRAPH_PATH = ""
 
 
+def load_sync_translation_settings(config):
+    global MODELS, MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS
+
+    sync = config.get("sync")
+    if not isinstance(sync, dict):
+        sync = {}
+
+    custom_models = sync.get("models")
+    single_model = sync.get("model")
+    if not custom_models and single_model:
+        custom_models = [single_model]
+    elif isinstance(custom_models, str):
+        custom_models = [custom_models]
+    if custom_models:
+        MODELS = [str(m) for m in custom_models if m]
+        print(f"Using sync model list: {MODELS}")
+
+    previous_items = MAX_ITEMS
+    previous_chars = MAX_CHARS
+    previous_output_tokens = SYNC_MAX_OUTPUT_TOKENS
+
+    MAX_ITEMS = _coerce_positive_int(sync.get("chunk_size"), MAX_ITEMS)
+    MAX_CHARS = _coerce_positive_int(
+        sync.get("max_source_chars", sync.get("target_chars")),
+        MAX_CHARS,
+    )
+    SYNC_MAX_OUTPUT_TOKENS = _coerce_positive_int(
+        sync.get("max_output_tokens"),
+        SYNC_MAX_OUTPUT_TOKENS,
+    )
+
+    if MAX_ITEMS != previous_items:
+        print(f"Using sync chunk size: {MAX_ITEMS}")
+    if MAX_CHARS != previous_chars:
+        print(f"Using sync max source chars: {MAX_CHARS}")
+    if SYNC_MAX_OUTPUT_TOKENS != previous_output_tokens:
+        print(f"Using sync max output tokens: {SYNC_MAX_OUTPUT_TOKENS}")
+
+
+def load_include_filters_from_config(config):
+    global INCLUDE_FILES, INCLUDE_PREFIXES
+
+    include_files = config.get("include_files")
+    if include_files:
+        if isinstance(include_files, str):
+            include_files = [include_files]
+        INCLUDE_FILES = {_normalize_rel_path(p) for p in include_files if _normalize_rel_path(p)}
+        print(f"Using include_files allowlist ({len(INCLUDE_FILES)}).")
+
+    include_prefixes = config.get("include_prefixes")
+    if include_prefixes:
+        if isinstance(include_prefixes, str):
+            include_prefixes = [include_prefixes]
+        INCLUDE_PREFIXES = {_normalize_rel_path(p) for p in include_prefixes if _normalize_rel_path(p)}
+        print(f"Using include_prefixes allowlist ({len(INCLUDE_PREFIXES)}).")
+
+
 def load_translator_settings():
     """Loads per-game settings (game root, tl subdir) from translator_config.json or env."""
     global BASE_DIR, TL_DIR, TL_SUBDIR, ENV_GAME_ROOT, WORK_GAME_DIR, SOURCE_GAME_DIR, GLOSSARY_FILE
@@ -706,13 +764,16 @@ def load_translator_settings():
 
     PREP_UNPACK_COMMAND = _coerce_command(prepare.get("unpack_command"))
     PREP_TEMPLATE_COMMAND = _coerce_command(prepare.get("template_command"))
+    load_include_filters_from_config(config)
+    load_sync_translation_settings(config)
     load_sync_rag_settings(config)
     load_sync_story_memory_settings(config)
 
 
 def load_config():
     """Loads API keys and settings from api_keys.json or environment."""
-    global API_KEYS, MODELS, MAX_CHARS, MAX_ITEMS, INCLUDE_FILES, INCLUDE_PREFIXES
+    global API_KEYS, MODELS, MAX_CHARS, MAX_ITEMS, SYNC_MAX_OUTPUT_TOKENS
+    global INCLUDE_FILES, INCLUDE_PREFIXES
     
     # Try loading from JSON
     if os.path.exists(CONFIG_FILE):
@@ -722,8 +783,12 @@ def load_config():
                 keys = config.get("api_keys", [])
                 custom_models = config.get("models", [])
                 single_model = config.get("model")
-                batch_size = config.get("batch_size")
+                batch_size = config.get("sync_chunk_size", config.get("batch_size"))
                 max_chars = config.get("max_chars")
+                sync_max_chars = config.get("sync_max_source_chars")
+                if sync_max_chars is not None:
+                    max_chars = sync_max_chars
+                sync_max_output_tokens = config.get("sync_max_output_tokens")
                 include_files = config.get("include_files")
                 include_prefixes = config.get("include_prefixes")
                 
@@ -760,6 +825,15 @@ def load_config():
                             print(f"Using custom max_chars: {MAX_CHARS}")
                 except (TypeError, ValueError):
                     print("Warning: Invalid max_chars in config; using default.")
+
+                try:
+                    if sync_max_output_tokens is not None:
+                        sync_max_output_tokens = int(sync_max_output_tokens)
+                        if sync_max_output_tokens > 0:
+                            SYNC_MAX_OUTPUT_TOKENS = sync_max_output_tokens
+                            print(f"Using custom sync max output tokens: {SYNC_MAX_OUTPUT_TOKENS}")
+                except (TypeError, ValueError):
+                    print("Warning: Invalid sync_max_output_tokens in config; using default.")
 
                 if include_files:
                     if isinstance(include_files, str):
@@ -2446,7 +2520,7 @@ def call_gemini_sdk(prompt, items):
         # Generation config
         generation_config = {
             "temperature": 0.2,
-            "max_output_tokens": 8192,
+            "max_output_tokens": SYNC_MAX_OUTPUT_TOKENS,
             "response_mime_type": "application/json",
             "response_json_schema": build_response_json_schema(items),
         }

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -622,7 +622,7 @@ def load_sync_story_memory_settings(config):
 
 
 def load_sync_translation_settings(config):
-    global MODELS, MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS
+    global MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS
 
     sync = config.get("sync")
     if not isinstance(sync, dict):
@@ -635,8 +635,7 @@ def load_sync_translation_settings(config):
     elif isinstance(custom_models, str):
         custom_models = [custom_models]
     if custom_models:
-        MODELS = [str(m) for m in custom_models if m]
-        print(f"Using sync model list: {MODELS}")
+        replace_model_list(custom_models, "sync")
 
     previous_items = MAX_ITEMS
     previous_chars = MAX_CHARS
@@ -676,6 +675,23 @@ def coerce_normalized_rel_path_set(value):
         if path:
             normalized.add(path)
     return normalized
+
+
+def replace_model_list(values, label):
+    global MODELS, CURRENT_MODEL_INDEX
+
+    models = []
+    for value in values:
+        model = str(value).strip()
+        if model:
+            models.append(model)
+    if not models:
+        return False
+
+    MODELS = models
+    CURRENT_MODEL_INDEX = 0
+    print(f"Using {label} model list: {MODELS}")
+    return True
 
 
 def load_include_filters_from_config(config):
@@ -817,8 +833,7 @@ def load_config():
                     custom_models = [custom_models]
 
                 if custom_models:
-                    MODELS = [str(m) for m in custom_models if m]
-                    print(f"Using custom model list: {MODELS}")
+                    replace_model_list(custom_models, "custom")
 
                 try:
                     if batch_size is not None:

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -660,21 +660,33 @@ def load_sync_translation_settings(config):
         print(f"Using sync max output tokens: {SYNC_MAX_OUTPUT_TOKENS}")
 
 
+def coerce_normalized_rel_path_set(value):
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        values = []
+
+    normalized = set()
+    for item in values:
+        path = _normalize_rel_path(item)
+        if path:
+            normalized.add(path)
+    return normalized
+
+
 def load_include_filters_from_config(config):
     global INCLUDE_FILES, INCLUDE_PREFIXES
 
-    include_files = config.get("include_files")
-    if include_files:
-        if isinstance(include_files, str):
-            include_files = [include_files]
-        INCLUDE_FILES = {_normalize_rel_path(p) for p in include_files if _normalize_rel_path(p)}
+    if "include_files" in config:
+        INCLUDE_FILES = coerce_normalized_rel_path_set(config.get("include_files"))
         print(f"Using include_files allowlist ({len(INCLUDE_FILES)}).")
 
-    include_prefixes = config.get("include_prefixes")
-    if include_prefixes:
-        if isinstance(include_prefixes, str):
-            include_prefixes = [include_prefixes]
-        INCLUDE_PREFIXES = {_normalize_rel_path(p) for p in include_prefixes if _normalize_rel_path(p)}
+    if "include_prefixes" in config:
+        INCLUDE_PREFIXES = coerce_normalized_rel_path_set(config.get("include_prefixes"))
         print(f"Using include_prefixes allowlist ({len(INCLUDE_PREFIXES)}).")
 
 
@@ -835,16 +847,12 @@ def load_config():
                 except (TypeError, ValueError):
                     print("Warning: Invalid sync_max_output_tokens in config; using default.")
 
-                if include_files:
-                    if isinstance(include_files, str):
-                        include_files = [include_files]
-                    INCLUDE_FILES = {_normalize_rel_path(p) for p in include_files if _normalize_rel_path(p)}
+                if "include_files" in config:
+                    INCLUDE_FILES = coerce_normalized_rel_path_set(include_files)
                     print(f"Using include_files allowlist ({len(INCLUDE_FILES)}).")
 
-                if include_prefixes:
-                    if isinstance(include_prefixes, str):
-                        include_prefixes = [include_prefixes]
-                    INCLUDE_PREFIXES = {_normalize_rel_path(p) for p in include_prefixes if _normalize_rel_path(p)}
+                if "include_prefixes" in config:
+                    INCLUDE_PREFIXES = coerce_normalized_rel_path_set(include_prefixes)
                     print(f"Using include_prefixes allowlist ({len(INCLUDE_PREFIXES)}).")
                     
         except Exception as e:


### PR DESCRIPTION
## Summary

- Move recommended runtime settings into `translator_config.json`, keeping `api_keys.json` focused on API keys.
- Add synchronized `sync` settings for model, chunk size, source character budget, and output token budget.
- Raise normal translation chunk defaults to 20 items with a 6000 source-character guard and 16384 output tokens for both sync and Batch flows.
- Add source-character-aware Batch chunking so long game text is split before requests become too large.

## Impact

Short dialogue can batch more efficiently, while long dialogue blocks are separated earlier to reduce truncated JSON and large failure batches. Existing legacy `api_keys.json` fields remain compatible as fallbacks.

## Validation

- `python -m json.tool translator_config.example.json`
- `python -m json.tool api_keys.example.json`
- `python -m py_compile translator_runtime.py gemini_translate_batch.py translation_core.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`