### PR TITLE
[codex] Complete source index diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,38 @@ python gemini_translate_batch.py bootstrap-source-index
 3. 优先输出详细的同步前统计信息（stats）。
 4. 默认会自动清理/Prune 过期的 stale 记录；如需保留，可传入 `--no-prune`。
 
+Batch 构建时是否检索 source index 由 `batch.source_index.enabled` 控制。当前 source index 复用 `batch.rag` 中的 embedding 模型、query/document task type、output dimensionality 和 `segment_lines`；`batch.source_index` 自身控制检索开关、命中数、相似度阈值、单条原文截断预算和独立存储目录：
+
+```json
+{
+  "batch": {
+    "rag": {
+      "embedding_model": "gemini-embedding-001",
+      "query_task_type": "RETRIEVAL_QUERY",
+      "document_task_type": "RETRIEVAL_DOCUMENT",
+      "output_dimensionality": 768,
+      "segment_lines": 4
+    },
+    "source_index": {
+      "enabled": true,
+      "top_k": 4,
+      "min_similarity": 0.72,
+      "char_limit": 220,
+      "store_dir": ""
+    }
+  }
+}
+```
+
+启用后，普通 Batch manifest 会写入：
+
+- `source_index_store_path`：实际使用的 source-only store 路径。
+- `source_index_settings`：schema version、`top_k`、`min_similarity`、`char_limit` 和每个 chunk 的字符预算。
+- `source_index_summary`：命中 chunk 数、source hit 数、命中率、截断次数、实际注入字符数、字符预算、metadata/stale 过滤数、相似度过滤数、检索失败数和失败原因。
+- 每个 chunk 的 `source_index_stats`：查询字符数、命中数、metadata 过滤明细、截断数、store schema version 和 store 路径。
+
+Prompt 中 source index 命中会进入独立的 `RELATED PROJECT CONTEXT` 分区，只包含 `Source excerpt`，不会混入 `RETRIEVED MEMORY`，也不会携带译文。`batch.source_index.enabled=false` 时不会读取 source store，也不会增加该 prompt 分区。
+
 
 ### 可选：Structured Story Memory
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -134,6 +134,7 @@ _RAG_PRESERVED_TERMS_CACHE_KEY = None
 SOURCE_INDEX_ENABLED = False
 SOURCE_INDEX_STORE_DIR = ''
 _SOURCE_INDEX_STORE = None
+SOURCE_INDEX_SCHEMA_VERSION = 1
 SOURCE_INDEX_TOP_K = 4
 SOURCE_INDEX_MIN_SIMILARITY = 0.72
 SOURCE_INDEX_CHAR_LIMIT = 220
@@ -557,6 +558,10 @@ def get_default_source_index_store_dir():
     return os.path.join(LOG_DIR, 'source_index_store', guess_project_slug())
 
 
+def get_source_index_char_budget():
+    return max(0, int(SOURCE_INDEX_TOP_K or 0)) * max(0, int(SOURCE_INDEX_CHAR_LIMIT or 0))
+
+
 def get_source_index_store(update_metadata=True):
     global _SOURCE_INDEX_STORE, SOURCE_INDEX_STORE_DIR
     if not SOURCE_INDEX_STORE_DIR:
@@ -565,6 +570,7 @@ def get_source_index_store(update_metadata=True):
         _SOURCE_INDEX_STORE = JsonSourceIndexStore(SOURCE_INDEX_STORE_DIR)
     if update_metadata:
         _SOURCE_INDEX_STORE.set_metadata(
+            schema_version=SOURCE_INDEX_SCHEMA_VERSION,
             project_slug=guess_project_slug(),
             embedding_model=RAG_EMBEDDING_MODEL,
             document_task_type=RAG_DOCUMENT_TASK_TYPE,
@@ -779,34 +785,58 @@ def retrieve_source_hits(target_items, context_past):
 
     query_text = build_rag_query_text(target_items, context_past)
     if not query_text:
-        return [], {'enabled': True, 'reason': 'empty_query'}
+        return [], {
+            'enabled': True,
+            'reason': 'empty_query',
+            'source_context_char_budget': get_source_index_char_budget(),
+        }
 
     try:
         store = get_source_index_store(update_metadata=False)
         if store is None or store.count_segments() <= 0:
-            return [], {'enabled': True, 'reason': 'empty_source_store'}
+            return [], {
+                'enabled': True,
+                'reason': 'empty_source_store',
+                'source_context_char_budget': get_source_index_char_budget(),
+                'store_dir': getattr(store, 'store_dir', SOURCE_INDEX_STORE_DIR or ''),
+                'store_schema_version': (getattr(store, 'metadata', {}) or {}).get('schema_version') if store else None,
+            }
         query_vector = embed_query_text(query_text)
-        matches = store.search_segments(
+        matches, search_diagnostics = store.search_segments(
             query_vector,
             top_k=SOURCE_INDEX_TOP_K,
             min_similarity=SOURCE_INDEX_MIN_SIMILARITY,
             embedding_model=RAG_EMBEDDING_MODEL,
             embedding_task_type=RAG_DOCUMENT_TASK_TYPE,
             embedding_dim=RAG_OUTPUT_DIMENSIONALITY,
+            return_diagnostics=True,
         )
     except Exception as exc:
         print(f'Warning: Source index retrieval failed: {exc}')
-        return [], {'enabled': True, 'error': str(exc)}
+        return [], {
+            'enabled': True,
+            'error': str(exc),
+            'failure_reason': 'retrieval_error',
+            'source_context_char_budget': get_source_index_char_budget(),
+        }
 
     hits = []
+    truncated_count = 0
+    source_context_chars = 0
     for match in matches:
         source_text = match.get('source_text', '')
+        truncated_source_text = truncate_text(source_text, SOURCE_INDEX_CHAR_LIMIT)
+        was_truncated = isinstance(source_text, str) and truncated_source_text != source_text
+        if was_truncated:
+            truncated_count += 1
+        source_context_chars += len(truncated_source_text)
         hit = {
             'source_id': match.get('source_id', ''),
             'file_rel_path': match.get('file_rel_path', ''),
             'line_start': match.get('line_start', 0),
             'line_end': match.get('line_end', 0),
-            'source_text': truncate_text(source_text, SOURCE_INDEX_CHAR_LIMIT),
+            'source_text': truncated_source_text,
+            'source_text_truncated': was_truncated,
             'score': float(match.get('score', 0.0)),
         }
         hits.append(hit)
@@ -814,7 +844,18 @@ def retrieve_source_hits(target_items, context_past):
     return hits, {
         'enabled': True,
         'query_text': truncate_text(query_text, 400),
+        'query_char_count': len(query_text),
         'hit_count': len(hits),
+        'matched_count': search_diagnostics.get('matched_before_top_k', len(matches)),
+        'filtered_count': search_diagnostics.get('metadata_filtered_count', 0),
+        'stale_hits_skipped': search_diagnostics.get('metadata_filtered_count', 0),
+        'below_similarity_count': search_diagnostics.get('below_similarity_count', 0),
+        'truncated_count': truncated_count,
+        'source_context_chars': source_context_chars,
+        'source_context_char_budget': get_source_index_char_budget(),
+        'store_dir': getattr(store, 'store_dir', SOURCE_INDEX_STORE_DIR or ''),
+        'store_schema_version': (getattr(store, 'metadata', {}) or {}).get('schema_version'),
+        'search_diagnostics': search_diagnostics,
     }
 
 
@@ -1673,16 +1714,38 @@ def summarize_batch_source_index(chunks):
     chunk_count = len(chunks)
     chunks_with_source_hits = sum(1 for chunk in chunks if chunk.get('source_hits'))
     source_hit_count = sum(len(chunk.get('source_hits') or []) for chunk in chunks)
+    stats_list = [chunk.get('source_index_stats') or {} for chunk in chunks]
+    source_retrieval_errors = sum(1 for stats in stats_list if stats.get('error'))
+    failure_reasons = {}
+    for stats in stats_list:
+        reason = stats.get('failure_reason') or stats.get('reason')
+        if reason:
+            failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
+    store_schema_versions = sorted(
+        {
+            stats.get('store_schema_version')
+            for stats in stats_list
+            if stats.get('store_schema_version') is not None
+        },
+        key=str,
+    )
     return {
         'enabled': SOURCE_INDEX_ENABLED,
         'store_dir': SOURCE_INDEX_STORE_DIR or get_default_source_index_store_dir(),
+        'schema_version': SOURCE_INDEX_SCHEMA_VERSION,
+        'store_schema_versions': store_schema_versions,
+        'per_chunk_char_budget': get_source_index_char_budget(),
         'chunks_with_source_hits': chunks_with_source_hits,
         'source_hit_count': source_hit_count,
         'source_hit_rate': (chunks_with_source_hits / chunk_count) if chunk_count else 0.0,
-        'source_retrieval_errors': sum(
-            1 for chunk in chunks
-            if (chunk.get('source_index_stats') or {}).get('error')
-        ),
+        'source_retrieval_errors': source_retrieval_errors,
+        'source_retrieval_failure_reasons': failure_reasons,
+        'source_context_truncation_count': sum(int(stats.get('truncated_count') or 0) for stats in stats_list),
+        'source_context_char_count': sum(int(stats.get('source_context_chars') or 0) for stats in stats_list),
+        'source_context_char_budget': sum(int(stats.get('source_context_char_budget') or 0) for stats in stats_list),
+        'source_filtered_count': sum(int(stats.get('filtered_count') or 0) for stats in stats_list),
+        'stale_hits_skipped': sum(int(stats.get('stale_hits_skipped') or 0) for stats in stats_list),
+        'below_similarity_count': sum(int(stats.get('below_similarity_count') or 0) for stats in stats_list),
     }
 
 
@@ -1819,11 +1882,13 @@ def create_batch_package(display_name_override='', skip_prepare=False):
         } if RAG_ENABLED else {},
         'rag_summary': summarize_batch_rag(chunks, rag_prepare_summary) if RAG_ENABLED else {},
         'source_index_enabled': SOURCE_INDEX_ENABLED,
-        'source_index_store_path': SOURCE_INDEX_STORE_DIR if SOURCE_INDEX_ENABLED else '',
+        'source_index_store_path': (SOURCE_INDEX_STORE_DIR or get_default_source_index_store_dir()) if SOURCE_INDEX_ENABLED else '',
         'source_index_settings': {
+            'schema_version': SOURCE_INDEX_SCHEMA_VERSION,
             'top_k': SOURCE_INDEX_TOP_K,
             'min_similarity': SOURCE_INDEX_MIN_SIMILARITY,
             'char_limit': SOURCE_INDEX_CHAR_LIMIT,
+            'char_budget_per_chunk': get_source_index_char_budget(),
         } if SOURCE_INDEX_ENABLED else {},
         'source_index_summary': summarize_batch_source_index(chunks) if SOURCE_INDEX_ENABLED else {},
         'story_memory_enabled': STORY_MEMORY_ENABLED,

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -938,28 +938,57 @@ class JsonSourceIndexStore(object):
         embedding_model=None,
         embedding_task_type=None,
         embedding_dim=None,
+        return_diagnostics=False,
     ):
         self.load()
         results = []
+        diagnostics = {
+            'segments_seen': 0,
+            'segments_with_embedding': 0,
+            'invalid_embedding_count': 0,
+            'filtered_embedding_model_count': 0,
+            'filtered_embedding_task_type_count': 0,
+            'filtered_embedding_dim_count': 0,
+            'metadata_filtered_count': 0,
+            'below_similarity_count': 0,
+            'matched_before_top_k': 0,
+            'returned_count': 0,
+        }
         for record in self.segments.values():
+            diagnostics['segments_seen'] += 1
             vector = record.get('embedding')
             if not isinstance(vector, list) or not vector:
+                diagnostics['invalid_embedding_count'] += 1
                 continue
+            diagnostics['segments_with_embedding'] += 1
             metadata = record.get('embedding_metadata') or {}
             if embedding_model is not None and metadata.get('embedding_model') != embedding_model:
+                diagnostics['filtered_embedding_model_count'] += 1
                 continue
             if embedding_task_type is not None and metadata.get('embedding_task_type') != embedding_task_type:
+                diagnostics['filtered_embedding_task_type_count'] += 1
                 continue
             if embedding_dim is not None:
                 if metadata.get('embedding_dim') != embedding_dim or len(vector) != embedding_dim:
+                    diagnostics['filtered_embedding_dim_count'] += 1
                     continue
             score = cosine_similarity(query_vector, vector)
             if score < min_similarity:
+                diagnostics['below_similarity_count'] += 1
                 continue
             result = dict(record)
             result['score'] = score
             results.append(result)
+        diagnostics['metadata_filtered_count'] = (
+            diagnostics['filtered_embedding_model_count']
+            + diagnostics['filtered_embedding_task_type_count']
+            + diagnostics['filtered_embedding_dim_count']
+        )
+        diagnostics['matched_before_top_k'] = len(results)
         results.sort(key=lambda item: float(item.get('score') or 0.0), reverse=True)
         if top_k > 0:
-            return results[:top_k]
+            results = results[:top_k]
+        diagnostics['returned_count'] = len(results)
+        if return_diagnostics:
+            return results, diagnostics
         return results

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -199,6 +199,7 @@ class SourceIndexStoreTests(unittest.TestCase):
 
                 reloaded = JsonSourceIndexStore(str(store_dir))
                 reloaded.load()
+                self.assertEqual(reloaded.metadata['schema_version'], batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
                 self.assertEqual(reloaded.count_segments(), 1)
                 self.assertIn(unchanged_id, reloaded.segments)
                 self.assertNotIn('stale_id', reloaded.segments)
@@ -383,6 +384,13 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertNotIn('translated_text', hit)
             self.assertAlmostEqual(hit['score'], 1.0)
             self.assertFalse(unused_rag_store_dir.exists())
+            self.assertEqual(stats['matched_count'], 1)
+            self.assertEqual(stats['below_similarity_count'], 1)
+            self.assertEqual(stats['filtered_count'], 0)
+            self.assertEqual(stats['truncated_count'], 0)
+            self.assertEqual(stats['source_context_chars'], len('Good morning everyone'))
+            self.assertEqual(stats['source_context_char_budget'], 100)
+            self.assertEqual(stats['search_diagnostics']['segments_seen'], 2)
 
     def test_retrieve_source_hits_filters_stale_embedding_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -410,6 +418,64 @@ class SourceIndexIntegrationTests(unittest.TestCase):
 
             self.assertTrue(stats['enabled'])
             self.assertEqual([hit['source_id'] for hit in hits], ['current'])
+            self.assertEqual(stats['filtered_count'], 1)
+            self.assertEqual(stats['stale_hits_skipped'], 1)
+            self.assertEqual(stats['search_diagnostics']['filtered_embedding_task_type_count'], 1)
+
+    def test_retrieve_source_hits_reports_truncation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_store_dir = tmp_path / 'source_store'
+            source_store_dir.mkdir()
+
+            batch_mod.SOURCE_INDEX_ENABLED = True
+            batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+            batch_mod._SOURCE_INDEX_STORE = None
+            batch_mod.SOURCE_INDEX_TOP_K = 1
+            batch_mod.SOURCE_INDEX_MIN_SIMILARITY = 0.0
+            batch_mod.SOURCE_INDEX_CHAR_LIMIT = 12
+
+            long_source = 'Long source text for truncation'
+            segment = self.make_segment('long', source=long_source, embedding=[1.0, 0.0, 0.0])
+            JsonSourceIndexStore(str(source_store_dir)).upsert_segments([segment])
+
+            with (
+                mock.patch('gemini_translate_batch.embed_query_text', return_value=[1.0, 0.0, 0.0]),
+                mock.patch('gemini_translate_batch.RAG_OUTPUT_DIMENSIONALITY', 3),
+            ):
+                hits, stats = batch_mod.retrieve_source_hits([{'text': 'Long source'}], [])
+
+            self.assertEqual(len(hits), 1)
+            self.assertEqual(hits[0]['source_text'], 'Long sour...')
+            self.assertTrue(hits[0]['source_text_truncated'])
+            self.assertEqual(stats['truncated_count'], 1)
+            self.assertEqual(stats['source_context_chars'], 12)
+            self.assertEqual(stats['source_context_char_budget'], 12)
+
+    def test_retrieve_source_hits_reports_failure_reason(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_store_dir = tmp_path / 'source_store'
+            source_store_dir.mkdir()
+
+            batch_mod.SOURCE_INDEX_ENABLED = True
+            batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
+            batch_mod._SOURCE_INDEX_STORE = None
+            JsonSourceIndexStore(str(source_store_dir)).upsert_segments([
+                self.make_segment('s1', source='Hello world', embedding=[1.0, 0.0, 0.0])
+            ])
+
+            with mock.patch('gemini_translate_batch.embed_query_text', side_effect=RuntimeError('embed failed')):
+                hits, stats = batch_mod.retrieve_source_hits([{'text': 'Hello world'}], [])
+
+            self.assertEqual(hits, [])
+            self.assertTrue(stats['enabled'])
+            self.assertEqual(stats['failure_reason'], 'retrieval_error')
+            self.assertIn('embed failed', stats['error'])
+            self.assertEqual(
+                stats['source_context_char_budget'],
+                batch_mod.SOURCE_INDEX_TOP_K * batch_mod.SOURCE_INDEX_CHAR_LIMIT,
+            )
 
     def test_retrieve_source_hits_degrades_when_source_store_is_locked(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -438,6 +504,22 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertEqual(hits, [])
             self.assertTrue(stats['enabled'])
             self.assertEqual(stats['reason'], 'empty_source_store')
+            self.assertEqual(stats['source_context_char_budget'], 5 * batch_mod.SOURCE_INDEX_CHAR_LIMIT)
+
+    def test_source_index_disabled_does_not_read_store_or_add_prompt_context(self):
+        batch_mod.SOURCE_INDEX_ENABLED = False
+
+        with mock.patch('gemini_translate_batch.get_source_index_store') as store_mock:
+            hits, stats = batch_mod.retrieve_source_hits([{'text': 'Hello world'}], [])
+
+        self.assertEqual(hits, [])
+        self.assertEqual(stats, {'enabled': False})
+        store_mock.assert_not_called()
+        reference_blocks = prompt_context.build_reference_blocks(
+            include_translation_memory=False,
+            source_hits=hits,
+        )
+        self.assertNotIn('RELATED PROJECT CONTEXT:', reference_blocks)
 
     def test_format_source_hits_block_and_prompt_injection(self):
         hits = [
@@ -504,14 +586,20 @@ class SourceIndexIntegrationTests(unittest.TestCase):
                 batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / 'latest_manifest.txt')
 
                 batch_mod.SOURCE_INDEX_ENABLED = True
+                batch_mod.SOURCE_INDEX_TOP_K = 2
+                batch_mod.SOURCE_INDEX_MIN_SIMILARITY = 0.0
+                batch_mod.SOURCE_INDEX_CHAR_LIMIT = 20
                 source_store_dir = tmp_path / 'source_store'
                 source_store_dir.mkdir()
                 batch_mod.SOURCE_INDEX_STORE_DIR = str(source_store_dir)
                 batch_mod._SOURCE_INDEX_STORE = None
 
                 store = JsonSourceIndexStore(str(source_store_dir))
+                store.set_metadata(schema_version=batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
                 seg = self.make_segment('s1', source='Hello world', embedding=[1.0, 0.0, 0.0])
-                store.upsert_segments([seg])
+                stale_seg = self.make_segment('stale', source='Stale source', embedding=[1.0, 0.0, 0.0])
+                stale_seg['embedding_metadata']['embedding_task_type'] = 'SEMANTIC_SIMILARITY'
+                store.upsert_segments([seg, stale_seg])
 
                 # Mock pending file jobs so we bypass the file scanner
                 mock_jobs = [
@@ -549,12 +637,25 @@ class SourceIndexIntegrationTests(unittest.TestCase):
                     manifest_data = json.load(f)
 
                 self.assertTrue(manifest_data.get('source_index_enabled'))
+                self.assertEqual(manifest_data['source_index_store_path'], str(source_store_dir))
                 self.assertEqual(manifest_data['source_index_settings']['top_k'], batch_mod.SOURCE_INDEX_TOP_K)
+                self.assertEqual(manifest_data['source_index_settings']['schema_version'], batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
+                self.assertEqual(manifest_data['source_index_settings']['char_budget_per_chunk'], 40)
                 self.assertIn('source_index_summary', manifest_data)
 
                 summary = manifest_data['source_index_summary']
+                self.assertEqual(summary['schema_version'], batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
+                self.assertEqual(summary['store_schema_versions'], [batch_mod.SOURCE_INDEX_SCHEMA_VERSION])
+                self.assertEqual(summary['per_chunk_char_budget'], 40)
                 self.assertEqual(summary['chunks_with_source_hits'], 1)
                 self.assertEqual(summary['source_hit_count'], 1)
+                self.assertEqual(summary['source_context_truncation_count'], 0)
+                self.assertEqual(summary['source_context_char_count'], len('Hello world'))
+                self.assertEqual(summary['source_context_char_budget'], 40)
+                self.assertEqual(summary['source_filtered_count'], 1)
+                self.assertEqual(summary['stale_hits_skipped'], 1)
+                self.assertEqual(summary['below_similarity_count'], 0)
+                self.assertEqual(summary['source_retrieval_failure_reasons'], {})
 
                 requests_path = os.path.join(os.path.dirname(manifest_path), 'requests.jsonl')
                 self.assertTrue(os.path.exists(requests_path))

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -67,6 +67,13 @@
       "history_char_limit": 220,
       "store_dir": ""
     },
+    "source_index": {
+      "enabled": false,
+      "top_k": 4,
+      "min_similarity": 0.72,
+      "char_limit": 220,
+      "store_dir": ""
+    },
     "story_memory": {
       "enabled": false,
       "graph_file": "logs/story_memory/story_graph.json",


### PR DESCRIPTION
## Summary

Closes #36.

This PR wraps up the remaining source-only index work after #62 and #63 by making diagnostics, configuration examples, and test coverage explicit enough to treat the feature as complete.

## Changes

- Add source index schema version metadata and surface it in manifest settings/summary.
- Expand source retrieval diagnostics with query length, match count, metadata/stale filtering counts, similarity filtering counts, truncation counts, injected character count, character budget, store path, and failure reason.
- Extend `JsonSourceIndexStore.search_segments()` with optional diagnostics while preserving the existing return shape by default.
- Make `source_index_store_path` report the default store path when source index is enabled.
- Add `batch.source_index` to `translator_config.example.json`.
- Document the source index build/use flow, prompt boundary, config knobs, and manifest diagnostics in README.
- Add regression coverage for disabled behavior, truncation, retrieval failures, schema metadata, stale metadata filtering, and manifest summary fields.

## Validation

- `python -m unittest -q tests.test_source_index`
- `python -m py_compile gemini_translate_batch.py rag_memory.py prompt_context.py translation_core.py tests/test_source_index.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python -m json.tool translator_config.example.json`
- `git diff --check origin/main`