### PR TITLE
[codex] Add revision golden corpus regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,18 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning
 - 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
 
-### Batch golden corpus 测试
+### Golden corpus 测试
 
 `tests/fixtures/golden_batch_minimal/` 保存了一个最小 TL fixture、固定 mock 模型结果和预期输出，用来离线验证普通 Batch 翻译的 `build -> check -> apply` 合约。这个测试不调用 Gemini，也不需要真实 API key。
 
 ```bash
 python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
+```
+
+`tests/fixtures/golden_revision_minimal/` 保存了一个最小订正 fixture，用来离线验证 `build-revisions -> preview-revisions -> apply-revisions` 合约，覆盖已有 `new` 行订正、保持不变项和写回前源快照校验。
+
+```bash
+python -m unittest tests.test_regressions.RevisionGoldenCorpusTests -q
 ```
 
 如果有意修改 prompt、manifest、schema 或写回行为，先确认差异合理，再更新 golden 输出：
@@ -224,6 +230,10 @@ python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
 $env:UPDATE_GOLDEN_BATCH = "1"
 python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
 Remove-Item Env:UPDATE_GOLDEN_BATCH
+
+$env:UPDATE_GOLDEN_REVISION = "1"
+python -m unittest tests.test_regressions.RevisionGoldenCorpusTests -q
+Remove-Item Env:UPDATE_GOLDEN_REVISION
 ```
 
 ### 可选：Batch RAG 预建库

--- a/tests/fixtures/golden_revision_minimal/expected/applied/chapter01/revisions.rpy
+++ b/tests/fixtures/golden_revision_minimal/expected/applied/chapter01/revisions.rpy
@@ -1,0 +1,9 @@
+translate schinese chapter01_terms:
+    old "Void Gate"
+    new "虚空之门"
+
+    old "Crystal Key"
+    new "晶核钥匙"
+
+    old "Already Good"
+    new "已经很好"

--- a/tests/fixtures/golden_revision_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/manifest_snapshot.json
@@ -1,0 +1,76 @@
+{
+  "mode": "revision",
+  "core_schema_version": 1,
+  "summary": {
+    "file_count": 1,
+    "chunk_count": 1,
+    "item_count": 3
+  },
+  "settings": {
+    "revision_chunk_size": 3,
+    "max_output_tokens": 16384,
+    "temperature": 0.2,
+    "thinking_level": "minimal"
+  },
+  "revision_settings": {
+    "chunk_size": 3
+  },
+  "files": {
+    "chapter01/revisions.rpy": {
+      "task_count": 3
+    }
+  },
+  "chunks": [
+    {
+      "key": "rv-4e4faec80d-00001",
+      "mode": "revision",
+      "file_rel_path": "chapter01/revisions.rpy",
+      "chunk_index": 1,
+      "line_numbers": [
+        3,
+        6,
+        9
+      ],
+      "context_past": [],
+      "context_future": [],
+      "items": [
+        {
+          "id": "chapter01/revisions.rpy:2:8:revision:0",
+          "text": "Void Gate",
+          "source": "Void Gate",
+          "current_translation": "虚空门",
+          "line": 2,
+          "line_number": 3,
+          "start": 8,
+          "end": 13,
+          "prefix": "",
+          "quote": "\""
+        },
+        {
+          "id": "chapter01/revisions.rpy:5:8:revision:1",
+          "text": "Crystal Key",
+          "source": "Crystal Key",
+          "current_translation": "水晶钥匙",
+          "line": 5,
+          "line_number": 6,
+          "start": 8,
+          "end": 14,
+          "prefix": "",
+          "quote": "\""
+        },
+        {
+          "id": "chapter01/revisions.rpy:8:8:revision:2",
+          "text": "Already Good",
+          "source": "Already Good",
+          "current_translation": "已经很好",
+          "line": 8,
+          "line_number": 9,
+          "start": 8,
+          "end": 14,
+          "prefix": "",
+          "quote": "\""
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
@@ -1,0 +1,99 @@
+{
+  "last_revision_preview_summary": {
+    "expected_chunks": 1,
+    "result_rows": 1,
+    "processed_chunks": 1,
+    "expected_items": 3,
+    "parsed_items": 3,
+    "candidate_valid_items": 2,
+    "revision_candidate_items": 2,
+    "valid_items": 2,
+    "unchanged_items": 1,
+    "pending_files": 1,
+    "pending_lines": 2,
+    "skipped_items": 0,
+    "source_mismatch_items": 0,
+    "failure_items": 0,
+    "chunk_row_errors": 0,
+    "missing_response_chunks": 0,
+    "partial_chunks": 0,
+    "max_tokens_chunks": 0,
+    "reason_counts": {}
+  },
+  "preview_rows": [
+    {
+      "id": "chapter01/revisions.rpy:2:8:revision:0",
+      "file_rel_path": "chapter01/revisions.rpy",
+      "line": 3,
+      "source": "Void Gate",
+      "current_translation": "虚空门",
+      "revised_translation": "虚空之门",
+      "should_update": true,
+      "reason": "统一核心术语",
+      "status": "pending",
+      "error": ""
+    },
+    {
+      "id": "chapter01/revisions.rpy:5:8:revision:1",
+      "file_rel_path": "chapter01/revisions.rpy",
+      "line": 6,
+      "source": "Crystal Key",
+      "current_translation": "水晶钥匙",
+      "revised_translation": "晶核钥匙",
+      "should_update": true,
+      "reason": "统一物品名",
+      "status": "pending",
+      "error": ""
+    },
+    {
+      "id": "chapter01/revisions.rpy:8:8:revision:2",
+      "file_rel_path": "chapter01/revisions.rpy",
+      "line": 9,
+      "source": "Already Good",
+      "current_translation": "已经很好",
+      "revised_translation": "已经很好",
+      "should_update": false,
+      "reason": "当前译文可保留",
+      "status": "unchanged",
+      "error": ""
+    }
+  ],
+  "revision_apply_summary": {
+    "applied_files": 1,
+    "applied_lines": 2,
+    "candidate_items": 2,
+    "recoverable_items": 2,
+    "unchanged_items": 1,
+    "skipped_items": 0,
+    "source_mismatch_items": 0,
+    "failure_count": 0,
+    "rag": {}
+  },
+  "last_revision_apply_summary": {
+    "expected_chunks": 1,
+    "result_rows": 1,
+    "processed_chunks": 1,
+    "expected_items": 3,
+    "parsed_items": 3,
+    "candidate_valid_items": 2,
+    "revision_candidate_items": 2,
+    "valid_items": 2,
+    "unchanged_items": 1,
+    "pending_files": 1,
+    "pending_lines": 2,
+    "skipped_items": 0,
+    "source_mismatch_items": 0,
+    "failure_items": 0,
+    "chunk_row_errors": 0,
+    "missing_response_chunks": 0,
+    "partial_chunks": 0,
+    "max_tokens_chunks": 0,
+    "reason_counts": {}
+  },
+  "progress": {
+    "chapter01/revisions.rpy": [
+      2,
+      5
+    ]
+  }
+}

--- a/tests/fixtures/golden_revision_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/request_snapshot.json
@@ -1,0 +1,72 @@
+{
+  "rows": [
+    {
+      "key": "rv-4e4faec80d-00001",
+      "file_rel_path": "chapter01/revisions.rpy",
+      "request_keys": [
+        "contents",
+        "generation_config",
+        "system_instruction"
+      ],
+      "content_roles": [
+        "user"
+      ],
+      "target_item_ids": [
+        "chapter01/revisions.rpy:2:8:revision:0",
+        "chapter01/revisions.rpy:5:8:revision:1",
+        "chapter01/revisions.rpy:8:8:revision:2"
+      ],
+      "system_instruction_sha256": "cea23eba3b14e7f566e675b00756c4c2a506f233ba7c41330de78ac76205cf1a",
+      "user_prompt_sha256": "a10edb06b82a7554c276dc9a0d2b0c37d1aa74c0bb81e5bd9e05e17123124bfc",
+      "generation_config": {
+        "keys": [
+          "max_output_tokens",
+          "response_json_schema",
+          "response_mime_type",
+          "temperature",
+          "thinking_config"
+        ],
+        "temperature": 0.2,
+        "max_output_tokens": 16384,
+        "response_mime_type": "application/json",
+        "thinking_config": {
+          "thinking_level": "MINIMAL"
+        },
+        "response_json_schema": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "should_update",
+              "revised_translation",
+              "reason"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "chapter01/revisions.rpy:2:8:revision:0",
+                  "chapter01/revisions.rpy:5:8:revision:1",
+                  "chapter01/revisions.rpy:8:8:revision:2"
+                ]
+              },
+              "should_update": {
+                "type": "boolean"
+              },
+              "revised_translation": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/golden_revision_minimal/expected/revision_preview.md
+++ b/tests/fixtures/golden_revision_minimal/expected/revision_preview.md
@@ -1,0 +1,11 @@
+# Revision Preview
+
+- Pending revisions: 2
+- Unchanged items: 1
+- Failure items: 0
+
+| Status | Source | Current | Revised | Reason | File | Line |
+| --- | --- | --- | --- | --- | --- | ---: |
+| pending | Void Gate | 虚空门 | 虚空之门 | 统一核心术语 | chapter01/revisions.rpy | 3 |
+| pending | Crystal Key | 水晶钥匙 | 晶核钥匙 | 统一物品名 | chapter01/revisions.rpy | 6 |
+| unchanged | Already Good | 已经很好 | 已经很好 | 当前译文可保留 | chapter01/revisions.rpy | 9 |

--- a/tests/fixtures/golden_revision_minimal/model_results.json
+++ b/tests/fixtures/golden_revision_minimal/model_results.json
@@ -1,0 +1,17 @@
+{
+  "Void Gate": {
+    "should_update": true,
+    "revised_translation": "虚空之门",
+    "reason": "统一核心术语"
+  },
+  "Crystal Key": {
+    "should_update": true,
+    "revised_translation": "晶核钥匙",
+    "reason": "统一物品名"
+  },
+  "Already Good": {
+    "should_update": false,
+    "revised_translation": "已经很好",
+    "reason": "当前译文可保留"
+  }
+}

--- a/tests/fixtures/golden_revision_minimal/tl/chapter01/revisions.rpy
+++ b/tests/fixtures/golden_revision_minimal/tl/chapter01/revisions.rpy
@@ -1,0 +1,9 @@
+translate schinese chapter01_terms:
+    old "Void Gate"
+    new "虚空门"
+
+    old "Crystal Key"
+    new "水晶钥匙"
+
+    old "Already Good"
+    new "已经很好"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -24,7 +24,9 @@ import translator_runtime as runtime
 
 
 GOLDEN_BATCH_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_batch_minimal'
+GOLDEN_REVISION_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_revision_minimal'
 UPDATE_GOLDEN_BATCH_ENV = 'UPDATE_GOLDEN_BATCH'
+UPDATE_GOLDEN_REVISION_ENV = 'UPDATE_GOLDEN_REVISION'
 
 
 class TranslationCoreRegressionTests(unittest.TestCase):
@@ -3327,6 +3329,356 @@ class BatchGoldenCorpusTests(unittest.TestCase):
                 self.assertEqual(applied_manifest['apply_summary']['skipped_items'], 1)
                 self.assertEqual(applied_manifest['apply_summary']['source_mismatch_items'], 1)
                 self.assertEqual(applied_manifest['apply_summary']['failure_count'], 1)
+            finally:
+                self._restore_batch_environment(old_values)
+
+
+class RevisionGoldenCorpusTests(unittest.TestCase):
+    def _copy_fixture_tl(self, root):
+        tl_dir = root / 'game' / 'tl' / 'schinese'
+        tl_dir.parent.mkdir(parents=True)
+        shutil.copytree(GOLDEN_REVISION_FIXTURE_DIR / 'tl', tl_dir)
+        return tl_dir
+
+    def _patch_batch_environment(self, root, tl_dir):
+        old_values = {
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+            'log_dir': batch_mod.LOG_DIR,
+            'jobs_dir': batch_mod.BATCH_JOBS_DIR,
+            'repair_dir': batch_mod.REPAIR_RUNS_DIR,
+            'sync_dir': batch_mod.SYNC_RUNS_DIR,
+            'latest': batch_mod.LATEST_MANIFEST_FILE,
+            'progress': batch_mod.PROGRESS_LOG,
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store': batch_mod._RAG_STORE,
+            'story_enabled': batch_mod.STORY_MEMORY_ENABLED,
+            'story_graph': batch_mod._STORY_GRAPH,
+            'story_graph_path': batch_mod._STORY_GRAPH_PATH,
+        }
+        log_dir = root / 'logs'
+        jobs_dir = log_dir / 'batch_jobs'
+        batch_mod.legacy.BASE_DIR = str(root)
+        batch_mod.legacy.TL_DIR = str(tl_dir)
+        batch_mod.legacy.INCLUDE_FILES = set()
+        batch_mod.legacy.INCLUDE_PREFIXES = set()
+        batch_mod.LOG_DIR = str(log_dir)
+        batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+        batch_mod.REPAIR_RUNS_DIR = str(log_dir / 'repair_runs')
+        batch_mod.SYNC_RUNS_DIR = str(log_dir / 'sync_runs')
+        batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
+        batch_mod.PROGRESS_LOG = str(log_dir / 'translation_progress_batch.json')
+        batch_mod.RAG_ENABLED = False
+        batch_mod._RAG_STORE = None
+        batch_mod.STORY_MEMORY_ENABLED = False
+        batch_mod._STORY_GRAPH = None
+        batch_mod._STORY_GRAPH_PATH = ''
+        return old_values
+
+    def _restore_batch_environment(self, old_values):
+        batch_mod.legacy.BASE_DIR = old_values['base_dir']
+        batch_mod.legacy.TL_DIR = old_values['tl_dir']
+        batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+        batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+        batch_mod.LOG_DIR = old_values['log_dir']
+        batch_mod.BATCH_JOBS_DIR = old_values['jobs_dir']
+        batch_mod.REPAIR_RUNS_DIR = old_values['repair_dir']
+        batch_mod.SYNC_RUNS_DIR = old_values['sync_dir']
+        batch_mod.LATEST_MANIFEST_FILE = old_values['latest']
+        batch_mod.PROGRESS_LOG = old_values['progress']
+        batch_mod.RAG_ENABLED = old_values['rag_enabled']
+        batch_mod._RAG_STORE = old_values['rag_store']
+        batch_mod.STORY_MEMORY_ENABLED = old_values['story_enabled']
+        batch_mod._STORY_GRAPH = old_values['story_graph']
+        batch_mod._STORY_GRAPH_PATH = old_values['story_graph_path']
+
+    def _load_manifest(self, manifest_path):
+        return json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+
+    def _assert_or_update_json(self, relative_path, actual):
+        expected_path = GOLDEN_REVISION_FIXTURE_DIR / relative_path
+        text = json.dumps(actual, ensure_ascii=False, indent=2) + '\n'
+        if os.environ.get(UPDATE_GOLDEN_REVISION_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(text, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        expected = json.loads(expected_path.read_text(encoding='utf-8'))
+        self.assertEqual(actual, expected)
+
+    def _assert_or_update_text(self, relative_path, actual):
+        expected_path = GOLDEN_REVISION_FIXTURE_DIR / relative_path
+        if os.environ.get(UPDATE_GOLDEN_REVISION_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(actual, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        self.assertEqual(actual, expected_path.read_text(encoding='utf-8'))
+
+    def _manifest_snapshot(self, manifest):
+        return {
+            'mode': manifest['mode'],
+            'core_schema_version': manifest['core_schema_version'],
+            'summary': manifest['summary'],
+            'settings': manifest['settings'],
+            'revision_settings': manifest['revision_settings'],
+            'files': {
+                rel_path: {'task_count': info['task_count']}
+                for rel_path, info in manifest['files'].items()
+            },
+            'chunks': [
+                {
+                    'key': chunk['key'],
+                    'mode': chunk['mode'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'chunk_index': chunk['chunk_index'],
+                    'line_numbers': chunk['line_numbers'],
+                    'context_past': chunk['context_past'],
+                    'context_future': chunk['context_future'],
+                    'items': [
+                        {
+                            key: item[key]
+                            for key in (
+                                'id',
+                                'text',
+                                'source',
+                                'current_translation',
+                                'line',
+                                'line_number',
+                                'start',
+                                'end',
+                                'prefix',
+                                'quote',
+                            )
+                            if key in item
+                        }
+                        for item in chunk['items']
+                    ],
+                }
+                for chunk in manifest['chunks']
+            ],
+        }
+
+    def _request_snapshot(self, manifest):
+        chunk_by_key = {chunk['key']: chunk for chunk in manifest['chunks']}
+        request_rows = [
+            json.loads(line)
+            for line in Path(manifest['input_jsonl_path']).read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+        rows = []
+        for row in request_rows:
+            request = row['request']
+            chunk = chunk_by_key[row['key']]
+            config = request['generation_config']
+            user_prompt = request['contents'][0]['parts'][0]['text']
+            system_text = request['system_instruction']['parts'][0]['text']
+            rows.append(
+                {
+                    'key': row['key'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'request_keys': sorted(request.keys()),
+                    'content_roles': [content.get('role') for content in request['contents']],
+                    'target_item_ids': [item['id'] for item in chunk['items']],
+                    'system_instruction_sha256': hashlib.sha256(system_text.encode('utf-8')).hexdigest(),
+                    'user_prompt_sha256': hashlib.sha256(user_prompt.encode('utf-8')).hexdigest(),
+                    'generation_config': {
+                        'keys': sorted(config.keys()),
+                        'temperature': config['temperature'],
+                        'max_output_tokens': config['max_output_tokens'],
+                        'response_mime_type': config['response_mime_type'],
+                        'thinking_config': config.get('thinking_config', {}),
+                        'response_json_schema': config['response_json_schema'],
+                    },
+                }
+            )
+        return {'rows': rows}
+
+    def _stable_revision_summary(self, summary):
+        return {
+            'expected_chunks': summary['expected_chunks'],
+            'result_rows': summary['result_rows'],
+            'processed_chunks': summary['processed_chunks'],
+            'expected_items': summary['expected_items'],
+            'parsed_items': summary['parsed_items'],
+            'candidate_valid_items': summary['candidate_valid_items'],
+            'revision_candidate_items': summary['revision_candidate_items'],
+            'valid_items': summary['valid_items'],
+            'unchanged_items': summary['unchanged_items'],
+            'pending_files': summary['pending_files'],
+            'pending_lines': summary['pending_lines'],
+            'skipped_items': summary['skipped_items'],
+            'source_mismatch_items': summary['source_mismatch_items'],
+            'failure_items': summary['failure_items'],
+            'chunk_row_errors': summary['chunk_row_errors'],
+            'missing_response_chunks': summary['missing_response_chunks'],
+            'partial_chunks': summary['partial_chunks'],
+            'max_tokens_chunks': summary['max_tokens_chunks'],
+            'reason_counts': summary['reason_counts'],
+        }
+
+    def _write_mock_revision_results(self, manifest_path):
+        manifest_path = Path(manifest_path)
+        manifest = self._load_manifest(manifest_path)
+        revisions = json.loads(
+            (GOLDEN_REVISION_FIXTURE_DIR / 'model_results.json').read_text(encoding='utf-8')
+        )
+        result_path = manifest_path.parent / 'results.jsonl'
+        rows = []
+        for chunk in manifest['chunks']:
+            result_items = []
+            for item in chunk['items']:
+                revision = revisions[item['source']]
+                result_items.append(
+                    {
+                        'id': item['id'],
+                        'should_update': revision['should_update'],
+                        'revised_translation': revision['revised_translation'],
+                        'reason': revision['reason'],
+                    }
+                )
+            response_text = json.dumps(result_items, ensure_ascii=False)
+            rows.append(
+                {
+                    'key': chunk['key'],
+                    'response': {
+                        'candidates': [
+                            {
+                                'content': {'parts': [{'text': response_text}]},
+                                'finishReason': 'STOP',
+                            }
+                        ],
+                        'usageMetadata': {
+                            'promptTokenCount': 100,
+                            'candidatesTokenCount': 40,
+                            'totalTokenCount': 140,
+                        },
+                    },
+                }
+            )
+        result_path.write_text(
+            ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+            encoding='utf-8',
+        )
+        manifest['result_jsonl_path'] = 'results.jsonl'
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2),
+            encoding='utf-8',
+        )
+
+    def _read_preview_rows(self, manifest):
+        preview_jsonl = Path(manifest['last_revision_preview']['jsonl_path'])
+        return [
+            json.loads(line)
+            for line in preview_jsonl.read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+
+    def test_golden_revision_build_preview_apply_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_revision_package(
+                        display_name_override='golden-revision-minimal',
+                        skip_prepare=True,
+                        chunk_size=3,
+                    )
+                )
+                self._write_mock_revision_results(manifest_path)
+                manifest = self._load_manifest(manifest_path)
+
+                self._assert_or_update_json(
+                    'expected/manifest_snapshot.json',
+                    self._manifest_snapshot(manifest),
+                )
+                self._assert_or_update_json(
+                    'expected/request_snapshot.json',
+                    self._request_snapshot(manifest),
+                )
+
+                preview_manifest = batch_mod.preview_revisions(str(manifest_path))
+                preview_rows = self._read_preview_rows(preview_manifest)
+                preview_markdown = Path(preview_manifest['last_revision_preview']['markdown_path']).read_text(
+                    encoding='utf-8'
+                )
+                applied_manifest = batch_mod.apply_revisions(str(manifest_path))
+                progress = json.loads(Path(batch_mod.PROGRESS_LOG).read_text(encoding='utf-8'))
+
+                preview_apply_snapshot = {
+                    'last_revision_preview_summary': self._stable_revision_summary(
+                        preview_manifest['last_revision_preview']['summary']
+                    ),
+                    'preview_rows': preview_rows,
+                    'revision_apply_summary': applied_manifest['revision_apply_summary'],
+                    'last_revision_apply_summary': self._stable_revision_summary(
+                        applied_manifest['last_revision_apply_summary']
+                    ),
+                    'progress': progress,
+                }
+                self._assert_or_update_json(
+                    'expected/preview_apply_snapshot.json',
+                    preview_apply_snapshot,
+                )
+                self._assert_or_update_text(
+                    'expected/revision_preview.md',
+                    preview_markdown,
+                )
+                self._assert_or_update_text(
+                    'expected/applied/chapter01/revisions.rpy',
+                    (tl_dir / 'chapter01' / 'revisions.rpy').read_text(encoding='utf-8'),
+                )
+
+                with self.assertRaisesRegex(SystemExit, 'already applied'):
+                    batch_mod.apply_revisions(str(manifest_path))
+            finally:
+                self._restore_batch_environment(old_values)
+
+    def test_golden_revision_apply_rejects_changed_current_translation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_revision_package(
+                        display_name_override='golden-revision-minimal',
+                        skip_prepare=True,
+                        chunk_size=3,
+                    )
+                )
+                self._write_mock_revision_results(manifest_path)
+                revisions_path = tl_dir / 'chapter01' / 'revisions.rpy'
+                revisions_path.write_text(
+                    revisions_path.read_text(encoding='utf-8').replace(
+                        'new "虚空门"',
+                        'new "星门"',
+                    ),
+                    encoding='utf-8',
+                )
+
+                preview_manifest = batch_mod.preview_revisions(str(manifest_path))
+                preview_rows = self._read_preview_rows(preview_manifest)
+                applied_manifest = batch_mod.apply_revisions(str(manifest_path))
+                final_revisions = revisions_path.read_text(encoding='utf-8')
+
+                self.assertIn('old "Void Gate"', final_revisions)
+                self.assertIn('new "星门"', final_revisions)
+                self.assertNotIn('new "虚空之门"', final_revisions)
+                self.assertIn('new "晶核钥匙"', final_revisions)
+                self.assertEqual(preview_rows[0]['status'], 'source_mismatch')
+                self.assertEqual(preview_rows[1]['status'], 'pending')
+                self.assertEqual(preview_rows[2]['status'], 'unchanged')
+                self.assertEqual(applied_manifest['revision_apply_summary']['candidate_items'], 2)
+                self.assertEqual(applied_manifest['revision_apply_summary']['recoverable_items'], 1)
+                self.assertEqual(applied_manifest['revision_apply_summary']['unchanged_items'], 1)
+                self.assertEqual(applied_manifest['revision_apply_summary']['skipped_items'], 1)
+                self.assertEqual(applied_manifest['revision_apply_summary']['source_mismatch_items'], 1)
+                self.assertEqual(applied_manifest['revision_apply_summary']['failure_count'], 1)
             finally:
                 self._restore_batch_environment(old_values)
 


### PR DESCRIPTION
## Summary

- Add a minimal Revision golden corpus fixture with fixed old/new TL input and mock revision results.
- Cover offline `build-revisions -> preview-revisions -> apply-revisions`, including pending updates, unchanged entries, repeated apply protection, and current-translation source mismatch handling.
- Document how to run and intentionally refresh both Batch and Revision golden outputs.

## Validation

- `python -m unittest tests.test_regressions.RevisionGoldenCorpusTests -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`