### PR TITLE
[codex] Close out issue 39 safety gate coverage

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3376,6 +3376,45 @@ class BatchGoldenCorpusTests(unittest.TestCase):
             finally:
                 self._restore_batch_environment(old_values)
 
+    def test_golden_batch_apply_rejects_changed_manifest_items_after_check(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = self._copy_fixture_tl(root)
+            old_values = self._patch_batch_environment(root, tl_dir)
+            try:
+                manifest_path = Path(
+                    batch_mod.create_batch_package(
+                        display_name_override='golden-batch-minimal',
+                        skip_prepare=True,
+                    )
+                )
+                self._write_mock_results(manifest_path)
+                checked_manifest = batch_mod.check_results(str(manifest_path))
+                self.assertEqual(checked_manifest['last_check_summary']['safety_level'], 'safe')
+
+                manifest = self._load_manifest(manifest_path)
+                manifest['chunks'][0]['items'].append(
+                    {
+                        'id': 'chapter01/dialogue.rpy:999:0',
+                        'file_rel_path': 'chapter01/dialogue.rpy',
+                        'line': 999,
+                        'start': 0,
+                        'end': 5,
+                        'text': 'extra',
+                        'prefix': '',
+                        'quote': '"',
+                    }
+                )
+                manifest_path.write_text(
+                    json.dumps(manifest, ensure_ascii=False, indent=2),
+                    encoding='utf-8',
+                )
+
+                with self.assertRaisesRegex(SystemExit, 'changed after the last check'):
+                    batch_mod.apply_results(str(manifest_path))
+            finally:
+                self._restore_batch_environment(old_values)
+
 
 class RevisionGoldenCorpusTests(unittest.TestCase):
     def _copy_fixture_tl(self, root):


### PR DESCRIPTION
## Summary

Closes #39.

PR #48 already added the normal translation check/apply safety gate. This closeout PR adds the missing regression coverage for one remaining checklist item: a manifest target-shape change after check must make apply reject the stale check before writing.

## Scope

- Adds a golden Batch regression for check -> manifest item mutation -> apply rejection.
- Keeps runtime behavior unchanged.
- Leaves revision manifests on the existing preview-revisions/apply-revisions snapshot validation path, as documented in README.

## Validation

- `python -m unittest tests.test_regressions.BatchGoldenCorpusTests.test_golden_batch_build_check_apply_end_to_end tests.test_regressions.BatchGoldenCorpusTests.test_golden_batch_apply_rejects_changed_source_snapshot tests.test_regressions.BatchGoldenCorpusTests.test_golden_batch_apply_rejects_changed_manifest_items_after_check -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`