### PR TITLE
[codex] Do not skip RPA unpack for TL-only files

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -871,6 +871,34 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
 
             run_mock.assert_not_called()
 
+    def test_prepare_tl_files_do_not_skip_rpa_unpack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            source_game = root / 'original' / 'game'
+            work_tl = base / 'game' / 'tl' / 'schinese'
+            work_tl.mkdir(parents=True)
+            (work_tl / 'script.rpy').write_text('translate schinese strings:\n', encoding='utf-8')
+            source_game.mkdir(parents=True)
+            archive = source_game / 'scripts.rpa'
+            archive.write_bytes(b'RPA-3.0 placeholder')
+
+            with (
+                mock.patch.object(runtime, 'BASE_DIR', str(base)),
+                mock.patch.object(runtime, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(runtime, 'TL_DIR', str(base / 'game' / 'tl' / 'schinese')),
+                mock.patch.object(runtime, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(runtime, 'PREP_ENABLED', True),
+                mock.patch.object(runtime, 'PREP_UNPACK_RPA', True),
+                mock.patch.object(runtime, 'PREP_GENERATE_TEMPLATE', False),
+                mock.patch.object(runtime, '_extract_rpa_scripts', return_value=2) as extract_mock,
+                mock.patch('sys.stdout', io.StringIO()),
+            ):
+                runtime.run_prepare_steps()
+
+            self.assertTrue((base / 'game' / 'tl' / 'schinese' / 'script.rpy').is_file())
+            extract_mock.assert_called_once_with(str(archive), str(base / 'game'))
+
     def test_prepare_missing_tl_without_launcher_errors(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -904,6 +904,25 @@ def _has_files_with_extensions(base_dir, extensions):
     return False
 
 
+def _is_translation_relpath(rel_path):
+    parts = rel_path.replace("\\", "/").split("/")
+    return bool(parts) and parts[0].lower() == "tl"
+
+
+def _has_non_translation_files_with_extensions(base_dir, extensions):
+    if not os.path.isdir(base_dir):
+        return False
+    for root, _, files in os.walk(base_dir):
+        for file in files:
+            if os.path.splitext(file)[1].lower() not in extensions:
+                continue
+            rel = os.path.relpath(os.path.join(root, file), base_dir)
+            if _is_translation_relpath(rel):
+                continue
+            return True
+    return False
+
+
 def _list_rpa_files(game_dir):
     if not game_dir or not os.path.isdir(game_dir):
         return []
@@ -939,7 +958,7 @@ def _guess_source_game_dir():
     for candidate in ordered:
         if not os.path.isdir(candidate):
             continue
-        if _has_files_with_extensions(candidate, SCRIPT_FILE_EXTENSIONS):
+        if _has_non_translation_files_with_extensions(candidate, SCRIPT_FILE_EXTENSIONS):
             return candidate
         if _list_rpa_files(candidate):
             return candidate
@@ -1390,7 +1409,7 @@ def run_prepare_steps():
         print(f"[Prepare] Copied {copied_scripts} script files into work/game.")
 
     if PREP_UNPACK_RPA:
-        has_scripts = _has_files_with_extensions(WORK_GAME_DIR, SCRIPT_FILE_EXTENSIONS)
+        has_scripts = _has_non_translation_files_with_extensions(WORK_GAME_DIR, SCRIPT_FILE_EXTENSIONS)
         if has_scripts:
             print("[Prepare] Script files already exist in work/game; skipping RPA unpack.")
         else:


### PR DESCRIPTION
## Summary

- Treat `game/tl/...` files as translation outputs, not source script files, when deciding whether RPA unpack can be skipped.
- Keep existing behavior of skipping RPA unpack when non-translation `.rpy` source scripts already exist in `work/game`.
- Add a regression test for projects that only have TL files plus an RPA archive before prepare runs.

## Why

A project may already contain TL files under `game/tl/...` while source scripts still live only in `.rpa` archives. The previous prepare check saw those TL `.rpy` files as scripts and skipped unpacking, leaving `work/game` without the actual source scripts.

## Validation

- `python -m py_compile translator_runtime.py tests\test_regressions.py`
- `python -m unittest tests.test_regressions.TranslatorRuntimeRegressionTests.test_prepare_tl_files_do_not_skip_rpa_unpack -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `git diff --check`