### PR TITLE
Increase translation chunk defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - Structured Story Memory 默认关闭；需要分别通过 `batch.story_memory.enabled=true` 或 `sync.story_memory.enabled=true` 启用
 - `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出
 - Batch 产物默认会写到本地 `logs/` 目录
-- 同步和普通 Batch 翻译默认每个 chunk 最多 20 条，同时受 `max_source_chars=6000` 保护；短句会合并，长句会自动提前切块，避免单个请求输出过长
+- 同步翻译默认每个 chunk 最多 40 条、`max_source_chars=12000`；普通 Batch 翻译默认每个 chunk 最多 60 条、`max_source_chars=18000`，并会继续按源文本长度提前切块，避免单个请求输出过长
 - `doctor` 会检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，适合在正式翻译前确认项目是否已准备好
 - `bootstrap-rag` 会扫描当前允许处理的全部 TL `.rpy` 文件，把已有译文预先写入本地 history store；适合在正式 `build / submit` 前先暖库
 - `probe` 会用同步请求做最小 smoke test

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -69,11 +69,11 @@ def initialize_batch_logging():
     sys.stdout = DualLogger(CONSOLE_LOG)
 
 BATCH_MODEL = 'gemini-3.1-flash-lite'
-BATCH_TARGET_SIZE = 20
-BATCH_TARGET_CHARS = 6000
-BATCH_CONTEXT_BEFORE = 8
-BATCH_CONTEXT_AFTER = 4
-BATCH_MAX_OUTPUT_TOKENS = 16384
+BATCH_TARGET_SIZE = 60
+BATCH_TARGET_CHARS = 18000
+BATCH_CONTEXT_BEFORE = 30
+BATCH_CONTEXT_AFTER = 10
+BATCH_MAX_OUTPUT_TOKENS = 32768
 BATCH_TEMPERATURE = 0.2
 BATCH_THINKING_LEVEL = 'minimal'
 BATCH_DISPLAY_NAME_PREFIX = 'renpy-translate'
@@ -1598,9 +1598,9 @@ def summarize_batch_story_memory(chunks, graph_file=None, max_context_chars=None
 
 def get_batch_risk_warnings():
     warnings_list = []
-    if BATCH_TARGET_SIZE > 20:
+    if BATCH_TARGET_SIZE > 80:
         warnings_list.append(f'chunk_size={BATCH_TARGET_SIZE} is aggressive for Gemini 3 Flash structured output.')
-    if BATCH_CONTEXT_BEFORE > 12 or BATCH_CONTEXT_AFTER > 6:
+    if BATCH_CONTEXT_BEFORE > 40 or BATCH_CONTEXT_AFTER > 20:
         warnings_list.append(
             f'context_before/context_after ({BATCH_CONTEXT_BEFORE}/{BATCH_CONTEXT_AFTER}) may inflate prompt tokens.'
         )

--- a/tests/fixtures/golden_batch_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_batch_minimal/expected/manifest_snapshot.json
@@ -7,11 +7,11 @@
     "item_count": 6
   },
   "settings": {
-    "target_size": 20,
-    "target_chars": 6000,
-    "context_before": 8,
-    "context_after": 4,
-    "max_output_tokens": 16384,
+    "target_size": 60,
+    "target_chars": 18000,
+    "context_before": 30,
+    "context_after": 10,
+    "max_output_tokens": 32768,
     "temperature": 0.2,
     "thinking_level": "minimal"
   },

--- a/tests/fixtures/golden_batch_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_batch_minimal/expected/request_snapshot.json
@@ -28,7 +28,7 @@
           "thinking_config"
         ],
         "temperature": 0.2,
-        "max_output_tokens": 16384,
+        "max_output_tokens": 32768,
         "response_mime_type": "application/json",
         "thinking_config": {
           "thinking_level": "MINIMAL"
@@ -88,7 +88,7 @@
           "thinking_config"
         ],
         "temperature": 0.2,
-        "max_output_tokens": 16384,
+        "max_output_tokens": 32768,
         "response_mime_type": "application/json",
         "thinking_config": {
           "thinking_level": "MINIMAL"

--- a/tests/fixtures/golden_keyword_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_keyword_minimal/expected/manifest_snapshot.json
@@ -9,7 +9,7 @@
   "settings": {
     "keyword_chunk_size": 2,
     "keyword_max_candidates_per_chunk": 4,
-    "max_output_tokens": 16384,
+    "max_output_tokens": 32768,
     "temperature": 0.2,
     "thinking_level": "minimal"
   },

--- a/tests/fixtures/golden_keyword_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_keyword_minimal/expected/request_snapshot.json
@@ -26,7 +26,7 @@
           "thinking_config"
         ],
         "temperature": 0.2,
-        "max_output_tokens": 16384,
+        "max_output_tokens": 32768,
         "response_mime_type": "application/json",
         "thinking_config": {
           "thinking_level": "MINIMAL"
@@ -129,7 +129,7 @@
           "thinking_config"
         ],
         "temperature": 0.2,
-        "max_output_tokens": 16384,
+        "max_output_tokens": 32768,
         "response_mime_type": "application/json",
         "thinking_config": {
           "thinking_level": "MINIMAL"

--- a/tests/fixtures/golden_revision_minimal/expected/manifest_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/manifest_snapshot.json
@@ -8,7 +8,7 @@
   },
   "settings": {
     "revision_chunk_size": 3,
-    "max_output_tokens": 16384,
+    "max_output_tokens": 32768,
     "temperature": 0.2,
     "thinking_level": "minimal"
   },

--- a/tests/fixtures/golden_revision_minimal/expected/request_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/request_snapshot.json
@@ -27,7 +27,7 @@
           "thinking_config"
         ],
         "temperature": 0.2,
-        "max_output_tokens": 16384,
+        "max_output_tokens": 32768,
         "response_mime_type": "application/json",
         "thinking_config": {
           "thinking_level": "MINIMAL"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -618,9 +618,9 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     mock.patch('sys.stdout', io.StringIO()),
                 ):
                     runtime.CURRENT_MODEL_INDEX = 3
-                    runtime.MAX_ITEMS = 20
-                    runtime.MAX_CHARS = 6000
-                    runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
+                    runtime.MAX_ITEMS = 40
+                    runtime.MAX_CHARS = 12000
+                    runtime.SYNC_MAX_OUTPUT_TOKENS = 24576
                     runtime.INCLUDE_FILES = set()
                     runtime.INCLUDE_PREFIXES = set()
                     runtime.load_translator_settings()
@@ -671,9 +671,9 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 ):
                     runtime.API_KEYS = []
                     runtime.CURRENT_MODEL_INDEX = 2
-                    runtime.MAX_ITEMS = 20
-                    runtime.MAX_CHARS = 6000
-                    runtime.SYNC_MAX_OUTPUT_TOKENS = 16384
+                    runtime.MAX_ITEMS = 40
+                    runtime.MAX_CHARS = 12000
+                    runtime.SYNC_MAX_OUTPUT_TOKENS = 24576
                     runtime.load_config()
 
                 self.assertEqual(runtime.MODELS, ['gemini-legacy-test'])

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -16,9 +16,9 @@
   },
   "sync": {
     "model": "gemini-3.1-flash-lite",
-    "chunk_size": 20,
-    "max_source_chars": 6000,
-    "max_output_tokens": 16384,
+    "chunk_size": 40,
+    "max_source_chars": 12000,
+    "max_output_tokens": 24576,
     "rag": {
       "enabled": false,
       "embedding_model": "gemini-embedding-001",
@@ -44,11 +44,11 @@
   },
   "batch": {
     "model": "gemini-3.1-flash-lite",
-    "chunk_size": 20,
-    "max_source_chars": 6000,
+    "chunk_size": 60,
+    "max_source_chars": 18000,
     "context_before": 30,
     "context_after": 10,
-    "max_output_tokens": 16384,
+    "max_output_tokens": 32768,
     "temperature": 0.4,
     "display_name_prefix": "renpy-translate",
     "macro_setting_file": "macro_setting.md",

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -91,9 +91,9 @@ PRESERVE_TERMS = [
 ]
 
 # Config Defaults
-MAX_CHARS = 6000
-MAX_ITEMS = 20    # Back to a safer batch size (50 was too aggressive)
-SYNC_MAX_OUTPUT_TOKENS = 16384
+MAX_CHARS = 12000
+MAX_ITEMS = 40
+SYNC_MAX_OUTPUT_TOKENS = 24576
 MIN_DELAY = 1.0  # Reduced delay for SDK
 MAX_DELAY = 3.0
 BATCH_RETRIES = 3


### PR DESCRIPTION
Summary:
- Increase sync defaults to 40 items, 12000 source chars, and 24576 output tokens.
- Increase Batch defaults to 60 items, 18000 source chars, 30/10 context, and 32768 output tokens.
- Refresh config example, README, warning thresholds, and golden snapshots.

Tests:
- python -m unittest discover -s tests -p test_*.py -q
- python -m py_compile gemini_translate_batch.py translator_runtime.py tests/test_regressions.py
- git diff --cached --check