### PR TITLE
[codex] Close identity v2 review gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ python gemini_translate_batch.py sync-keywords --limit 3
 - 如果确认没有进程正在写入同一个 RAG store，可手动删除残留的 `.rag_store.lock` 或 `*.tmp.*` 文件来恢复写入；自动清理失败时会输出包含文件路径的 warning
 - 加载 RAG store 时，损坏的 metadata 或坏 JSONL 行会输出 warning；可恢复的 history 记录会继续保留
 
+### Manifest / identity v2
+
+新建的普通翻译、订正和关键词 manifest 会写入 `manifest_version=2` 与 `core_schema_version=2`。普通翻译和订正 item 的 `id` 现在使用 identity v2：归一化后的文件相对路径、Ren'Py translate block 名、重复 block occurrence、block 内可翻译单元序号，以及原文 checksum。行号和列位置仍保存在 item 上，但它们是当前写回 location hint，不再是唯一身份。
+
+这个拆分的含义是：
+
+- `identity` 用于跨 `build / check / apply / repair` 识别同一个翻译单元。
+- `location` 是当前文件里的行号、列位置、translate block 等写回定位信息，可能因为插入空行、局部手改或模板刷新而漂移。
+- `snapshot` 是写回前校验用的当前源文本或当前译文；即使 identity 能重定位，`check/apply` 和 `apply-revisions` 仍会复核快照，不会盲写。
+
+v2 重定位覆盖普通 translation 和 revision manifest：`check`、`apply`、`preview-revisions` 和 `apply-revisions` 会在处理 v2 结果前重扫当前 TL 文件，用 v2 id 刷新行号和列位置；结果缺项、解析失败和 repair failure 报告也会尽量使用重扫后的当前位置。旧 manifest 保持兼容 fallback：`manifest_version` 缺失或为 `1` 时继续使用 manifest 内原始 location，不做 v2 重定位；`doctor` 会提示本地 `logs/batch_jobs` 中的旧 manifest。
+
+RAG / history store 继续以 `memory_id` 关联记录。升级到 v2 后，已有旧 key 不会立即强制迁移；写入新记录时会先尝试按 `source_checksum` 复用旧记录的 source embedding，避免因为 id 升级就全量重算。`doctor` 会提示 history store 中仍存在旧格式 key；如原文大量变动或文件结构重排，仍建议重新 `bootstrap-rag`。
+
 ### Golden corpus 测试
 
 `tests/fixtures/golden_batch_minimal/` 保存了一个最小 TL fixture、固定 mock 模型结果和预期输出，用来离线验证普通 Batch 翻译的 `build -> check -> apply` 合约。这个测试不调用 Gemini，也不需要真实 API key。

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3354,6 +3354,39 @@ def reconcile_revision_preview_entries(preview_entries, validation_failures):
     return reconciled
 
 
+def is_v2_manifest(manifest):
+    return manifest.get('manifest_version', 1) == 2 or manifest.get('version', 1) == 2
+
+
+def relocate_v2_chunk_items(manifest, chunk, scanned_units_by_file, mode):
+    if not is_v2_manifest(manifest):
+        return
+    file_key = chunk['file_rel_path']
+    if file_key not in scanned_units_by_file:
+        file_path = manifest.get('files', {}).get(file_key, {}).get('path')
+        if not file_path or not os.path.exists(file_path):
+            file_path = os.path.join(legacy.TL_DIR, file_key)
+        file_lines = []
+        if os.path.exists(file_path):
+            with open(file_path, 'r', encoding='utf-8-sig') as f:
+                file_lines = f.readlines()
+        scanned_units_by_file[file_key] = legacy.scan_all_translation_units(
+            file_lines,
+            file_key,
+            mode=mode,
+        )
+
+    scanned_map = scanned_units_by_file.get(file_key, {})
+    for item in chunk.get('items') or []:
+        scanned = scanned_map.get(item.get('id'))
+        if not scanned:
+            continue
+        scanned_line, scanned_start, scanned_end, _scanned_source = scanned
+        item['line'] = scanned_line
+        item['start'] = scanned_start
+        item['end'] = scanned_end
+
+
 def collect_revision_actions(manifest, validate_sources=False):
     result_path = resolve_manifest_result_path(manifest)
     if not os.path.isfile(result_path):
@@ -3404,6 +3437,12 @@ def collect_revision_actions(manifest, validate_sources=False):
             processed_keys.add(key)
             chunk = chunk_map[key]
             chunk_items = chunk['items']
+            relocate_v2_chunk_items(
+                manifest,
+                chunk,
+                scanned_units_by_file,
+                translation_core.MODE_REVISION,
+            )
             item_map = {item['id']: item for item in chunk_items}
             response_payload = row.get('response', {})
             finish_reason = extract_finish_reason(response_payload)
@@ -3485,29 +3524,6 @@ def collect_revision_actions(manifest, validate_sources=False):
                     continue
                 seen_ids.add(result_id)
                 summary['parsed_items'] += 1
-
-                is_v2 = (manifest.get('manifest_version', 1) == 2 or manifest.get('version', 1) == 2)
-                if is_v2:
-                    file_key = chunk['file_rel_path']
-                    if file_key not in scanned_units_by_file:
-                        file_path = manifest.get('files', {}).get(file_key, {}).get('path')
-                        if not file_path or not os.path.exists(file_path):
-                            file_path = os.path.join(legacy.TL_DIR, file_key)
-                        file_lines = []
-                        if os.path.exists(file_path):
-                            with open(file_path, 'r', encoding='utf-8-sig') as f:
-                                file_lines = f.readlines()
-                        scanned_units_by_file[file_key] = legacy.scan_all_translation_units(
-                            file_lines,
-                            file_key,
-                            mode=translation_core.MODE_REVISION,
-                        )
-                    scanned_map = scanned_units_by_file.get(file_key, {})
-                    if result_id in scanned_map:
-                        scanned_line, scanned_start, scanned_end, scanned_source = scanned_map[result_id]
-                        target_item['line'] = scanned_line
-                        target_item['start'] = scanned_start
-                        target_item['end'] = scanned_end
 
                 target_unit = translation_core.unit_from_manifest_item(
                     target_item,
@@ -3793,6 +3809,12 @@ def collect_result_actions(manifest, validate_sources=False):
             processed_keys.add(key)
             chunk = chunk_map[key]
             chunk_items = chunk['items']
+            relocate_v2_chunk_items(
+                manifest,
+                chunk,
+                scanned_units_by_file,
+                translation_core.MODE_TRANSLATION,
+            )
             item_map = {item['id']: item for item in chunk_items}
             response_payload = row.get('response', {})
             finish_reason = extract_finish_reason(response_payload)
@@ -3882,29 +3904,6 @@ def collect_result_actions(manifest, validate_sources=False):
                     bump_counter(summary['reason_counts'], 'duplicate_result_id')
                     continue
                 seen_ids.add(result_id)
-
-                is_v2 = (manifest.get('manifest_version', 1) == 2 or manifest.get('version', 1) == 2)
-                if is_v2:
-                    file_key = chunk['file_rel_path']
-                    if file_key not in scanned_units_by_file:
-                        file_path = manifest.get('files', {}).get(file_key, {}).get('path')
-                        if not file_path or not os.path.exists(file_path):
-                            file_path = os.path.join(legacy.TL_DIR, file_key)
-                        file_lines = []
-                        if os.path.exists(file_path):
-                            with open(file_path, 'r', encoding='utf-8-sig') as f:
-                                file_lines = f.readlines()
-                        scanned_units_by_file[file_key] = legacy.scan_all_translation_units(
-                            file_lines,
-                            file_key,
-                            mode=translation_core.MODE_TRANSLATION,
-                        )
-                    scanned_map = scanned_units_by_file.get(file_key, {})
-                    if result_id in scanned_map:
-                        scanned_line, scanned_start, scanned_end, scanned_source = scanned_map[result_id]
-                        target_item['line'] = scanned_line
-                        target_item['start'] = scanned_start
-                        target_item['end'] = scanned_end
 
                 target_unit = translation_core.unit_from_manifest_item(
                     target_item,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -111,6 +111,7 @@ CHECK_BLOCK_REASON_CODES = {
     'missing_manifest_file',
     'target_file_missing',
     'target_file_path_escaped',
+    'v2_relocation_missing',
 }
 
 RAG_ENABLED = False
@@ -1049,6 +1050,8 @@ def infer_failure_reason_code(entry):
         return 'missing_manifest_file'
     if 'target file missing' in error:
         return 'target_file_missing'
+    if 'v2 relocation missing' in error:
+        return 'v2_relocation_missing'
     if 'escapes' in error:
         return 'target_file_path_escaped'
     return 'unclassified_failure'
@@ -3360,7 +3363,7 @@ def is_v2_manifest(manifest):
 
 def relocate_v2_chunk_items(manifest, chunk, scanned_units_by_file, mode):
     if not is_v2_manifest(manifest):
-        return
+        return []
     file_key = chunk['file_rel_path']
     if file_key not in scanned_units_by_file:
         file_path = manifest.get('files', {}).get(file_key, {}).get('path')
@@ -3377,14 +3380,40 @@ def relocate_v2_chunk_items(manifest, chunk, scanned_units_by_file, mode):
         )
 
     scanned_map = scanned_units_by_file.get(file_key, {})
+    missing_items = []
     for item in chunk.get('items') or []:
         scanned = scanned_map.get(item.get('id'))
         if not scanned:
+            missing_items.append(item)
             continue
         scanned_line, scanned_start, scanned_end, _scanned_source = scanned
         item['line'] = scanned_line
+        item['line_number'] = scanned_line + 1
         item['start'] = scanned_start
         item['end'] = scanned_end
+    return missing_items
+
+
+def record_v2_relocation_failures(manifest, chunk, missing_items, summary, failure_entries, key=''):
+    if not missing_items:
+        return set()
+    bump_counter(summary['reason_counts'], 'v2_relocation_missing', len(missing_items))
+    missing_ids = set()
+    for item in missing_items:
+        item_id = str(item.get('id') or '')
+        if item_id:
+            missing_ids.add(item_id)
+        failure_entries.append(make_failure_entry(
+            manifest,
+            'V2 relocation missing for result item',
+            file_rel_path=chunk.get('file_rel_path', ''),
+            item_id=item_id,
+            line=item.get('line'),
+            text=item.get('source', item.get('text', '')),
+            key=key or chunk.get('key', ''),
+            reason_code='v2_relocation_missing',
+        ))
+    return missing_ids
 
 
 def collect_revision_actions(manifest, validate_sources=False):
@@ -3437,13 +3466,27 @@ def collect_revision_actions(manifest, validate_sources=False):
             processed_keys.add(key)
             chunk = chunk_map[key]
             chunk_items = chunk['items']
-            relocate_v2_chunk_items(
+            relocation_missing = relocate_v2_chunk_items(
                 manifest,
                 chunk,
                 scanned_units_by_file,
                 translation_core.MODE_REVISION,
             )
-            item_map = {item['id']: item for item in chunk_items}
+            relocation_missing_ids = record_v2_relocation_failures(
+                manifest,
+                chunk,
+                relocation_missing,
+                summary,
+                failure_entries,
+                key=key,
+            )
+            active_chunk_items = [
+                item for item in chunk_items
+                if str(item.get('id') or '') not in relocation_missing_ids
+            ]
+            if relocation_missing_ids and not active_chunk_items:
+                continue
+            item_map = {item['id']: item for item in active_chunk_items}
             response_payload = row.get('response', {})
             finish_reason = extract_finish_reason(response_payload)
             usage_metadata = summarize_usage_metadata(extract_usage_metadata(response_payload))
@@ -3453,7 +3496,7 @@ def collect_revision_actions(manifest, validate_sources=False):
             if row.get('error'):
                 summary['chunk_row_errors'] += 1
                 bump_counter(summary['reason_counts'], 'row_error')
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(make_failure_entry(
                         manifest,
                         serialize_unknown(row.get('error')),
@@ -3471,7 +3514,7 @@ def collect_revision_actions(manifest, validate_sources=False):
             if not response_text:
                 summary['missing_response_chunks'] += 1
                 bump_counter(summary['reason_counts'], 'missing_response_text')
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(make_failure_entry(
                         manifest,
                         'Missing text in response payload',
@@ -3492,7 +3535,7 @@ def collect_revision_actions(manifest, validate_sources=False):
                 summary['partial_chunks'] += 1
                 reason_name = 'truncated_output' if finish_reason == 'MAX_TOKENS' else 'failed_to_parse_revision_json'
                 bump_counter(summary['reason_counts'], reason_name)
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(make_failure_entry(
                         manifest,
                         f'Failed to parse revision JSON: {exc}',
@@ -3507,7 +3550,7 @@ def collect_revision_actions(manifest, validate_sources=False):
                     ))
                 continue
 
-            if len(result_items) < len(chunk_items):
+            if len(result_items) < len(active_chunk_items):
                 summary['partial_chunks'] += 1
                 reason_name = 'truncated_output' if finish_reason == 'MAX_TOKENS' else 'partial_revision_items'
                 bump_counter(summary['reason_counts'], reason_name)
@@ -3515,6 +3558,8 @@ def collect_revision_actions(manifest, validate_sources=False):
             seen_ids = set()
             for result_item in result_items:
                 result_id = result_item['id']
+                if result_id in relocation_missing_ids:
+                    continue
                 target_item = item_map.get(result_id)
                 if not target_item:
                     bump_counter(summary['reason_counts'], 'schema_or_item_mismatch')
@@ -3604,7 +3649,23 @@ def collect_revision_actions(manifest, validate_sources=False):
         bump_counter(summary['reason_counts'], 'missing_chunk_rows', len(missing_keys))
     for key in sorted(missing_keys):
         chunk = chunk_map[key]
+        relocation_missing = relocate_v2_chunk_items(
+            manifest,
+            chunk,
+            scanned_units_by_file,
+            translation_core.MODE_REVISION,
+        )
+        relocation_missing_ids = record_v2_relocation_failures(
+            manifest,
+            chunk,
+            relocation_missing,
+            summary,
+            failure_entries,
+            key=key,
+        )
         for item in chunk['items']:
+            if str(item.get('id') or '') in relocation_missing_ids:
+                continue
             failure_entries.append(make_failure_entry(
                 manifest,
                 'No result row found for chunk',
@@ -3809,13 +3870,27 @@ def collect_result_actions(manifest, validate_sources=False):
             processed_keys.add(key)
             chunk = chunk_map[key]
             chunk_items = chunk['items']
-            relocate_v2_chunk_items(
+            relocation_missing = relocate_v2_chunk_items(
                 manifest,
                 chunk,
                 scanned_units_by_file,
                 translation_core.MODE_TRANSLATION,
             )
-            item_map = {item['id']: item for item in chunk_items}
+            relocation_missing_ids = record_v2_relocation_failures(
+                manifest,
+                chunk,
+                relocation_missing,
+                summary,
+                failure_entries,
+                key=key,
+            )
+            active_chunk_items = [
+                item for item in chunk_items
+                if str(item.get('id') or '') not in relocation_missing_ids
+            ]
+            if relocation_missing_ids and not active_chunk_items:
+                continue
+            item_map = {item['id']: item for item in active_chunk_items}
             response_payload = row.get('response', {})
             finish_reason = extract_finish_reason(response_payload)
             usage_metadata = summarize_usage_metadata(extract_usage_metadata(response_payload))
@@ -3825,7 +3900,7 @@ def collect_result_actions(manifest, validate_sources=False):
             if row.get('error'):
                 summary['chunk_row_errors'] += 1
                 bump_counter(summary['reason_counts'], 'row_error')
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(
                         {
                             'timestamp': datetime.now().isoformat(timespec='seconds'),
@@ -3846,7 +3921,7 @@ def collect_result_actions(manifest, validate_sources=False):
             if not response_text:
                 summary['missing_response_chunks'] += 1
                 bump_counter(summary['reason_counts'], 'missing_response_text')
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(
                         {
                             'timestamp': datetime.now().isoformat(timespec='seconds'),
@@ -3870,7 +3945,7 @@ def collect_result_actions(manifest, validate_sources=False):
                 summary['partial_chunks'] += 1
                 reason_name = 'truncated_output' if finish_reason == 'MAX_TOKENS' else 'failed_to_parse_model_json'
                 bump_counter(summary['reason_counts'], reason_name)
-                for item in chunk_items:
+                for item in active_chunk_items:
                     failure_entries.append(
                         {
                             'timestamp': datetime.now().isoformat(timespec='seconds'),
@@ -3888,7 +3963,7 @@ def collect_result_actions(manifest, validate_sources=False):
                     )
                 continue
 
-            if len(result_items) < len(chunk_items):
+            if len(result_items) < len(active_chunk_items):
                 summary['partial_chunks'] += 1
                 reason_name = 'truncated_output' if finish_reason == 'MAX_TOKENS' else 'partial_result_items'
                 bump_counter(summary['reason_counts'], reason_name)
@@ -3896,6 +3971,8 @@ def collect_result_actions(manifest, validate_sources=False):
             seen_ids = set()
             for result_item in result_items:
                 result_id = result_item['id']
+                if result_id in relocation_missing_ids:
+                    continue
                 target_item = item_map.get(result_id)
                 if not target_item:
                     bump_counter(summary['reason_counts'], 'schema_or_item_mismatch')
@@ -3975,7 +4052,23 @@ def collect_result_actions(manifest, validate_sources=False):
         bump_counter(summary['reason_counts'], 'missing_chunk_rows', len(missing_keys))
     for key in sorted(missing_keys):
         chunk = chunk_map[key]
+        relocation_missing = relocate_v2_chunk_items(
+            manifest,
+            chunk,
+            scanned_units_by_file,
+            translation_core.MODE_TRANSLATION,
+        )
+        relocation_missing_ids = record_v2_relocation_failures(
+            manifest,
+            chunk,
+            relocation_missing,
+            summary,
+            failure_entries,
+            key=key,
+        )
         for item in chunk['items']:
+            if str(item.get('id') or '') in relocation_missing_ids:
+                continue
             failure_entries.append(
                 {
                     'timestamp': datetime.now().isoformat(timespec='seconds'),

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4364,6 +4364,29 @@ REPAIR_OLD_LINE_RE = re.compile(r'^\s*old\s+"(?P<text>.*)"\s*$')
 REPAIR_NEW_LINE_RE = re.compile(r'^\s*new\s+"(?P<text>.*)"\s*$')
 
 
+def is_voice_comment_match(match):
+    if not match:
+        return False
+    prefix = str(match.group('prefix') or '').strip()
+    return prefix.split(None, 1)[0:1] == ['voice']
+
+
+def is_voice_statement_line(line):
+    stripped = str(line or '').strip()
+    return stripped == 'voice' or stripped.startswith('voice ')
+
+
+def next_translation_entry_target_index(lines, index):
+    next_index = index + 1
+    while next_index < len(lines):
+        candidate = lines[next_index]
+        if not candidate.strip() or is_voice_statement_line(candidate):
+            next_index += 1
+            continue
+        break
+    return next_index
+
+
 def write_jsonl_file(path, entries):
     with open(path, 'w', encoding='utf-8') as handle:
         for entry in entries:
@@ -4448,9 +4471,10 @@ def collect_translation_entries_from_lines(lines, file_rel_path=''):
         raw_line = lines[index].rstrip('\n')
         comment_match = REPAIR_LINE_COMMENT_RE.match(raw_line)
         if comment_match:
-            next_index = index + 1
-            while next_index < len(lines) and not lines[next_index].strip():
-                next_index += 1
+            if is_voice_comment_match(comment_match):
+                index += 1
+                continue
+            next_index = next_translation_entry_target_index(lines, index)
             if next_index < len(lines):
                 token = extract_string_token_from_line(lines[next_index])
                 if token:

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -86,6 +86,27 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         self.assertEqual(tasks[2]["block_name"], "chapter1_next")
         self.assertEqual(tasks[2]["block_index"], 1)
 
+    def test_dotted_translate_block_names_are_identity_boundaries(self):
+        lines = [
+            "translate schinese chapter_1.part_1:\n",
+            "    # \"Line 1\"\n",
+            "    \"Line 1\"\n",
+            "translate schinese chapter_1.part_2:\n",
+            "    # \"Line 2\"\n",
+            "    \"Line 2\"\n",
+        ]
+
+        tasks = runtime.collect_tasks(lines)
+        self.assertEqual([task["block_name"] for task in tasks], [
+            "chapter_1.part_1",
+            "chapter_1.part_2",
+        ])
+        self.assertEqual([task["block_index"] for task in tasks], [1, 1])
+
+        mapping = runtime.scan_all_translation_units(lines, "script.rpy")
+        self.assertTrue(any(":chapter_1.part_1:1:" in item_id for item_id in mapping))
+        self.assertTrue(any(":chapter_1.part_2:1:" in item_id for item_id in mapping))
+
     def test_repeated_translate_block_names_do_not_collide(self):
         lines = [
             "translate schinese strings:\n",
@@ -172,6 +193,26 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
 
         expected_id = translation_core.build_identity_v2("", "start", 2, "Line 2")
         self.assertEqual(tasks[0]["id"], expected_id)
+
+    def test_voice_statement_does_not_hide_dialogue_source_marker(self):
+        lines = [
+            "translate schinese start:\n",
+            "    # voice \"audio/line_1.ogg\"\n",
+            "    # e \"Line 1\"\n",
+            "    voice \"audio/line_1.ogg\"\n",
+            "    e \"第一行\"\n",
+            "    # \"Line 2\"\n",
+            "    \"Line 2\"\n",
+        ]
+
+        self.assertEqual(runtime.find_source_text_for_translation_line(lines, 4), "Line 1")
+
+        mapping = runtime.scan_all_translation_units(lines, "script.rpy")
+        expected_line1_id = translation_core.build_identity_v2("script.rpy", "start", 1, "Line 1")
+        expected_line2_id = translation_core.build_identity_v2("script.rpy", "start", 2, "Line 2")
+        self.assertIn(expected_line1_id, mapping)
+        self.assertIn(expected_line2_id, mapping)
+        self.assertEqual(mapping[expected_line1_id][3], "第一行")
 
     def test_revision_identity_lookup_tolerates_blank_lines(self):
         file_rel_path = "script.rpy"
@@ -317,6 +358,97 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         self.assertEqual(len(replacements[file_rel_path][6]), 1)
         action_tuple = replacements[file_rel_path][6][0]
         self.assertEqual(action_tuple[2], "你好世界")
+
+    def test_collect_result_actions_relocates_missing_v2_response_items(self):
+        file_rel_path = "script.rpy"
+        file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        drifted_lines = [
+            "\n",
+            "init python:\n",
+            "    pass\n",
+            "\n",
+            "translate schinese chapter1:\n",
+            "    # \"Line 1\"\n",
+            "    \"Line 1\"\n",
+            "    # \"Line 2\"\n",
+            "    \"Line 2\"\n",
+        ]
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.writelines(drifted_lines)
+
+        id1 = translation_core.build_identity_v2(file_rel_path, "chapter1", 1, "Line 1")
+        id2 = translation_core.build_identity_v2(file_rel_path, "chapter1", 2, "Line 2")
+        result_path = os.path.join(self.tmp_dir, "results.jsonl")
+        manifest = {
+            "version": 2,
+            "manifest_version": 2,
+            "core_schema_version": 2,
+            "mode": batch_mod.MANIFEST_MODE_TRANSLATION,
+            "input_jsonl_path": os.path.join(self.tmp_dir, "requests.jsonl"),
+            "result_jsonl_path": result_path,
+            "settings": {},
+            "files": {
+                file_rel_path: {
+                    "path": file_path,
+                    "task_count": 2,
+                }
+            },
+            "chunks": [
+                {
+                    "key": "chunk_0",
+                    "file_rel_path": file_rel_path,
+                    "chunk_index": 1,
+                    "items": [
+                        {
+                            "id": id1,
+                            "text": "Line 1",
+                            "line": 2,
+                            "start": 4,
+                            "end": 12,
+                            "quote": "\"",
+                        },
+                        {
+                            "id": id2,
+                            "text": "Line 2",
+                            "line": 4,
+                            "start": 4,
+                            "end": 12,
+                            "quote": "\"",
+                        },
+                    ],
+                }
+            ],
+            "_manifest_path": os.path.join(self.tmp_dir, "manifest.json"),
+            "_package_dir": self.tmp_dir,
+        }
+
+        response_text = json.dumps([{"id": id1, "translation": "第一行"}], ensure_ascii=False)
+        with open(result_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "key": "chunk_0",
+                "response": {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": response_text}
+                                ]
+                            }
+                        }
+                    ]
+                },
+            }, ensure_ascii=False) + "\n")
+
+        replacements, _, failures, summary = batch_mod.collect_result_actions(
+            manifest,
+            validate_sources=False,
+        )
+        self.assertIn(6, replacements[file_rel_path])
+        self.assertEqual(summary["reason_counts"]["response_missing_item_id"], 1)
+        missing = [failure for failure in failures if failure.get("id") == id2][0]
+        self.assertEqual(missing["line"], 8)
 
     def test_collect_revision_actions_uses_v2_identity_after_line_drift(self):
         file_rel_path = "script.rpy"

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -473,6 +473,86 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         missing = [failure for failure in failures if failure.get("id") == id2][0]
         self.assertEqual(missing["line"], 8)
 
+    def test_collect_result_actions_blocks_missing_v2_relocation(self):
+        file_rel_path = "script.rpy"
+        file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        current_lines = [
+            "translate schinese new_block:\n",
+            "    # \"Same text\"\n",
+            "    \"Same text\"\n",
+        ]
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.writelines(current_lines)
+
+        missing_id = translation_core.build_identity_v2(file_rel_path, "old_block", 1, "Same text")
+        result_path = os.path.join(self.tmp_dir, "missing_relocation_results.jsonl")
+        manifest = {
+            "version": 2,
+            "manifest_version": 2,
+            "core_schema_version": 2,
+            "mode": batch_mod.MANIFEST_MODE_TRANSLATION,
+            "input_jsonl_path": os.path.join(self.tmp_dir, "requests.jsonl"),
+            "result_jsonl_path": result_path,
+            "settings": {},
+            "files": {
+                file_rel_path: {
+                    "path": file_path,
+                    "task_count": 1,
+                }
+            },
+            "chunks": [
+                {
+                    "key": "chunk_0",
+                    "file_rel_path": file_rel_path,
+                    "chunk_index": 1,
+                    "items": [
+                        {
+                            "id": missing_id,
+                            "text": "Same text",
+                            "line": 2,
+                            "start": 4,
+                            "end": 15,
+                            "quote": "\"",
+                        }
+                    ],
+                }
+            ],
+            "_manifest_path": os.path.join(self.tmp_dir, "manifest.json"),
+            "_package_dir": self.tmp_dir,
+        }
+
+        response_text = json.dumps([{"id": missing_id, "translation": "同一文本"}], ensure_ascii=False)
+        with open(result_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "key": "chunk_0",
+                "response": {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": response_text}
+                                ]
+                            }
+                        }
+                    ]
+                },
+            }, ensure_ascii=False) + "\n")
+
+        replacements, _, failures, summary = batch_mod.collect_result_actions(
+            manifest,
+            validate_sources=True,
+        )
+
+        self.assertEqual(replacements, {})
+        self.assertEqual(summary["reason_counts"]["v2_relocation_missing"], 1)
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["id"], missing_id)
+        self.assertEqual(failures[0]["reason_code"], "v2_relocation_missing")
+        safety = batch_mod.summarize_check_safety(summary)
+        self.assertEqual(safety["level"], batch_mod.CHECK_SAFETY_BLOCK)
+
     def test_collect_revision_actions_uses_v2_identity_after_line_drift(self):
         file_rel_path = "script.rpy"
         file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
@@ -554,7 +634,7 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
                 },
             }, ensure_ascii=False) + "\n")
 
-        replacements, _, failures, summary, _ = batch_mod.collect_revision_actions(
+        replacements, _, failures, summary, preview_entries = batch_mod.collect_revision_actions(
             manifest,
             validate_sources=True,
         )
@@ -564,6 +644,7 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         self.assertIn(6, replacements[file_rel_path])
         action_tuple = replacements[file_rel_path][6][0]
         self.assertEqual(action_tuple[2], "虚空之门")
+        self.assertEqual(preview_entries[0]["line"], 7)
 
     def test_collect_result_actions_compatibility_v1_fallback(self):
         # 测试旧版 V1 Manifest。如果 Manifest v1 发生漂移，我们将不会进行扫描修复，而是继续使用其内部的 line 定位。

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -214,6 +214,29 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         self.assertIn(expected_line2_id, mapping)
         self.assertEqual(mapping[expected_line1_id][3], "第一行")
 
+    def test_revision_entry_scanners_skip_voice_source_comments(self):
+        file_rel_path = "script.rpy"
+        lines = [
+            "translate schinese start:\n",
+            "    # voice \"audio/line_1.ogg\"\n",
+            "    # e \"Line 1\"\n",
+            "    voice \"audio/line_1.ogg\"\n",
+            "    e \"第一行\"\n",
+        ]
+
+        entries = batch_mod.collect_translation_entries_from_lines(lines, file_rel_path=file_rel_path)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["source"], "Line 1")
+        self.assertEqual(entries[0]["translation"], "第一行")
+        self.assertEqual(entries[0]["line_number"], 5)
+        expected_id = translation_core.build_identity_v2(file_rel_path, "start", 1, "Line 1")
+        self.assertEqual(entries[0]["identity_v2"], expected_id)
+
+        runtime_entries = runtime.collect_translation_entries_from_lines(lines)
+        self.assertEqual(len(runtime_entries), 1)
+        self.assertEqual(runtime_entries[0]["source"], "Line 1")
+        self.assertEqual(runtime_entries[0]["translation"], "第一行")
+
     def test_revision_identity_lookup_tolerates_blank_lines(self):
         file_rel_path = "script.rpy"
         file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2128,6 +2128,29 @@ def decode_string_literal_text(raw_text):
     return value if isinstance(value, str) else raw_text
 
 
+def is_voice_comment_match(match):
+    if not match:
+        return False
+    prefix = str(match.group("prefix") or "").strip()
+    return prefix.split(None, 1)[0:1] == ["voice"]
+
+
+def is_voice_statement_line(line):
+    stripped = str(line or "").strip()
+    return stripped == "voice" or stripped.startswith("voice ")
+
+
+def next_translation_entry_target_index(lines, index):
+    next_index = index + 1
+    while next_index < len(lines):
+        candidate = lines[next_index]
+        if not candidate.strip() or is_voice_statement_line(candidate):
+            next_index += 1
+            continue
+        break
+    return next_index
+
+
 def collect_translation_entries_from_lines(lines):
     entries = []
     index = 0
@@ -2135,9 +2158,10 @@ def collect_translation_entries_from_lines(lines):
         raw_line = lines[index].rstrip("\n")
         comment_match = TL_COMMENT_SOURCE_RE.match(raw_line)
         if comment_match:
-            next_index = index + 1
-            while next_index < len(lines) and not lines[next_index].strip():
-                next_index += 1
+            if is_voice_comment_match(comment_match):
+                index += 1
+                continue
+            next_index = next_translation_entry_target_index(lines, index)
             if next_index < len(lines):
                 candidate_line = lines[next_index].rstrip("\n")
                 if not TL_OLD_LINE_RE.match(candidate_line):
@@ -2878,8 +2902,7 @@ def find_source_text_for_translation_line(lines, idx):
 
         comment_match = TL_COMMENT_SOURCE_RE.match(lines[prev_idx].rstrip("\n"))
         if comment_match:
-            prefix = str(comment_match.group("prefix") or "").strip()
-            if prefix.split(None, 1)[0:1] == ["voice"]:
+            if is_voice_comment_match(comment_match):
                 continue
             return decode_string_literal_text(comment_match.group("text"))
 
@@ -2887,7 +2910,7 @@ def find_source_text_for_translation_line(lines, idx):
         if old_match:
             return decode_string_literal_text(old_match.group("text"))
 
-        if prev_line == "voice" or prev_line.startswith("voice "):
+        if is_voice_statement_line(prev_line):
             continue
         break
     return None

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2871,27 +2871,30 @@ def _is_character_display_token(line_idx, token, display_spans):
 
 
 def find_source_text_for_translation_line(lines, idx):
-    # 向上寻找最近的非空行
     for prev_idx in range(idx - 1, -1, -1):
         prev_line = lines[prev_idx].strip()
         if not prev_line:
             continue
 
-        # 尝试匹配 comment
         comment_match = TL_COMMENT_SOURCE_RE.match(lines[prev_idx].rstrip("\n"))
         if comment_match:
+            prefix = str(comment_match.group("prefix") or "").strip()
+            if prefix.split(None, 1)[0:1] == ["voice"]:
+                continue
             return decode_string_literal_text(comment_match.group("text"))
 
-        # 尝试匹配 old
         old_match = TL_OLD_LINE_RE.match(lines[prev_idx].rstrip("\n"))
         if old_match:
             return decode_string_literal_text(old_match.group("text"))
+
+        if prev_line == "voice" or prev_line.startswith("voice "):
+            continue
         break
     return None
 
 
 def _translate_block_name(line):
-    match = re.match(r'^\s*translate\s+\w+\s+(\w+):', line)
+    match = re.match(r'^\s*translate\s+\S+\s+([^\s:]+)\s*:', line)
     return match.group(1) if match else None
 
 
@@ -2949,6 +2952,8 @@ def scan_all_translation_units(lines, file_rel_path, mode=translation_core.MODE_
             not sline
             or sline.startswith("#")
             or sline.startswith("translate ")
+            or sline == "voice"
+            or sline.startswith("voice ")
             or (is_translation_file and sline.startswith("old "))
         ):
             continue
@@ -3044,6 +3049,8 @@ def collect_tasks(lines, skip_translated=True):
             not sline
             or sline.startswith("#")
             or sline.startswith("translate ")
+            or sline == "voice"
+            or sline.startswith("voice ")
             or (is_translation_file and sline.startswith("old "))
         ):
             continue


### PR DESCRIPTION
## Summary

- Fix the three post-merge Codex review findings from PR #59:
  - relocate all v2 chunk items before reporting missing/partial response failures
  - support dotted Ren'Py translate block names in identity v2 scanning
  - keep dialogue source markers across generated `voice` statements without counting voice lines as translation units
- Add focused identity-v2 regressions for those cases.
- Document manifest/identity v2 boundaries, legacy manifest fallback, RAG checksum fallback, and doctor warnings for #41 closeout.

## Validation

- `python -m unittest -q tests.test_identity_v2`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `git diff --check`

## Notes

This is a follow-up to #59 after the post-merge automated review comments landed.

Closes #41