### PR TITLE
[codex] Add keyword golden corpus regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ python -m unittest tests.test_regressions.BatchGoldenCorpusTests -q
 python -m unittest tests.test_regressions.RevisionGoldenCorpusTests -q
 ```
 
+`tests/fixtures/golden_keyword_minimal/` 保存了一个最小关键词提取 fixture，用来离线验证 `build-keywords -> export-keywords` 合约，覆盖候选项去重、来源行定位和 chunk 剧情概要导出。
+
+```bash
+python -m unittest tests.test_regressions.KeywordGoldenCorpusTests -q
+```
+
 如果有意修改 prompt、manifest、schema 或写回行为，先确认差异合理，再更新 golden 输出：
 
 ```powershell
@@ -234,6 +240,10 @@ Remove-Item Env:UPDATE_GOLDEN_BATCH
 $env:UPDATE_GOLDEN_REVISION = "1"
 python -m unittest tests.test_regressions.RevisionGoldenCorpusTests -q
 Remove-Item Env:UPDATE_GOLDEN_REVISION
+
+$env:UPDATE_GOLDEN_KEYWORD = "1"
+python -m unittest tests.test_regressions.KeywordGoldenCorpusTests -q
+Remove-Item Env:UPDATE_GOLDEN_KEYWORD
 ```
 
 ### 可选：Batch RAG 预建库

--- a/tests/fixtures/golden_keyword_minimal/expected/export_snapshot.json
+++ b/tests/fixtures/golden_keyword_minimal/expected/export_snapshot.json
@@ -1,0 +1,114 @@
+{
+  "summary": {
+    "expected_chunks": 2,
+    "result_rows": 2,
+    "processed_chunks": 2,
+    "parsed_chunks": 2,
+    "candidate_count_raw": 5,
+    "candidate_count_deduped": 3,
+    "chunk_row_errors": 0,
+    "unknown_chunk_keys": 0,
+    "missing_response_chunks": 0,
+    "missing_chunk_rows": 0,
+    "ambiguous_provenance_candidates": 0,
+    "chunk_summary_count": 2,
+    "ambiguous_summary_chunks": 0,
+    "parse_errors": 0,
+    "reason_counts": {}
+  },
+  "candidate_rows": [
+    {
+      "source": "Aether Compass",
+      "suggested_target": "以太罗盘",
+      "category": "item",
+      "confidence": 0.92,
+      "evidence": "Navigation item found by Noah.",
+      "source_item_ids": [
+        "chapter01/keywords.rpy:9:keyword:2"
+      ],
+      "source_files": [
+        "chapter01/keywords.rpy"
+      ],
+      "source_lines": [
+        9
+      ],
+      "occurrences": 1
+    },
+    {
+      "source": "Void Gate",
+      "suggested_target": "虚空门",
+      "category": "place",
+      "confidence": 0.86,
+      "evidence": "Recurring gate name.",
+      "source_item_ids": [
+        "chapter01/keywords.rpy:2:keyword:0",
+        "chapter01/keywords.rpy:9:keyword:2"
+      ],
+      "source_files": [
+        "chapter01/keywords.rpy"
+      ],
+      "source_lines": [
+        2,
+        9
+      ],
+      "occurrences": 2
+    },
+    {
+      "source": "Crystal Key",
+      "suggested_target": "水晶钥匙",
+      "category": "item",
+      "confidence": 0.74,
+      "evidence": "Quest key item.",
+      "source_item_ids": [
+        "chapter01/keywords.rpy:5:keyword:1",
+        "chapter01/keywords.rpy:12:keyword:3"
+      ],
+      "source_files": [
+        "chapter01/keywords.rpy"
+      ],
+      "source_lines": [
+        5,
+        12
+      ],
+      "occurrences": 2
+    }
+  ],
+  "summary_rows": [
+    {
+      "key": "kw-cd03d6447e-00001",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "chunk_index": 1,
+      "line_numbers": [
+        2,
+        5
+      ],
+      "chunk_summary": "术语表片段介绍虚空门和水晶钥匙。",
+      "summary_evidence_item_ids": [
+        "chapter01/keywords.rpy:2:keyword:0",
+        "chapter01/keywords.rpy:5:keyword:1"
+      ],
+      "source_lines": [
+        2,
+        5
+      ]
+    },
+    {
+      "key": "kw-cd03d6447e-00002",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "chunk_index": 2,
+      "line_numbers": [
+        9,
+        12
+      ],
+      "chunk_summary": "诺亚在虚空门附近找到以太罗盘，水晶钥匙随后发光。",
+      "summary_evidence_item_ids": [
+        "chapter01/keywords.rpy:9:keyword:2",
+        "chapter01/keywords.rpy:12:keyword:3"
+      ],
+      "source_lines": [
+        9,
+        12
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/golden_keyword_minimal/expected/keyword_candidates.md
+++ b/tests/fixtures/golden_keyword_minimal/expected/keyword_candidates.md
@@ -1,0 +1,12 @@
+# Keyword Candidates
+
+- Candidate count: 3
+- Parsed chunks: 2/2
+- Missing chunk rows: 0
+- Ambiguous provenance candidates: 0
+
+| Source | Suggested target | Category | Confidence | Evidence | Files |
+| --- | --- | --- | ---: | --- | --- |
+| Aether Compass | 以太罗盘 | item | 0.92 | Navigation item found by Noah. | chapter01/keywords.rpy |
+| Void Gate | 虚空门 | place | 0.86 | Recurring gate name. | chapter01/keywords.rpy |
+| Crystal Key | 水晶钥匙 | item | 0.74 | Quest key item. | chapter01/keywords.rpy |

--- a/tests/fixtures/golden_keyword_minimal/expected/keyword_chunk_summaries.md
+++ b/tests/fixtures/golden_keyword_minimal/expected/keyword_chunk_summaries.md
@@ -1,0 +1,10 @@
+# Keyword Chunk Summaries
+
+- Summary count: 2
+- Parsed chunks: 2/2
+- Ambiguous summary provenance chunks: 0
+
+| File | Chunk lines | Evidence lines | Summary | Evidence item ids |
+| --- | ---: | ---: | --- | --- |
+| chapter01/keywords.rpy | 2, 5 | 2, 5 | 术语表片段介绍虚空门和水晶钥匙。 | chapter01/keywords.rpy:2:keyword:0, chapter01/keywords.rpy:5:keyword:1 |
+| chapter01/keywords.rpy | 9, 12 | 9, 12 | 诺亚在虚空门附近找到以太罗盘，水晶钥匙随后发光。 | chapter01/keywords.rpy:9:keyword:2, chapter01/keywords.rpy:12:keyword:3 |

--- a/tests/fixtures/golden_keyword_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_keyword_minimal/expected/manifest_snapshot.json
@@ -1,0 +1,80 @@
+{
+  "mode": "keyword_extraction",
+  "core_schema_version": 1,
+  "summary": {
+    "file_count": 1,
+    "chunk_count": 2,
+    "item_count": 4
+  },
+  "settings": {
+    "keyword_chunk_size": 2,
+    "keyword_max_candidates_per_chunk": 4,
+    "max_output_tokens": 16384,
+    "temperature": 0.2,
+    "thinking_level": "minimal"
+  },
+  "keyword_settings": {
+    "chunk_size": 2,
+    "max_candidates_per_chunk": 4
+  },
+  "files": {
+    "chapter01/keywords.rpy": {
+      "task_count": 4
+    }
+  },
+  "chunks": [
+    {
+      "key": "kw-cd03d6447e-00001",
+      "mode": "keyword_extraction",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "chunk_index": 1,
+      "line_numbers": [
+        2,
+        5
+      ],
+      "items": [
+        {
+          "id": "chapter01/keywords.rpy:2:keyword:0",
+          "text": "Void Gate",
+          "file_rel_path": "chapter01/keywords.rpy",
+          "line_number": 2,
+          "translation_line_number": 3
+        },
+        {
+          "id": "chapter01/keywords.rpy:5:keyword:1",
+          "text": "Crystal Key",
+          "file_rel_path": "chapter01/keywords.rpy",
+          "line_number": 5,
+          "translation_line_number": 6
+        }
+      ]
+    },
+    {
+      "key": "kw-cd03d6447e-00002",
+      "mode": "keyword_extraction",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "chunk_index": 2,
+      "line_numbers": [
+        9,
+        12
+      ],
+      "items": [
+        {
+          "id": "chapter01/keywords.rpy:9:keyword:2",
+          "text": "Noah found the Aether Compass near the Void Gate.",
+          "file_rel_path": "chapter01/keywords.rpy",
+          "line_number": 9,
+          "translation_line_number": 10,
+          "speaker_id": "e"
+        },
+        {
+          "id": "chapter01/keywords.rpy:12:keyword:3",
+          "text": "The Crystal Key pulsed once.",
+          "file_rel_path": "chapter01/keywords.rpy",
+          "line_number": 12,
+          "translation_line_number": 13
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/golden_keyword_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_keyword_minimal/expected/request_snapshot.json
@@ -1,0 +1,210 @@
+{
+  "rows": [
+    {
+      "key": "kw-cd03d6447e-00001",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "request_keys": [
+        "contents",
+        "generation_config",
+        "system_instruction"
+      ],
+      "content_roles": [
+        "user"
+      ],
+      "target_item_ids": [
+        "chapter01/keywords.rpy:2:keyword:0",
+        "chapter01/keywords.rpy:5:keyword:1"
+      ],
+      "system_instruction_sha256": "0b3714ae80303fe380c603eb3db7a25aa96b49bdf4a5f333189402a0878e5d6d",
+      "user_prompt_sha256": "f43ad090ffe3634f8fec06e6818d103109873b52fb04ec1c52618ac3d26d2f5c",
+      "generation_config": {
+        "keys": [
+          "max_output_tokens",
+          "response_json_schema",
+          "response_mime_type",
+          "temperature",
+          "thinking_config"
+        ],
+        "temperature": 0.2,
+        "max_output_tokens": 16384,
+        "response_mime_type": "application/json",
+        "thinking_config": {
+          "thinking_level": "MINIMAL"
+        },
+        "response_json_schema": {
+          "type": "object",
+          "required": [
+            "candidates",
+            "chunk_summary",
+            "summary_evidence_item_ids"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "candidates": {
+              "type": "array",
+              "maxItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "source",
+                  "suggested_target",
+                  "category",
+                  "confidence",
+                  "evidence",
+                  "source_item_ids"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "suggested_target": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "term",
+                      "character",
+                      "place",
+                      "item",
+                      "ability",
+                      "concept",
+                      "relationship",
+                      "style",
+                      "other"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "number"
+                  },
+                  "evidence": {
+                    "type": "string"
+                  },
+                  "source_item_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "chunk_summary": {
+              "type": "string"
+            },
+            "summary_evidence_item_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "key": "kw-cd03d6447e-00002",
+      "file_rel_path": "chapter01/keywords.rpy",
+      "request_keys": [
+        "contents",
+        "generation_config",
+        "system_instruction"
+      ],
+      "content_roles": [
+        "user"
+      ],
+      "target_item_ids": [
+        "chapter01/keywords.rpy:9:keyword:2",
+        "chapter01/keywords.rpy:12:keyword:3"
+      ],
+      "system_instruction_sha256": "0b3714ae80303fe380c603eb3db7a25aa96b49bdf4a5f333189402a0878e5d6d",
+      "user_prompt_sha256": "cf2b0379021530f50669ddfa6bddc15a1419cb5653070e29aabddbe96ed12725",
+      "generation_config": {
+        "keys": [
+          "max_output_tokens",
+          "response_json_schema",
+          "response_mime_type",
+          "temperature",
+          "thinking_config"
+        ],
+        "temperature": 0.2,
+        "max_output_tokens": 16384,
+        "response_mime_type": "application/json",
+        "thinking_config": {
+          "thinking_level": "MINIMAL"
+        },
+        "response_json_schema": {
+          "type": "object",
+          "required": [
+            "candidates",
+            "chunk_summary",
+            "summary_evidence_item_ids"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "candidates": {
+              "type": "array",
+              "maxItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "source",
+                  "suggested_target",
+                  "category",
+                  "confidence",
+                  "evidence",
+                  "source_item_ids"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "suggested_target": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "term",
+                      "character",
+                      "place",
+                      "item",
+                      "ability",
+                      "concept",
+                      "relationship",
+                      "style",
+                      "other"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "number"
+                  },
+                  "evidence": {
+                    "type": "string"
+                  },
+                  "source_item_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "chunk_summary": {
+              "type": "string"
+            },
+            "summary_evidence_item_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/golden_keyword_minimal/model_results.json
+++ b/tests/fixtures/golden_keyword_minimal/model_results.json
@@ -1,0 +1,42 @@
+{
+  "candidates": [
+    {
+      "source": "Void Gate",
+      "suggested_target": "虚空门",
+      "category": "place",
+      "confidence": 0.86,
+      "evidence": "Recurring gate name."
+    },
+    {
+      "source": "Crystal Key",
+      "suggested_target": "水晶钥匙",
+      "category": "item",
+      "confidence": 0.74,
+      "evidence": "Quest key item."
+    },
+    {
+      "source": "Aether Compass",
+      "suggested_target": "以太罗盘",
+      "category": "item",
+      "confidence": 0.92,
+      "evidence": "Navigation item found by Noah."
+    }
+  ],
+  "chunk_summaries": {
+    "1": {
+      "chunk_summary": "术语表片段介绍虚空门和水晶钥匙。",
+      "sources": [
+        "Void Gate",
+        "Crystal Key"
+      ]
+    },
+    "2": {
+      "chunk_summary": "诺亚在虚空门附近找到以太罗盘，水晶钥匙随后发光。",
+      "sources": [
+        "Aether Compass",
+        "Void Gate",
+        "Crystal Key"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/golden_keyword_minimal/tl/chapter01/keywords.rpy
+++ b/tests/fixtures/golden_keyword_minimal/tl/chapter01/keywords.rpy
@@ -1,0 +1,13 @@
+translate schinese chapter01_terms:
+    old "Void Gate"
+    new "虚空门"
+
+    old "Crystal Key"
+    new "水晶钥匙"
+
+translate schinese chapter01_scene:
+    # e "Noah found the Aether Compass near the Void Gate."
+    e "Noah found the Aether Compass near the Void Gate."
+
+    # "The Crystal Key pulsed once."
+    "The Crystal Key pulsed once."

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -25,8 +25,10 @@ import translator_runtime as runtime
 
 GOLDEN_BATCH_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_batch_minimal'
 GOLDEN_REVISION_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_revision_minimal'
+GOLDEN_KEYWORD_FIXTURE_DIR = Path(__file__).parent / 'fixtures' / 'golden_keyword_minimal'
 UPDATE_GOLDEN_BATCH_ENV = 'UPDATE_GOLDEN_BATCH'
 UPDATE_GOLDEN_REVISION_ENV = 'UPDATE_GOLDEN_REVISION'
+UPDATE_GOLDEN_KEYWORD_ENV = 'UPDATE_GOLDEN_KEYWORD'
 
 
 class TranslationCoreRegressionTests(unittest.TestCase):
@@ -3679,6 +3681,299 @@ class RevisionGoldenCorpusTests(unittest.TestCase):
                 self.assertEqual(applied_manifest['revision_apply_summary']['skipped_items'], 1)
                 self.assertEqual(applied_manifest['revision_apply_summary']['source_mismatch_items'], 1)
                 self.assertEqual(applied_manifest['revision_apply_summary']['failure_count'], 1)
+            finally:
+                self._restore_batch_environment(old_values)
+
+
+class KeywordGoldenCorpusTests(unittest.TestCase):
+    def _copy_fixture_tl(self, root):
+        tl_dir = root / 'game' / 'tl' / 'schinese'
+        tl_dir.parent.mkdir(parents=True)
+        shutil.copytree(GOLDEN_KEYWORD_FIXTURE_DIR / 'tl', tl_dir)
+        return tl_dir
+
+    def _patch_batch_environment(self, root, tl_dir):
+        old_values = {
+            'base_dir': batch_mod.legacy.BASE_DIR,
+            'tl_dir': batch_mod.legacy.TL_DIR,
+            'include_files': set(batch_mod.legacy.INCLUDE_FILES),
+            'include_prefixes': set(batch_mod.legacy.INCLUDE_PREFIXES),
+            'log_dir': batch_mod.LOG_DIR,
+            'jobs_dir': batch_mod.BATCH_JOBS_DIR,
+            'repair_dir': batch_mod.REPAIR_RUNS_DIR,
+            'sync_dir': batch_mod.SYNC_RUNS_DIR,
+            'latest': batch_mod.LATEST_MANIFEST_FILE,
+            'rag_enabled': batch_mod.RAG_ENABLED,
+            'rag_store': batch_mod._RAG_STORE,
+            'story_enabled': batch_mod.STORY_MEMORY_ENABLED,
+            'story_graph': batch_mod._STORY_GRAPH,
+            'story_graph_path': batch_mod._STORY_GRAPH_PATH,
+        }
+        log_dir = root / 'logs'
+        jobs_dir = log_dir / 'batch_jobs'
+        batch_mod.legacy.BASE_DIR = str(root)
+        batch_mod.legacy.TL_DIR = str(tl_dir)
+        batch_mod.legacy.INCLUDE_FILES = set()
+        batch_mod.legacy.INCLUDE_PREFIXES = set()
+        batch_mod.LOG_DIR = str(log_dir)
+        batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+        batch_mod.REPAIR_RUNS_DIR = str(log_dir / 'repair_runs')
+        batch_mod.SYNC_RUNS_DIR = str(log_dir / 'sync_runs')
+        batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
+        batch_mod.RAG_ENABLED = False
+        batch_mod._RAG_STORE = None
+        batch_mod.STORY_MEMORY_ENABLED = False
+        batch_mod._STORY_GRAPH = None
+        batch_mod._STORY_GRAPH_PATH = ''
+        return old_values
+
+    def _restore_batch_environment(self, old_values):
+        batch_mod.legacy.BASE_DIR = old_values['base_dir']
+        batch_mod.legacy.TL_DIR = old_values['tl_dir']
+        batch_mod.legacy.INCLUDE_FILES = old_values['include_files']
+        batch_mod.legacy.INCLUDE_PREFIXES = old_values['include_prefixes']
+        batch_mod.LOG_DIR = old_values['log_dir']
+        batch_mod.BATCH_JOBS_DIR = old_values['jobs_dir']
+        batch_mod.REPAIR_RUNS_DIR = old_values['repair_dir']
+        batch_mod.SYNC_RUNS_DIR = old_values['sync_dir']
+        batch_mod.LATEST_MANIFEST_FILE = old_values['latest']
+        batch_mod.RAG_ENABLED = old_values['rag_enabled']
+        batch_mod._RAG_STORE = old_values['rag_store']
+        batch_mod.STORY_MEMORY_ENABLED = old_values['story_enabled']
+        batch_mod._STORY_GRAPH = old_values['story_graph']
+        batch_mod._STORY_GRAPH_PATH = old_values['story_graph_path']
+
+    def _load_manifest(self, manifest_path):
+        return json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+
+    def _assert_or_update_json(self, relative_path, actual):
+        expected_path = GOLDEN_KEYWORD_FIXTURE_DIR / relative_path
+        text = json.dumps(actual, ensure_ascii=False, indent=2) + '\n'
+        if os.environ.get(UPDATE_GOLDEN_KEYWORD_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(text, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        expected = json.loads(expected_path.read_text(encoding='utf-8'))
+        self.assertEqual(actual, expected)
+
+    def _assert_or_update_text(self, relative_path, actual):
+        expected_path = GOLDEN_KEYWORD_FIXTURE_DIR / relative_path
+        if os.environ.get(UPDATE_GOLDEN_KEYWORD_ENV):
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text(actual, encoding='utf-8')
+            return
+        self.assertTrue(expected_path.is_file(), f'Missing golden file: {expected_path}')
+        self.assertEqual(actual, expected_path.read_text(encoding='utf-8'))
+
+    def _manifest_snapshot(self, manifest):
+        return {
+            'mode': manifest['mode'],
+            'core_schema_version': manifest['core_schema_version'],
+            'summary': manifest['summary'],
+            'settings': manifest['settings'],
+            'keyword_settings': manifest['keyword_settings'],
+            'files': {
+                rel_path: {'task_count': info['task_count']}
+                for rel_path, info in manifest['files'].items()
+            },
+            'chunks': [
+                {
+                    'key': chunk['key'],
+                    'mode': chunk['mode'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'chunk_index': chunk['chunk_index'],
+                    'line_numbers': chunk['line_numbers'],
+                    'items': [
+                        {
+                            key: item[key]
+                            for key in (
+                                'id',
+                                'text',
+                                'file_rel_path',
+                                'line_number',
+                                'translation_line_number',
+                                'speaker_id',
+                                'speaker_name',
+                            )
+                            if key in item
+                        }
+                        for item in chunk['items']
+                    ],
+                }
+                for chunk in manifest['chunks']
+            ],
+        }
+
+    def _request_snapshot(self, manifest):
+        chunk_by_key = {chunk['key']: chunk for chunk in manifest['chunks']}
+        request_rows = [
+            json.loads(line)
+            for line in Path(manifest['input_jsonl_path']).read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+        rows = []
+        for row in request_rows:
+            request = row['request']
+            chunk = chunk_by_key[row['key']]
+            config = request['generation_config']
+            user_prompt = request['contents'][0]['parts'][0]['text']
+            system_text = request['system_instruction']['parts'][0]['text']
+            rows.append(
+                {
+                    'key': row['key'],
+                    'file_rel_path': chunk['file_rel_path'],
+                    'request_keys': sorted(request.keys()),
+                    'content_roles': [content.get('role') for content in request['contents']],
+                    'target_item_ids': [item['id'] for item in chunk['items']],
+                    'system_instruction_sha256': hashlib.sha256(system_text.encode('utf-8')).hexdigest(),
+                    'user_prompt_sha256': hashlib.sha256(user_prompt.encode('utf-8')).hexdigest(),
+                    'generation_config': {
+                        'keys': sorted(config.keys()),
+                        'temperature': config['temperature'],
+                        'max_output_tokens': config['max_output_tokens'],
+                        'response_mime_type': config['response_mime_type'],
+                        'thinking_config': config.get('thinking_config', {}),
+                        'response_json_schema': config['response_json_schema'],
+                    },
+                }
+            )
+        return {'rows': rows}
+
+    def _read_jsonl(self, path):
+        return [
+            json.loads(line)
+            for line in Path(path).read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+
+    def _item_matches_source(self, item, source):
+        return str(source or '').lower() in str(item.get('text') or '').lower()
+
+    def _items_matching_sources(self, chunk, sources):
+        matched = []
+        seen = set()
+        for source in sources or []:
+            for item in chunk.get('items') or []:
+                item_id = item.get('id')
+                if item_id in seen:
+                    continue
+                if self._item_matches_source(item, source):
+                    seen.add(item_id)
+                    matched.append(item)
+        return matched
+
+    def _write_mock_keyword_results(self, manifest_path):
+        manifest_path = Path(manifest_path)
+        manifest = self._load_manifest(manifest_path)
+        model_results = json.loads(
+            (GOLDEN_KEYWORD_FIXTURE_DIR / 'model_results.json').read_text(encoding='utf-8')
+        )
+        candidate_specs = model_results['candidates']
+        summary_specs = model_results['chunk_summaries']
+        result_path = manifest_path.parent / 'results.jsonl'
+        rows = []
+        for chunk in manifest['chunks']:
+            candidates = []
+            for spec in candidate_specs:
+                matched_items = self._items_matching_sources(chunk, [spec['source']])
+                if not matched_items:
+                    continue
+                candidate = {
+                    'source': spec['source'],
+                    'suggested_target': spec['suggested_target'],
+                    'category': spec['category'],
+                    'confidence': spec['confidence'],
+                    'evidence': spec['evidence'],
+                    'source_item_ids': [item['id'] for item in matched_items],
+                }
+                candidates.append(candidate)
+            summary_spec = summary_specs[str(chunk['chunk_index'])]
+            summary_items = self._items_matching_sources(chunk, summary_spec['sources'])
+            response_text = json.dumps(
+                {
+                    'candidates': candidates,
+                    'chunk_summary': summary_spec['chunk_summary'],
+                    'summary_evidence_item_ids': [item['id'] for item in summary_items],
+                },
+                ensure_ascii=False,
+            )
+            rows.append(
+                {
+                    'key': chunk['key'],
+                    'response': {
+                        'candidates': [
+                            {
+                                'content': {'parts': [{'text': response_text}]},
+                                'finishReason': 'STOP',
+                            }
+                        ],
+                        'usageMetadata': {
+                            'promptTokenCount': 120,
+                            'candidatesTokenCount': 50,
+                            'totalTokenCount': 170,
+                        },
+                    },
+                }
+            )
+        result_path.write_text(
+            ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+            encoding='utf-8',
+        )
+        manifest['result_jsonl_path'] = 'results.jsonl'
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2),
+            encoding='utf-8',
+        )
+
+    def test_golden_keyword_build_export_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_keyword_package(
+                        display_name_override='golden-keyword-minimal',
+                        skip_prepare=True,
+                        chunk_size=2,
+                        max_candidates_per_chunk=4,
+                    )
+                )
+                self._write_mock_keyword_results(manifest_path)
+                manifest = self._load_manifest(manifest_path)
+
+                self._assert_or_update_json(
+                    'expected/manifest_snapshot.json',
+                    self._manifest_snapshot(manifest),
+                )
+                self._assert_or_update_json(
+                    'expected/request_snapshot.json',
+                    self._request_snapshot(manifest),
+                )
+
+                export = batch_mod.export_keyword_candidates(str(manifest_path))
+                export_snapshot = {
+                    'summary': export['summary'],
+                    'candidate_rows': self._read_jsonl(export['jsonl_path']),
+                    'summary_rows': self._read_jsonl(export['summary_jsonl_path']),
+                }
+                self._assert_or_update_json(
+                    'expected/export_snapshot.json',
+                    export_snapshot,
+                )
+                self._assert_or_update_text(
+                    'expected/keyword_candidates.md',
+                    Path(export['markdown_path']).read_text(encoding='utf-8'),
+                )
+                self._assert_or_update_text(
+                    'expected/keyword_chunk_summaries.md',
+                    Path(export['summary_markdown_path']).read_text(encoding='utf-8'),
+                )
+
+                self.assertEqual(export['summary']['candidate_count_raw'], 5)
+                self.assertEqual(export['summary']['candidate_count_deduped'], 3)
+                self.assertEqual(export['summary']['chunk_summary_count'], 2)
             finally:
                 self._restore_batch_environment(old_values)
 


### PR DESCRIPTION
## Summary
- add a minimal keyword extraction golden corpus fixture
- cover `build-keywords -> export-keywords` with stable manifest, request, JSONL, and Markdown snapshots
- document the new keyword golden corpus test and update command

## Validation
- `python -m unittest tests.test_regressions.KeywordGoldenCorpusTests -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`