### PR TITLE
[codex] Add batch golden corpus regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning
 - 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
 
+### Batch golden corpus 测试
+
+`tests/fixtures/golden_batch_minimal/` 保存了一个最小 TL fixture、固定 mock 模型结果和预期输出，用来离线验证普通 Batch 翻译的 `build -> check -> apply` 合约。这个测试不调用 Gemini，也不需要真实 API key。
+
+```bash
+python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
+```
+
+如果有意修改 prompt、manifest、schema 或写回行为，先确认差异合理，再更新 golden 输出：
+
+```powershell
+$env:UPDATE_GOLDEN_BATCH = "1"
+python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
+Remove-Item Env:UPDATE_GOLDEN_BATCH
+```
+
 ### 可选：Batch RAG 预建库
 
 如果项目里已经有一部分人工译文或旧译文，可以先运行：

--- a/tests/fixtures/golden_batch_minimal/expected/applied/chapter01/dialogue.rpy
+++ b/tests/fixtures/golden_batch_minimal/expected/applied/chapter01/dialogue.rpy
@@ -1,0 +1,16 @@
+translate schinese chapter01_start:
+    # e "Welcome back, traveler."
+    e "旅人，欢迎回来。"
+
+    # "The gate is quiet tonight."
+    "今晚大门很安静。"
+
+    # e "Don't touch the crystal."
+    e "请勿触碰水晶。"
+
+    # Escaped quote coverage.
+    "离开前说「你好」。"
+
+translate schinese chapter01_done:
+    # Already translated lines should not become pending.
+    e "已经翻译"

--- a/tests/fixtures/golden_batch_minimal/expected/applied/chapter02/strings.rpy
+++ b/tests/fixtures/golden_batch_minimal/expected/applied/chapter02/strings.rpy
@@ -1,0 +1,9 @@
+translate schinese strings:
+    old "Start Game"
+    new "开始游戏"
+
+    old "Load Game"
+    new "读取游戏"
+
+    old "已翻译"
+    new "已翻译"

--- a/tests/fixtures/golden_batch_minimal/expected/check_apply_snapshot.json
+++ b/tests/fixtures/golden_batch_minimal/expected/check_apply_snapshot.json
@@ -1,0 +1,42 @@
+{
+  "last_check_summary": {
+    "expected_chunks": 2,
+    "result_rows": 2,
+    "processed_chunks": 2,
+    "expected_items": 6,
+    "candidate_valid_items": 6,
+    "valid_items": 6,
+    "pending_files": 2,
+    "pending_lines": 6,
+    "skipped_items": 0,
+    "source_mismatch_items": 0,
+    "failure_items": 0,
+    "chunk_row_errors": 0,
+    "missing_response_chunks": 0,
+    "partial_chunks": 0,
+    "max_tokens_chunks": 0,
+    "reason_counts": {}
+  },
+  "apply_summary": {
+    "applied_files": 2,
+    "applied_lines": 6,
+    "candidate_items": 6,
+    "recoverable_items": 6,
+    "skipped_items": 0,
+    "source_mismatch_items": 0,
+    "failure_count": 0,
+    "rag": {}
+  },
+  "progress": {
+    "chapter01/dialogue.rpy": [
+      2,
+      5,
+      8,
+      11
+    ],
+    "chapter02/strings.rpy": [
+      2,
+      5
+    ]
+  }
+}

--- a/tests/fixtures/golden_batch_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_batch_minimal/expected/manifest_snapshot.json
@@ -1,0 +1,124 @@
+{
+  "mode": "translation",
+  "core_schema_version": 1,
+  "summary": {
+    "file_count": 2,
+    "chunk_count": 2,
+    "item_count": 6
+  },
+  "settings": {
+    "target_size": 20,
+    "target_chars": 6000,
+    "context_before": 8,
+    "context_after": 4,
+    "max_output_tokens": 16384,
+    "temperature": 0.2,
+    "thinking_level": "minimal"
+  },
+  "files": {
+    "chapter01/dialogue.rpy": {
+      "task_count": 4
+    },
+    "chapter02/strings.rpy": {
+      "task_count": 2
+    }
+  },
+  "chunks": [
+    {
+      "key": "004851531f-00001",
+      "file_rel_path": "chapter01/dialogue.rpy",
+      "chunk_index": 1,
+      "line_numbers": [
+        2,
+        5,
+        8,
+        11
+      ],
+      "source_char_count": 102,
+      "context_past": [],
+      "context_future": [],
+      "items": [
+        {
+          "id": "chapter01/dialogue.rpy:2:6",
+          "text": "Welcome back, traveler.",
+          "line": 2,
+          "start": 6,
+          "end": 31,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "e",
+          "speaker": "e"
+        },
+        {
+          "id": "chapter01/dialogue.rpy:5:4",
+          "text": "The gate is quiet tonight.",
+          "line": 5,
+          "start": 4,
+          "end": 32,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "",
+          "speaker": ""
+        },
+        {
+          "id": "chapter01/dialogue.rpy:8:6",
+          "text": "Don't touch the crystal.",
+          "line": 8,
+          "start": 6,
+          "end": 32,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "e",
+          "speaker": "e"
+        },
+        {
+          "id": "chapter01/dialogue.rpy:11:4",
+          "text": "Say \"hello\" before you leave.",
+          "line": 11,
+          "start": 4,
+          "end": 37,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "",
+          "speaker": ""
+        }
+      ]
+    },
+    {
+      "key": "029e98ba77-00001",
+      "file_rel_path": "chapter02/strings.rpy",
+      "chunk_index": 1,
+      "line_numbers": [
+        2,
+        5
+      ],
+      "source_char_count": 19,
+      "context_past": [],
+      "context_future": [],
+      "items": [
+        {
+          "id": "chapter02/strings.rpy:2:8",
+          "text": "Start Game",
+          "line": 2,
+          "start": 8,
+          "end": 20,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "",
+          "speaker": ""
+        },
+        {
+          "id": "chapter02/strings.rpy:5:8",
+          "text": "Load Game",
+          "line": 5,
+          "start": 8,
+          "end": 19,
+          "prefix": "",
+          "quote": "\"",
+          "speaker_id": "",
+          "speaker": ""
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/golden_batch_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_batch_minimal/expected/request_snapshot.json
@@ -1,0 +1,124 @@
+{
+  "rows": [
+    {
+      "key": "004851531f-00001",
+      "file_rel_path": "chapter01/dialogue.rpy",
+      "request_keys": [
+        "contents",
+        "generation_config",
+        "system_instruction"
+      ],
+      "content_roles": [
+        "user"
+      ],
+      "target_item_ids": [
+        "chapter01/dialogue.rpy:2:6",
+        "chapter01/dialogue.rpy:5:4",
+        "chapter01/dialogue.rpy:8:6",
+        "chapter01/dialogue.rpy:11:4"
+      ],
+      "system_instruction_sha256": "ed66ec81d9c32d4234192d16005de338331e27e05443a46ce36adcfedaa22648",
+      "user_prompt_sha256": "15f6c9f1cdb47e127d158c5292990a5998fb09e7466877fa2d6c598d63863267",
+      "generation_config": {
+        "keys": [
+          "max_output_tokens",
+          "response_json_schema",
+          "response_mime_type",
+          "temperature",
+          "thinking_config"
+        ],
+        "temperature": 0.2,
+        "max_output_tokens": 16384,
+        "response_mime_type": "application/json",
+        "thinking_config": {
+          "thinking_level": "MINIMAL"
+        },
+        "response_json_schema": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "translation"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "chapter01/dialogue.rpy:2:6",
+                  "chapter01/dialogue.rpy:5:4",
+                  "chapter01/dialogue.rpy:8:6",
+                  "chapter01/dialogue.rpy:11:4"
+                ]
+              },
+              "translation": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "key": "029e98ba77-00001",
+      "file_rel_path": "chapter02/strings.rpy",
+      "request_keys": [
+        "contents",
+        "generation_config",
+        "system_instruction"
+      ],
+      "content_roles": [
+        "user"
+      ],
+      "target_item_ids": [
+        "chapter02/strings.rpy:2:8",
+        "chapter02/strings.rpy:5:8"
+      ],
+      "system_instruction_sha256": "ed66ec81d9c32d4234192d16005de338331e27e05443a46ce36adcfedaa22648",
+      "user_prompt_sha256": "283aef76e3aa3ddf073df41dd9ecb8c9f1ee4062ad6be8032c2fa6ecc9d02314",
+      "generation_config": {
+        "keys": [
+          "max_output_tokens",
+          "response_json_schema",
+          "response_mime_type",
+          "temperature",
+          "thinking_config"
+        ],
+        "temperature": 0.2,
+        "max_output_tokens": 16384,
+        "response_mime_type": "application/json",
+        "thinking_config": {
+          "thinking_level": "MINIMAL"
+        },
+        "response_json_schema": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "translation"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "chapter02/strings.rpy:2:8",
+                  "chapter02/strings.rpy:5:8"
+                ]
+              },
+              "translation": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/golden_batch_minimal/model_results.json
+++ b/tests/fixtures/golden_batch_minimal/model_results.json
@@ -1,0 +1,8 @@
+{
+  "Welcome back, traveler.": "旅人，欢迎回来。",
+  "The gate is quiet tonight.": "今晚大门很安静。",
+  "Don't touch the crystal.": "请勿触碰水晶。",
+  "Say \"hello\" before you leave.": "离开前说「你好」。",
+  "Start Game": "开始游戏",
+  "Load Game": "读取游戏"
+}

--- a/tests/fixtures/golden_batch_minimal/tl/chapter01/dialogue.rpy
+++ b/tests/fixtures/golden_batch_minimal/tl/chapter01/dialogue.rpy
@@ -1,0 +1,16 @@
+translate schinese chapter01_start:
+    # e "Welcome back, traveler."
+    e "Welcome back, traveler."
+
+    # "The gate is quiet tonight."
+    "The gate is quiet tonight."
+
+    # e "Don't touch the crystal."
+    e "Don't touch the crystal."
+
+    # Escaped quote coverage.
+    "Say \"hello\" before you leave."
+
+translate schinese chapter01_done:
+    # Already translated lines should not become pending.
+    e "已经翻译"

--- a/tests/fixtures/golden_batch_minimal/tl/chapter02/strings.rpy
+++ b/tests/fixtures/golden_batch_minimal/tl/chapter02/strings.rpy
@@ -1,0 +1,9 @@
+translate schinese strings:
+    old "Start Game"
+    new "Start Game"
+
+    old "Load Game"
+    new "Load Game"
+
+    old "已翻译"
+    new "已翻译"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3025,6 +3025,8 @@ class BatchGoldenCorpusTests(unittest.TestCase):
             'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
             'log_dir': batch_mod.LOG_DIR,
             'jobs_dir': batch_mod.BATCH_JOBS_DIR,
+            'repair_dir': batch_mod.REPAIR_RUNS_DIR,
+            'sync_dir': batch_mod.SYNC_RUNS_DIR,
             'latest': batch_mod.LATEST_MANIFEST_FILE,
             'progress': batch_mod.PROGRESS_LOG,
             'rag_enabled': batch_mod.RAG_ENABLED,
@@ -3035,12 +3037,16 @@ class BatchGoldenCorpusTests(unittest.TestCase):
         }
         log_dir = root / 'logs'
         jobs_dir = log_dir / 'batch_jobs'
+        repair_dir = log_dir / 'repair_runs'
+        sync_dir = log_dir / 'sync_runs'
         batch_mod.legacy.BASE_DIR = str(root)
         batch_mod.legacy.TL_DIR = str(tl_dir)
         batch_mod.legacy.INCLUDE_FILES = set()
         batch_mod.legacy.INCLUDE_PREFIXES = set()
         batch_mod.LOG_DIR = str(log_dir)
         batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+        batch_mod.REPAIR_RUNS_DIR = str(repair_dir)
+        batch_mod.SYNC_RUNS_DIR = str(sync_dir)
         batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
         batch_mod.PROGRESS_LOG = str(log_dir / 'translation_progress_batch.json')
         batch_mod.RAG_ENABLED = False
@@ -3057,6 +3063,8 @@ class BatchGoldenCorpusTests(unittest.TestCase):
         batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
         batch_mod.LOG_DIR = old_values['log_dir']
         batch_mod.BATCH_JOBS_DIR = old_values['jobs_dir']
+        batch_mod.REPAIR_RUNS_DIR = old_values['repair_dir']
+        batch_mod.SYNC_RUNS_DIR = old_values['sync_dir']
         batch_mod.LATEST_MANIFEST_FILE = old_values['latest']
         batch_mod.PROGRESS_LOG = old_values['progress']
         batch_mod.RAG_ENABLED = old_values['rag_enabled']

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,9 +1,11 @@
 import ast
+import hashlib
 import importlib
 import io
 import json
 import os
 import pickle
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -19,6 +21,10 @@ import rag_memory
 import story_memory
 import translation_core
 import translator_runtime as runtime
+
+
+GOLDEN_BATCH_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_batch_minimal'
+UPDATE_GOLDEN_BATCH_ENV = 'UPDATE_GOLDEN_BATCH'
 
 
 class TranslationCoreRegressionTests(unittest.TestCase):
@@ -3002,6 +3008,319 @@ class BatchRagRegressionTests(unittest.TestCase):
             batch_mod._RAG_STORE = old_values['rag_store']
             batch_mod.RAG_OUTPUT_DIMENSIONALITY = old_values['rag_dim']
             batch_mod.RAG_SEGMENT_LINES = old_values['rag_segment_lines']
+
+
+class BatchGoldenCorpusTests(unittest.TestCase):
+    def _copy_fixture_tl(self, root):
+        tl_dir = root / 'game' / 'tl' / 'schinese'
+        tl_dir.parent.mkdir(parents=True)
+        shutil.copytree(GOLDEN_BATCH_FIXTURE_DIR / 'tl', tl_dir)
+        return tl_dir
+
+    def _patch_batch_environment(self, root, tl_dir):
+        old_values = {
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+            'log_dir': batch_mod.LOG_DIR,
+            'jobs_dir': batch_mod.BATCH_JOBS_DIR,
+            'latest': batch_mod.LATEST_MANIFEST_FILE,
+            'progress': batch_mod.PROGRESS_LOG,
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store': batch_mod._RAG_STORE,
+            'story_enabled': batch_mod.STORY_MEMORY_ENABLED,
+            'story_graph': batch_mod._STORY_GRAPH,
+            'story_graph_path': batch_mod._STORY_GRAPH_PATH,
+        }
+        log_dir = root / 'logs'
+        jobs_dir = log_dir / 'batch_jobs'
+        batch_mod.legacy.BASE_DIR = str(root)
+        batch_mod.legacy.TL_DIR = str(tl_dir)
+        batch_mod.legacy.INCLUDE_FILES = set()
+        batch_mod.legacy.INCLUDE_PREFIXES = set()
+        batch_mod.LOG_DIR = str(log_dir)
+        batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+        batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
+        batch_mod.PROGRESS_LOG = str(log_dir / 'translation_progress_batch.json')
+        batch_mod.RAG_ENABLED = False
+        batch_mod._RAG_STORE = None
+        batch_mod.STORY_MEMORY_ENABLED = False
+        batch_mod._STORY_GRAPH = None
+        batch_mod._STORY_GRAPH_PATH = ''
+        return old_values
+
+    def _restore_batch_environment(self, old_values):
+        batch_mod.legacy.BASE_DIR = old_values['base_dir']
+        batch_mod.legacy.TL_DIR = old_values['tl_dir']
+        batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+        batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+        batch_mod.LOG_DIR = old_values['log_dir']
+        batch_mod.BATCH_JOBS_DIR = old_values['jobs_dir']
+        batch_mod.LATEST_MANIFEST_FILE = old_values['latest']
+        batch_mod.PROGRESS_LOG = old_values['progress']
+        batch_mod.RAG_ENABLED = old_values['rag_enabled']
+        batch_mod._RAG_STORE = old_values['rag_store']
+        batch_mod.STORY_MEMORY_ENABLED = old_values['story_enabled']
+        batch_mod._STORY_GRAPH = old_values['story_graph']
+        batch_mod._STORY_GRAPH_PATH = old_values['story_graph_path']
+
+    def _load_manifest(self, manifest_path):
+        return json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+
+    def _manifest_snapshot(self, manifest):
+        return {
+            'mode': manifest['mode'],
+            'core_schema_version': manifest['core_schema_version'],
+            'summary': manifest['summary'],
+            'settings': manifest['settings'],
+            'files': {
+                rel_path: {'task_count': info['task_count']}
+                for rel_path, info in manifest['files'].items()
+            },
+            'chunks': [
+                {
+                    'key': chunk['key'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'chunk_index': chunk['chunk_index'],
+                    'line_numbers': chunk['line_numbers'],
+                    'source_char_count': chunk['source_char_count'],
+                    'context_past': [
+                        {'line': item['line'], 'text': item['text']}
+                        for item in chunk['context_past']
+                    ],
+                    'context_future': [
+                        {'line': item['line'], 'text': item['text']}
+                        for item in chunk['context_future']
+                    ],
+                    'items': [
+                        {
+                            key: item[key]
+                            for key in (
+                                'id',
+                                'text',
+                                'line',
+                                'line_number',
+                                'start',
+                                'end',
+                                'prefix',
+                                'quote',
+                                'speaker_id',
+                                'speaker',
+                                'speaker_name',
+                            )
+                            if key in item
+                        }
+                        for item in chunk['items']
+                    ],
+                }
+                for chunk in manifest['chunks']
+            ],
+        }
+
+    def _request_snapshot(self, manifest):
+        chunk_by_key = {chunk['key']: chunk for chunk in manifest['chunks']}
+        request_rows = [
+            json.loads(line)
+            for line in Path(manifest['input_jsonl_path']).read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+        rows = []
+        for row in request_rows:
+            request = row['request']
+            chunk = chunk_by_key[row['key']]
+            config = request['generation_config']
+            user_prompt = request['contents'][0]['parts'][0]['text']
+            system_text = request['system_instruction']['parts'][0]['text']
+            rows.append(
+                {
+                    'key': row['key'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'request_keys': sorted(request.keys()),
+                    'content_roles': [content.get('role') for content in request['contents']],
+                    'target_item_ids': [item['id'] for item in chunk['items']],
+                    'system_instruction_sha256': hashlib.sha256(system_text.encode('utf-8')).hexdigest(),
+                    'user_prompt_sha256': hashlib.sha256(user_prompt.encode('utf-8')).hexdigest(),
+                    'generation_config': {
+                        'keys': sorted(config.keys()),
+                        'temperature': config['temperature'],
+                        'max_output_tokens': config['max_output_tokens'],
+                        'response_mime_type': config['response_mime_type'],
+                        'thinking_config': config.get('thinking_config', {}),
+                        'response_json_schema': config['response_json_schema'],
+                    },
+                }
+            )
+        return {'rows': rows}
+
+    def _stable_summary(self, summary):
+        return {
+            'expected_chunks': summary['expected_chunks'],
+            'result_rows': summary['result_rows'],
+            'processed_chunks': summary['processed_chunks'],
+            'expected_items': summary['expected_items'],
+            'candidate_valid_items': summary['candidate_valid_items'],
+            'valid_items': summary['valid_items'],
+            'pending_files': summary['pending_files'],
+            'pending_lines': summary['pending_lines'],
+            'skipped_items': summary['skipped_items'],
+            'source_mismatch_items': summary['source_mismatch_items'],
+            'failure_items': summary['failure_items'],
+            'chunk_row_errors': summary['chunk_row_errors'],
+            'missing_response_chunks': summary['missing_response_chunks'],
+            'partial_chunks': summary['partial_chunks'],
+            'max_tokens_chunks': summary['max_tokens_chunks'],
+            'reason_counts': summary['reason_counts'],
+        }
+
+    def _assert_or_update_json(self, relative_path, actual):
+        expected_path = GOLDEN_BATCH_FIXTURE_DIR / relative_path
+        text = json.dumps(actual, ensure_ascii=False, indent=2) + '\n'
+        if os.environ.get(UPDATE_GOLDEN_BATCH_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(text, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        expected = json.loads(expected_path.read_text(encoding='utf-8'))
+        self.assertEqual(actual, expected)
+
+    def _assert_or_update_text(self, relative_path, actual):
+        expected_path = GOLDEN_BATCH_FIXTURE_DIR / relative_path
+        if os.environ.get(UPDATE_GOLDEN_BATCH_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(actual, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        self.assertEqual(actual, expected_path.read_text(encoding='utf-8'))
+
+    def _write_mock_results(self, manifest_path):
+        manifest_path = Path(manifest_path)
+        manifest = self._load_manifest(manifest_path)
+        translations = json.loads(
+            (GOLDEN_BATCH_FIXTURE_DIR / 'model_results.json').read_text(encoding='utf-8')
+        )
+        result_path = manifest_path.parent / 'results.jsonl'
+        rows = []
+        for chunk in manifest['chunks']:
+            result_items = [
+                {'id': item['id'], 'translation': translations[item['text']]}
+                for item in chunk['items']
+            ]
+            response_text = json.dumps(result_items, ensure_ascii=False)
+            rows.append(
+                {
+                    'key': chunk['key'],
+                    'response': {
+                        'candidates': [
+                            {
+                                'content': {'parts': [{'text': response_text}]},
+                                'finishReason': 'STOP',
+                            }
+                        ],
+                        'usageMetadata': {
+                            'promptTokenCount': 100,
+                            'candidatesTokenCount': 40,
+                            'totalTokenCount': 140,
+                        },
+                    },
+                }
+            )
+        result_path.write_text(
+            ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+            encoding='utf-8',
+        )
+        manifest['result_jsonl_path'] = 'results.jsonl'
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2),
+            encoding='utf-8',
+        )
+
+    def test_golden_batch_build_check_apply_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_batch_package(
+                        display_name_override='golden-batch-minimal',
+                        skip_prepare=True,
+                    )
+                )
+                self._write_mock_results(manifest_path)
+                manifest = self._load_manifest(manifest_path)
+
+                self._assert_or_update_json(
+                    'expected/manifest_snapshot.json',
+                    self._manifest_snapshot(manifest),
+                )
+                self._assert_or_update_json(
+                    'expected/request_snapshot.json',
+                    self._request_snapshot(manifest),
+                )
+
+                checked_manifest = batch_mod.check_results(str(manifest_path))
+                applied_manifest = batch_mod.apply_results(str(manifest_path))
+                progress = json.loads(Path(batch_mod.PROGRESS_LOG).read_text(encoding='utf-8'))
+
+                check_apply_snapshot = {
+                    'last_check_summary': self._stable_summary(checked_manifest['last_check_summary']),
+                    'apply_summary': applied_manifest['apply_summary'],
+                    'progress': progress,
+                }
+                self._assert_or_update_json(
+                    'expected/check_apply_snapshot.json',
+                    check_apply_snapshot,
+                )
+                self._assert_or_update_text(
+                    'expected/applied/chapter01/dialogue.rpy',
+                    (tl_dir / 'chapter01' / 'dialogue.rpy').read_text(encoding='utf-8'),
+                )
+                self._assert_or_update_text(
+                    'expected/applied/chapter02/strings.rpy',
+                    (tl_dir / 'chapter02' / 'strings.rpy').read_text(encoding='utf-8'),
+                )
+
+                with self.assertRaisesRegex(SystemExit, 'already applied'):
+                    batch_mod.apply_results(str(manifest_path))
+            finally:
+                self._restore_batch_environment(old_values)
+
+    def test_golden_batch_apply_rejects_changed_source_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_batch_package(
+                        display_name_override='golden-batch-minimal',
+                        skip_prepare=True,
+                    )
+                )
+                self._write_mock_results(manifest_path)
+                dialogue_path = tl_dir / 'chapter01' / 'dialogue.rpy'
+                dialogue_path.write_text(
+                    dialogue_path.read_text(encoding='utf-8').replace(
+                        'e "Welcome back, traveler."',
+                        'e "Welcome home, traveler."',
+                    ),
+                    encoding='utf-8',
+                )
+
+                applied_manifest = batch_mod.apply_results(str(manifest_path))
+                final_dialogue = dialogue_path.read_text(encoding='utf-8')
+
+                self.assertIn('e "Welcome home, traveler."', final_dialogue)
+                self.assertNotIn('e "旅人，欢迎回来。"', final_dialogue)
+                self.assertIn('e "请勿触碰水晶。"', final_dialogue)
+                self.assertEqual(applied_manifest['apply_summary']['candidate_items'], 6)
+                self.assertEqual(applied_manifest['apply_summary']['recoverable_items'], 5)
+                self.assertEqual(applied_manifest['apply_summary']['skipped_items'], 1)
+                self.assertEqual(applied_manifest['apply_summary']['source_mismatch_items'], 1)
+                self.assertEqual(applied_manifest['apply_summary']['failure_count'], 1)
+            finally:
+                self._restore_batch_environment(old_values)
 
 
 class BatchRepairRegressionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add a minimal golden Batch corpus fixture with fixed TL inputs, mock model outputs, and expected snapshots.
- Cover offline `build -> check -> apply`, repeated apply protection, and source snapshot mismatch handling.
- Document how to run and intentionally refresh the golden corpus outputs.

Fixes #40

## Validation

- `python -m unittest discover -s tests -p "test_*.py" -q`