### PR TITLE
[codex] Inject source index context into batch prompts

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -557,12 +557,13 @@ def get_default_source_index_store_dir():
     return os.path.join(LOG_DIR, 'source_index_store', guess_project_slug())
 
 
-def get_source_index_store():
+def get_source_index_store(update_metadata=True):
     global _SOURCE_INDEX_STORE, SOURCE_INDEX_STORE_DIR
     if not SOURCE_INDEX_STORE_DIR:
         SOURCE_INDEX_STORE_DIR = get_default_source_index_store_dir()
     if _SOURCE_INDEX_STORE is None or os.path.abspath(_SOURCE_INDEX_STORE.store_dir) != os.path.abspath(SOURCE_INDEX_STORE_DIR):
         _SOURCE_INDEX_STORE = JsonSourceIndexStore(SOURCE_INDEX_STORE_DIR)
+    if update_metadata:
         _SOURCE_INDEX_STORE.set_metadata(
             project_slug=guess_project_slug(),
             embedding_model=RAG_EMBEDDING_MODEL,
@@ -775,15 +776,15 @@ def retrieve_history_hits(target_items, context_past):
 def retrieve_source_hits(target_items, context_past):
     if not SOURCE_INDEX_ENABLED:
         return [], {'enabled': False}
-    store = get_source_index_store()
-    if store is None or store.count_segments() <= 0:
-        return [], {'enabled': True, 'reason': 'empty_source_store'}
 
     query_text = build_rag_query_text(target_items, context_past)
     if not query_text:
         return [], {'enabled': True, 'reason': 'empty_query'}
 
     try:
+        store = get_source_index_store(update_metadata=False)
+        if store is None or store.count_segments() <= 0:
+            return [], {'enabled': True, 'reason': 'empty_source_store'}
         query_vector = embed_query_text(query_text)
         matches = store.search_segments(
             query_vector,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -134,6 +134,9 @@ _RAG_PRESERVED_TERMS_CACHE_KEY = None
 SOURCE_INDEX_ENABLED = False
 SOURCE_INDEX_STORE_DIR = ''
 _SOURCE_INDEX_STORE = None
+SOURCE_INDEX_TOP_K = 4
+SOURCE_INDEX_MIN_SIMILARITY = 0.72
+SOURCE_INDEX_CHAR_LIMIT = 220
 
 STORY_MEMORY_ENABLED = False
 STORY_MEMORY_GRAPH_FILE = ''
@@ -217,6 +220,7 @@ def load_batch_settings():
     global RAG_TOP_K_TERMS, RAG_MIN_SIMILARITY, RAG_SEGMENT_LINES
     global RAG_BOOTSTRAP_ON_BUILD, RAG_HISTORY_CHAR_LIMIT, _RAG_STORE
     global SOURCE_INDEX_ENABLED, SOURCE_INDEX_STORE_DIR, _SOURCE_INDEX_STORE
+    global SOURCE_INDEX_TOP_K, SOURCE_INDEX_MIN_SIMILARITY, SOURCE_INDEX_CHAR_LIMIT
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
@@ -353,6 +357,9 @@ def load_batch_settings():
         source_index_config = {}
 
     SOURCE_INDEX_ENABLED = coerce_bool(source_index_config.get('enabled'), SOURCE_INDEX_ENABLED)
+    SOURCE_INDEX_TOP_K = coerce_positive_int(source_index_config.get('top_k'), SOURCE_INDEX_TOP_K)
+    SOURCE_INDEX_MIN_SIMILARITY = coerce_float(source_index_config.get('min_similarity'), SOURCE_INDEX_MIN_SIMILARITY)
+    SOURCE_INDEX_CHAR_LIMIT = coerce_positive_int(source_index_config.get('char_limit'), SOURCE_INDEX_CHAR_LIMIT)
     source_index_store_dir = source_index_config.get('store_dir')
     if source_index_store_dir:
         SOURCE_INDEX_STORE_DIR = legacy._resolve_path(legacy.BASE_DIR, source_index_store_dir)
@@ -757,6 +764,51 @@ def retrieve_history_hits(target_items, context_past):
                 'score': float(match.get('score', 0.0)),
             }
         )
+
+    return hits, {
+        'enabled': True,
+        'query_text': truncate_text(query_text, 400),
+        'hit_count': len(hits),
+    }
+
+
+def retrieve_source_hits(target_items, context_past):
+    if not SOURCE_INDEX_ENABLED:
+        return [], {'enabled': False}
+    store = get_source_index_store()
+    if store is None or store.count_segments() <= 0:
+        return [], {'enabled': True, 'reason': 'empty_source_store'}
+
+    query_text = build_rag_query_text(target_items, context_past)
+    if not query_text:
+        return [], {'enabled': True, 'reason': 'empty_query'}
+
+    try:
+        query_vector = embed_query_text(query_text)
+        matches = store.search_segments(
+            query_vector,
+            top_k=SOURCE_INDEX_TOP_K,
+            min_similarity=SOURCE_INDEX_MIN_SIMILARITY,
+            embedding_model=RAG_EMBEDDING_MODEL,
+            embedding_task_type=RAG_DOCUMENT_TASK_TYPE,
+            embedding_dim=RAG_OUTPUT_DIMENSIONALITY,
+        )
+    except Exception as exc:
+        print(f'Warning: Source index retrieval failed: {exc}')
+        return [], {'enabled': True, 'error': str(exc)}
+
+    hits = []
+    for match in matches:
+        source_text = match.get('source_text', '')
+        hit = {
+            'source_id': match.get('source_id', ''),
+            'file_rel_path': match.get('file_rel_path', ''),
+            'line_start': match.get('line_start', 0),
+            'line_end': match.get('line_end', 0),
+            'source_text': truncate_text(source_text, SOURCE_INDEX_CHAR_LIMIT),
+            'score': float(match.get('score', 0.0)),
+        }
+        hits.append(hit)
 
     return hits, {
         'enabled': True,
@@ -1456,6 +1508,7 @@ def build_user_prompt(
     glossary_hits=None,
     history_hits=None,
     story_hits=None,
+    source_hits=None,
 ):
     return translation_core.build_translation_user_prompt(
         translation_core.ContextWindow(context_past, context_future),
@@ -1464,6 +1517,7 @@ def build_user_prompt(
             glossary_hits=glossary_hits,
             history_hits=history_hits,
             story_hits=story_hits,
+            source_hits=source_hits,
         ),
         history_char_limit=RAG_HISTORY_CHAR_LIMIT,
         story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
@@ -1511,6 +1565,7 @@ def build_batch_request(chunk):
                                 glossary_hits=chunk.get('glossary_hits') or [],
                                 history_hits=chunk.get('history_hits') or [],
                                 story_hits=chunk.get('story_hits') if 'story_hits' in chunk else None,
+                                source_hits=chunk.get('source_hits') or [],
                             )
                         }
                     ],
@@ -1562,6 +1617,7 @@ def build_chunks(file_jobs):
             context_future = tasks[end:min(total, end + BATCH_CONTEXT_AFTER)]
             glossary_hits = retrieve_glossary_hits(target_items) if RAG_ENABLED else []
             history_hits, rag_stats = retrieve_history_hits(target_items, context_past) if RAG_ENABLED else ([], {})
+            source_hits, source_index_stats = retrieve_source_hits(target_items, context_past) if SOURCE_INDEX_ENABLED else ([], {})
             story_hits = retrieve_batch_story_hits(
                 job['file_rel_path'],
                 target_items,
@@ -1582,6 +1638,8 @@ def build_chunks(file_jobs):
                 'glossary_hits': glossary_hits,
                 'history_hits': history_hits,
                 'rag_stats': rag_stats,
+                'source_hits': source_hits,
+                'source_index_stats': source_index_stats,
                 'items': [
                     translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
                     for unit in target_units
@@ -1606,6 +1664,23 @@ def summarize_batch_rag(chunks, prepare_summary):
         'history_retrieval_errors': sum(
             1 for chunk in chunks
             if (chunk.get('rag_stats') or {}).get('error')
+        ),
+    }
+
+
+def summarize_batch_source_index(chunks):
+    chunk_count = len(chunks)
+    chunks_with_source_hits = sum(1 for chunk in chunks if chunk.get('source_hits'))
+    source_hit_count = sum(len(chunk.get('source_hits') or []) for chunk in chunks)
+    return {
+        'enabled': SOURCE_INDEX_ENABLED,
+        'store_dir': SOURCE_INDEX_STORE_DIR or get_default_source_index_store_dir(),
+        'chunks_with_source_hits': chunks_with_source_hits,
+        'source_hit_count': source_hit_count,
+        'source_hit_rate': (chunks_with_source_hits / chunk_count) if chunk_count else 0.0,
+        'source_retrieval_errors': sum(
+            1 for chunk in chunks
+            if (chunk.get('source_index_stats') or {}).get('error')
         ),
     }
 
@@ -1742,6 +1817,14 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             'bootstrap_on_build': RAG_BOOTSTRAP_ON_BUILD,
         } if RAG_ENABLED else {},
         'rag_summary': summarize_batch_rag(chunks, rag_prepare_summary) if RAG_ENABLED else {},
+        'source_index_enabled': SOURCE_INDEX_ENABLED,
+        'source_index_store_path': SOURCE_INDEX_STORE_DIR if SOURCE_INDEX_ENABLED else '',
+        'source_index_settings': {
+            'top_k': SOURCE_INDEX_TOP_K,
+            'min_similarity': SOURCE_INDEX_MIN_SIMILARITY,
+            'char_limit': SOURCE_INDEX_CHAR_LIMIT,
+        } if SOURCE_INDEX_ENABLED else {},
+        'source_index_summary': summarize_batch_source_index(chunks) if SOURCE_INDEX_ENABLED else {},
         'story_memory_enabled': STORY_MEMORY_ENABLED,
         'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
         'story_memory_settings': {
@@ -5538,6 +5621,7 @@ def build_repair_request(job):
                                 job['items'],
                                 job['context_future'],
                                 story_hits=job.get('story_hits') if 'story_hits' in job else None,
+                                source_hits=job.get('source_hits') or [],
                             )
                         }
                     ],

--- a/prompt_context.py
+++ b/prompt_context.py
@@ -46,12 +46,28 @@ def format_history_hits_block(
     return "\n".join(lines) if lines else empty_label
 
 
+def format_source_hits_block(hits, empty_label="(none)"):
+    if not hits:
+        return empty_label
+    lines = []
+    for hit in hits:
+        file_rel_path = hit.get("file_rel_path", "")
+        line_start = hit.get("line_start", "")
+        line_end = hit.get("line_end", "")
+        score = float(hit.get("score", 0.0))
+        source_text = hit.get("source_text", "")
+        prefix = f"- [{file_rel_path}:{line_start}-{line_end} score={score:.3f}]"
+        lines.append(f"{prefix} Source excerpt: {source_text}")
+    return "\n".join(lines) if lines else empty_label
+
+
 def build_reference_blocks(
     *,
     include_translation_memory=True,
     glossary_hits=None,
     history_hits=None,
     story_hits=None,
+    source_hits=None,
     history_char_limit=220,
     story_char_limit=1200,
     include_source_text=True,
@@ -65,6 +81,11 @@ def build_reference_blocks(
             f"{format_glossary_hits_block(glossary_hits or [], empty_label)}\n\n"
             "RETRIEVED MEMORY:\n"
             f"{format_history_hits_block(history_hits or [], empty_label, history_char_limit, include_source_text)}\n\n"
+        )
+    if source_hits:
+        blocks.append(
+            "RELATED PROJECT CONTEXT:\n"
+            f"{format_source_hits_block(source_hits, empty_label)}\n\n"
         )
     if story_memory.has_story_hits(story_hits):
         blocks.append(

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -930,13 +930,29 @@ class JsonSourceIndexStore(object):
         self.load()
         return list(self.file_index.get(file_rel_path, set()))
 
-    def search_segments(self, query_vector, top_k=4, min_similarity=0.72):
+    def search_segments(
+        self,
+        query_vector,
+        top_k=4,
+        min_similarity=0.72,
+        embedding_model=None,
+        embedding_task_type=None,
+        embedding_dim=None,
+    ):
         self.load()
         results = []
         for record in self.segments.values():
             vector = record.get('embedding')
             if not isinstance(vector, list) or not vector:
                 continue
+            metadata = record.get('embedding_metadata') or {}
+            if embedding_model is not None and metadata.get('embedding_model') != embedding_model:
+                continue
+            if embedding_task_type is not None and metadata.get('embedding_task_type') != embedding_task_type:
+                continue
+            if embedding_dim is not None:
+                if metadata.get('embedding_dim') != embedding_dim or len(vector) != embedding_dim:
+                    continue
             score = cosine_similarity(query_vector, vector)
             if score < min_similarity:
                 continue

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -411,6 +411,34 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertTrue(stats['enabled'])
             self.assertEqual([hit['source_id'] for hit in hits], ['current'])
 
+    def test_retrieve_source_hits_degrades_when_source_store_is_locked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_store_dir = tmp_path / 'source_store'
+            source_store_dir.mkdir()
+            lock_path = source_store_dir / '.source_index.lock'
+            lock_path.write_text(
+                json.dumps({
+                    'operation': 'bootstrap_source_index',
+                    'owner': socket.gethostname(),
+                    'pid': os.getpid(),
+                    'created_at': now_iso(),
+                }),
+                encoding='utf-8',
+            )
+
+            batch_mod.SOURCE_INDEX_ENABLED = True
+            batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+            batch_mod._SOURCE_INDEX_STORE = None
+            batch_mod.SOURCE_INDEX_TOP_K = 5
+            batch_mod.SOURCE_INDEX_MIN_SIMILARITY = 0.0
+
+            hits, stats = batch_mod.retrieve_source_hits([{'text': 'Hello world'}], [])
+
+            self.assertEqual(hits, [])
+            self.assertTrue(stats['enabled'])
+            self.assertEqual(stats['reason'], 'empty_source_store')
+
     def test_format_source_hits_block_and_prompt_injection(self):
         hits = [
             {
@@ -467,11 +495,13 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             old_tl_dir = batch_mod.legacy.TL_DIR
             old_base_dir = batch_mod.legacy.BASE_DIR
             old_jobs_dir = batch_mod.BATCH_JOBS_DIR
+            old_latest_manifest_file = batch_mod.LATEST_MANIFEST_FILE
 
             try:
                 batch_mod.legacy.TL_DIR = str(tl_dir)
                 batch_mod.legacy.BASE_DIR = str(tmp_path)
                 batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+                batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
 
                 batch_mod.SOURCE_INDEX_ENABLED = True
                 source_store_dir = tmp_path / 'source_store'
@@ -540,6 +570,7 @@ class SourceIndexIntegrationTests(unittest.TestCase):
                 batch_mod.legacy.TL_DIR = old_tl_dir
                 batch_mod.legacy.BASE_DIR = old_base_dir
                 batch_mod.BATCH_JOBS_DIR = old_jobs_dir
+                batch_mod.LATEST_MANIFEST_FILE = old_latest_manifest_file
 
 
 if __name__ == '__main__':

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
+import prompt_context
 from rag_memory import JsonSourceIndexStore, JsonSourceIndexStoreLockError, now_iso
 
 
@@ -301,6 +302,244 @@ class SourceIndexStoreTests(unittest.TestCase):
             finally:
                 batch_mod.SOURCE_INDEX_STORE_DIR = old_store_dir
                 batch_mod.legacy.TL_DIR = old_tl_dir
+
+
+class SourceIndexIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.old_source_index_enabled = batch_mod.SOURCE_INDEX_ENABLED
+        self.old_source_index_store_dir = batch_mod.SOURCE_INDEX_STORE_DIR
+        self.old_source_index_store = batch_mod._SOURCE_INDEX_STORE
+        self.old_rag_store_dir = batch_mod.RAG_STORE_DIR
+        self.old_source_index_top_k = batch_mod.SOURCE_INDEX_TOP_K
+        self.old_source_index_min_similarity = batch_mod.SOURCE_INDEX_MIN_SIMILARITY
+        self.old_source_index_char_limit = batch_mod.SOURCE_INDEX_CHAR_LIMIT
+
+    def tearDown(self):
+        batch_mod.SOURCE_INDEX_ENABLED = self.old_source_index_enabled
+        batch_mod.SOURCE_INDEX_STORE_DIR = self.old_source_index_store_dir
+        batch_mod._SOURCE_INDEX_STORE = self.old_source_index_store
+        batch_mod.RAG_STORE_DIR = self.old_rag_store_dir
+        batch_mod.SOURCE_INDEX_TOP_K = self.old_source_index_top_k
+        batch_mod.SOURCE_INDEX_MIN_SIMILARITY = self.old_source_index_min_similarity
+        batch_mod.SOURCE_INDEX_CHAR_LIMIT = self.old_source_index_char_limit
+
+    def make_segment(self, source_id, file_rel_path='script.rpy', source='Hello', start=10, end=13, embedding=None):
+        return {
+            'source_id': source_id,
+            'file_rel_path': file_rel_path,
+            'line_start': start,
+            'line_end': end,
+            'line_span': [start, end],
+            'source_text': source,
+            'source_checksum': batch_mod.hash_text(source),
+            'embedding': embedding or [1.0, 0.0, 0.0],
+            'embedding_metadata': {
+                'embedding_model': 'gemini-embedding-001',
+                'embedding_task_type': 'RETRIEVAL_DOCUMENT',
+                'embedding_dim': 3,
+                'embedding_text_checksum': batch_mod.hash_text(source),
+            },
+            'created_at': '2026-06-14T09:00:00',
+            'updated_at': '2026-06-14T09:00:00',
+        }
+
+    def test_retrieve_source_hits_enabled_and_lookup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_store_dir = tmp_path / 'source_store'
+            unused_rag_store_dir = tmp_path / 'unused_rag_store'
+            source_store_dir.mkdir()
+
+            batch_mod.SOURCE_INDEX_ENABLED = True
+            batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+            batch_mod._SOURCE_INDEX_STORE = None
+            batch_mod.RAG_STORE_DIR = str(unused_rag_store_dir)
+            batch_mod.SOURCE_INDEX_TOP_K = 2
+            batch_mod.SOURCE_INDEX_MIN_SIMILARITY = 0.5
+            batch_mod.SOURCE_INDEX_CHAR_LIMIT = 50
+
+            store = JsonSourceIndexStore(str(source_store_dir))
+            seg1 = self.make_segment('s1', source='Good morning everyone', embedding=[1.0, 0.0, 0.0])
+            seg2 = self.make_segment('s2', source='See you tomorrow', embedding=[0.0, 1.0, 0.0])
+            store.upsert_segments([seg1, seg2])
+
+            target_items = [{'text': 'Good morning'}]
+            context_past = []
+
+            with (
+                mock.patch('gemini_translate_batch.embed_query_text', return_value=[1.0, 0.0, 0.0]) as mock_embed,
+                mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+            ):
+                hits, stats = batch_mod.retrieve_source_hits(target_items, context_past)
+
+            self.assertTrue(stats['enabled'])
+            self.assertEqual(stats['hit_count'], 1)
+            self.assertEqual(len(hits), 1)
+
+            mock_embed.assert_called_once()
+            hit = hits[0]
+            self.assertEqual(hit['source_id'], 's1')
+            self.assertEqual(hit['source_text'], 'Good morning everyone')
+            self.assertNotIn('translated_text', hit)
+            self.assertAlmostEqual(hit['score'], 1.0)
+            self.assertFalse(unused_rag_store_dir.exists())
+
+    def test_retrieve_source_hits_filters_stale_embedding_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_store_dir = tmp_path / 'source_store'
+            source_store_dir.mkdir()
+
+            batch_mod.SOURCE_INDEX_ENABLED = True
+            batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+            batch_mod._SOURCE_INDEX_STORE = None
+            batch_mod.SOURCE_INDEX_TOP_K = 5
+            batch_mod.SOURCE_INDEX_MIN_SIMILARITY = 0.0
+            batch_mod.SOURCE_INDEX_CHAR_LIMIT = 50
+
+            stale = self.make_segment('stale', source='Stale source', embedding=[1.0, 0.0, 0.0])
+            stale['embedding_metadata']['embedding_task_type'] = 'SEMANTIC_SIMILARITY'
+            current = self.make_segment('current', source='Current source', embedding=[0.9, 0.1, 0.0])
+            JsonSourceIndexStore(str(source_store_dir)).upsert_segments([stale, current])
+
+            with (
+                mock.patch('gemini_translate_batch.embed_query_text', return_value=[1.0, 0.0, 0.0]),
+                mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+            ):
+                hits, stats = batch_mod.retrieve_source_hits([{'text': 'source'}], [])
+
+            self.assertTrue(stats['enabled'])
+            self.assertEqual([hit['source_id'] for hit in hits], ['current'])
+
+    def test_format_source_hits_block_and_prompt_injection(self):
+        hits = [
+            {
+                'source_id': 's1',
+                'file_rel_path': 'script.rpy',
+                'line_start': 10,
+                'line_end': 12,
+                'source_text': 'Hello world',
+                'translated_text': '你好世界',
+                'score': 0.95,
+            },
+            {
+                'source_id': 's2',
+                'file_rel_path': 'other.rpy',
+                'line_start': 5,
+                'line_end': 5,
+                'source_text': 'Untranslated text',
+                'score': 0.82,
+            }
+        ]
+
+        formatted = prompt_context.format_source_hits_block(hits)
+        expected_line1 = "- [script.rpy:10-12 score=0.950] Source excerpt: Hello world"
+        expected_line2 = "- [other.rpy:5-5 score=0.820] Source excerpt: Untranslated text"
+        self.assertIn(expected_line1, formatted)
+        self.assertIn(expected_line2, formatted)
+        self.assertNotIn('你好世界', formatted)
+        self.assertNotIn('Translation:', formatted)
+        self.assertNotIn('(untranslated)', formatted)
+
+        ref_blocks = prompt_context.build_reference_blocks(source_hits=hits)
+        self.assertIn('RELATED PROJECT CONTEXT:', ref_blocks)
+        self.assertIn(expected_line1, ref_blocks)
+        self.assertIn(expected_line2, ref_blocks)
+
+    def test_create_batch_package_source_index_integration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            tl_dir = tmp_path / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            rpy_path = tl_dir / 'script.rpy'
+            rpy_path.write_text(
+                "# game/script.rpy:10\n"
+                "translate schinese start_f3396d11:\n"
+                "    # \"Hello world\"\n"
+                "    \"你好世界\"\n",
+                encoding='utf-8',
+            )
+
+            jobs_dir = tmp_path / 'jobs'
+            jobs_dir.mkdir()
+
+            old_tl_dir = batch_mod.legacy.TL_DIR
+            old_base_dir = batch_mod.legacy.BASE_DIR
+            old_jobs_dir = batch_mod.BATCH_JOBS_DIR
+
+            try:
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.BASE_DIR = str(tmp_path)
+                batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+
+                batch_mod.SOURCE_INDEX_ENABLED = True
+                source_store_dir = tmp_path / 'source_store'
+                source_store_dir.mkdir()
+                batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+                batch_mod._SOURCE_INDEX_STORE = None
+
+                store = JsonSourceIndexStore(str(source_store_dir))
+                seg = self.make_segment('s1', source='Hello world', embedding=[1.0, 0.0, 0.0])
+                store.upsert_segments([seg])
+
+                # Mock pending file jobs so we bypass the file scanner
+                mock_jobs = [
+                    {
+                        'file_rel_path': 'script.rpy',
+                        'file_path': str(rpy_path),
+                        'task_count': 1,
+                        'tasks': [
+                            {
+                                'id': 'script.rpy:4:0',
+                                'text': 'Hello world',
+                                'line': 4,
+                                'start': 0,
+                                'end': 11,
+                                'speaker_id': 'n',
+                                'speaker_name': 'Noah',
+                                'progress_entry': 'task:4:0',
+                            }
+                        ]
+                    }
+                ]
+
+                with (
+                    mock.patch('gemini_translate_batch.collect_pending_file_jobs', return_value=mock_jobs),
+                    mock.patch('gemini_translate_batch.embed_query_text', return_value=[1.0, 0.0, 0.0]),
+                    mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+                    mock.patch('gemini_translate_batch.legacy.run_prepare_steps'),
+                ):
+                    manifest_path = batch_mod.create_batch_package(skip_prepare=True)
+
+                self.assertIsNotNone(manifest_path)
+                self.assertTrue(os.path.exists(manifest_path))
+
+                with open(manifest_path, 'r', encoding='utf-8') as f:
+                    manifest_data = json.load(f)
+
+                self.assertTrue(manifest_data.get('source_index_enabled'))
+                self.assertEqual(manifest_data['source_index_settings']['top_k'], batch_mod.SOURCE_INDEX_TOP_K)
+                self.assertIn('source_index_summary', manifest_data)
+
+                summary = manifest_data['source_index_summary']
+                self.assertEqual(summary['chunks_with_source_hits'], 1)
+                self.assertEqual(summary['source_hit_count'], 1)
+
+                requests_path = os.path.join(os.path.dirname(manifest_path), 'requests.jsonl')
+                self.assertTrue(os.path.exists(requests_path))
+                with open(requests_path, 'r', encoding='utf-8') as f:
+                    request_line = json.loads(f.readline())
+
+                user_prompt = request_line['request']['contents'][0]['parts'][0]['text']
+                self.assertIn('RELATED PROJECT CONTEXT:', user_prompt)
+                self.assertIn('Source excerpt: Hello world', user_prompt)
+                self.assertNotIn('Hello world -> (untranslated)', user_prompt)
+
+            finally:
+                batch_mod.legacy.TL_DIR = old_tl_dir
+                batch_mod.legacy.BASE_DIR = old_base_dir
+                batch_mod.BATCH_JOBS_DIR = old_jobs_dir
 
 
 if __name__ == '__main__':

--- a/translation_core.py
+++ b/translation_core.py
@@ -82,6 +82,7 @@ class ContextBundle:
     history_hits: list = field(default_factory=list)
     story_hits: object = None
     rag_stats: dict = field(default_factory=dict)
+    source_hits: list = field(default_factory=list)
 
 
 @dataclass
@@ -424,12 +425,13 @@ def format_revision_context_block(items, empty_label='(none)'):
     return '\n'.join(lines) if lines else empty_label
 
 
-def build_context_bundle(glossary_hits=None, history_hits=None, story_hits=None, rag_stats=None):
+def build_context_bundle(glossary_hits=None, history_hits=None, story_hits=None, rag_stats=None, source_hits=None):
     return ContextBundle(
         glossary_hits=list(glossary_hits or []),
         history_hits=list(history_hits or []),
         story_hits=story_hits,
         rag_stats=dict(rag_stats or {}),
+        source_hits=list(source_hits or []),
     )
 
 
@@ -447,6 +449,7 @@ def build_reference_blocks(
         glossary_hits=context_bundle.glossary_hits,
         history_hits=context_bundle.history_hits,
         story_hits=context_bundle.story_hits,
+        source_hits=context_bundle.source_hits,
         history_char_limit=history_char_limit,
         story_char_limit=story_char_limit,
         include_source_text=include_source_text,


### PR DESCRIPTION
## Summary

Refs #36.

This PR wires the source-only index into batch prompt construction as a follow-up to the source index store/bootstrap work. It keeps the new source context separate from translation memory so project-wide source excerpts can inform long-distance context without being treated as prior translations.

## Changes

- Add source index retrieval during batch chunk construction and pass `source_hits` through prompt building.
- Render source index hits under `RELATED PROJECT CONTEXT` as source-only excerpts.
- Keep source retrieval independent from the RAG translation history store.
- Filter source segment retrieval by the active embedding model, task type, and output dimensionality to avoid stale embeddings.
- Add source index integration and regression tests for prompt injection, source-only boundaries, and stale metadata filtering.

## Validation

- `python -m unittest -q tests.test_source_index`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python -m py_compile gemini_translate_batch.py prompt_context.py translation_core.py rag_memory.py`
- `git diff --check origin/main`

## Notes

This intentionally uses `Refs #36` rather than `Closes #36` because the remaining #36 scope still includes fuller diagnostics/documentation items such as truncation counts, character budget reporting, store schema version reporting, and more detailed failure/stale-hit diagnostics.