### PR TITLE
[codex] Add GUI translation workflow runner

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
@@ -415,8 +416,14 @@ class MainWindow(QMainWindow):
             )
             return
 
+        try:
+            manifest = self.state.load_resume_manifest(latest_manifest)
+        except ValueError as exc:
+            QMessageBox.warning(self, "无法继续最新任务", str(exc))
+            return
+
         self.log_view.clear()
-        self._workflow = TranslationWorkflow.resume_latest(str(latest_manifest))
+        self._workflow = TranslationWorkflow.resume_manifest(str(latest_manifest), manifest)
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
         self._append_log("=== 正在继续最新 Batch 翻译任务 ===\n")
@@ -558,7 +565,7 @@ class MainWindow(QMainWindow):
 
         if update.should_continue:
             self.statusBar().showMessage(update.heading, 3000)
-            self._run_workflow_current_step()
+            QTimer.singleShot(0, self._run_workflow_current_step)
             return
 
         self._active_command = ""

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -40,6 +40,7 @@ from .doctor_report import (
     summarize_doctor_output,
 )
 from .project_state import ProjectState
+from .translation_workflow import TranslationWorkflow, WorkflowUpdate
 
 
 class MainWindow(QMainWindow):
@@ -56,6 +57,8 @@ class MainWindow(QMainWindow):
         self._batch_thinking_user_changed = False
         self._active_command = ""
         self._doctor_output_lines: list[str] = []
+        self._workflow: TranslationWorkflow | None = None
+        self._workflow_step_output_lines: list[str] = []
 
         central = QWidget()
         self.setCentralWidget(central)
@@ -181,6 +184,15 @@ class MainWindow(QMainWindow):
         self.api_btn.clicked.connect(self._on_manage_api_keys)
         action_layout.addWidget(self.api_btn)
 
+        self.translate_btn = QPushButton("开始翻译任务")
+        self.translate_btn.setObjectName("translate_btn")
+        self.translate_btn.clicked.connect(self._on_start_translation)
+        action_layout.addWidget(self.translate_btn)
+
+        self.resume_btn = QPushButton("继续最新任务")
+        self.resume_btn.clicked.connect(self._on_resume_translation)
+        action_layout.addWidget(self.resume_btn)
+
         self.kill_btn = QPushButton("停止当前任务")
         self.kill_btn.setObjectName("kill_btn")
         self.kill_btn.clicked.connect(self._on_kill)
@@ -217,8 +229,29 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(doctor_summary_box)
 
+        # Translation workflow summary
+        workflow_box = QGroupBox("翻译任务进度")
+        workflow_layout = QVBoxLayout(workflow_box)
+        workflow_layout.setSpacing(6)
+        workflow_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.workflow_status_label = QLabel()
+        self.workflow_status_label.setObjectName("workflow_status_label")
+        workflow_layout.addWidget(self.workflow_status_label)
+
+        self.workflow_message_label = QLabel()
+        self.workflow_message_label.setWordWrap(True)
+        workflow_layout.addWidget(self.workflow_message_label)
+
+        self.workflow_facts_label = QLabel()
+        self.workflow_facts_label.setWordWrap(True)
+        self.workflow_facts_label.setObjectName("workflow_facts_label")
+        workflow_layout.addWidget(self.workflow_facts_label)
+
+        layout.addWidget(workflow_box)
+
         # Output
-        out_label = QLabel("诊断输出（来自命令行）")
+        out_label = QLabel("诊断 / 任务输出（来自命令行）")
         layout.addWidget(out_label)
 
         self.log_view = QTextEdit()
@@ -235,6 +268,11 @@ class MainWindow(QMainWindow):
         self._refresh_project_label()
         self._load_config_to_ui()
         self._set_doctor_summary(idle_summary())
+        self._set_workflow_summary(
+            "idle",
+            "尚未开始翻译任务",
+            "运行项目检查后，可以开始基础 Batch 翻译流程。",
+        )
 
         # Status
         self.statusBar().showMessage(
@@ -261,7 +299,14 @@ class MainWindow(QMainWindow):
             self._load_config_to_ui()
             self._active_command = ""
             self._doctor_output_lines = []
+            self._workflow = None
+            self._workflow_step_output_lines = []
             self._set_doctor_summary(stale_summary())
+            self._set_workflow_summary(
+                "stale",
+                "项目已切换",
+                "翻译任务状态已清空；请先针对新项目重新检查。",
+            )
             self._append_log(f"项目目录已设置为：{directory}")
 
     def _masked_key(self, key: str) -> str:
@@ -329,12 +374,54 @@ class MainWindow(QMainWindow):
         self._doctor_output_lines = []
         self._set_doctor_summary(running_summary())
         self._append_log("=== 正在运行：gemini_translate_batch.py doctor ===\n")
-        self.doctor_btn.setEnabled(False)
-        self.kill_btn.setEnabled(True)
+        self._set_task_running(True)
 
         script = self.state.get_batch_script_path()
         # Run with no extra args — it will pick up translator_config.json
         self.runner.run(script, ["doctor"])
+
+    def _on_start_translation(self):
+        if not self.state.get_game_root():
+            QMessageBox.information(
+                self,
+                "请先选择项目",
+                "请先选择游戏的 work 目录。",
+            )
+            return
+
+        self.log_view.clear()
+        self._workflow = TranslationWorkflow.start_new()
+        self._active_command = "translation_workflow"
+        self._workflow_step_output_lines = []
+        self._append_log("=== 正在运行：基础 Batch 翻译流程 ===\n")
+        self._set_task_running(True)
+        self._run_workflow_current_step()
+
+    def _on_resume_translation(self):
+        if not self.state.get_game_root():
+            QMessageBox.information(
+                self,
+                "请先选择项目",
+                "请先选择游戏的 work 目录。",
+            )
+            return
+
+        latest_manifest = self.state.get_latest_manifest_path()
+        if latest_manifest is None:
+            QMessageBox.information(
+                self,
+                "没有可继续的任务",
+                "未找到 latest manifest；请先开始一个翻译任务。",
+            )
+            return
+
+        self.log_view.clear()
+        self._workflow = TranslationWorkflow.resume_latest(str(latest_manifest))
+        self._active_command = "translation_workflow"
+        self._workflow_step_output_lines = []
+        self._append_log("=== 正在继续最新 Batch 翻译任务 ===\n")
+        self._set_task_running(True)
+        self._run_workflow_current_step()
 
     def _on_kill(self):
         self.runner.kill()
@@ -344,6 +431,8 @@ class MainWindow(QMainWindow):
     def _on_cli_line_ready(self, text: str):
         if self._active_command == "doctor":
             self._doctor_output_lines.append(text)
+        elif self._active_command == "translation_workflow":
+            self._workflow_step_output_lines.append(text)
         self._append_log(text)
 
     def _append_log(self, text: str):
@@ -351,6 +440,57 @@ class MainWindow(QMainWindow):
         # scroll to bottom
         scrollbar = self.log_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
+
+    def _set_task_running(self, running: bool):
+        self.select_btn.setEnabled(not running)
+        self.doctor_btn.setEnabled(not running)
+        self.api_btn.setEnabled(not running)
+        self.translate_btn.setEnabled(not running)
+        self.resume_btn.setEnabled(not running)
+        self.save_config_btn.setEnabled(not running)
+        self.kill_btn.setEnabled(running)
+
+    def _set_workflow_summary(
+        self,
+        status: str,
+        heading: str,
+        message: str,
+        facts: list[str] | None = None,
+    ):
+        self.workflow_status_label.setText(heading)
+        self.workflow_status_label.setProperty("status", status)
+        self.workflow_status_label.style().unpolish(self.workflow_status_label)
+        self.workflow_status_label.style().polish(self.workflow_status_label)
+        self.workflow_message_label.setText(message)
+        self.workflow_facts_label.setText("\n".join(facts or []))
+
+    def _set_workflow_update(self, update: WorkflowUpdate):
+        self._set_workflow_summary(
+            update.status,
+            update.heading,
+            update.message,
+            update.facts,
+        )
+
+    def _run_workflow_current_step(self):
+        if self._workflow is None:
+            self._set_task_running(False)
+            return
+
+        step = self._workflow.current_step()
+        if step is None:
+            self._set_task_running(False)
+            self._active_command = ""
+            self._workflow = None
+            return
+
+        facts = []
+        if self._workflow.manifest_path:
+            facts.append(f"Manifest：{self._workflow.manifest_path}")
+        self._workflow_step_output_lines = []
+        self._set_workflow_summary("running", step.heading, step.message, facts)
+        self._append_log(f"\n=== {step.heading}：gemini_translate_batch.py {' '.join(step.args)} ===\n")
+        self.runner.run(self.state.get_batch_script_path(), step.args)
 
     def _set_doctor_summary(self, summary: DoctorSummary):
         self.doctor_status_label.setText(summary.heading)
@@ -374,13 +514,11 @@ class MainWindow(QMainWindow):
         self._append_log(message)
         if self._active_command == "doctor":
             self._doctor_output_lines.append(message)
-        self.doctor_btn.setEnabled(True)
-        self.kill_btn.setEnabled(False)
-        self.statusBar().showMessage("项目检查失败，请查看诊断输出。", 6000)
+        elif self._active_command == "translation_workflow":
+            self._workflow_step_output_lines.append(message)
+        self.statusBar().showMessage("任务运行失败，请查看命令行输出。", 6000)
 
     def _on_finished(self, exit_code: int):
-        self.doctor_btn.setEnabled(True)
-        self.kill_btn.setEnabled(False)
         self._append_log(f"\n[进程已结束，退出码：{exit_code}]")
         if self._active_command == "doctor":
             api_key_count, api_key_source = self.state.get_api_key_status()
@@ -392,10 +530,46 @@ class MainWindow(QMainWindow):
             )
             self._set_doctor_summary(summary)
             self._active_command = ""
-        if exit_code == 0:
-            self.statusBar().showMessage("项目检查完成。", 6000)
+            self._set_task_running(False)
+            if exit_code == 0:
+                self.statusBar().showMessage("项目检查完成。", 6000)
+            else:
+                self.statusBar().showMessage(f"项目检查失败（退出码：{exit_code}）", 6000)
+            return
+
+        if self._active_command == "translation_workflow":
+            self._on_workflow_step_finished(exit_code)
+            return
+
+        self._set_task_running(False)
+
+    def _on_workflow_step_finished(self, exit_code: int):
+        if self._workflow is None:
+            self._active_command = ""
+            self._set_task_running(False)
+            return
+
+        update = self._workflow.complete_current_step(
+            exit_code,
+            "\n".join(self._workflow_step_output_lines),
+        )
+        self._set_workflow_update(update)
+        self._workflow_step_output_lines = []
+
+        if update.should_continue:
+            self.statusBar().showMessage(update.heading, 3000)
+            self._run_workflow_current_step()
+            return
+
+        self._active_command = ""
+        self._workflow = None
+        self._set_task_running(False)
+        if update.status == "failed":
+            self.statusBar().showMessage("翻译任务失败，请查看命令行输出。", 8000)
+        elif update.status == "waiting":
+            self.statusBar().showMessage("Batch 任务仍在处理，可稍后继续最新任务。", 8000)
         else:
-            self.statusBar().showMessage(f"项目检查失败（退出码：{exit_code}）", 6000)
+            self.statusBar().showMessage("翻译任务流程完成。", 6000)
 
     # --- Config loading/saving helpers ---
 

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -45,11 +45,16 @@ class ProjectState:
     def get_batch_script_path(self) -> Path:
         return self.batch_script
 
+    def get_cli_root_dir(self) -> Path:
+        if (self.tool_root / "api_keys.json").exists():
+            return self.tool_root
+        return self.tool_root.parent
+
     def get_logs_dir(self) -> Path:
-        return self.tool_root / "logs" / "batch_jobs"
+        return self.get_cli_root_dir() / "logs" / "batch_jobs"
 
     def get_latest_manifest_path(self) -> Path | None:
-        latest_file = self.tool_root / "logs" / "batch_jobs" / "latest_manifest.txt"
+        latest_file = self.get_logs_dir() / "latest_manifest.txt"
         if latest_file.exists():
             try:
                 content = latest_file.read_text(encoding="utf-8").strip()
@@ -58,6 +63,23 @@ class ProjectState:
             except Exception:
                 pass
         return None
+
+    def load_resume_manifest(self, manifest_path: str | Path) -> dict[str, Any]:
+        manifest = self._read_json_object(Path(manifest_path), "batch manifest")
+        mode = manifest.get("mode", "translation")
+        if mode != "translation":
+            raise ValueError("最新任务不是基础翻译任务，不能在这里继续。")
+
+        game_root = self.get_game_root()
+        base_dir = manifest.get("base_dir")
+        if not isinstance(base_dir, str) or not base_dir.strip():
+            raise ValueError("最新任务缺少项目目录信息，不能安全继续。")
+        if game_root is not None and self._normalized_path_text(base_dir) != self._normalized_path_text(game_root):
+            raise ValueError("最新任务属于其他项目，请先选择对应 work 目录。")
+        return manifest
+
+    def _normalized_path_text(self, path: str | Path) -> str:
+        return os.path.normcase(os.path.abspath(str(path)))
 
     def _resolve_api_keys_path(self) -> Path:
         root_api_keys = self.tool_root / "api_keys.json"

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -123,7 +123,8 @@ QPushButton:disabled {
 /* Primary Action Buttons */
 QPushButton#save_config_btn,
 QPushButton#doctor_btn,
-QPushButton#api_btn {
+QPushButton#api_btn,
+QPushButton#translate_btn {
     background-color: #2563eb;
     border: 1px solid #2563eb;
     color: #ffffff;
@@ -132,14 +133,16 @@ QPushButton#api_btn {
 
 QPushButton#save_config_btn:hover,
 QPushButton#doctor_btn:hover,
-QPushButton#api_btn:hover {
+QPushButton#api_btn:hover,
+QPushButton#translate_btn:hover {
     background-color: #1d4ed8;
     border-color: #1d4ed8;
 }
 
 QPushButton#save_config_btn:pressed,
 QPushButton#doctor_btn:pressed,
-QPushButton#api_btn:pressed {
+QPushButton#api_btn:pressed,
+QPushButton#translate_btn:pressed {
     background-color: #1e40af;
     border-color: #1e40af;
 }
@@ -206,6 +209,33 @@ QLabel#doctor_status_label[status="blocked"] {
 }
 
 QLabel#doctor_facts_label {
+    color: #334155;
+}
+
+QLabel#workflow_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#workflow_status_label[status="idle"],
+QLabel#workflow_status_label[status="running"] {
+    color: #2563eb;
+}
+
+QLabel#workflow_status_label[status="done"] {
+    color: #15803d;
+}
+
+QLabel#workflow_status_label[status="waiting"],
+QLabel#workflow_status_label[status="stale"] {
+    color: #b45309;
+}
+
+QLabel#workflow_status_label[status="failed"] {
+    color: #b91c1c;
+}
+
+QLabel#workflow_facts_label {
     color: #334155;
 }
 

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import PurePosixPath, PureWindowsPath
 
 
 TERMINAL_FAILURE_STATES = {
@@ -57,6 +57,12 @@ def extract_job_state(output: str) -> str:
 
 def extract_safety_status(output: str) -> str:
     return _extract_line_value(output, "Safety status:")
+
+
+def manifest_path_for_package(package_path: str) -> str:
+    if re.match(r"^[A-Za-z]:", package_path) or package_path.startswith("\\\\") or "\\" in package_path:
+        return str(PureWindowsPath(package_path) / "manifest.json")
+    return str(PurePosixPath(package_path) / "manifest.json")
 
 
 def _extract_line_value(output: str, prefix: str) -> str:
@@ -143,7 +149,7 @@ class TranslationWorkflow:
                 facts=[],
             )
 
-        self.manifest_path = str(Path(package_path) / "manifest.json")
+        self.manifest_path = manifest_path_for_package(package_path)
         return self._continue_or_finish()
 
     def _finish_status(self, output: str) -> WorkflowUpdate | None:

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -84,6 +84,12 @@ class TranslationWorkflow:
     def resume_latest(cls, manifest_path: str) -> "TranslationWorkflow":
         return cls(["status"], manifest_path=manifest_path)
 
+    @classmethod
+    def resume_manifest(cls, manifest_path: str, manifest: dict[str, object]) -> "TranslationWorkflow":
+        if not manifest.get("job_name"):
+            return cls(["submit", "status"], manifest_path=manifest_path)
+        return cls.resume_latest(manifest_path)
+
     def current_step(self) -> WorkflowStep | None:
         if not self._pending_steps:
             return None

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -1,0 +1,219 @@
+"""Batch translation workflow state for the GUI.
+
+This module only plans and interprets CLI steps. The GUI still executes the
+existing command-line tool through ``CliRunner``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TERMINAL_FAILURE_STATES = {
+    "JOB_STATE_FAILED",
+    "JOB_STATE_CANCELLED",
+    "JOB_STATE_EXPIRED",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    key: str
+    args: list[str]
+    heading: str
+    message: str
+
+
+@dataclass(frozen=True)
+class WorkflowUpdate:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    should_continue: bool = False
+
+
+STEP_TEXT = {
+    "build": ("正在准备翻译内容", "正在扫描待翻译文本并生成 Batch 请求包。"),
+    "submit": ("正在提交翻译任务", "正在上传请求文件并创建 Batch 任务。"),
+    "status": ("正在刷新任务状态", "正在向 Batch API 查询当前处理状态。"),
+    "download": ("正在获取翻译结果", "任务已完成，正在下载结果文件。"),
+    "check": ("正在检查翻译结果", "正在校验结果是否可以进入写回前预览。"),
+}
+
+
+def extract_created_package_path(output: str) -> str:
+    return _extract_line_value(output, "Created batch package:")
+
+
+def extract_manifest_path(output: str) -> str:
+    return _extract_line_value(output, "Manifest:")
+
+
+def extract_job_state(output: str) -> str:
+    return _extract_line_value(output, "State:")
+
+
+def extract_safety_status(output: str) -> str:
+    return _extract_line_value(output, "Safety status:")
+
+
+def _extract_line_value(output: str, prefix: str) -> str:
+    pattern = re.compile(rf"^\s*{re.escape(prefix)}\s*(.+?)\s*$", re.MULTILINE)
+    match = pattern.search(output)
+    return match.group(1).strip() if match else ""
+
+
+class TranslationWorkflow:
+    def __init__(self, pending_steps: list[str], manifest_path: str = ""):
+        self._pending_steps = list(pending_steps)
+        self.manifest_path = manifest_path
+
+    @classmethod
+    def start_new(cls) -> "TranslationWorkflow":
+        return cls(["build", "submit", "status"])
+
+    @classmethod
+    def resume_latest(cls, manifest_path: str) -> "TranslationWorkflow":
+        return cls(["status"], manifest_path=manifest_path)
+
+    def current_step(self) -> WorkflowStep | None:
+        if not self._pending_steps:
+            return None
+        key = self._pending_steps[0]
+        heading, message = STEP_TEXT[key]
+        return WorkflowStep(
+            key=key,
+            args=self._args_for_step(key),
+            heading=heading,
+            message=message,
+        )
+
+    def complete_current_step(self, exit_code: int, output: str) -> WorkflowUpdate:
+        if not self._pending_steps:
+            return WorkflowUpdate(
+                status="failed",
+                heading="翻译流程状态异常",
+                message="没有正在等待完成的步骤。",
+                facts=[],
+            )
+
+        key = self._pending_steps.pop(0)
+        if exit_code != 0:
+            self._pending_steps.clear()
+            return WorkflowUpdate(
+                status="failed",
+                heading="翻译流程中断",
+                message=f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。",
+                facts=self._facts(),
+            )
+
+        if key == "build":
+            return self._finish_build(output)
+        if key == "submit":
+            manifest_path = extract_manifest_path(output)
+            if manifest_path:
+                self.manifest_path = manifest_path
+        if key == "status":
+            status_update = self._finish_status(output)
+            if status_update is not None:
+                return status_update
+        if key == "check":
+            return self._finish_check(output)
+
+        return self._continue_or_finish()
+
+    def _finish_build(self, output: str) -> WorkflowUpdate:
+        package_path = extract_created_package_path(output)
+        if not package_path:
+            if "No pending lines to translate." in output:
+                self._pending_steps.clear()
+                return WorkflowUpdate(
+                    status="done",
+                    heading="没有待翻译内容",
+                    message="当前项目没有需要提交到 Batch 的待翻译行。",
+                    facts=[],
+                )
+            self._pending_steps.clear()
+            return WorkflowUpdate(
+                status="failed",
+                heading="无法定位 Batch 请求包",
+                message="build 已结束，但输出中没有请求包路径；请查看原始输出。",
+                facts=[],
+            )
+
+        self.manifest_path = str(Path(package_path) / "manifest.json")
+        return self._continue_or_finish()
+
+    def _finish_status(self, output: str) -> WorkflowUpdate | None:
+        state = extract_job_state(output)
+        if state == "JOB_STATE_SUCCEEDED":
+            if "download" not in self._pending_steps:
+                self._pending_steps[:0] = ["download", "check"]
+            return self._continue_or_finish(
+                extra_facts=[f"Batch 状态：{state}"],
+            )
+        if state in TERMINAL_FAILURE_STATES:
+            self._pending_steps.clear()
+            return WorkflowUpdate(
+                status="failed",
+                heading="Batch 任务没有成功完成",
+                message=f"当前状态为 {state}，请查看原始输出后重试或重新生成任务。",
+                facts=self._facts([f"Batch 状态：{state}"]),
+            )
+
+        self._pending_steps.clear()
+        state_text = state or "未知"
+        return WorkflowUpdate(
+            status="waiting",
+            heading="Batch 任务仍在处理",
+            message="稍后可以继续刷新最新任务状态；任务成功后再下载并检查结果。",
+            facts=self._facts([f"Batch 状态：{state_text}"]),
+        )
+
+    def _finish_check(self, output: str) -> WorkflowUpdate:
+        safety = extract_safety_status(output)
+        if safety == "safe":
+            heading = "翻译结果检查通过"
+            message = "结果为 safe，可以进入后续写回前预览。"
+        elif safety in {"warn", "block"}:
+            heading = "翻译结果需要处理"
+            message = f"结果为 {safety}，普通流程不应写回；请先查看问题并重试或修复。"
+        else:
+            heading = "翻译结果检查完成"
+            message = "未能识别安全状态，请查看原始输出。"
+
+        self._pending_steps.clear()
+        facts = self._facts([f"安全状态：{safety or '未知'}"])
+        return WorkflowUpdate(status="done", heading=heading, message=message, facts=facts)
+
+    def _continue_or_finish(self, extra_facts: list[str] | None = None) -> WorkflowUpdate:
+        next_step = self.current_step()
+        if next_step is None:
+            return WorkflowUpdate(
+                status="done",
+                heading="翻译流程完成",
+                message="当前翻译任务流程已完成。",
+                facts=self._facts(extra_facts),
+            )
+        return WorkflowUpdate(
+            status="running",
+            heading=next_step.heading,
+            message=next_step.message,
+            facts=self._facts(extra_facts),
+            should_continue=True,
+        )
+
+    def _args_for_step(self, key: str) -> list[str]:
+        if key == "build" or not self.manifest_path:
+            return [key]
+        return [key, self.manifest_path]
+
+    def _facts(self, extra_facts: list[str] | None = None) -> list[str]:
+        facts: list[str] = []
+        if self.manifest_path:
+            facts.append(f"Manifest：{self.manifest_path}")
+        if extra_facts:
+            facts.extend(extra_facts)
+        return facts

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -211,6 +211,28 @@ class GuiProjectStateTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "属于其他项目"):
                 state.load_resume_manifest(manifest)
 
+    def test_load_resume_manifest_allows_missing_game_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            manifest = root / "manifest.json"
+            base_dir = root / "Game Work"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "mode": "translation",
+                        "base_dir": str(base_dir),
+                        "job_name": "batches/example",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            loaded = state.load_resume_manifest(manifest)
+
+            self.assertEqual(loaded["base_dir"], str(base_dir))
+            self.assertEqual(loaded["job_name"], "batches/example")
+
     def test_save_api_keys_preserves_existing_file_mode(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -127,6 +127,90 @@ class GuiProjectStateTests(unittest.TestCase):
 
             self.assertEqual(state._resolve_api_keys_path(), root_path)
 
+    def test_logs_dir_uses_legacy_root_when_root_api_keys_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = workspace / "renpy-translation-lab"
+            root.mkdir()
+            state = self.make_state(root)
+
+            self.assertEqual(state.get_logs_dir(), workspace / "logs" / "batch_jobs")
+
+    def test_logs_dir_prefers_tool_root_when_root_api_keys_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "api_keys.json").write_text(
+                json.dumps({"api_keys": ["root-key"]}),
+                encoding="utf-8",
+            )
+            state = self.make_state(root)
+
+            self.assertEqual(state.get_logs_dir(), root / "logs" / "batch_jobs")
+
+    def test_latest_manifest_path_uses_cli_log_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = workspace / "renpy-translation-lab"
+            root.mkdir()
+            jobs_dir = workspace / "logs" / "batch_jobs"
+            jobs_dir.mkdir(parents=True)
+            manifest = jobs_dir / "job1" / "manifest.json"
+            manifest.parent.mkdir()
+            manifest.write_text("{}", encoding="utf-8")
+            (jobs_dir / "latest_manifest.txt").write_text(str(manifest), encoding="utf-8")
+            state = self.make_state(root)
+
+            self.assertEqual(state.get_latest_manifest_path(), manifest)
+
+    def test_load_resume_manifest_accepts_current_translation_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state._game_root = root / "Game Work"
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "mode": "translation",
+                        "base_dir": str(state._game_root),
+                        "job_name": "batches/example",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            loaded = state.load_resume_manifest(manifest)
+
+            self.assertEqual(loaded["job_name"], "batches/example")
+
+    def test_load_resume_manifest_rejects_non_translation_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state._game_root = root / "Game Work"
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"mode": "revision", "base_dir": str(state._game_root)}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "不是基础翻译任务"):
+                state.load_resume_manifest(manifest)
+
+    def test_load_resume_manifest_rejects_other_project(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            state._game_root = root / "Game Work"
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"mode": "translation", "base_dir": str(root / "Other Work")}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "属于其他项目"):
+                state.load_resume_manifest(manifest)
+
     def test_save_api_keys_preserves_existing_file_mode(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_gui_translation_workflow.py
+++ b/tests/test_gui_translation_workflow.py
@@ -67,6 +67,22 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
         self.assertTrue(any("JOB_STATE_RUNNING" in fact for fact in update.facts))
         self.assertIsNone(workflow.current_step())
 
+    def test_resume_unsubmitted_manifest_starts_from_submit(self):
+        workflow = TranslationWorkflow.resume_manifest(
+            "C:\\package\\manifest.json",
+            {"job_name": ""},
+        )
+
+        self.assertEqual(workflow.current_step().args, ["submit", "C:\\package\\manifest.json"])
+
+    def test_resume_submitted_manifest_starts_from_status(self):
+        workflow = TranslationWorkflow.resume_manifest(
+            "C:\\package\\manifest.json",
+            {"job_name": "batches/example"},
+        )
+
+        self.assertEqual(workflow.current_step().args, ["status", "C:\\package\\manifest.json"])
+
     def test_status_succeeded_continues_to_download_and_check(self):
         workflow = TranslationWorkflow.resume_latest("C:\\package\\manifest.json")
 

--- a/tests/test_gui_translation_workflow.py
+++ b/tests/test_gui_translation_workflow.py
@@ -1,0 +1,96 @@
+import unittest
+
+from gui_qt.translation_workflow import (
+    TranslationWorkflow,
+    extract_created_package_path,
+    extract_job_state,
+    extract_safety_status,
+)
+
+
+BUILD_OUTPUT = """
+Created batch package: C:\\Games\\Example\\work\\logs\\batch_jobs\\job1
+Pending files: 2
+Chunks: 3
+Items: 10
+"""
+
+
+class GuiTranslationWorkflowTests(unittest.TestCase):
+    def test_extracts_cli_output_fields(self):
+        self.assertEqual(
+            extract_created_package_path(BUILD_OUTPUT),
+            "C:\\Games\\Example\\work\\logs\\batch_jobs\\job1",
+        )
+        self.assertEqual(extract_job_state("State: JOB_STATE_SUCCEEDED\n"), "JOB_STATE_SUCCEEDED")
+        self.assertEqual(extract_safety_status("Safety status: safe\n"), "safe")
+
+    def test_start_workflow_builds_then_submits_created_manifest(self):
+        workflow = TranslationWorkflow.start_new()
+
+        self.assertEqual(workflow.current_step().args, ["build"])
+        update = workflow.complete_current_step(0, BUILD_OUTPUT)
+
+        self.assertTrue(update.should_continue)
+        self.assertEqual(update.status, "running")
+        self.assertEqual(
+            workflow.current_step().args,
+            ["submit", "C:\\Games\\Example\\work\\logs\\batch_jobs\\job1\\manifest.json"],
+        )
+
+    def test_build_without_pending_lines_finishes_without_submitting_stale_manifest(self):
+        workflow = TranslationWorkflow.start_new()
+
+        update = workflow.complete_current_step(0, "No pending lines to translate.\n")
+
+        self.assertEqual(update.status, "done")
+        self.assertIn("没有待翻译内容", update.heading)
+        self.assertIsNone(workflow.current_step())
+
+    def test_status_waiting_stops_before_download(self):
+        workflow = TranslationWorkflow.resume_latest("C:\\package\\manifest.json")
+
+        update = workflow.complete_current_step(0, "State: JOB_STATE_RUNNING\n")
+
+        self.assertEqual(update.status, "waiting")
+        self.assertTrue(any("JOB_STATE_RUNNING" in fact for fact in update.facts))
+        self.assertIsNone(workflow.current_step())
+
+    def test_status_succeeded_continues_to_download_and_check(self):
+        workflow = TranslationWorkflow.resume_latest("C:\\package\\manifest.json")
+
+        status_update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED\n")
+        self.assertTrue(status_update.should_continue)
+        self.assertEqual(workflow.current_step().args, ["download", "C:\\package\\manifest.json"])
+
+        download_update = workflow.complete_current_step(0, "Saved results to: C:\\package\\results.jsonl\n")
+        self.assertTrue(download_update.should_continue)
+        self.assertEqual(workflow.current_step().args, ["check", "C:\\package\\manifest.json"])
+
+        check_update = workflow.complete_current_step(0, "Safety status: safe\n")
+        self.assertEqual(check_update.status, "done")
+        self.assertIn("safe", check_update.facts[-1])
+        self.assertIsNone(workflow.current_step())
+
+    def test_check_warn_is_done_but_not_writeback_ready(self):
+        workflow = TranslationWorkflow.resume_latest("C:\\package\\manifest.json")
+        workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED\n")
+        workflow.complete_current_step(0, "Saved results to: C:\\package\\results.jsonl\n")
+
+        update = workflow.complete_current_step(0, "Safety status: warn\n")
+
+        self.assertEqual(update.status, "done")
+        self.assertIn("不应写回", update.message)
+
+    def test_nonzero_exit_fails_current_step(self):
+        workflow = TranslationWorkflow.start_new()
+
+        update = workflow.complete_current_step(1, "boom")
+
+        self.assertEqual(update.status, "failed")
+        self.assertFalse(update.should_continue)
+        self.assertIsNone(workflow.current_step())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_translation_workflow.py
+++ b/tests/test_gui_translation_workflow.py
@@ -5,6 +5,7 @@ from gui_qt.translation_workflow import (
     extract_created_package_path,
     extract_job_state,
     extract_safety_status,
+    manifest_path_for_package,
 )
 
 
@@ -17,6 +18,16 @@ Items: 10
 
 
 class GuiTranslationWorkflowTests(unittest.TestCase):
+    def test_manifest_path_for_package_preserves_input_path_style(self):
+        self.assertEqual(
+            manifest_path_for_package("C:\\Games\\Example\\work\\logs\\batch_jobs\\job1"),
+            "C:\\Games\\Example\\work\\logs\\batch_jobs\\job1\\manifest.json",
+        )
+        self.assertEqual(
+            manifest_path_for_package("/tmp/jobs/job1"),
+            "/tmp/jobs/job1/manifest.json",
+        )
+
     def test_extracts_cli_output_fields(self):
         self.assertEqual(
             extract_created_package_path(BUILD_OUTPUT),


### PR DESCRIPTION
## Summary

- add a testable GUI translation workflow state machine for `build -> submit -> status -> download -> check`
- add Start Translation and Continue Latest Task actions to the optional PySide6 workbench
- surface friendly workflow progress while preserving raw CLI output in the existing log view
- stop before download when Batch status is still running, and only continue to `download -> check` after `JOB_STATE_SUCCEEDED`
- keep apply/writeback out of this slice; this PR only reaches result checking

Refs #42

## Validation

- `python -m unittest -q tests.test_gui_translation_workflow tests.test_gui_app_config tests.test_gui_doctor_report tests.test_gui_project_state`
- `python -m py_compile gui_qt\app.py gui_qt\translation_workflow.py`
- `git diff --check`
- `python -m unittest discover -s tests -q` （267 tests OK）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-step translation workflow with “开始翻译任务” and “继续最新任务”, including step-by-step progress, status messages, and optional facts.
* **Refactor**
  * Improved task/run lifecycle behavior with centralized run-state UI controls and clearer diagnostic/task output separation.
  * Refined workflow step completion and continuation/finalization handling.
* **Bug Fixes**
  * Strengthened resume-manifest validation and ensured correct log/manifest directory resolution based on project layout.
* **Style**
  * Updated primary button styling and added color-coded workflow status/facts labels.
* **Tests**
  * Added/expanded coverage for workflow parsing, transitions, resume paths, safety outcomes, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->