### PR TITLE
[codex] Add Windows CI coverage and path alias handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ python -m unittest tests.test_batch_golden_corpus.KeywordGoldenCorpusTests -q
 Remove-Item Env:UPDATE_GOLDEN_KEYWORD
 ```
 
+> [!NOTE]
+> 项目的持续集成 (CI) 分别在 Ubuntu 和 Windows 环境下自动运行上述全部单元测试，以验证跨平台路径、文件读写及数据格式合约。CI 中的测试仅使用离线 Mock，不覆盖真实的 Ren'Py SDK 模板生成和 Gemini 网络请求。
+
+
 ### 可选：Batch RAG 预建库
 
 如果项目里已经有一部分人工译文或旧译文，可以先运行：

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -10,6 +10,7 @@ import sys
 import time
 import tokenize
 from datetime import datetime
+from pathlib import Path
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if SCRIPT_DIR not in sys.path:
@@ -807,8 +808,16 @@ def require_manifest_mode(manifest, expected_mode, command_name):
         )
 
 
+def _canonical_abs_path(path):
+    abs_path = os.path.abspath(path)
+    try:
+        return str(Path(abs_path).resolve(strict=False))
+    except OSError:
+        return abs_path
+
+
 def _normalized_abs_path(path):
-    return os.path.normcase(os.path.abspath(path))
+    return os.path.normcase(_canonical_abs_path(path))
 
 
 def path_is_within_dir(base_dir, candidate):
@@ -845,9 +854,9 @@ def resolve_path_under_dir(base_dir, value, field_name):
         raise SystemExit(f'Unsafe {field_name}: empty path.')
     raw = value.strip()
     if os.path.isabs(raw):
-        candidate = os.path.abspath(raw)
+        candidate = _canonical_abs_path(raw)
     else:
-        candidate = os.path.abspath(os.path.join(base_dir, normalize_safe_rel_path(raw, field_name)))
+        candidate = _canonical_abs_path(os.path.join(base_dir, normalize_safe_rel_path(raw, field_name)))
     if not path_is_within_dir(base_dir, candidate):
         raise SystemExit(f'Unsafe {field_name}: {value} escapes {base_dir}.')
     return candidate

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1521,6 +1521,31 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(items[0]['source'], 'Hello')
         self.assertEqual(items[0]['line'], 1)
 
+    @unittest.skipUnless(os.name == 'nt', 'Windows path alias regression')
+    def test_resolve_path_under_dir_accepts_windows_short_path_alias(self):
+        short_base = r'C:\Users\RUNNER~1\AppData\Local\Temp\case'
+        long_base = r'C:\Users\runneradmin\AppData\Local\Temp\case'
+        short_file = short_base + r'\script.rpy'
+        long_file = long_base + r'\script.rpy'
+
+        def canonical(path):
+            normalized = os.path.normcase(os.path.abspath(path))
+            if normalized == os.path.normcase(os.path.abspath(short_base)):
+                return long_base
+            if normalized == os.path.normcase(os.path.abspath(short_file)):
+                return long_file
+            return os.path.abspath(path)
+
+        with mock.patch.object(batch_mod, '_canonical_abs_path', side_effect=canonical):
+            self.assertEqual(
+                batch_mod.resolve_path_under_dir(short_base, 'script.rpy', 'repair file'),
+                long_file,
+            )
+            self.assertEqual(
+                batch_mod.resolve_path_under_dir(short_base, long_file, 'repair file'),
+                long_file,
+            )
+
     def test_load_repair_report_items_rejects_file_outside_tl_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- Run the unittest workflow on both `ubuntu-latest` and `windows-latest`.
- Add a README note that CI covers offline mocked tests on both platforms, not live Ren'Py SDK generation or Gemini network calls.
- Normalize repair/report path resolution through canonical absolute paths so Windows 8.3 short-path aliases like `RUNNER~1` are treated as the same directory as their long path.

## Validation

- `python -m unittest tests.test_batch_repair.BatchRepairRegressionTests.test_load_repair_report_items_accepts_batch_failure_log_shape tests.test_batch_repair.BatchRepairRegressionTests.test_repair_jobs_parse_line_start_end_repair_id tests.test_batch_repair.BatchRepairRegressionTests.test_resolve_path_under_dir_accepts_windows_short_path_alias -q`
- `git diff --check codex/issue-54-split-tests...HEAD`
- Prior PR CI passed on both `ubuntu-latest` and `windows-latest`; this branch has been rebased onto the updated #57 and CI is expected to rerun.

## Notes

This is a stacked PR targeting `codex/issue-54-split-tests` so the review starts from the split-test branch. After PR #57 lands, this can be retargeted or rebased onto `main`.