### PR TITLE
[codex] Add source index bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Batch 模式：
 ```bash
 python gemini_translate_batch.py doctor
 python gemini_translate_batch.py bootstrap-rag
+python gemini_translate_batch.py bootstrap-source-index
 python gemini_translate_batch.py build
 python gemini_translate_batch.py submit
 python gemini_translate_batch.py status
@@ -314,6 +315,24 @@ JSONL 每行是一个对象，支持以下字段：
 命令输出会包含 `scan_scope`、`files_scanned`、`scanned`、`external_seed_records`、`external_seed_invalid_json`、`external_seed_filtered`、`external_seed_skipped`、`embedded`、`reused_embeddings`、`upserted` 和 history record 数量，方便确认预建库是否真的扫描并写入了内容。
 
 注意：`bootstrap-rag` 解决的是“build 前先用已有译文暖库”的问题；它不会让已经 build / split 完的旧请求动态吃到后续 apply 的新结果。需要滚动回灌时，仍要按波次重新 build，或等待后续动态波次编排能力。
+
+### 可选：Batch Source-Only 索引预建
+
+为了支持独立的原文字段索引（不混入翻译历史记忆库），可以使用 `bootstrap-source-index` 命令：
+
+```bash
+python gemini_translate_batch.py bootstrap-source-index
+```
+
+这个命令会：
+1. 扫描当前所有的 `.rpy` 翻译模板文件，将原文分组为 source segments。
+2. 对比本地数据库中已有的索引：
+   - 如果对应位置的内容和模型配置未发生变化，则直接**复用**现有的 Embedding 向量，避免重复调用 API 造成浪费。
+   - 如果发生变化或不存在，则分批调用 Embedding 接口生成向量。
+   - 识别并列出所有在数据库中存在但在当前项目中已失效的**过期片段（Stale segments）**。
+3. 优先输出详细的同步前统计信息（stats）。
+4. 默认会自动清理/Prune 过期的 stale 记录；如需保留，可传入 `--no-prune`。
+
 
 ### 可选：Structured Story Memory
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -16,7 +16,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
-from rag_memory import JsonRagStore, hash_text, truncate_text
+from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreLockError, hash_text, truncate_text
 import prompt_context
 import story_memory
 import translation_core
@@ -131,6 +131,10 @@ _RAG_STORE = None
 _RAG_PRESERVED_TERMS_CACHE = None
 _RAG_PRESERVED_TERMS_CACHE_KEY = None
 
+SOURCE_INDEX_ENABLED = False
+SOURCE_INDEX_STORE_DIR = ''
+_SOURCE_INDEX_STORE = None
+
 STORY_MEMORY_ENABLED = False
 STORY_MEMORY_GRAPH_FILE = ''
 STORY_MEMORY_MAX_CONTEXT_CHARS = 1200
@@ -212,6 +216,7 @@ def load_batch_settings():
     global RAG_DOCUMENT_TASK_TYPE, RAG_OUTPUT_DIMENSIONALITY, RAG_TOP_K_HISTORY
     global RAG_TOP_K_TERMS, RAG_MIN_SIMILARITY, RAG_SEGMENT_LINES
     global RAG_BOOTSTRAP_ON_BUILD, RAG_HISTORY_CHAR_LIMIT, _RAG_STORE
+    global SOURCE_INDEX_ENABLED, SOURCE_INDEX_STORE_DIR, _SOURCE_INDEX_STORE
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
@@ -342,6 +347,19 @@ def load_batch_settings():
         RAG_STORE_DIR = ''
 
     _RAG_STORE = None
+
+    source_index_config = batch.get('source_index')
+    if not isinstance(source_index_config, dict):
+        source_index_config = {}
+
+    SOURCE_INDEX_ENABLED = coerce_bool(source_index_config.get('enabled'), SOURCE_INDEX_ENABLED)
+    source_index_store_dir = source_index_config.get('store_dir')
+    if source_index_store_dir:
+        SOURCE_INDEX_STORE_DIR = legacy._resolve_path(legacy.BASE_DIR, source_index_store_dir)
+    else:
+        SOURCE_INDEX_STORE_DIR = ''
+
+    _SOURCE_INDEX_STORE = None
 
     story_config = batch.get('story_memory')
     if not isinstance(story_config, dict):
@@ -526,6 +544,25 @@ def hash_key(text):
 
 def get_default_rag_store_dir():
     return os.path.join(LOG_DIR, 'rag_store', guess_project_slug())
+
+
+def get_default_source_index_store_dir():
+    return os.path.join(LOG_DIR, 'source_index_store', guess_project_slug())
+
+
+def get_source_index_store():
+    global _SOURCE_INDEX_STORE, SOURCE_INDEX_STORE_DIR
+    if not SOURCE_INDEX_STORE_DIR:
+        SOURCE_INDEX_STORE_DIR = get_default_source_index_store_dir()
+    if _SOURCE_INDEX_STORE is None or os.path.abspath(_SOURCE_INDEX_STORE.store_dir) != os.path.abspath(SOURCE_INDEX_STORE_DIR):
+        _SOURCE_INDEX_STORE = JsonSourceIndexStore(SOURCE_INDEX_STORE_DIR)
+        _SOURCE_INDEX_STORE.set_metadata(
+            project_slug=guess_project_slug(),
+            embedding_model=RAG_EMBEDDING_MODEL,
+            document_task_type=RAG_DOCUMENT_TASK_TYPE,
+            output_dimensionality=RAG_OUTPUT_DIMENSIONALITY,
+        )
+    return _SOURCE_INDEX_STORE
 
 
 def get_rag_store():
@@ -4768,6 +4805,50 @@ def collect_rag_seed_records_for_jobs(file_jobs, quality_state='seed'):
     return records
 
 
+def build_source_segment(file_rel_path, group):
+    source_text = '\n'.join(entry.get('source', '') for entry in group).strip()
+    line_start = group[0]['line_number']
+    line_end = group[-1]['line_number']
+    source_id = hash_key(f"{file_rel_path}:{line_start}:{line_end}")
+    source_checksum = hash_text(source_text)
+    now = datetime.now().isoformat(timespec='seconds')
+    return {
+        'source_id': source_id,
+        'file_rel_path': file_rel_path,
+        'line_start': line_start,
+        'line_end': line_end,
+        'line_span': [line_start, line_end],
+        'source_text': source_text,
+        'source_checksum': source_checksum,
+        'embedding': [],
+        'embedding_metadata': {},
+        'created_at': now,
+        'updated_at': now,
+    }
+
+
+def collect_source_segments_for_jobs(file_jobs):
+    records = []
+    segment_size = max(1, RAG_SEGMENT_LINES)
+    for job in file_jobs:
+        file_rel_path = job.get('file_rel_path')
+        file_path = job.get('file_path')
+        if not file_rel_path or not file_path or not os.path.isfile(file_path):
+            continue
+        with open(file_path, 'r', encoding='utf-8-sig') as handle:
+            entries = collect_translation_entries_from_lines(handle.readlines(), file_rel_path=file_rel_path)
+        usable_entries = []
+        for entry in entries:
+            src = (entry.get('source') or '').strip()
+            if src:
+                usable_entries.append(entry)
+        for start in range(0, len(usable_entries), segment_size):
+            group = usable_entries[start:start + segment_size]
+            if group:
+                records.append(build_source_segment(file_rel_path, group))
+    return records
+
+
 def coerce_external_seed_text(row, keys):
     for key in keys:
         value = row.get(key)
@@ -5033,6 +5114,180 @@ def print_rag_bootstrap_summary(summary):
             print(f'- {key}: {summary[key]}')
     if summary.get('error'):
         print(f"- error: {summary['error']}")
+
+
+def embed_source_segments(records):
+    embedded_records = []
+    batch_size = 16
+    for start in range(0, len(records), batch_size):
+        batch = records[start:start + batch_size]
+        vectors = embed_texts([record['source_text'] for record in batch], RAG_DOCUMENT_TASK_TYPE)
+        for record, vector in zip(batch, vectors):
+            enriched = dict(record)
+            enriched['embedding'] = vector
+            enriched['embedding_metadata'] = {
+                'embedding_model': RAG_EMBEDDING_MODEL,
+                'embedding_task_type': RAG_DOCUMENT_TASK_TYPE,
+                'embedding_dim': len(vector),
+                'embedding_text_checksum': hash_text(record.get('source_text', '')),
+            }
+            enriched['updated_at'] = datetime.now().isoformat(timespec='seconds')
+            embedded_records.append(enriched)
+    return embedded_records
+
+
+def source_segment_has_current_embedding(existing, record):
+    if not existing or existing.get('source_checksum') != record.get('source_checksum'):
+        return False
+    embedding = existing.get('embedding')
+    if not isinstance(embedding, list) or not embedding:
+        return False
+    if len(embedding) != RAG_OUTPUT_DIMENSIONALITY:
+        return False
+    metadata = existing.get('embedding_metadata') or {}
+    return (
+        metadata.get('embedding_model') == RAG_EMBEDDING_MODEL
+        and metadata.get('embedding_task_type') == RAG_DOCUMENT_TASK_TYPE
+        and metadata.get('embedding_dim') == RAG_OUTPUT_DIMENSIONALITY
+        and metadata.get('embedding_text_checksum') == hash_text(record.get('source_text', ''))
+    )
+
+
+def print_source_index_bootstrap_summary(summary):
+    print('Source Index bootstrap final summary:')
+    for key in (
+        'store_dir',
+        'files_scanned',
+        'scanned',
+        'history_records_before',
+        'reused_embeddings',
+        'embedding_pending',
+        'embedded',
+        'upserted',
+        'stale_count',
+        'prune_enabled',
+        'pruned',
+        'history_records_after',
+    ):
+        if key in summary:
+            print(f'- {key}: {summary[key]}')
+    if summary.get('error'):
+        print(f"- error: {summary['error']}")
+
+
+def bootstrap_source_index(skip_prepare=False, prune=True):
+    if not skip_prepare:
+        legacy.run_prepare_steps()
+    if not os.path.isdir(legacy.TL_DIR):
+        raise SystemExit(f'TL dir does not exist: {legacy.TL_DIR}')
+
+    store = get_source_index_store()
+    store.load()
+
+    scan_jobs = all_rag_file_jobs()
+    scanned_segments = collect_source_segments_for_jobs(scan_jobs)
+
+    stored_before = store.count_segments()
+    scanned_ids = {seg['source_id'] for seg in scanned_segments}
+
+    records_to_embed = []
+    records_with_reused_embedding = []
+
+    for record in scanned_segments:
+        existing = store.get_segment(record['source_id'])
+        if not existing:
+            for seg in store.segments.values():
+                if source_segment_has_current_embedding(seg, record):
+                    existing = seg
+                    break
+
+        if source_segment_has_current_embedding(existing, record):
+            enriched = dict(record)
+            enriched['embedding'] = existing['embedding']
+            enriched['embedding_metadata'] = existing['embedding_metadata']
+            if 'created_at' in existing:
+                enriched['created_at'] = existing['created_at']
+            records_with_reused_embedding.append(enriched)
+        else:
+            records_to_embed.append(record)
+
+    stale_segments = []
+    for source_id, seg in store.segments.items():
+        if source_id not in scanned_ids:
+            stale_segments.append(seg)
+
+    stale_count = len(stale_segments)
+    stale_details = [
+        {
+            'source_id': seg['source_id'],
+            'file_rel_path': seg['file_rel_path'],
+            'line_start': seg['line_start'],
+            'line_end': seg['line_end'],
+        }
+        for seg in stale_segments
+    ]
+
+    print("=" * 60)
+    print("Source Index Sync Stats (Pre-run):")
+    print(f"- Store directory: {store.store_dir}")
+    print(f"- Files scanned: {len(scan_jobs)}")
+    print(f"- Total segments scanned from files: {len(scanned_segments)}")
+    print(f"- Total segments stored previously: {stored_before}")
+    print(f"- Unchanged segments (reusing embeddings): {len(records_with_reused_embedding)}")
+    print(f"- New/updated segments (need embeddings): {len(records_to_embed)}")
+    print(f"- Stale segments in database: {stale_count}")
+    if stale_count > 0:
+        print("  Stale segments details:")
+        for item in stale_details:
+            print(f"    * {item['file_rel_path']}:{item['line_start']}-{item['line_end']} (ID: {item['source_id']})")
+    print("=" * 60)
+    sys.stdout.flush()
+
+    summary = {
+        'enabled': True,
+        'store_dir': store.store_dir,
+        'files_scanned': len(scan_jobs),
+        'scanned': len(scanned_segments),
+        'history_records_before': stored_before,
+        'reused_embeddings': len(records_with_reused_embedding),
+        'embedding_pending': len(records_to_embed),
+        'stale_count': stale_count,
+        'prune_enabled': prune,
+        'embedded': 0,
+        'upserted': 0,
+        'pruned': 0,
+    }
+
+    if not records_to_embed and (not stale_segments or not prune):
+        summary['history_records_after'] = store.count_segments()
+        print("No new embeddings required, and no stale segments to prune.")
+        return summary
+
+    try:
+        embedded_records = []
+        if records_to_embed:
+            print(f"Generating embeddings for {len(records_to_embed)} segments...")
+            sys.stdout.flush()
+            embedded_records = embed_source_segments(records_to_embed)
+            summary['embedded'] = len(embedded_records)
+
+        upsert_count = store.upsert_segments(records_with_reused_embedding + embedded_records)
+        summary['upserted'] = upsert_count
+
+        if stale_segments and prune:
+            print(f"Pruning {stale_count} stale segments...")
+            sys.stdout.flush()
+            prune_count = store.delete_segments([seg['source_id'] for seg in stale_segments])
+            summary['pruned'] = prune_count
+
+        summary['history_records_after'] = store.count_segments()
+        print(f"Sync complete. Stored segments count is now: {summary['history_records_after']}.")
+    except Exception as exc:
+        print(f'Warning: Failed to update Source Index store: {exc}')
+        summary['error'] = str(exc)
+        summary['history_records_after'] = store.count_segments()
+
+    return summary
 
 
 def bootstrap_rag_store(skip_prepare=False, seed_jsonl_paths=None):
@@ -6180,6 +6435,21 @@ def build_arg_parser():
         help='Import external parallel corpus JSONL rows as additional RAG seed records. Can be repeated.',
     )
 
+    bootstrap_source_index_parser = subparsers.add_parser(
+        'bootstrap-source-index',
+        help='Prebuild or refresh the Batch source-only index store from all allowed TL files.',
+    )
+    bootstrap_source_index_parser.add_argument(
+        '--skip-prepare',
+        action='store_true',
+        help='Skip auto prepare steps before scanning TL files.',
+    )
+    bootstrap_source_index_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Do not prune stale segments from the index store after indexing.',
+    )
+
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
     submit_parser.add_argument(
         'target',
@@ -6452,6 +6722,11 @@ def main(argv=None):
 
     if command == 'bootstrap-rag':
         bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)
+        return
+
+    if command == 'bootstrap-source-index':
+        summary = bootstrap_source_index(skip_prepare=args.skip_prepare, prune=(not args.no_prune))
+        print_source_index_bootstrap_summary(summary)
         return
 
     if command == 'submit':

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 from contextlib import contextmanager
 import hashlib
 import json
@@ -494,7 +494,6 @@ class JsonRagStore(object):
         if top_k > 0:
             return results[:top_k]
         return results
-
     def _sort_key(self, record):
         quality_state = record.get('quality_state') or ''
         quality_rank = {
@@ -505,3 +504,446 @@ class JsonRagStore(object):
             'sync_applied': 1,
         }.get(quality_state, 0)
         return (float(record.get('score') or 0.0), quality_rank, record.get('created_at') or '')
+
+
+class JsonSourceIndexStoreLockError(RuntimeError):
+    pass
+
+
+class JsonSourceIndexStore(object):
+    def __init__(self, store_dir):
+        self.store_dir = os.path.abspath(store_dir)
+        self.metadata_path = os.path.join(self.store_dir, 'source_metadata.json')
+        self.segments_path = os.path.join(self.store_dir, 'source_segments.jsonl')
+        self.lock_path = os.path.join(self.store_dir, '.source_index.lock')
+        self._loaded = False
+        self._disk_snapshot = None
+        self.metadata = {}
+        self.segments = {}
+        self.file_index = {}
+
+    def _warn(self, message):
+        print(f'Warning: {message}')
+
+    def load(self):
+        if self._loaded:
+            return
+        self._load_from_disk()
+
+    def _load_from_disk(self):
+        os.makedirs(self.store_dir, exist_ok=True)
+        self.metadata = self._load_json_file(self.metadata_path)
+        self.segments = {}
+        self.file_index = {}
+        if os.path.isfile(self.segments_path):
+            with open(self.segments_path, 'r', encoding='utf-8-sig') as handle:
+                for line_number, raw_line in enumerate(handle, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        self._warn(f'Skipping invalid source segment row {self.segments_path}:{line_number}: {exc}')
+                        continue
+                    if not isinstance(record, dict):
+                        self._warn(f'Skipping non-object source segment row {self.segments_path}:{line_number}')
+                        continue
+                    source_id = record.get('source_id')
+                    if source_id:
+                        self.segments[source_id] = record
+                        self._index_record(source_id, record)
+        self._loaded = True
+        self._disk_snapshot = self._disk_version()
+
+    def _file_version(self, path):
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
+
+    def _disk_version(self):
+        return (
+            self._file_version(self.metadata_path),
+            self._file_version(self.segments_path),
+        )
+
+    def _refresh_from_disk_if_changed(self):
+        if not self._loaded or self._disk_snapshot != self._disk_version():
+            self._load_from_disk()
+
+    def _load_json_file(self, path):
+        if not os.path.isfile(path):
+            return {}
+        try:
+            with open(path, 'r', encoding='utf-8-sig') as handle:
+                data = json.load(handle)
+        except Exception as exc:
+            self._warn(f'Failed to load source metadata {path}: {exc}')
+            return {}
+        if not isinstance(data, dict):
+            self._warn(f'Ignoring non-object source metadata {path}')
+            return {}
+        return data
+
+    def count_segments(self):
+        self.load()
+        return len(self.segments)
+
+    def get_segment(self, source_id):
+        self.load()
+        return self.segments.get(source_id)
+
+    def set_metadata(self, **updates):
+        with self._locked('set_metadata') as lock_info:
+            self._refresh_from_disk_if_changed()
+            self._update_metadata_unlocked('set_metadata', updates, lock_info)
+
+    def _write_metadata(self):
+        def write(handle):
+            json.dump(self.metadata, handle, ensure_ascii=False, indent=2)
+
+        self._atomic_write(self.metadata_path, write)
+
+    def _write_segments(self):
+        def write(handle):
+            for source_id in sorted(self.segments):
+                handle.write(json.dumps(self.segments[source_id], ensure_ascii=False) + '\n')
+
+        self._atomic_write(self.segments_path, write)
+
+    def _atomic_write(self, path, writer):
+        os.makedirs(self.store_dir, exist_ok=True)
+        tmp_path = f'{path}.tmp.{os.getpid()}.{id(self)}'
+        try:
+            with open(tmp_path, 'w', encoding='utf-8') as handle:
+                writer(handle)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+            self._disk_snapshot = self._disk_version()
+        finally:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError as exc:
+                    self._warn(f'Failed to remove temporary source store file {tmp_path}: {exc}')
+
+    def _lock_owner(self, operation):
+        return {
+            'operation': operation,
+            'owner': socket.gethostname(),
+            'pid': os.getpid(),
+            'created_at': now_iso(),
+        }
+
+    def _format_lock_owner(self, data):
+        if not isinstance(data, dict):
+            return 'unknown owner'
+        parts = []
+        operation = data.get('operation')
+        owner = data.get('owner')
+        pid = data.get('pid')
+        created_at = data.get('created_at')
+        released_at = data.get('released_at')
+        if operation:
+            parts.append(f'operation={operation}')
+        if owner:
+            parts.append(f'owner={owner}')
+        if pid:
+            parts.append(f'pid={pid}')
+        if created_at:
+            parts.append(f'created_at={created_at}')
+        if released_at:
+            parts.append(f'released_at={released_at}')
+        return ', '.join(parts) if parts else 'unknown owner'
+
+    def _read_lock_owner(self):
+        try:
+            with open(self.lock_path, 'r', encoding='utf-8-sig') as handle:
+                return json.load(handle)
+        except Exception:
+            return {}
+
+    def _lock_age_seconds(self, data):
+        if not isinstance(data, dict):
+            return None
+        created_at = data.get('created_at')
+        if not created_at:
+            return None
+        try:
+            created_at = datetime.fromisoformat(str(created_at))
+        except (TypeError, ValueError):
+            return None
+        return (datetime.now() - created_at).total_seconds()
+
+    def _lock_file_age_seconds(self):
+        try:
+            return datetime.now().timestamp() - os.path.getmtime(self.lock_path)
+        except OSError:
+            return None
+
+    def _is_lock_owner_alive(self, pid):
+        try:
+            pid = int(pid)
+        except (TypeError, ValueError):
+            return None
+        if pid <= 0:
+            return None
+        if os.name == 'nt':
+            return self._is_windows_process_alive(pid)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return None
+        return True
+
+    def _is_windows_process_alive(self, pid):
+        import ctypes
+
+        process_query_limited_information = 0x1000
+        error_invalid_parameter = 87
+        still_active = 259
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+        kernel32.OpenProcess.argtypes = (ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong)
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.GetExitCodeProcess.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong))
+        kernel32.GetExitCodeProcess.restype = ctypes.c_int
+        kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+        kernel32.CloseHandle.restype = ctypes.c_int
+        handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+        if not handle:
+            if ctypes.get_last_error() == error_invalid_parameter:
+                return False
+            return True
+        try:
+            exit_code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return True
+            return exit_code.value == still_active
+        finally:
+            kernel32.CloseHandle(handle)
+
+    def _is_stale_lock(self, data):
+        if not isinstance(data, dict):
+            age_seconds = self._lock_file_age_seconds()
+            return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
+        if data.get('released_at'):
+            return True
+        local_owner = data.get('owner') == socket.gethostname()
+        if local_owner and data.get('pid') is not None:
+            is_alive = self._is_lock_owner_alive(data.get('pid'))
+            if is_alive is False:
+                return True
+            if is_alive is True:
+                return False
+        age_seconds = self._lock_age_seconds(data)
+        if age_seconds is None and not data:
+            age_seconds = self._lock_file_age_seconds()
+        return age_seconds is not None and age_seconds >= LOCK_STALE_AFTER_SECONDS
+
+    def _recover_stale_lock(self, existing):
+        if not self._is_stale_lock(existing):
+            return False
+        try:
+            os.remove(self.lock_path)
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            self._warn(f'Failed to remove stale source store lock {self.lock_path}: {exc}')
+            return False
+        self._warn(f'Recovered stale source store lock {self.lock_path} ({self._format_lock_owner(existing)})')
+        return True
+
+    def _open_lock_file(self):
+        return os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+
+    def _lock_path_is_regular_file(self):
+        try:
+            lock_stat = os.lstat(self.lock_path)
+        except FileNotFoundError:
+            return True
+        return stat.S_ISREG(lock_stat.st_mode)
+
+    def _mark_lock_released(self, lock_info):
+        if not os.path.exists(self.lock_path):
+            return True
+        if not self._lock_path_is_regular_file():
+            self._warn(f'Failed to mark source store lock released {self.lock_path}: not a regular file')
+            return False
+        released_info = dict(lock_info)
+        released_info['released_at'] = now_iso()
+        tmp_path = f'{self.lock_path}.released.tmp.{os.getpid()}.{id(self)}'
+        try:
+            fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            try:
+                handle = os.fdopen(fd, 'w', encoding='utf-8')
+            except OSError:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
+            with handle:
+                json.dump(released_info, handle, ensure_ascii=False)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.lock_path)
+        except Exception as exc:
+            self._warn(f'Failed to mark source store lock released {self.lock_path}: {exc}')
+            return False
+        finally:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError as exc:
+                    self._warn(f'Failed to remove temporary source store lock marker {tmp_path}: {exc}')
+        return True
+
+    @contextmanager
+    def _locked(self, operation):
+        os.makedirs(self.store_dir, exist_ok=True)
+        lock_info = self._lock_owner(operation)
+        try:
+            fd = self._open_lock_file()
+        except FileExistsError:
+            existing = self._read_lock_owner()
+            if not self._recover_stale_lock(existing):
+                raise JsonSourceIndexStoreLockError(
+                    f'Source store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
+                )
+            try:
+                fd = self._open_lock_file()
+            except FileExistsError:
+                existing = self._read_lock_owner()
+                raise JsonSourceIndexStoreLockError(
+                    f'Source store is locked at {self.lock_path} ({self._format_lock_owner(existing)}).'
+                )
+
+        try:
+            operation_succeeded = False
+            with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+                json.dump(lock_info, handle, ensure_ascii=False)
+            yield lock_info
+            operation_succeeded = True
+        finally:
+            try:
+                os.remove(self.lock_path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                self._mark_lock_released(lock_info)
+                self._warn(f'Failed to remove source store lock {self.lock_path}: {exc}')
+                if operation_succeeded:
+                    raise JsonSourceIndexStoreLockError(
+                        f'Failed to remove source store lock {self.lock_path}: {exc}'
+                    ) from exc
+
+    def _update_metadata_unlocked(self, operation, updates, lock_info):
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+        for key, value in updates.items():
+            self.metadata[key] = value
+        updated_at = now_iso()
+        self.metadata['updated_at'] = updated_at
+        if 'created_at' not in self.metadata:
+            self.metadata['created_at'] = updated_at
+        self.metadata['last_write'] = {
+            'operation': operation,
+            'owner': lock_info.get('owner'),
+            'pid': lock_info.get('pid'),
+            'lock_created_at': lock_info.get('created_at'),
+            'updated_at': updated_at,
+        }
+        self._write_metadata()
+
+    def _index_record(self, source_id, record):
+        file_rel_path = record.get('file_rel_path')
+        if not file_rel_path:
+            return
+        self.file_index.setdefault(file_rel_path, set()).add(source_id)
+
+    def _unindex_record(self, source_id, record):
+        file_rel_path = record.get('file_rel_path')
+        if not file_rel_path:
+            return
+        bucket = self.file_index.get(file_rel_path)
+        if not bucket:
+            return
+        bucket.discard(source_id)
+        if not bucket:
+            self.file_index.pop(file_rel_path, None)
+
+    def upsert_segments(self, records):
+        with self._locked('upsert_segments') as lock_info:
+            self._refresh_from_disk_if_changed()
+            changed = 0
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                source_id = record.get('source_id')
+                embedding = record.get('embedding')
+                if not source_id or not isinstance(embedding, list) or not embedding:
+                    continue
+                existing = self.segments.get(source_id)
+                if existing == record:
+                    continue
+                if existing:
+                    self._unindex_record(source_id, existing)
+                self.segments[source_id] = record
+                self._index_record(source_id, record)
+                changed += 1
+            if changed:
+                self._write_segments()
+                self._update_metadata_unlocked(
+                    'upsert_segments',
+                    {'segment_count': len(self.segments)},
+                    lock_info,
+                )
+        return changed
+
+    def delete_segments(self, source_ids):
+        with self._locked('delete_segments') as lock_info:
+            self._refresh_from_disk_if_changed()
+            changed = 0
+            for source_id in source_ids:
+                existing = self.segments.pop(source_id, None)
+                if not existing:
+                    continue
+                self._unindex_record(source_id, existing)
+                changed += 1
+            if changed:
+                self._write_segments()
+                self._update_metadata_unlocked(
+                    'delete_segments',
+                    {'segment_count': len(self.segments)},
+                    lock_info,
+                )
+        return changed
+
+    def segment_ids_for_file(self, file_rel_path):
+        self.load()
+        return list(self.file_index.get(file_rel_path, set()))
+
+    def search_segments(self, query_vector, top_k=4, min_similarity=0.72):
+        self.load()
+        results = []
+        for record in self.segments.values():
+            vector = record.get('embedding')
+            if not isinstance(vector, list) or not vector:
+                continue
+            score = cosine_similarity(query_vector, vector)
+            if score < min_similarity:
+                continue
+            result = dict(record)
+            result['score'] = score
+            results.append(result)
+        results.sort(key=lambda item: float(item.get('score') or 0.0), reverse=True)
+        if top_k > 0:
+            return results[:top_k]
+        return results

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import socket
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+from rag_memory import JsonSourceIndexStore, JsonSourceIndexStoreLockError, now_iso
+
+
+class SourceIndexStoreTests(unittest.TestCase):
+    def make_segment(self, source_id, file_rel_path='script.rpy', source='Hello', start=10, end=13):
+        return {
+            'source_id': source_id,
+            'file_rel_path': file_rel_path,
+            'line_start': start,
+            'line_end': end,
+            'line_span': [start, end],
+            'source_text': source,
+            'source_checksum': batch_mod.hash_text(source),
+            'embedding': [0.1, 0.2, 0.3],
+            'embedding_metadata': {
+                'embedding_model': 'gemini-embedding-001',
+                'embedding_task_type': 'RETRIEVAL_DOCUMENT',
+                'embedding_dim': 3,
+                'embedding_text_checksum': batch_mod.hash_text(source),
+            },
+            'created_at': '2026-06-14T09:00:00',
+            'updated_at': '2026-06-14T09:00:00',
+        }
+
+    def test_json_store_lifecycle_and_warnings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            metadata_path = store_dir / 'source_metadata.json'
+            segments_path = store_dir / 'source_segments.jsonl'
+            metadata_path.write_text('{bad json', encoding='utf-8')
+            segments_path.write_text(
+                json.dumps(self.make_segment('s1'), ensure_ascii=False) + '\n'
+                '{bad row\n'
+                '[]\n',
+                encoding='utf-8',
+            )
+
+            store = JsonSourceIndexStore(str(store_dir))
+            with mock.patch('builtins.print') as print_mock:
+                count = store.count_segments()
+
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(count, 1)
+        self.assertIn('Failed to load source metadata', warnings)
+        self.assertIn('Skipping invalid source segment row', warnings)
+        self.assertIn('Skipping non-object source segment row', warnings)
+
+    def test_json_store_atomic_write_safety(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            segments_path = store_dir / 'source_segments.jsonl'
+            original = self.make_segment('s1')
+            segments_path.write_text(
+                json.dumps(original, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+            store = JsonSourceIndexStore(str(store_dir))
+
+            with mock.patch.object(batch_mod.os, 'replace', side_effect=OSError('replace failed')):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    store.upsert_segments([self.make_segment('s2')])
+
+            persisted = segments_path.read_text(encoding='utf-8')
+            temp_files = list(store_dir.glob('*.tmp.*'))
+
+        self.assertEqual(persisted, json.dumps(original, ensure_ascii=False) + '\n')
+        self.assertEqual(temp_files, [])
+
+    def test_json_store_lock_conflict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.source_index.lock'
+            lock_path.write_text(
+                json.dumps({'operation': 'upsert_segments', 'owner': 'test-host', 'pid': 123}),
+                encoding='utf-8',
+            )
+            store = JsonSourceIndexStore(str(store_dir))
+
+            with self.assertRaisesRegex(JsonSourceIndexStoreLockError, 'test-host'):
+                store.upsert_segments([self.make_segment('s1')])
+
+            self.assertFalse((store_dir / 'source_segments.jsonl').exists())
+
+    def test_json_store_recovers_stale_lock_dead_owner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp)
+            lock_path = store_dir / '.source_index.lock'
+            lock_path.write_text(
+                json.dumps({
+                    'operation': 'upsert_segments',
+                    'owner': socket.gethostname(),
+                    'pid': 987654,
+                    'created_at': now_iso(),
+                }),
+                encoding='utf-8',
+            )
+            store = JsonSourceIndexStore(str(store_dir))
+
+            with (
+                mock.patch.object(JsonSourceIndexStore, '_is_lock_owner_alive', return_value=False),
+                mock.patch('builtins.print') as print_mock,
+            ):
+                store.upsert_segments([self.make_segment('s1')])
+
+            reloaded = JsonSourceIndexStore(str(store_dir))
+            segment_ids = reloaded.segment_ids_for_file('script.rpy')
+            warnings = '\n'.join(str(call.args[0]) for call in print_mock.call_args_list)
+
+        self.assertEqual(segment_ids, ['s1'])
+        self.assertIn('Recovered stale source store lock', warnings)
+
+    def test_collect_source_segments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tl_dir = Path(tmp) / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            rpy_path = tl_dir / 'script.rpy'
+            rpy_content = (
+                "# game/script.rpy:10\n"
+                "translate schinese start_f3396d11:\n"
+                "    # \"Hello world\"\n"
+                "    \"你好世界\"\n"
+                "\n"
+                "# game/script.rpy:15\n"
+                "translate schinese start_12345678:\n"
+                "    # \"Goodbye world\"\n"
+                "    \"再见世界\"\n"
+            )
+            rpy_path.write_text(rpy_content, encoding='utf-8')
+
+            file_jobs = [{'file_rel_path': 'script.rpy', 'file_path': str(rpy_path)}]
+            with mock.patch('gemini_translate_batch.RAG_SEGMENT_LINES', 1):
+                segments = batch_mod.collect_source_segments_for_jobs(file_jobs)
+
+            self.assertEqual(len(segments), 2)
+            self.assertEqual(segments[0]['source_text'], 'Hello world')
+            self.assertEqual(segments[1]['source_text'], 'Goodbye world')
+            self.assertEqual(segments[0]['line_start'], 4)
+            self.assertEqual(segments[0]['line_end'], 4)
+            self.assertEqual(segments[0]['line_span'], [4, 4])
+
+    def test_bootstrap_source_index_sync_and_pruning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp) / 'store'
+            tl_dir = Path(tmp) / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+
+            old_store_dir = batch_mod.SOURCE_INDEX_STORE_DIR
+            old_tl_dir = batch_mod.legacy.TL_DIR
+            try:
+                batch_mod.SOURCE_INDEX_STORE_DIR = str(store_dir)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+
+                rpy_path = tl_dir / 'script.rpy'
+                rpy_content = (
+                    "# game/script.rpy:10\n"
+                    "translate schinese start_f3396d11:\n"
+                    "    # \"Hello world\"\n"
+                    "    \"你好世界\"\n"
+                )
+                rpy_path.write_text(rpy_content, encoding='utf-8')
+
+                store = JsonSourceIndexStore(str(store_dir))
+                stale_record = self.make_segment('stale_id', file_rel_path='script.rpy', source='Old stale text', start=1, end=2)
+                unchanged_id = batch_mod.hash_key('script.rpy:4:4')
+                unchanged_record = self.make_segment(unchanged_id, file_rel_path='script.rpy', source='Hello world', start=4, end=4)
+                unchanged_record['embedding'] = [0.9, 0.9, 0.9]
+                unchanged_record['embedding_metadata']['embedding_model'] = batch_mod.RAG_EMBEDDING_MODEL
+
+                store.upsert_segments([stale_record, unchanged_record])
+
+                mock_embeddings = [[0.9, 0.9, 0.9]]
+                with (
+                    mock.patch('gemini_translate_batch.embed_texts', return_value=mock_embeddings) as embed_mock,
+                    mock.patch('gemini_translate_batch.all_rag_file_jobs', return_value=[{'file_rel_path': 'script.rpy', 'file_path': str(rpy_path)}]),
+                    mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+                    mock.patch('gemini_translate_batch.RAG_SEGMENT_LINES', 1),
+                ):
+                    summary = batch_mod.bootstrap_source_index(skip_prepare=True, prune=True)
+
+                embed_mock.assert_not_called()
+                self.assertEqual(summary['scanned'], 1)
+                self.assertEqual(summary['reused_embeddings'], 1)
+                self.assertEqual(summary['embedding_pending'], 0)
+                self.assertEqual(summary['stale_count'], 1)
+                self.assertEqual(summary['pruned'], 1)
+
+                reloaded = JsonSourceIndexStore(str(store_dir))
+                reloaded.load()
+                self.assertEqual(reloaded.count_segments(), 1)
+                self.assertIn(unchanged_id, reloaded.segments)
+                self.assertNotIn('stale_id', reloaded.segments)
+            finally:
+                batch_mod.SOURCE_INDEX_STORE_DIR = old_store_dir
+                batch_mod.legacy.TL_DIR = old_tl_dir
+
+    def test_bootstrap_source_index_reembeds_when_embedding_metadata_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp) / 'store'
+            tl_dir = Path(tmp) / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+
+            old_store_dir = batch_mod.SOURCE_INDEX_STORE_DIR
+            old_tl_dir = batch_mod.legacy.TL_DIR
+            try:
+                batch_mod.SOURCE_INDEX_STORE_DIR = str(store_dir)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+
+                rpy_path = tl_dir / 'script.rpy'
+                rpy_content = (
+                    "# game/script.rpy:10\n"
+                    "translate schinese start_f3396d11:\n"
+                    "    # \"Hello world\"\n"
+                    "    \"你好世界\"\n"
+                )
+                rpy_path.write_text(rpy_content, encoding='utf-8')
+
+                source_id = batch_mod.hash_key('script.rpy:4:4')
+                outdated_record = self.make_segment(source_id, file_rel_path='script.rpy', source='Hello world', start=4, end=4)
+                outdated_record['embedding'] = [0.4, 0.4]
+                outdated_record['embedding_metadata']['embedding_dim'] = 2
+                outdated_record['embedding_metadata']['embedding_task_type'] = 'SEMANTIC_SIMILARITY'
+                JsonSourceIndexStore(str(store_dir)).upsert_segments([outdated_record])
+
+                mock_embeddings = [[0.8, 0.8, 0.8]]
+                with (
+                    mock.patch('gemini_translate_batch.embed_texts', return_value=mock_embeddings) as embed_mock,
+                    mock.patch('gemini_translate_batch.all_rag_file_jobs', return_value=[{'file_rel_path': 'script.rpy', 'file_path': str(rpy_path)}]),
+                    mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+                    mock.patch('gemini_translate_batch.RAG_SEGMENT_LINES', 1),
+                ):
+                    summary = batch_mod.bootstrap_source_index(skip_prepare=True, prune=True)
+
+                embed_mock.assert_called_once()
+                self.assertEqual(summary['reused_embeddings'], 0)
+                self.assertEqual(summary['embedding_pending'], 1)
+                self.assertEqual(summary['embedded'], 1)
+
+                reloaded = JsonSourceIndexStore(str(store_dir))
+                reloaded.load()
+                updated = reloaded.get_segment(source_id)
+                self.assertEqual(updated['embedding'], mock_embeddings[0])
+                self.assertEqual(updated['embedding_metadata']['embedding_dim'], 3)
+                self.assertEqual(updated['embedding_metadata']['embedding_task_type'], batch_mod.RAG_DOCUMENT_TASK_TYPE)
+            finally:
+                batch_mod.SOURCE_INDEX_STORE_DIR = old_store_dir
+                batch_mod.legacy.TL_DIR = old_tl_dir
+
+    def test_bootstrap_source_index_without_pruning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = Path(tmp) / 'store'
+            tl_dir = Path(tmp) / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+
+            old_store_dir = batch_mod.SOURCE_INDEX_STORE_DIR
+            old_tl_dir = batch_mod.legacy.TL_DIR
+            try:
+                batch_mod.SOURCE_INDEX_STORE_DIR = str(store_dir)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+
+                rpy_path = tl_dir / 'script.rpy'
+                rpy_content = (
+                    "# game/script.rpy:10\n"
+                    "translate schinese start_f3396d11:\n"
+                    "    # \"Hello world\"\n"
+                    "    \"你好世界\"\n"
+                )
+                rpy_path.write_text(rpy_content, encoding='utf-8')
+
+                store = JsonSourceIndexStore(str(store_dir))
+                stale_record = self.make_segment('stale_id', file_rel_path='script.rpy', source='Old stale text', start=1, end=2)
+                store.upsert_segments([stale_record])
+
+                mock_embeddings = [[0.1, 0.2, 0.3]]
+                with (
+                    mock.patch('gemini_translate_batch.embed_texts', return_value=mock_embeddings),
+                    mock.patch('gemini_translate_batch.all_rag_file_jobs', return_value=[{'file_rel_path': 'script.rpy', 'file_path': str(rpy_path)}]),
+                    mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+                    mock.patch('gemini_translate_batch.RAG_SEGMENT_LINES', 1),
+                ):
+                    summary = batch_mod.bootstrap_source_index(skip_prepare=True, prune=False)
+
+                self.assertEqual(summary['stale_count'], 1)
+                self.assertEqual(summary['pruned'], 0)
+
+                reloaded = JsonSourceIndexStore(str(store_dir))
+                reloaded.load()
+                self.assertEqual(reloaded.count_segments(), 2)
+                self.assertIn('stale_id', reloaded.segments)
+            finally:
+                batch_mod.SOURCE_INDEX_STORE_DIR = old_store_dir
+                batch_mod.legacy.TL_DIR = old_tl_dir
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a standalone source-only index store backed by `source_segments.jsonl` and `source_metadata.json`, separate from the translation-memory history store.
- Add `bootstrap-source-index` to scan TL source entries into stable source segments, reuse current embeddings, report stale segments, and optionally prune stale records.
- Tighten embedding reuse so source index records only reuse vectors when checksum, model, task type, dimensionality, and embedding text checksum all match.
- Document the first-stage source index bootstrap flow and add source index store/bootstrap regression tests.

Refs #36

## Validation

- python -m unittest -q tests.test_source_index
- python -m unittest discover -s tests -p "test_*.py" -q
- python -m py_compile gemini_translate_batch.py rag_memory.py
- python gemini_translate_batch.py bootstrap-source-index --help
- git diff --cached --check
