### PR TITLE
Document optional env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,14 @@
 # Copy this file to .env and fill in local values.
 # Keep .env private; do not commit real API keys or machine-specific paths.
+# Leave optional variables blank or commented out unless you actually use them.
 
-GEMINI_API_KEY=your-primary-gemini-api-key
-GEMINI_API_KEY_2=your-secondary-gemini-api-key
-GEMINI_API_KEY_3=your-tertiary-gemini-api-key
+GEMINI_API_KEY=
+# GEMINI_API_KEY_2=
+# GEMINI_API_KEY_3=
 
-# Path to the target game's work directory.
-GAME_ROOT=path/to/Game_Example/work
-
-# Optional alias used by some local workflows.
-SA_GAME_ROOT=path/to/Game_Example/work
+# Path to the target game's work directory. Set GAME_ROOT or SA_GAME_ROOT, not both.
+GAME_ROOT=
+# SA_GAME_ROOT=
 
 # Path to a local Ren'Py SDK directory.
-RENPY_SDK_DIR=path/to/renpy-sdk
+RENPY_SDK_DIR=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env and fill in local values.
+# Keep .env private; do not commit real API keys or machine-specific paths.
+
+GEMINI_API_KEY=your-primary-gemini-api-key
+GEMINI_API_KEY_2=your-secondary-gemini-api-key
+GEMINI_API_KEY_3=your-tertiary-gemini-api-key
+
+# Path to the target game's work directory.
+GAME_ROOT=path/to/Game_Example/work
+
+# Optional alias used by some local workflows.
+SA_GAME_ROOT=path/to/Game_Example/work
+
+# Path to a local Ren'Py SDK directory.
+RENPY_SDK_DIR=path/to/renpy-sdk

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 .mypy_cache/
 
 # Local config / secrets
+/.env
 /api_keys.json
 /translator_config.json
 /glossary*.json

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ pip install -r requirements.txt
 - `macro_setting.md` 往往包含剧情、角色口吻、世界观约束，也建议本地维护
 - 如果你不想使用 `api_keys.json`，也可以改用环境变量 `GEMINI_API_KEY`、`GEMINI_API_KEY_2`、`GEMINI_API_KEY_3`
 - 如果你不想使用 `translator_config.json`，也可以至少通过 `GAME_ROOT` 或 `SA_GAME_ROOT` 指向目标 `work` 目录
+- 也可以把 `.env.example` 复制为 `.env`，填写后供本地 shell/启动器加载；`.env` 只用于本机私有配置，不应提交
+- `.env` 不是必需文件；当前脚本不会自动加载 `.env`，默认复制并填写 `api_keys.json` / `translator_config.json` 即可使用
 - `glossary.json` 是可选文件；不存在时脚本会退回内置默认术语规则
 
 ### 3. 准备项目目录


### PR DESCRIPTION
## Summary

- Ignore the local root `.env` file so environment-based secrets are not accidentally committed.
- Add `.env.example` with placeholder-only Gemini key and local path variables.
- Clarify in README that `.env` is optional, is not auto-loaded by the scripts, and the default `api_keys.json` / `translator_config.json` workflow still works.

Fixes #52

## Validation

- `git check-ignore -v .env`
- `rg -n "AIza|C:/|C:\\|/Users/|/home/|hubor|RenPy_Workspace" .env.example`
- `git diff --check`
- `git diff --cached --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`