### PR TITLE
[codex] Add GUI doctor result summary

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -32,7 +32,13 @@ from PySide6.QtWidgets import (
 )
 
 from .cli_runner import CliRunner
-from .doctor_report import DoctorSummary, idle_summary, running_summary, summarize_doctor_output
+from .doctor_report import (
+    DoctorSummary,
+    idle_summary,
+    running_summary,
+    stale_summary,
+    summarize_doctor_output,
+)
 from .project_state import ProjectState
 
 
@@ -253,6 +259,9 @@ class MainWindow(QMainWindow):
                 return
             self._refresh_project_label()
             self._load_config_to_ui()
+            self._active_command = ""
+            self._doctor_output_lines = []
+            self._set_doctor_summary(stale_summary())
             self._append_log(f"项目目录已设置为：{directory}")
 
     def _masked_key(self, key: str) -> str:
@@ -356,6 +365,8 @@ class MainWindow(QMainWindow):
             )
         elif summary.status in {"idle", "running"}:
             self.doctor_findings_view.setPlainText("等待项目检查结果。")
+        elif summary.status == "stale":
+            self.doctor_findings_view.setPlainText("请重新运行项目检查。")
         else:
             self.doctor_findings_view.setPlainText("未发现需要处理的事项。")
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -32,6 +32,7 @@ from PySide6.QtWidgets import (
 )
 
 from .cli_runner import CliRunner
+from .doctor_report import DoctorSummary, idle_summary, running_summary, summarize_doctor_output
 from .project_state import ProjectState
 
 
@@ -47,6 +48,8 @@ class MainWindow(QMainWindow):
         self._updating_batch_thinking_combo = False
         self._batch_thinking_config_has_key = False
         self._batch_thinking_user_changed = False
+        self._active_command = ""
+        self._doctor_output_lines: list[str] = []
 
         central = QWidget()
         self.setCentralWidget(central)
@@ -181,6 +184,33 @@ class MainWindow(QMainWindow):
         action_layout.addStretch()
         layout.addLayout(action_layout)
 
+        # Doctor summary
+        doctor_summary_box = QGroupBox("项目检查摘要")
+        doctor_summary_layout = QVBoxLayout(doctor_summary_box)
+        doctor_summary_layout.setSpacing(6)
+        doctor_summary_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.doctor_status_label = QLabel()
+        self.doctor_status_label.setObjectName("doctor_status_label")
+        doctor_summary_layout.addWidget(self.doctor_status_label)
+
+        self.doctor_message_label = QLabel()
+        self.doctor_message_label.setWordWrap(True)
+        doctor_summary_layout.addWidget(self.doctor_message_label)
+
+        self.doctor_facts_label = QLabel()
+        self.doctor_facts_label.setWordWrap(True)
+        self.doctor_facts_label.setObjectName("doctor_facts_label")
+        doctor_summary_layout.addWidget(self.doctor_facts_label)
+
+        self.doctor_findings_view = QTextEdit()
+        self.doctor_findings_view.setReadOnly(True)
+        self.doctor_findings_view.setMaximumHeight(92)
+        self.doctor_findings_view.setObjectName("doctor_findings_view")
+        doctor_summary_layout.addWidget(self.doctor_findings_view)
+
+        layout.addWidget(doctor_summary_box)
+
         # Output
         out_label = QLabel("诊断输出（来自命令行）")
         layout.addWidget(out_label)
@@ -192,12 +222,13 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.log_view, 1)
 
         # Connect runner
-        self.runner.line_ready.connect(self._append_log)
+        self.runner.line_ready.connect(self._on_cli_line_ready)
         self.runner.finished.connect(self._on_finished)
         self.runner.error.connect(self._on_runner_error)
 
         self._refresh_project_label()
         self._load_config_to_ui()
+        self._set_doctor_summary(idle_summary())
 
         # Status
         self.statusBar().showMessage(
@@ -285,6 +316,9 @@ class MainWindow(QMainWindow):
             return
 
         self.log_view.clear()
+        self._active_command = "doctor"
+        self._doctor_output_lines = []
+        self._set_doctor_summary(running_summary())
         self._append_log("=== 正在运行：gemini_translate_batch.py doctor ===\n")
         self.doctor_btn.setEnabled(False)
         self.kill_btn.setEnabled(True)
@@ -298,14 +332,37 @@ class MainWindow(QMainWindow):
 
     # --- Runner callbacks ---
 
+    def _on_cli_line_ready(self, text: str):
+        if self._active_command == "doctor":
+            self._doctor_output_lines.append(text)
+        self._append_log(text)
+
     def _append_log(self, text: str):
         self.log_view.append(text.rstrip("\n"))
         # scroll to bottom
         scrollbar = self.log_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
+    def _set_doctor_summary(self, summary: DoctorSummary):
+        self.doctor_status_label.setText(summary.heading)
+        self.doctor_status_label.setProperty("status", summary.status)
+        self.doctor_status_label.style().unpolish(self.doctor_status_label)
+        self.doctor_status_label.style().polish(self.doctor_status_label)
+        self.doctor_message_label.setText(summary.message)
+        self.doctor_facts_label.setText("\n".join(summary.facts))
+        if summary.findings:
+            self.doctor_findings_view.setPlainText(
+                "\n".join(f"- {finding}" for finding in summary.findings)
+            )
+        elif summary.status in {"idle", "running"}:
+            self.doctor_findings_view.setPlainText("等待项目检查结果。")
+        else:
+            self.doctor_findings_view.setPlainText("未发现需要处理的事项。")
+
     def _on_runner_error(self, message: str):
         self._append_log(message)
+        if self._active_command == "doctor":
+            self._doctor_output_lines.append(message)
         self.doctor_btn.setEnabled(True)
         self.kill_btn.setEnabled(False)
         self.statusBar().showMessage("项目检查失败，请查看诊断输出。", 6000)
@@ -314,6 +371,16 @@ class MainWindow(QMainWindow):
         self.doctor_btn.setEnabled(True)
         self.kill_btn.setEnabled(False)
         self._append_log(f"\n[进程已结束，退出码：{exit_code}]")
+        if self._active_command == "doctor":
+            api_key_count, api_key_source = self.state.get_api_key_status()
+            summary = summarize_doctor_output(
+                "\n".join(self._doctor_output_lines),
+                exit_code,
+                api_key_count=api_key_count,
+                api_key_source=api_key_source,
+            )
+            self._set_doctor_summary(summary)
+            self._active_command = ""
         if exit_code == 0:
             self.statusBar().showMessage("项目检查完成。", 6000)
         else:

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -1,0 +1,177 @@
+"""User-facing summaries for the GUI doctor command."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DoctorSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+
+
+MODE_MESSAGES = {
+    "can_generate_template": "Ren'Py 模板生成环境可用，可以检查或刷新翻译模板。",
+    "existing_tl_only": "已有翻译文件可处理；模板生成环境不可用，后续依赖现有 TL 文件。",
+    "blocked_missing_template": "缺少可处理的翻译文件，也无法自动生成模板。",
+}
+
+
+def _parse_bool(value: str) -> bool | None:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    return None
+
+
+def _parse_counts(raw_counts: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, value in re.findall(r"([a-z_]+)=(-?\d+)", raw_counts):
+        counts[key] = int(value)
+    return counts
+
+
+def parse_doctor_output(output: str) -> dict[str, object]:
+    parsed: dict[str, object] = {"warnings": []}
+    in_warnings = False
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if line == "Warnings:":
+            in_warnings = True
+            continue
+
+        if in_warnings:
+            if line.startswith("- "):
+                parsed.setdefault("warnings", []).append(line[2:].strip())
+                continue
+            in_warnings = False
+
+        if line.startswith("- Base dir:"):
+            parsed["base_dir"] = line.split(":", 1)[1].strip()
+            continue
+
+        if line.startswith("- TL dir:"):
+            match = re.match(r"- TL dir:\s*(.*?)\s*\(exists:\s*(True|False)\)", line)
+            if match:
+                parsed["tl_dir"] = match.group(1).strip()
+                parsed["tl_exists"] = _parse_bool(match.group(2))
+            continue
+
+        if line.startswith("- Language:"):
+            parsed["language"] = line.split(":", 1)[1].strip()
+            continue
+
+        if line.startswith("- Template generation:"):
+            parsed["template_generation"] = line.split(":", 1)[1].strip()
+            parsed["can_generate_template"] = line.startswith("- Template generation: available")
+            continue
+
+        if line.startswith("- Mode:"):
+            parsed["mode"] = line.split(":", 1)[1].strip()
+            continue
+
+        if line.startswith("- TL scan:"):
+            parsed["counts"] = _parse_counts(line.split(":", 1)[1])
+            continue
+
+    return parsed
+
+
+def summarize_doctor_output(
+    output: str,
+    exit_code: int,
+    api_key_count: int | None = None,
+    api_key_source: str = "",
+) -> DoctorSummary:
+    parsed = parse_doctor_output(output)
+    warnings = [
+        warning
+        for warning in parsed.get("warnings", [])
+        if isinstance(warning, str) and warning.strip()
+    ]
+    counts = parsed.get("counts") if isinstance(parsed.get("counts"), dict) else {}
+    mode = parsed.get("mode") if isinstance(parsed.get("mode"), str) else ""
+
+    facts: list[str] = []
+    if parsed.get("base_dir"):
+        facts.append(f"项目目录：{parsed['base_dir']}")
+    if parsed.get("tl_dir"):
+        exists_text = "存在" if parsed.get("tl_exists") is True else "不存在"
+        facts.append(f"翻译目录：{exists_text}")
+    if parsed.get("language"):
+        facts.append(f"目标语言：{parsed['language']}")
+    if mode:
+        facts.append(f"检查模式：{mode}")
+    if counts:
+        rpy_files = int(counts.get("rpy_files", 0))
+        old_lines = int(counts.get("old_lines", 0))
+        new_lines = int(counts.get("new_lines", 0))
+        facts.append(f"扫描到 {rpy_files} 个 .rpy 文件，old/new 行数 {old_lines}/{new_lines}")
+
+    findings = list(warnings)
+    if api_key_count is not None:
+        if api_key_count > 0:
+            if api_key_source == "environment":
+                facts.append(f"API Key：已通过环境变量配置 {api_key_count} 个")
+            else:
+                facts.append(f"API Key：已配置 {api_key_count} 个")
+        else:
+            findings.append("尚未配置 API Key；doctor 不调用 Gemini，但后续翻译任务需要 API Key。")
+
+    if exit_code != 0:
+        return DoctorSummary(
+            status="blocked",
+            heading="项目检查失败",
+            message="命令行检查没有正常完成，请查看下方诊断输出。",
+            facts=facts,
+            findings=findings,
+        )
+
+    if mode == "blocked_missing_template":
+        status = "blocked"
+        heading = "需要先准备翻译模板"
+    elif findings:
+        status = "warning"
+        heading = "检查完成，但有需要处理的事项"
+    else:
+        status = "ready"
+        heading = "项目检查通过"
+
+    message = MODE_MESSAGES.get(mode, "项目检查已完成。")
+    return DoctorSummary(
+        status=status,
+        heading=heading,
+        message=message,
+        facts=facts,
+        findings=findings,
+    )
+
+
+def running_summary() -> DoctorSummary:
+    return DoctorSummary(
+        status="running",
+        heading="正在检查项目",
+        message="正在运行 doctor；完成后这里会显示可读摘要。",
+        facts=[],
+        findings=[],
+    )
+
+
+def idle_summary() -> DoctorSummary:
+    return DoctorSummary(
+        status="idle",
+        heading="尚未运行项目检查",
+        message="选择游戏 work 目录后运行 doctor。",
+        facts=[],
+        findings=[],
+    )

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -15,7 +15,7 @@ class DoctorSummary:
 
 
 MODE_MESSAGES = {
-    "can_generate_template": "Ren'Py 模板生成环境可用，可以检查或刷新翻译模板。",
+    "can_generate_template": "Ren'Py 模板生成环境可用；如翻译模板尚不存在，需要先生成或刷新模板。",
     "existing_tl_only": "已有翻译文件可处理；模板生成环境不可用，后续依赖现有 TL 文件。",
     "blocked_missing_template": "缺少可处理的翻译文件，也无法自动生成模板。",
 }
@@ -119,6 +119,16 @@ def summarize_doctor_output(
         facts.append(f"扫描到 {rpy_files} 个 .rpy 文件，old/new 行数 {old_lines}/{new_lines}")
 
     findings = list(warnings)
+    if mode == "can_generate_template":
+        if parsed.get("tl_exists") is False:
+            findings.append(
+                "翻译目录尚不存在；doctor 可以生成模板，但还没有可检查的 TL 文件。"
+                "请先生成或刷新翻译模板后重新检查。"
+            )
+        elif counts and int(counts.get("rpy_files", 0)) == 0:
+            findings.append(
+                "翻译目录中没有可处理的 .rpy 文件；请先生成或刷新翻译模板后重新检查。"
+            )
     if api_key_count is not None:
         if api_key_count > 0:
             if api_key_source == "environment":
@@ -172,6 +182,16 @@ def idle_summary() -> DoctorSummary:
         status="idle",
         heading="尚未运行项目检查",
         message="选择游戏 work 目录后运行 doctor。",
+        facts=[],
+        findings=[],
+    )
+
+
+def stale_summary() -> DoctorSummary:
+    return DoctorSummary(
+        status="stale",
+        heading="项目已切换，请重新运行检查",
+        message="当前摘要已清空；请针对新的 work 目录重新运行 doctor。",
         facts=[],
         findings=[],
     )

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -166,8 +166,31 @@ class ProjectState:
         except Exception:
             return []
 
+    def _is_placeholder_api_key(self, value: str) -> bool:
+        text = value.strip().lower()
+        if not text:
+            return True
+        placeholder_markers = (
+            "your-key",
+            "your api key",
+            "your-api-key",
+            "your_gemini_api_key",
+            "your-gemini-api-key",
+            "paste-key",
+            "paste-api-key",
+            "replace-me",
+        )
+        return any(marker in text for marker in placeholder_markers)
+
+    def _valid_api_keys(self, keys: list[str]) -> list[str]:
+        return [
+            key
+            for key in keys
+            if isinstance(key, str) and key.strip() and not self._is_placeholder_api_key(key)
+        ]
+
     def get_api_key_status(self) -> tuple[int, str]:
-        file_keys = self.load_api_keys()
+        file_keys = self._valid_api_keys(self.load_api_keys())
         if file_keys:
             return len(file_keys), "file"
         env_keys = [
@@ -175,7 +198,7 @@ class ProjectState:
             os.environ.get("GEMINI_API_KEY_2"),
             os.environ.get("GEMINI_API_KEY_3"),
         ]
-        configured_env_keys = [key for key in env_keys if isinstance(key, str) and key.strip()]
+        configured_env_keys = self._valid_api_keys([key for key in env_keys if isinstance(key, str)])
         if configured_env_keys:
             return len(configured_env_keys), "environment"
         return 0, ""

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -166,6 +166,20 @@ class ProjectState:
         except Exception:
             return []
 
+    def get_api_key_status(self) -> tuple[int, str]:
+        file_keys = self.load_api_keys()
+        if file_keys:
+            return len(file_keys), "file"
+        env_keys = [
+            os.environ.get("GEMINI_API_KEY"),
+            os.environ.get("GEMINI_API_KEY_2"),
+            os.environ.get("GEMINI_API_KEY_3"),
+        ]
+        configured_env_keys = [key for key in env_keys if isinstance(key, str) and key.strip()]
+        if configured_env_keys:
+            return len(configured_env_keys), "environment"
+        return 0, ""
+
     def save_api_keys(self, keys: list[str]) -> None:
         """Save API keys while preserving legacy/unknown fields."""
         data = self._read_json_object(self.api_keys_path, "api_keys.json")

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -197,6 +197,10 @@ QLabel#doctor_status_label[status="warning"] {
     color: #b45309;
 }
 
+QLabel#doctor_status_label[status="stale"] {
+    color: #b45309;
+}
+
 QLabel#doctor_status_label[status="blocked"] {
     color: #b91c1c;
 }

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -179,6 +179,40 @@ QTextEdit#log_view {
     padding: 12px;
 }
 
+QLabel#doctor_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#doctor_status_label[status="idle"],
+QLabel#doctor_status_label[status="running"] {
+    color: #2563eb;
+}
+
+QLabel#doctor_status_label[status="ready"] {
+    color: #15803d;
+}
+
+QLabel#doctor_status_label[status="warning"] {
+    color: #b45309;
+}
+
+QLabel#doctor_status_label[status="blocked"] {
+    color: #b91c1c;
+}
+
+QLabel#doctor_facts_label {
+    color: #334155;
+}
+
+QTextEdit#doctor_findings_view {
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    color: #334155;
+    padding: 8px;
+}
+
 /* ScrollBar Styling */
 QScrollBar:vertical {
     background-color: #0f172a;

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -1,0 +1,80 @@
+import unittest
+
+from gui_qt.doctor_report import parse_doctor_output, summarize_doctor_output
+
+
+DOCTOR_OUTPUT = """
+============================================================
+Gemini Batch Translator (Ren'Py)
+============================================================
+Doctor report:
+- Base dir: C:\\Games\\Example\\work
+- TL dir: C:\\Games\\Example\\work\\game\\tl\\schinese (exists: True)
+- Language: schinese
+- Template generation: unavailable (no command resolved)
+- Mode: existing_tl_only
+- TL scan: rpy_files=3, translate_blocks=2, string_sections=1, old_lines=10, new_lines=10, commented_original_lines=2
+"""
+
+
+class GuiDoctorReportTests(unittest.TestCase):
+    def test_parse_doctor_output_extracts_mode_and_counts(self):
+        parsed = parse_doctor_output(DOCTOR_OUTPUT)
+
+        self.assertEqual(parsed["mode"], "existing_tl_only")
+        self.assertEqual(parsed["tl_exists"], True)
+        self.assertEqual(parsed["counts"]["rpy_files"], 3)
+        self.assertEqual(parsed["counts"]["old_lines"], 10)
+
+    def test_successful_existing_tl_without_api_key_is_warning(self):
+        summary = summarize_doctor_output(DOCTOR_OUTPUT, exit_code=0, api_key_count=0)
+
+        self.assertEqual(summary.status, "warning")
+        self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
+        self.assertIn("已有翻译文件", summary.message)
+        self.assertTrue(any("API Key" in finding for finding in summary.findings))
+
+    def test_successful_clean_report_is_ready(self):
+        summary = summarize_doctor_output(DOCTOR_OUTPUT, exit_code=0, api_key_count=2)
+
+        self.assertEqual(summary.status, "ready")
+        self.assertEqual(summary.heading, "项目检查通过")
+        self.assertTrue(any("API Key：已配置 2 个" in fact for fact in summary.facts))
+        self.assertEqual(summary.findings, [])
+
+    def test_environment_api_key_source_is_reported(self):
+        summary = summarize_doctor_output(
+            DOCTOR_OUTPUT,
+            exit_code=0,
+            api_key_count=1,
+            api_key_source="environment",
+        )
+
+        self.assertTrue(any("环境变量" in fact for fact in summary.facts))
+
+    def test_blocked_missing_template_is_blocked(self):
+        output = DOCTOR_OUTPUT.replace("existing_tl_only", "blocked_missing_template")
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
+
+        self.assertEqual(summary.status, "blocked")
+        self.assertEqual(summary.heading, "需要先准备翻译模板")
+
+    def test_nonzero_exit_is_blocked(self):
+        summary = summarize_doctor_output("startup failed", exit_code=1, api_key_count=1)
+
+        self.assertEqual(summary.status, "blocked")
+        self.assertEqual(summary.heading, "项目检查失败")
+        self.assertIn("命令行检查没有正常完成", summary.message)
+
+    def test_doctor_warnings_are_preserved(self):
+        output = DOCTOR_OUTPUT + "\nWarnings:\n- old/new line counts differ; string translation blocks may be malformed.\n"
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
+
+        self.assertEqual(summary.status, "warning")
+        self.assertTrue(any("old/new line counts differ" in finding for finding in summary.findings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -1,6 +1,6 @@
 import unittest
 
-from gui_qt.doctor_report import parse_doctor_output, summarize_doctor_output
+from gui_qt.doctor_report import parse_doctor_output, stale_summary, summarize_doctor_output
 
 
 DOCTOR_OUTPUT = """
@@ -14,6 +14,20 @@ Doctor report:
 - Template generation: unavailable (no command resolved)
 - Mode: existing_tl_only
 - TL scan: rpy_files=3, translate_blocks=2, string_sections=1, old_lines=10, new_lines=10, commented_original_lines=2
+"""
+
+GENERATE_TEMPLATE_OUTPUT = """
+============================================================
+Gemini Batch Translator (Ren'Py)
+============================================================
+Doctor report:
+- Base dir: C:\\Games\\Example\\work
+- TL dir: C:\\Games\\Example\\work\\game\\tl\\schinese (exists: False)
+- Language: schinese
+- Template generation: available (renpy-sdk)
+- Template command: C:\\RenPy\\renpy.exe C:\\Games\\Example\\work\\game translate schinese
+- Mode: can_generate_template
+- TL scan: rpy_files=0, translate_blocks=0, string_sections=0, old_lines=0, new_lines=0, commented_original_lines=0
 """
 
 
@@ -41,6 +55,26 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.heading, "项目检查通过")
         self.assertTrue(any("API Key：已配置 2 个" in fact for fact in summary.facts))
         self.assertEqual(summary.findings, [])
+
+    def test_can_generate_template_without_tl_files_is_warning(self):
+        summary = summarize_doctor_output(
+            GENERATE_TEMPLATE_OUTPUT,
+            exit_code=0,
+            api_key_count=1,
+        )
+
+        self.assertEqual(summary.status, "warning")
+        self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
+        self.assertTrue(any("翻译目录尚不存在" in finding for finding in summary.findings))
+        self.assertTrue(any("扫描到 0 个 .rpy 文件" in fact for fact in summary.facts))
+
+    def test_can_generate_template_with_empty_tl_dir_is_warning(self):
+        output = GENERATE_TEMPLATE_OUTPUT.replace("(exists: False)", "(exists: True)")
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
+
+        self.assertEqual(summary.status, "warning")
+        self.assertTrue(any("没有可处理的 .rpy 文件" in finding for finding in summary.findings))
 
     def test_environment_api_key_source_is_reported(self):
         summary = summarize_doctor_output(
@@ -74,6 +108,12 @@ class GuiDoctorReportTests(unittest.TestCase):
 
         self.assertEqual(summary.status, "warning")
         self.assertTrue(any("old/new line counts differ" in finding for finding in summary.findings))
+
+    def test_stale_summary_marks_previous_result_invalid(self):
+        summary = stale_summary()
+
+        self.assertEqual(summary.status, "stale")
+        self.assertIn("重新运行", summary.heading)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -46,12 +46,36 @@ class GuiProjectStateTests(unittest.TestCase):
             root = Path(tmp)
             state = self.make_state(root)
             state.api_keys_path.write_text(
-                json.dumps({"api_keys": ["file-key"]}),
+                json.dumps({"api_keys": ["file-key", "your-key-here", " "]}),
                 encoding="utf-8",
             )
 
             with patch.dict(os.environ, {"GEMINI_API_KEY": "env-key"}):
                 self.assertEqual(state.get_api_key_status(), (1, "file"))
+
+    def test_api_key_status_ignores_file_placeholders_before_env_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state.api_keys_path.write_text(
+                json.dumps({"api_keys": ["your-key-here", "replace-me", " "]}),
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"GEMINI_API_KEY": "env-key"}):
+                self.assertEqual(state.get_api_key_status(), (1, "environment"))
+
+    def test_api_key_status_treats_only_placeholders_as_unconfigured(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state.api_keys_path.write_text(
+                json.dumps({"api_keys": ["your_gemini_api_key", "paste-api-key"]}),
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(state.get_api_key_status(), (0, ""))
 
     def test_api_key_status_falls_back_to_environment(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -41,6 +41,33 @@ class GuiProjectStateTests(unittest.TestCase):
             self.assertEqual(saved["batch_size"], 5)
             self.assertEqual(saved["legacy"], {"enabled": True})
 
+    def test_api_key_status_uses_file_keys_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state.api_keys_path.write_text(
+                json.dumps({"api_keys": ["file-key"]}),
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"GEMINI_API_KEY": "env-key"}):
+                self.assertEqual(state.get_api_key_status(), (1, "file"))
+
+    def test_api_key_status_falls_back_to_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "GEMINI_API_KEY": "env-key",
+                    "GEMINI_API_KEY_2": " ",
+                    "GEMINI_API_KEY_3": "env-key-3",
+                },
+            ):
+                self.assertEqual(state.get_api_key_status(), (2, "environment"))
+
     def test_api_keys_path_uses_legacy_data_file_when_root_file_absent(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)


### PR DESCRIPTION
## Summary

Refs #42.

Adds the next GUI workbench step for project checking. This PR keeps the GUI as a shell over the existing `doctor` CLI output, but gives normal users a readable project-check summary above the raw diagnostic log.

## What changed

- Add `gui_qt.doctor_report` to parse the current `doctor` report text into a GUI-facing summary.
- Show a `项目检查摘要` panel with ready / warning / blocked states, key facts, and user-facing findings.
- Preserve the raw CLI output in the existing diagnostics log for advanced users.
- Include API key status in the summary, including environment-variable keys as read-only configured keys.
- Add QSS styling for the doctor summary status and findings panel.
- Add focused tests for doctor output parsing, summary classification, and API key status detection.

## Scope notes

This does not implement the full one-click translation flow yet. It does not run `build -> submit -> status -> download -> check`, does not restore manifest state, and does not expose apply/write-back controls. Those remain future `Refs #42` work.

## Validation

- `python -m unittest -q tests.test_gui_doctor_report tests.test_gui_project_state tests.test_gui_app_config`
- `python -m unittest discover -s tests -q`
- `python -m py_compile gui_qt\app.py gui_qt\doctor_report.py gui_qt\project_state.py tests\test_gui_doctor_report.py tests\test_gui_project_state.py`
- `git diff --check`
- `python gemini_translate_batch.py doctor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “project doctor” summary panel that reports readiness (ready/warning/blocked), key facts, and curated findings (with a new “stale” state).
  * Doctor runs now produce structured, localized summaries from parsed output and detected API key configuration.
* **UI Updates**
  * Improved doctor panel UI with status-colored labels and a dedicated capped read-only findings view.
* **Tests**
  * Expanded unit coverage for doctor output parsing/summarization and `get_api_key_status` logic, including placeholder/invalid key handling and file-vs-environment precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->