### PR TITLE
[codex] Add GUI model configuration controls

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -24,6 +24,8 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QInputDialog,
     QLineEdit,
+    QComboBox,
+    QGridLayout,
 )
 
 from .cli_runner import CliRunner
@@ -64,6 +66,76 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(proj_box)
 
+        # Config box
+        config_box = QGroupBox("参数与模型配置")
+        config_layout = QGridLayout(config_box)
+        config_layout.setSpacing(10)
+
+        # Sync Model
+        config_layout.addWidget(QLabel("Sync 翻译模型："), 0, 0)
+        self.sync_model_combo = QComboBox()
+        self.sync_model_combo.addItems([
+            "gemini-3.5-flash",
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
+            "gemini-3-flash-preview",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+        ])
+        config_layout.addWidget(self.sync_model_combo, 0, 1)
+
+        # Batch Model
+        config_layout.addWidget(QLabel("Batch 翻译模型："), 0, 2)
+        self.batch_model_combo = QComboBox()
+        self.batch_model_combo.addItems([
+            "gemini-3.5-flash",
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
+            "gemini-3-flash-preview",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+        ])
+        config_layout.addWidget(self.batch_model_combo, 0, 3)
+
+        # Sync RAG embedding
+        config_layout.addWidget(QLabel("Sync RAG 向量模型："), 1, 0)
+        self.sync_embedding_combo = QComboBox()
+        self.sync_embedding_combo.addItems([
+            "gemini-embedding-2",
+            "gemini-embedding-001",
+        ])
+        config_layout.addWidget(self.sync_embedding_combo, 1, 1)
+
+        # Batch RAG embedding
+        config_layout.addWidget(QLabel("Batch RAG 向量模型："), 1, 2)
+        self.batch_embedding_combo = QComboBox()
+        self.batch_embedding_combo.addItems([
+            "gemini-embedding-2",
+            "gemini-embedding-001",
+        ])
+        config_layout.addWidget(self.batch_embedding_combo, 1, 3)
+
+        # Batch thinking level
+        config_layout.addWidget(QLabel("Batch 思考程度："), 2, 0)
+        self.batch_thinking_combo = QComboBox()
+        self.batch_thinking_combo.addItem("（不启用）", "")
+        self.batch_thinking_combo.addItem("低 (low)", "low")
+        self.batch_thinking_combo.addItem("中 (medium)", "medium")
+        self.batch_thinking_combo.addItem("高 (high)", "high")
+        config_layout.addWidget(self.batch_thinking_combo, 2, 1)
+
+        # Connect model change signal to dynamically toggle thinking level
+        self.batch_model_combo.currentTextChanged.connect(self._on_batch_model_changed)
+
+        # Save config button
+        self.save_config_btn = QPushButton("保存参数配置")
+        self.save_config_btn.clicked.connect(self._on_save_config)
+        config_layout.addWidget(self.save_config_btn, 2, 3)
+
+        layout.addWidget(config_box)
+
         # Actions row
         action_layout = QHBoxLayout()
         self.doctor_btn = QPushButton("检查项目（doctor）")
@@ -101,6 +173,7 @@ class MainWindow(QMainWindow):
         self.runner.error.connect(self._on_runner_error)
 
         self._refresh_project_label()
+        self._load_config_to_ui()
 
         # Status
         self.statusBar().showMessage(
@@ -124,6 +197,7 @@ class MainWindow(QMainWindow):
                 self._append_log(f"更新 translator_config.json 失败：{exc}")
                 return
             self._refresh_project_label()
+            self._load_config_to_ui()
             self._append_log(f"项目目录已设置为：{directory}")
 
     def _masked_key(self, key: str) -> str:
@@ -220,6 +294,80 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("项目检查完成。", 6000)
         else:
             self.statusBar().showMessage(f"项目检查失败（退出码：{exit_code}）", 6000)
+
+    # --- Config loading/saving helpers ---
+
+    def _set_combo_value(self, combo: QComboBox, value: str):
+        if not value:
+            combo.setCurrentIndex(-1)
+            return
+        idx = combo.findText(value)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+        else:
+            combo.addItem(value)
+            combo.setCurrentIndex(combo.count() - 1)
+
+    def _load_config_to_ui(self):
+        config = self.state.load_translator_config()
+        
+        # Populate sync model
+        sync_val = config.get("sync", {}).get("model", "")
+        self._set_combo_value(self.sync_model_combo, sync_val)
+        
+        # Populate batch model
+        batch_val = config.get("batch", {}).get("model", "")
+        self._set_combo_value(self.batch_model_combo, batch_val)
+        
+        # Populate sync embedding
+        sync_emb_val = config.get("sync", {}).get("rag", {}).get("embedding_model", "")
+        self._set_combo_value(self.sync_embedding_combo, sync_emb_val)
+        
+        # Populate batch embedding
+        batch_emb_val = config.get("batch", {}).get("rag", {}).get("embedding_model", "")
+        self._set_combo_value(self.batch_embedding_combo, batch_emb_val)
+        
+        # Populate thinking level
+        thinking_val = config.get("batch", {}).get("thinking_level", "")
+        self._on_batch_model_changed(batch_val)
+        idx = self.batch_thinking_combo.findData(thinking_val)
+        if idx >= 0:
+            self.batch_thinking_combo.setCurrentIndex(idx)
+        else:
+            if thinking_val:
+                self.batch_thinking_combo.addItem(f"{thinking_val} (自定义)", thinking_val)
+                self.batch_thinking_combo.setCurrentIndex(self.batch_thinking_combo.count() - 1)
+            else:
+                self.batch_thinking_combo.setCurrentIndex(0)
+
+    def _on_batch_model_changed(self, text: str):
+        model_name = text.strip()
+        is_thinking_supported = model_name.startswith("gemini-3") or model_name.startswith("gemini-2.5")
+        self.batch_thinking_combo.setEnabled(is_thinking_supported)
+        if not is_thinking_supported:
+            self.batch_thinking_combo.setCurrentIndex(0)
+
+    def _on_save_config(self):
+        if not self.state.get_game_root():
+            QMessageBox.information(self, "未选择项目", "请先选择游戏的 work 目录。")
+            return
+        
+        try:
+            config = self.state.load_translator_config()
+            
+            config.setdefault("sync", {})["model"] = self.sync_model_combo.currentText().strip()
+            config.setdefault("batch", {})["model"] = self.batch_model_combo.currentText().strip()
+            config.setdefault("sync", {}).setdefault("rag", {})["embedding_model"] = self.sync_embedding_combo.currentText().strip()
+            config.setdefault("batch", {}).setdefault("rag", {})["embedding_model"] = self.batch_embedding_combo.currentText().strip()
+            thinking_val = self.batch_thinking_combo.currentData()
+            config.setdefault("batch", {})["thinking_level"] = thinking_val if thinking_val is not None else ""
+            
+            self.state.save_translator_config(config)
+            self._append_log("配置已成功保存至 translator_config.json。")
+            self.statusBar().showMessage("配置已成功保存", 3000)
+        except Exception as exc:
+            QMessageBox.warning(self, "保存配置失败", str(exc))
+            self._append_log(f"保存配置失败：{exc}")
 
 
 def run_app(argv: list[str] | None = None) -> int:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 from PySide6.QtWidgets import (
     QApplication,
@@ -62,7 +63,7 @@ class MainWindow(QMainWindow):
         proj_layout.setSpacing(10)
 
         proj_layout.addWidget(QLabel("当前游戏 work 目录："))
-        
+
         self.project_path_edit = QLineEdit("尚未选择项目")
         self.project_path_edit.setReadOnly(True)
         self.project_path_edit.setObjectName("project_path_edit")
@@ -132,6 +133,7 @@ class MainWindow(QMainWindow):
 
         self.batch_thinking_combo = QComboBox()
         self.batch_thinking_combo.addItem("（不启用）", "")
+        self.batch_thinking_combo.addItem("最小 (minimal)", "minimal")
         self.batch_thinking_combo.addItem("低 (low)", "low")
         self.batch_thinking_combo.addItem("中 (medium)", "medium")
         self.batch_thinking_combo.addItem("高 (high)", "high")
@@ -314,6 +316,17 @@ class MainWindow(QMainWindow):
 
     # --- Config loading/saving helpers ---
 
+    def _config_section(self, config: dict[str, Any], key: str) -> dict[str, Any]:
+        section = config.get(key)
+        return section if isinstance(section, dict) else {}
+
+    def _ensure_config_section(self, config: dict[str, Any], key: str) -> dict[str, Any]:
+        section = config.get(key)
+        if not isinstance(section, dict):
+            section = {}
+            config[key] = section
+        return section
+
     def _set_combo_value(self, combo: QComboBox, value: str):
         if not value:
             combo.setCurrentIndex(-1)
@@ -327,25 +340,29 @@ class MainWindow(QMainWindow):
 
     def _load_config_to_ui(self):
         config = self.state.load_translator_config()
-        
+        sync_config = self._config_section(config, "sync")
+        batch_config = self._config_section(config, "batch")
+        sync_rag_config = self._config_section(sync_config, "rag")
+        batch_rag_config = self._config_section(batch_config, "rag")
+
         # Populate sync model
-        sync_val = config.get("sync", {}).get("model", "")
+        sync_val = sync_config.get("model", "")
         self._set_combo_value(self.sync_model_combo, sync_val)
-        
+
         # Populate batch model
-        batch_val = config.get("batch", {}).get("model", "")
+        batch_val = batch_config.get("model", "")
         self._set_combo_value(self.batch_model_combo, batch_val)
-        
+
         # Populate sync embedding
-        sync_emb_val = config.get("sync", {}).get("rag", {}).get("embedding_model", "")
+        sync_emb_val = sync_rag_config.get("embedding_model", "")
         self._set_combo_value(self.sync_embedding_combo, sync_emb_val)
-        
+
         # Populate batch embedding
-        batch_emb_val = config.get("batch", {}).get("rag", {}).get("embedding_model", "")
+        batch_emb_val = batch_rag_config.get("embedding_model", "")
         self._set_combo_value(self.batch_embedding_combo, batch_emb_val)
-        
+
         # Populate thinking level
-        thinking_val = config.get("batch", {}).get("thinking_level", "")
+        thinking_val = batch_config.get("thinking_level", "")
         self._on_batch_model_changed(batch_val)
         idx = self.batch_thinking_combo.findData(thinking_val)
         if idx >= 0:
@@ -368,17 +385,21 @@ class MainWindow(QMainWindow):
         if not self.state.get_game_root():
             QMessageBox.information(self, "未选择项目", "请先选择游戏的 work 目录。")
             return
-        
+
         try:
             config = self.state.load_translator_config()
-            
-            config.setdefault("sync", {})["model"] = self.sync_model_combo.currentText().strip()
-            config.setdefault("batch", {})["model"] = self.batch_model_combo.currentText().strip()
-            config.setdefault("sync", {}).setdefault("rag", {})["embedding_model"] = self.sync_embedding_combo.currentText().strip()
-            config.setdefault("batch", {}).setdefault("rag", {})["embedding_model"] = self.batch_embedding_combo.currentText().strip()
+            sync_config = self._ensure_config_section(config, "sync")
+            batch_config = self._ensure_config_section(config, "batch")
+            sync_rag_config = self._ensure_config_section(sync_config, "rag")
+            batch_rag_config = self._ensure_config_section(batch_config, "rag")
+
+            sync_config["model"] = self.sync_model_combo.currentText().strip()
+            batch_config["model"] = self.batch_model_combo.currentText().strip()
+            sync_rag_config["embedding_model"] = self.sync_embedding_combo.currentText().strip()
+            batch_rag_config["embedding_model"] = self.batch_embedding_combo.currentText().strip()
             thinking_val = self.batch_thinking_combo.currentData()
-            config.setdefault("batch", {})["thinking_level"] = thinking_val if thinking_val is not None else ""
-            
+            batch_config["thinking_level"] = thinking_val if thinking_val is not None else ""
+
             self.state.save_translator_config(config)
             self._append_log("配置已成功保存至 translator_config.json。")
             self.statusBar().showMessage("配置已成功保存", 3000)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -327,7 +327,11 @@ class MainWindow(QMainWindow):
             config[key] = section
         return section
 
-    def _set_combo_value(self, combo: QComboBox, value: str):
+    def _config_string(self, value: Any) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+    def _set_combo_value(self, combo: QComboBox, value: Any):
+        value = self._config_string(value)
         if not value:
             combo.setCurrentIndex(-1)
             return
@@ -346,7 +350,17 @@ class MainWindow(QMainWindow):
         batch_rag_config = self._config_section(batch_config, "rag")
 
         # Populate sync model
-        sync_val = sync_config.get("model", "")
+        sync_models = sync_config.get("models")
+        sync_val = ""
+        if isinstance(sync_models, list):
+            for model in sync_models:
+                sync_val = self._config_string(model)
+                if sync_val:
+                    break
+        elif isinstance(sync_models, str):
+            sync_val = self._config_string(sync_models)
+        if not sync_val:
+            sync_val = sync_config.get("model", "")
         self._set_combo_value(self.sync_model_combo, sync_val)
 
         # Populate batch model
@@ -362,7 +376,7 @@ class MainWindow(QMainWindow):
         self._set_combo_value(self.batch_embedding_combo, batch_emb_val)
 
         # Populate thinking level
-        thinking_val = batch_config.get("thinking_level", "")
+        thinking_val = self._config_string(batch_config.get("thinking_level", ""))
         self._on_batch_model_changed(batch_val)
         idx = self.batch_thinking_combo.findData(thinking_val)
         if idx >= 0:
@@ -375,8 +389,8 @@ class MainWindow(QMainWindow):
                 self.batch_thinking_combo.setCurrentIndex(0)
 
     def _on_batch_model_changed(self, text: str):
-        model_name = text.strip()
-        is_thinking_supported = model_name.startswith("gemini-3") or model_name.startswith("gemini-2.5")
+        model_name = self._config_string(text)
+        is_thinking_supported = model_name.startswith("gemini-3")
         self.batch_thinking_combo.setEnabled(is_thinking_supported)
         if not is_thinking_supported:
             self.batch_thinking_combo.setCurrentIndex(0)
@@ -393,12 +407,22 @@ class MainWindow(QMainWindow):
             sync_rag_config = self._ensure_config_section(sync_config, "rag")
             batch_rag_config = self._ensure_config_section(batch_config, "rag")
 
-            sync_config["model"] = self.sync_model_combo.currentText().strip()
+            sync_model = self.sync_model_combo.currentText().strip()
+            sync_config["model"] = sync_model
+            if "models" in sync_config:
+                if sync_model:
+                    sync_config["models"] = [sync_model]
+                else:
+                    sync_config.pop("models", None)
             batch_config["model"] = self.batch_model_combo.currentText().strip()
             sync_rag_config["embedding_model"] = self.sync_embedding_combo.currentText().strip()
             batch_rag_config["embedding_model"] = self.batch_embedding_combo.currentText().strip()
             thinking_val = self.batch_thinking_combo.currentData()
-            batch_config["thinking_level"] = thinking_val if thinking_val is not None else ""
+            thinking_level = thinking_val if isinstance(thinking_val, str) else ""
+            if thinking_level:
+                batch_config["thinking_level"] = thinking_level
+            elif "thinking_level" in batch_config:
+                batch_config["thinking_level"] = ""
 
             self.state.save_translator_config(config)
             self._append_log("配置已成功保存至 translator_config.json。")

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -26,6 +26,8 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QComboBox,
     QGridLayout,
+    QFrame,
+    QFormLayout,
 )
 
 from .cli_runner import CliRunner
@@ -44,35 +46,44 @@ class MainWindow(QMainWindow):
         central = QWidget()
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(8)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
 
         # Header
         header = QLabel("实验性图形工作台 - 复用现有命令行流程")
-        header.setStyleSheet("color: #1f2937; font-size: 15px; font-weight: 600;")
+        header.setObjectName("header_label")
         layout.addWidget(header)
 
         # Project row
-        proj_box = QGroupBox("当前项目")
-        proj_layout = QHBoxLayout(proj_box)
+        project_frame = QFrame()
+        project_frame.setObjectName("project_frame")
+        proj_layout = QHBoxLayout(project_frame)
+        proj_layout.setContentsMargins(12, 10, 12, 10)
+        proj_layout.setSpacing(10)
 
-        self.project_label = QLabel("尚未选择项目")
-        self.project_label.setStyleSheet("color: #334155;")
-        proj_layout.addWidget(self.project_label, 1)
+        proj_layout.addWidget(QLabel("当前游戏 work 目录："))
+        
+        self.project_path_edit = QLineEdit("尚未选择项目")
+        self.project_path_edit.setReadOnly(True)
+        self.project_path_edit.setObjectName("project_path_edit")
+        proj_layout.addWidget(self.project_path_edit, 1)
 
-        self.select_btn = QPushButton("选择游戏 work 目录...")
+        self.select_btn = QPushButton("选择游戏目录...")
         self.select_btn.clicked.connect(self._on_select_project)
         proj_layout.addWidget(self.select_btn)
 
-        layout.addWidget(proj_box)
+        layout.addWidget(project_frame)
 
-        # Config box
-        config_box = QGroupBox("参数与模型配置")
-        config_layout = QGridLayout(config_box)
-        config_layout.setSpacing(10)
+        # Configuration Row (Sync + Batch side-by-side)
+        config_row = QHBoxLayout()
+        config_row.setSpacing(16)
 
-        # Sync Model
-        config_layout.addWidget(QLabel("Sync 翻译模型："), 0, 0)
+        # Sync Box
+        sync_box = QGroupBox("同步翻译配置 (Sync API)")
+        sync_layout = QFormLayout(sync_box)
+        sync_layout.setSpacing(8)
+        sync_layout.setContentsMargins(12, 16, 12, 12)
+
         self.sync_model_combo = QComboBox()
         self.sync_model_combo.addItems([
             "gemini-3.5-flash",
@@ -83,10 +94,23 @@ class MainWindow(QMainWindow):
             "gemini-2.5-flash",
             "gemini-2.5-flash-lite",
         ])
-        config_layout.addWidget(self.sync_model_combo, 0, 1)
+        sync_layout.addRow("翻译模型：", self.sync_model_combo)
 
-        # Batch Model
-        config_layout.addWidget(QLabel("Batch 翻译模型："), 0, 2)
+        self.sync_embedding_combo = QComboBox()
+        self.sync_embedding_combo.addItems([
+            "gemini-embedding-2",
+            "gemini-embedding-001",
+        ])
+        sync_layout.addRow("RAG 向量模型：", self.sync_embedding_combo)
+
+        config_row.addWidget(sync_box, 1)
+
+        # Batch Box
+        batch_box = QGroupBox("批量离线配置 (Batch API)")
+        batch_layout = QFormLayout(batch_box)
+        batch_layout.setSpacing(8)
+        batch_layout.setContentsMargins(12, 16, 12, 12)
+
         self.batch_model_combo = QComboBox()
         self.batch_model_combo.addItems([
             "gemini-3.5-flash",
@@ -97,56 +121,52 @@ class MainWindow(QMainWindow):
             "gemini-2.5-flash",
             "gemini-2.5-flash-lite",
         ])
-        config_layout.addWidget(self.batch_model_combo, 0, 3)
+        batch_layout.addRow("翻译模型：", self.batch_model_combo)
 
-        # Sync RAG embedding
-        config_layout.addWidget(QLabel("Sync RAG 向量模型："), 1, 0)
-        self.sync_embedding_combo = QComboBox()
-        self.sync_embedding_combo.addItems([
-            "gemini-embedding-2",
-            "gemini-embedding-001",
-        ])
-        config_layout.addWidget(self.sync_embedding_combo, 1, 1)
-
-        # Batch RAG embedding
-        config_layout.addWidget(QLabel("Batch RAG 向量模型："), 1, 2)
         self.batch_embedding_combo = QComboBox()
         self.batch_embedding_combo.addItems([
             "gemini-embedding-2",
             "gemini-embedding-001",
         ])
-        config_layout.addWidget(self.batch_embedding_combo, 1, 3)
+        batch_layout.addRow("RAG 向量模型：", self.batch_embedding_combo)
 
-        # Batch thinking level
-        config_layout.addWidget(QLabel("Batch 思考程度："), 2, 0)
         self.batch_thinking_combo = QComboBox()
         self.batch_thinking_combo.addItem("（不启用）", "")
         self.batch_thinking_combo.addItem("低 (low)", "low")
         self.batch_thinking_combo.addItem("中 (medium)", "medium")
         self.batch_thinking_combo.addItem("高 (high)", "high")
-        config_layout.addWidget(self.batch_thinking_combo, 2, 1)
+        batch_layout.addRow("Batch 思考程度：", self.batch_thinking_combo)
+
+        config_row.addWidget(batch_box, 1)
+
+        layout.addLayout(config_row)
+
+        # Save config row
+        save_layout = QHBoxLayout()
+        save_layout.addStretch()
+        self.save_config_btn = QPushButton("保存参数配置")
+        self.save_config_btn.setObjectName("save_config_btn")
+        self.save_config_btn.clicked.connect(self._on_save_config)
+        save_layout.addWidget(self.save_config_btn)
+        layout.addLayout(save_layout)
 
         # Connect model change signal to dynamically toggle thinking level
         self.batch_model_combo.currentTextChanged.connect(self._on_batch_model_changed)
 
-        # Save config button
-        self.save_config_btn = QPushButton("保存参数配置")
-        self.save_config_btn.clicked.connect(self._on_save_config)
-        config_layout.addWidget(self.save_config_btn, 2, 3)
-
-        layout.addWidget(config_box)
-
         # Actions row
         action_layout = QHBoxLayout()
         self.doctor_btn = QPushButton("检查项目（doctor）")
+        self.doctor_btn.setObjectName("doctor_btn")
         self.doctor_btn.clicked.connect(self._on_run_doctor)
         action_layout.addWidget(self.doctor_btn)
 
-        self.api_btn = QPushButton("管理 API Key（基础）")
+        self.api_btn = QPushButton("管理 API Key")
+        self.api_btn.setObjectName("api_btn")
         self.api_btn.clicked.connect(self._on_manage_api_keys)
         action_layout.addWidget(self.api_btn)
 
         self.kill_btn = QPushButton("停止当前任务")
+        self.kill_btn.setObjectName("kill_btn")
         self.kill_btn.clicked.connect(self._on_kill)
         self.kill_btn.setEnabled(False)
         action_layout.addWidget(self.kill_btn)
@@ -161,10 +181,7 @@ class MainWindow(QMainWindow):
         self.log_view = QTextEdit()
         self.log_view.setReadOnly(True)
         self.log_view.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
-        self.log_view.setStyleSheet(
-            "font-family: Consolas, 'Courier New', monospace; "
-            "font-size: 12px; background: #1e1e1e; color: #ddd;"
-        )
+        self.log_view.setObjectName("log_view")
         layout.addWidget(self.log_view, 1)
 
         # Connect runner
@@ -247,9 +264,9 @@ class MainWindow(QMainWindow):
     def _refresh_project_label(self):
         root = self.state.get_game_root()
         if root:
-            self.project_label.setText(str(root))
+            self.project_path_edit.setText(str(root))
         else:
-            self.project_label.setText("（尚未选择项目）")
+            self.project_path_edit.setText("（尚未选择项目）")
 
     def _on_run_doctor(self):
         if not self.state.get_game_root():

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -1,92 +1,205 @@
-/* Minimal stable light theme for the first version GUI.
-   Explicit colors avoid unreadable text when Windows is using dark mode. */
-QMainWindow,
+/* Premium Slate Theme for the GUI Workbench */
+
+/* Global Window styling */
+QMainWindow {
+    background-color: #f8fafc;
+}
+
 QWidget {
-    background: #f6f7f9;
-    color: #202124;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 13px;
+    color: #0f172a;
 }
 
-QLabel {
-    background: transparent;
-    color: #202124;
+/* Header style */
+#header_label {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1e3a8a;
+    padding-bottom: 4px;
 }
 
-QGroupBox {
-    background: #f6f7f9;
-    border: 1px solid #d0d7de;
+/* Project Path Frame styling */
+#project_frame {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+}
+
+#project_path_edit {
+    background-color: #f1f5f9;
+    border: 1px solid #cbd5e1;
     border-radius: 6px;
-    color: #1f2937;
-    font-weight: 500;
-    margin-top: 12px;
-    padding: 10px 8px 8px 8px;
+    color: #334155;
+    padding: 6px 10px;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+}
+
+/* GroupBox styling */
+QGroupBox {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    margin-top: 16px;
+    font-weight: 600;
+    color: #0f172a;
+    padding-top: 24px;
 }
 
 QGroupBox::title {
-    background: #f6f7f9;
-    color: #475569;
-    left: 10px;
-    padding: 0 4px;
     subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 12px;
+    top: 6px;
+    background-color: #ffffff;
+    padding: 0 6px;
+    color: #2563eb;
+    font-size: 13px;
 }
 
-QPushButton {
-    background: #ffffff;
-    border: 1px solid #cbd5e1;
-    border-radius: 4px;
-    color: #1f2937;
-    min-height: 24px;
-    padding: 6px 14px;
-}
-
-QPushButton:hover {
-    background: #f8fafc;
-    border-color: #94a3b8;
-}
-
-QPushButton:pressed {
-    background: #e2e8f0;
-}
-
-QPushButton:disabled {
-    background: #f1f5f9;
-    border-color: #e2e8f0;
-    color: #94a3b8;
-}
-
-QTextEdit {
-    background: #1e1e1e;
-    border: 1px solid #444444;
-    color: #dddddd;
-    selection-background-color: #2563eb;
-    selection-color: #ffffff;
-}
-
-QStatusBar {
-    background: #f6f7f9;
+/* Form layout labels */
+QLabel {
     color: #475569;
+    font-weight: 500;
 }
 
+/* Input Elements (ComboBox) styling */
 QComboBox {
-    background: #ffffff;
+    background-color: #ffffff;
     border: 1px solid #cbd5e1;
-    border-radius: 4px;
-    color: #1f2937;
-    min-height: 24px;
-    padding: 3px 6px;
+    border-radius: 6px;
+    color: #0f172a;
+    padding: 5px 10px;
+    min-height: 20px;
 }
 
 QComboBox:hover {
-    border-color: #94a3b8;
+    border-color: #3b82f6;
+}
+
+QComboBox:focus {
+    border-color: #2563eb;
 }
 
 QComboBox:disabled {
-    background: #f1f5f9;
+    background-color: #f1f5f9;
     border-color: #e2e8f0;
     color: #94a3b8;
 }
 
 QComboBox::drop-down {
     border: none;
-    width: 20px;
+    width: 24px;
 }
 
+/* Default Buttons styling */
+QPushButton {
+    background-color: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    color: #334155;
+    font-weight: 500;
+    padding: 8px 16px;
+    min-height: 18px;
+}
+
+QPushButton:hover {
+    background-color: #f8fafc;
+    border-color: #94a3b8;
+    color: #0f172a;
+}
+
+QPushButton:pressed {
+    background-color: #f1f5f9;
+}
+
+QPushButton:disabled {
+    background-color: #f1f5f9;
+    border-color: #e2e8f0;
+    color: #cbd5e1;
+}
+
+/* Primary Action Buttons */
+QPushButton#save_config_btn,
+QPushButton#doctor_btn {
+    background-color: #2563eb;
+    border: 1px solid #2563eb;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+QPushButton#save_config_btn:hover,
+QPushButton#doctor_btn:hover {
+    background-color: #1d4ed8;
+    border-color: #1d4ed8;
+}
+
+QPushButton#save_config_btn:pressed,
+QPushButton#doctor_btn:pressed {
+    background-color: #1e40af;
+    border-color: #1e40af;
+}
+
+/* Danger Action Button */
+QPushButton#kill_btn {
+    background-color: #ef4444;
+    border: 1px solid #ef4444;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+QPushButton#kill_btn:hover {
+    background-color: #dc2626;
+    border-color: #dc2626;
+}
+
+QPushButton#kill_btn:pressed {
+    background-color: #b91c1c;
+    border-color: #b91c1c;
+}
+
+QPushButton#kill_btn:disabled {
+    background-color: #f1f5f9;
+    border-color: #e2e8f0;
+    color: #cbd5e1;
+}
+
+/* Log View (QTextEdit) terminal styling */
+QTextEdit#log_view {
+    background-color: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 8px;
+    color: #e2e8f0;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+    padding: 12px;
+}
+
+/* ScrollBar Styling */
+QScrollBar:vertical {
+    background-color: #0f172a;
+    width: 12px;
+    margin: 0px;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #334155;
+    min-height: 20px;
+    border-radius: 6px;
+    border: 2px solid #0f172a;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #475569;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0px;
+}
+
+QScrollBar::add-page:vertical,
+QScrollBar::sub-page:vertical {
+    background: none;
+}

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -122,7 +122,8 @@ QPushButton:disabled {
 
 /* Primary Action Buttons */
 QPushButton#save_config_btn,
-QPushButton#doctor_btn {
+QPushButton#doctor_btn,
+QPushButton#api_btn {
     background-color: #2563eb;
     border: 1px solid #2563eb;
     color: #ffffff;
@@ -130,13 +131,15 @@ QPushButton#doctor_btn {
 }
 
 QPushButton#save_config_btn:hover,
-QPushButton#doctor_btn:hover {
+QPushButton#doctor_btn:hover,
+QPushButton#api_btn:hover {
     background-color: #1d4ed8;
     border-color: #1d4ed8;
 }
 
 QPushButton#save_config_btn:pressed,
-QPushButton#doctor_btn:pressed {
+QPushButton#doctor_btn:pressed,
+QPushButton#api_btn:pressed {
     background-color: #1e40af;
     border-color: #1e40af;
 }

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -65,3 +65,28 @@ QStatusBar {
     background: #f6f7f9;
     color: #475569;
 }
+
+QComboBox {
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    color: #1f2937;
+    min-height: 24px;
+    padding: 3px 6px;
+}
+
+QComboBox:hover {
+    border-color: #94a3b8;
+}
+
+QComboBox:disabled {
+    background: #f1f5f9;
+    border-color: #e2e8f0;
+    color: #94a3b8;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 20px;
+}
+

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -249,6 +249,7 @@ class GuiProjectStateTests(unittest.TestCase):
             state.save_translator_config(config)
 
             saved = json.loads(state.config_path.read_text(encoding="utf-8"))
+            self.assertEqual(saved["game_root"], "some_root")
             self.assertEqual(saved["sync"]["model"], "gemini-new")
             self.assertEqual(saved["sync"]["chunk_size"], 40)
             self.assertEqual(saved["batch"]["model"], "gemini-new-batch")

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -220,6 +220,41 @@ class GuiProjectStateTests(unittest.TestCase):
 
             self.assertEqual(state.load_translator_config(), {})
 
+    def test_save_model_config_preserves_other_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state.config_path.write_text(
+                json.dumps(
+                    {
+                        "game_root": "some_root",
+                        "sync": {
+                            "model": "gemini-old",
+                            "chunk_size": 40,
+                        },
+                        "batch": {
+                            "model": "gemini-old-batch",
+                            "thinking_level": "",
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            config = state.load_translator_config()
+            config.setdefault("sync", {})["model"] = "gemini-new"
+            config.setdefault("batch", {})["model"] = "gemini-new-batch"
+            config.setdefault("batch", {})["thinking_level"] = "high"
+            state.save_translator_config(config)
+
+            saved = json.loads(state.config_path.read_text(encoding="utf-8"))
+            self.assertEqual(saved["sync"]["model"], "gemini-new")
+            self.assertEqual(saved["sync"]["chunk_size"], 40)
+            self.assertEqual(saved["batch"]["model"], "gemini-new-batch")
+            self.assertEqual(saved["batch"]["thinking_level"], "high")
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -257,4 +257,3 @@ class GuiProjectStateTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary

Refs #42.

Adds a second GUI iteration on top of the optional PySide6 shell:

- adds Sync and Batch model selectors, RAG embedding selectors, and Batch thinking-level control
- saves those choices back to `translator_config.json` while preserving unrelated config fields
- refreshes the workbench layout and QSS styling for the expanded controls
- hardens GUI config handling when nested `sync`, `batch`, or `rag` sections are malformed

## Validation

- `python -c "import ast, pathlib; files=[r'gui_qt\\app.py', r'gui_qt\\project_state.py', r'tests\\test_gui_project_state.py']; [ast.parse(pathlib.Path(f).read_text(encoding='utf-8'), filename=f) for f in files]; print('AST parse ok')"`
- `python -B -m unittest discover -s tests -p test_gui_project_state.py -q`
- `git diff --check origin/main..HEAD`

## Notes

This PR is intentionally scoped to GUI configuration controls. It does not change the CLI translation pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration persistence for model and embedding selections in Sync and Batch settings.
  * Introduced batch "thinking level" selector for supported models.
  * Added save configuration button to persist settings.

* **Style**
  * Applied "Premium Slate Theme" with improved visual styling for buttons, input fields, and layout components.

* **Tests**
  * Added test to ensure configuration changes preserve existing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->