### PR TITLE
[codex] Add GUI check summary and safe apply writeback

### DIFF
--- a/gui_qt/api_key_dialog.py
+++ b/gui_qt/api_key_dialog.py
@@ -15,27 +15,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-
-def mask_api_key(key: str) -> str:
-    stripped = key.strip()
-    if not stripped:
-        return "(空)"
-    suffix = stripped[-4:] if len(stripped) > 4 else "****"
-    return f"********{suffix}"
-
-
-def commit_pending_key(keys: list[str], pending_key: str) -> tuple[list[str], str | None]:
-    """Merge a non-empty input value into the key list before saving.
-
-    Returns ``(updated_keys, error_message)``. ``error_message`` is set when the
-    pending value duplicates an existing key.
-    """
-    pending = pending_key.strip()
-    if not pending:
-        return list(keys), None
-    if pending in keys:
-        return list(keys), "duplicate"
-    return [*keys, pending], None
+from .api_key_helpers import commit_pending_key, mask_api_key
 
 
 class ApiKeyDialog(QDialog):

--- a/gui_qt/api_key_dialog.py
+++ b/gui_qt/api_key_dialog.py
@@ -1,0 +1,212 @@
+"""Small dialog for viewing and editing local API keys."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def mask_api_key(key: str) -> str:
+    stripped = key.strip()
+    if not stripped:
+        return "(空)"
+    suffix = stripped[-4:] if len(stripped) > 4 else "****"
+    return f"********{suffix}"
+
+
+def commit_pending_key(keys: list[str], pending_key: str) -> tuple[list[str], str | None]:
+    """Merge a non-empty input value into the key list before saving.
+
+    Returns ``(updated_keys, error_message)``. ``error_message`` is set when the
+    pending value duplicates an existing key.
+    """
+    pending = pending_key.strip()
+    if not pending:
+        return list(keys), None
+    if pending in keys:
+        return list(keys), "duplicate"
+    return [*keys, pending], None
+
+
+class ApiKeyDialog(QDialog):
+    """Manage keys stored in api_keys.json without using QInputDialog."""
+
+    def __init__(
+        self,
+        parent: QWidget | None,
+        *,
+        keys: list[str],
+        env_key_count: int = 0,
+    ):
+        super().__init__(parent)
+        self.setObjectName("api_key_dialog")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setWindowTitle("管理 API Key")
+        self.setModal(True)
+        self.resize(480, 420)
+        self._keys = [key for key in keys if isinstance(key, str)]
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        intro = QLabel(
+            "Key 仅保存在本地 api_keys.json，不会上传或代理。"
+            "可添加多个 Key；删除选中项后点击「保存」生效。"
+        )
+        intro.setWordWrap(True)
+        intro.setObjectName("config_hint_label")
+        layout.addWidget(intro)
+
+        layout.addWidget(QLabel("已保存的 Key："))
+
+        self.key_list = QListWidget()
+        self.key_list.setObjectName("api_key_list")
+        self.key_list.setMinimumHeight(120)
+        layout.addWidget(self.key_list)
+
+        list_actions = QHBoxLayout()
+        self.remove_btn = QPushButton("删除选中")
+        self.remove_btn.setObjectName("secondary_btn")
+        self.remove_btn.clicked.connect(self._on_remove_selected)
+        list_actions.addWidget(self.remove_btn)
+        list_actions.addStretch()
+        layout.addLayout(list_actions)
+
+        layout.addWidget(QLabel("添加新 Key："))
+
+        input_hint = QLabel(
+            "输入框默认以圆点隐藏 Key。点「显示明文」可核对粘贴内容是否正确，"
+            "再点「隐藏明文」恢复隐藏。"
+        )
+        input_hint.setWordWrap(True)
+        input_hint.setObjectName("config_hint_label")
+        layout.addWidget(input_hint)
+
+        input_row = QHBoxLayout()
+        input_row.setSpacing(8)
+        self.new_key_edit = QLineEdit()
+        self.new_key_edit.setPlaceholderText("在此粘贴新的 API Key")
+        self.new_key_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.new_key_edit.setObjectName("api_key_input")
+        input_row.addWidget(self.new_key_edit, 1)
+
+        self.toggle_visible_btn = QPushButton("显示明文")
+        self.toggle_visible_btn.setObjectName("secondary_btn")
+        self.toggle_visible_btn.setCheckable(True)
+        self.toggle_visible_btn.setToolTip("切换输入框中 Key 的显示/隐藏，方便核对是否粘贴正确")
+        self.toggle_visible_btn.toggled.connect(self._on_toggle_visibility)
+        input_row.addWidget(self.toggle_visible_btn)
+
+        self.add_btn = QPushButton("添加 Key")
+        self.add_btn.setObjectName("api_btn")
+        self.add_btn.clicked.connect(self._on_add_key)
+        input_row.addWidget(self.add_btn)
+        layout.addLayout(input_row)
+
+        self.new_key_edit.returnPressed.connect(self._on_add_key)
+
+        self.env_label = QLabel()
+        self.env_label.setWordWrap(True)
+        self.env_label.setObjectName("config_hint_label")
+        layout.addWidget(self.env_label)
+
+        if env_key_count > 0:
+            self.env_label.setText(
+                f"另检测到 {env_key_count} 个通过环境变量配置的有效 Key（只读，不会写入文件）。"
+            )
+        else:
+            self.env_label.hide()
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
+        )
+        save_btn = button_box.button(QDialogButtonBox.StandardButton.Save)
+        if save_btn is not None:
+            save_btn.setText("保存")
+        cancel_btn = button_box.button(QDialogButtonBox.StandardButton.Cancel)
+        if cancel_btn is not None:
+            cancel_btn.setText("取消")
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+        self._refresh_key_list()
+
+    def result_keys(self) -> list[str]:
+        return list(self._keys)
+
+    def _on_accept(self) -> None:
+        pending = self.new_key_edit.text().strip()
+        updated_keys, error = commit_pending_key(self._keys, pending)
+        if error == "duplicate":
+            QMessageBox.information(
+                self,
+                "Key 已存在",
+                "输入框中的 Key 已在列表中。请清空输入框，或先删除列表中的重复项后再保存。",
+            )
+            return
+
+        if pending:
+            self._keys = updated_keys
+            self.new_key_edit.clear()
+            self._refresh_key_list()
+
+        self.accept()
+
+    def _refresh_key_list(self) -> None:
+        self.key_list.clear()
+        if not self._keys:
+            self.key_list.addItem("（尚未保存任何 Key）")
+            self.remove_btn.setEnabled(False)
+            return
+
+        self.remove_btn.setEnabled(True)
+        for index, key in enumerate(self._keys, start=1):
+            self.key_list.addItem(f"{index}. {mask_api_key(key)}")
+
+    def _on_toggle_visibility(self, checked: bool) -> None:
+        self.new_key_edit.setEchoMode(
+            QLineEdit.EchoMode.Normal if checked else QLineEdit.EchoMode.Password
+        )
+        self.toggle_visible_btn.setText("隐藏明文" if checked else "显示明文")
+
+    def _on_add_key(self) -> None:
+        value = self.new_key_edit.text().strip()
+        if not value:
+            QMessageBox.information(self, "请输入 Key", "请先粘贴要添加的 API Key。")
+            return
+
+        updated_keys, error = commit_pending_key(self._keys, value)
+        if error == "duplicate":
+            QMessageBox.information(self, "Key 已存在", "这个 Key 已经在列表中。")
+            return
+
+        self._keys = updated_keys
+        self.new_key_edit.clear()
+        self._refresh_key_list()
+        self.key_list.setCurrentRow(self.key_list.count() - 1)
+
+    def _on_remove_selected(self) -> None:
+        if not self._keys:
+            return
+
+        row = self.key_list.currentRow()
+        if row < 0 or row >= len(self._keys):
+            QMessageBox.information(self, "请选择 Key", "请先在列表中选中要删除的 Key。")
+            return
+
+        self._keys.pop(row)
+        self._refresh_key_list()
+        if self._keys:
+            self.key_list.setCurrentRow(min(row, self.key_list.count() - 1))

--- a/gui_qt/api_key_helpers.py
+++ b/gui_qt/api_key_helpers.py
@@ -1,0 +1,24 @@
+"""Pure helpers for API key masking and list updates (no Qt dependency)."""
+from __future__ import annotations
+
+
+def mask_api_key(key: str) -> str:
+    stripped = key.strip()
+    if not stripped:
+        return "(空)"
+    suffix = stripped[-4:] if len(stripped) > 4 else "****"
+    return f"********{suffix}"
+
+
+def commit_pending_key(keys: list[str], pending_key: str) -> tuple[list[str], str | None]:
+    """Merge a non-empty input value into the key list before saving.
+
+    Returns ``(updated_keys, error_message)``. ``error_message`` is set when the
+    pending value duplicates an existing key (compared after stripping).
+    """
+    pending = pending_key.strip()
+    if not pending:
+        return list(keys), None
+    if any(pending == existing.strip() for existing in keys):
+        return list(keys), "duplicate"
+    return [*keys, pending], None

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -81,7 +81,10 @@ class MainWindow(QMainWindow):
 
         header = QLabel("Ren'Py Translation Lab · 图形工作台")
         header.setObjectName("header_label")
-        subtitle = QLabel("选择项目、运行检查与翻译；详细日志请切换到「诊断日志」页。")
+        subtitle = QLabel(
+            "先环境检查，再开始翻译；翻译完成后的写回状态显示在右侧任务卡片内。"
+            "详细日志请切换到「诊断日志」页。"
+        )
         subtitle.setObjectName("subtitle_label")
         subtitle.setWordWrap(True)
         root_layout.addWidget(header)
@@ -111,7 +114,7 @@ class MainWindow(QMainWindow):
         self._set_workflow_summary(
             "idle",
             "尚未开始翻译任务",
-            "运行项目检查后，可以开始基础 Batch 翻译流程。",
+            "完成环境检查后，可以开始基础 Batch 翻译流程。",
         )
         self._refresh_writeback_from_latest_manifest()
 
@@ -152,7 +155,7 @@ class MainWindow(QMainWindow):
 
         primary_layout = QHBoxLayout()
         primary_layout.setSpacing(10)
-        self.doctor_btn = QPushButton("检查项目")
+        self.doctor_btn = QPushButton("环境检查")
         self.doctor_btn.setObjectName("doctor_btn")
         self.doctor_btn.clicked.connect(self._on_run_doctor)
         primary_layout.addWidget(self.doctor_btn)
@@ -181,45 +184,10 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(actions_box)
 
-        writeback_box = QGroupBox("检查结果与写回")
-        writeback_layout = QVBoxLayout(writeback_box)
-        writeback_layout.setSpacing(6)
-        writeback_layout.setContentsMargins(12, 16, 12, 12)
-
-        self.writeback_status_label = QLabel()
-        self.writeback_status_label.setObjectName("writeback_status_label")
-        writeback_layout.addWidget(self.writeback_status_label)
-
-        self.writeback_message_label = QLabel()
-        self.writeback_message_label.setWordWrap(True)
-        writeback_layout.addWidget(self.writeback_message_label)
-
-        self.writeback_facts_label = QLabel()
-        self.writeback_facts_label.setWordWrap(True)
-        self.writeback_facts_label.setObjectName("writeback_facts_label")
-        writeback_layout.addWidget(self.writeback_facts_label)
-
-        self.writeback_findings_view = QTextEdit()
-        self.writeback_findings_view.setReadOnly(True)
-        self.writeback_findings_view.setMaximumHeight(88)
-        self.writeback_findings_view.setObjectName("writeback_findings_view")
-        writeback_layout.addWidget(self.writeback_findings_view)
-
-        writeback_actions = QHBoxLayout()
-        self.apply_btn = QPushButton("写回翻译")
-        self.apply_btn.setObjectName("apply_btn")
-        self.apply_btn.clicked.connect(self._on_apply_writeback)
-        self.apply_btn.setEnabled(False)
-        writeback_actions.addWidget(self.apply_btn)
-        writeback_actions.addStretch()
-        writeback_layout.addLayout(writeback_actions)
-
-        layout.addWidget(writeback_box)
-
         status_row = QHBoxLayout()
         status_row.setSpacing(16)
 
-        doctor_summary_box = QGroupBox("项目检查")
+        doctor_summary_box = QGroupBox("环境检查 (doctor)")
         doctor_summary_layout = QVBoxLayout(doctor_summary_box)
         doctor_summary_layout.setSpacing(6)
         doctor_summary_layout.setContentsMargins(12, 16, 12, 12)
@@ -262,6 +230,43 @@ class MainWindow(QMainWindow):
         self.workflow_facts_label.setWordWrap(True)
         self.workflow_facts_label.setObjectName("workflow_facts_label")
         workflow_layout.addWidget(self.workflow_facts_label)
+
+        workflow_separator = QFrame()
+        workflow_separator.setFrameShape(QFrame.Shape.HLine)
+        workflow_separator.setObjectName("workflow_separator")
+        workflow_layout.addWidget(workflow_separator)
+
+        writeback_heading = QLabel("写回翻译")
+        writeback_heading.setObjectName("workflow_section_label")
+        workflow_layout.addWidget(writeback_heading)
+
+        self.writeback_status_label = QLabel()
+        self.writeback_status_label.setObjectName("writeback_status_label")
+        workflow_layout.addWidget(self.writeback_status_label)
+
+        self.writeback_message_label = QLabel()
+        self.writeback_message_label.setWordWrap(True)
+        workflow_layout.addWidget(self.writeback_message_label)
+
+        self.writeback_facts_label = QLabel()
+        self.writeback_facts_label.setWordWrap(True)
+        self.writeback_facts_label.setObjectName("writeback_facts_label")
+        workflow_layout.addWidget(self.writeback_facts_label)
+
+        self.writeback_findings_view = QTextEdit()
+        self.writeback_findings_view.setReadOnly(True)
+        self.writeback_findings_view.setMaximumHeight(72)
+        self.writeback_findings_view.setObjectName("writeback_findings_view")
+        workflow_layout.addWidget(self.writeback_findings_view)
+
+        writeback_actions = QHBoxLayout()
+        self.apply_btn = QPushButton("写回翻译")
+        self.apply_btn.setObjectName("apply_btn")
+        self.apply_btn.clicked.connect(self._on_apply_writeback)
+        self.apply_btn.setEnabled(False)
+        writeback_actions.addWidget(self.apply_btn)
+        writeback_actions.addStretch()
+        workflow_layout.addLayout(writeback_actions)
 
         status_row.addWidget(workflow_box, 1)
         layout.addLayout(status_row, 1)
@@ -695,9 +700,9 @@ class MainWindow(QMainWindow):
                 "\n".join(f"- {finding}" for finding in summary.findings)
             )
         elif summary.status in {"idle", "running"}:
-            self.writeback_findings_view.setPlainText("等待检查结果。")
+            self.writeback_findings_view.setPlainText("翻译任务完成 check 后，这里会显示写回建议。")
         elif summary.status == "stale":
-            self.writeback_findings_view.setPlainText("请针对当前任务重新运行 check。")
+            self.writeback_findings_view.setPlainText("请针对当前任务重新完成翻译与 check。")
         elif summary.status == "safe":
             self.writeback_findings_view.setPlainText("未发现阻止写回的问题。")
         elif summary.status == "applied":

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -31,7 +31,8 @@ from PySide6.QtWidgets import (
     QTabWidget,
 )
 
-from .api_key_dialog import ApiKeyDialog, mask_api_key
+from .api_key_dialog import ApiKeyDialog
+from .api_key_helpers import mask_api_key
 from .check_report import (
     WritebackSummary,
     idle_writeback_summary,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1,9 +1,9 @@
 """Main GUI application for the optional workbench.
 
 This is the first version shell (per #42):
-- Pure PySide6
+- Pure PySide6 with tabbed layout (workbench / config / diagnostics)
 - Delegates everything to the existing CLI via QProcess
-- Starts with project selection + doctor execution + live logs
+- Workbench tab: project selection, doctor + translation workflow status
 """
 from __future__ import annotations
 
@@ -24,14 +24,14 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QMessageBox,
     QGroupBox,
-    QInputDialog,
     QLineEdit,
     QComboBox,
-    QGridLayout,
     QFrame,
     QFormLayout,
+    QTabWidget,
 )
 
+from .api_key_dialog import ApiKeyDialog, mask_api_key
 from .cli_runner import CliRunner
 from .doctor_report import (
     DoctorSummary,
@@ -63,16 +63,56 @@ class MainWindow(QMainWindow):
 
         central = QWidget()
         self.setCentralWidget(central)
-        layout = QVBoxLayout(central)
-        layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(12)
+        root_layout = QVBoxLayout(central)
+        root_layout.setContentsMargins(16, 16, 16, 16)
+        root_layout.setSpacing(12)
 
-        # Header
-        header = QLabel("实验性图形工作台 - 复用现有命令行流程")
+        header = QLabel("Ren'Py Translation Lab · 图形工作台")
         header.setObjectName("header_label")
-        layout.addWidget(header)
+        subtitle = QLabel("选择项目、运行检查与翻译；详细日志请切换到「诊断日志」页。")
+        subtitle.setObjectName("subtitle_label")
+        subtitle.setWordWrap(True)
+        root_layout.addWidget(header)
+        root_layout.addWidget(subtitle)
 
-        # Project row
+        self.tab_widget = QTabWidget()
+        self.tab_widget.setObjectName("main_tabs")
+        root_layout.addWidget(self.tab_widget, 1)
+
+        self._build_workbench_tab()
+        self._build_config_tab()
+        self._build_log_tab()
+
+        self.batch_model_combo.currentTextChanged.connect(self._on_batch_model_changed)
+        self.batch_thinking_combo.currentIndexChanged.connect(self._on_batch_thinking_changed)
+        self.tab_widget.currentChanged.connect(self._on_tab_changed)
+
+        # Connect runner
+        self.runner.line_ready.connect(self._on_cli_line_ready)
+        self.runner.finished.connect(self._on_finished)
+        self.runner.error.connect(self._on_runner_error)
+
+        self._refresh_project_label()
+        self._refresh_api_status()
+        self._load_config_to_ui()
+        self._set_doctor_summary(idle_summary())
+        self._set_workflow_summary(
+            "idle",
+            "尚未开始翻译任务",
+            "运行项目检查后，可以开始基础 Batch 翻译流程。",
+        )
+
+        # Status
+        self.statusBar().showMessage(
+            "图形界面是可选组件；核心命令行不受影响。"
+        )
+
+    def _build_workbench_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 16, 12, 12)
+        layout.setSpacing(14)
+
         project_frame = QFrame()
         project_frame.setObjectName("project_frame")
         proj_layout = QHBoxLayout(project_frame)
@@ -92,12 +132,133 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(project_frame)
 
-        # Configuration Row (Sync + Batch side-by-side)
+        actions_box = QGroupBox("操作")
+        actions_layout = QVBoxLayout(actions_box)
+        actions_layout.setSpacing(10)
+        actions_layout.setContentsMargins(12, 16, 12, 12)
+
+        primary_layout = QHBoxLayout()
+        primary_layout.setSpacing(10)
+        self.doctor_btn = QPushButton("检查项目")
+        self.doctor_btn.setObjectName("doctor_btn")
+        self.doctor_btn.clicked.connect(self._on_run_doctor)
+        primary_layout.addWidget(self.doctor_btn)
+
+        self.translate_btn = QPushButton("开始翻译任务")
+        self.translate_btn.setObjectName("translate_btn")
+        self.translate_btn.clicked.connect(self._on_start_translation)
+        primary_layout.addWidget(self.translate_btn)
+        primary_layout.addStretch()
+        actions_layout.addLayout(primary_layout)
+
+        secondary_layout = QHBoxLayout()
+        secondary_layout.setSpacing(10)
+        self.resume_btn = QPushButton("继续最新任务")
+        self.resume_btn.setObjectName("secondary_btn")
+        self.resume_btn.clicked.connect(self._on_resume_translation)
+        secondary_layout.addWidget(self.resume_btn)
+        secondary_layout.addStretch()
+
+        self.kill_btn = QPushButton("停止当前任务")
+        self.kill_btn.setObjectName("kill_btn")
+        self.kill_btn.clicked.connect(self._on_kill)
+        self.kill_btn.setEnabled(False)
+        secondary_layout.addWidget(self.kill_btn)
+        actions_layout.addLayout(secondary_layout)
+
+        layout.addWidget(actions_box)
+
+        status_row = QHBoxLayout()
+        status_row.setSpacing(16)
+
+        doctor_summary_box = QGroupBox("项目检查")
+        doctor_summary_layout = QVBoxLayout(doctor_summary_box)
+        doctor_summary_layout.setSpacing(6)
+        doctor_summary_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.doctor_status_label = QLabel()
+        self.doctor_status_label.setObjectName("doctor_status_label")
+        doctor_summary_layout.addWidget(self.doctor_status_label)
+
+        self.doctor_message_label = QLabel()
+        self.doctor_message_label.setWordWrap(True)
+        doctor_summary_layout.addWidget(self.doctor_message_label)
+
+        self.doctor_facts_label = QLabel()
+        self.doctor_facts_label.setWordWrap(True)
+        self.doctor_facts_label.setObjectName("doctor_facts_label")
+        doctor_summary_layout.addWidget(self.doctor_facts_label)
+
+        self.doctor_findings_view = QTextEdit()
+        self.doctor_findings_view.setReadOnly(True)
+        self.doctor_findings_view.setMaximumHeight(110)
+        self.doctor_findings_view.setObjectName("doctor_findings_view")
+        doctor_summary_layout.addWidget(self.doctor_findings_view)
+
+        status_row.addWidget(doctor_summary_box, 1)
+
+        workflow_box = QGroupBox("翻译任务")
+        workflow_layout = QVBoxLayout(workflow_box)
+        workflow_layout.setSpacing(6)
+        workflow_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.workflow_status_label = QLabel()
+        self.workflow_status_label.setObjectName("workflow_status_label")
+        workflow_layout.addWidget(self.workflow_status_label)
+
+        self.workflow_message_label = QLabel()
+        self.workflow_message_label.setWordWrap(True)
+        workflow_layout.addWidget(self.workflow_message_label)
+
+        self.workflow_facts_label = QLabel()
+        self.workflow_facts_label.setWordWrap(True)
+        self.workflow_facts_label.setObjectName("workflow_facts_label")
+        workflow_layout.addWidget(self.workflow_facts_label)
+
+        status_row.addWidget(workflow_box, 1)
+        layout.addLayout(status_row, 1)
+
+        self.tab_widget.addTab(tab, "工作台")
+
+    def _build_config_tab(self) -> None:
+        tab = QWidget()
+        self._config_tab = tab
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 16, 12, 12)
+        layout.setSpacing(14)
+
+        api_box = QGroupBox("API Key")
+        api_layout = QVBoxLayout(api_box)
+        api_layout.setSpacing(10)
+        api_layout.setContentsMargins(12, 16, 12, 12)
+
+        api_hint = QLabel(
+            "翻译任务需要 Gemini API Key。Key 保存在本地 api_keys.json，"
+            "不会上传或代理。也可通过环境变量 GEMINI_API_KEY 配置。"
+        )
+        api_hint.setWordWrap(True)
+        api_hint.setObjectName("config_hint_label")
+        api_layout.addWidget(api_hint)
+
+        self.api_status_label = QLabel()
+        self.api_status_label.setWordWrap(True)
+        self.api_status_label.setObjectName("api_status_label")
+        api_layout.addWidget(self.api_status_label)
+
+        api_actions = QHBoxLayout()
+        self.api_btn = QPushButton("管理 API Key")
+        self.api_btn.setObjectName("api_btn")
+        self.api_btn.clicked.connect(self._on_manage_api_keys)
+        api_actions.addWidget(self.api_btn)
+        api_actions.addStretch()
+        api_layout.addLayout(api_actions)
+
+        layout.addWidget(api_box)
+
         config_row = QHBoxLayout()
         config_row.setSpacing(16)
 
-        # Sync Box
-        sync_box = QGroupBox("同步翻译配置 (Sync API)")
+        sync_box = QGroupBox("同步翻译 (Sync API)")
         sync_layout = QFormLayout(sync_box)
         sync_layout.setSpacing(8)
         sync_layout.setContentsMargins(12, 16, 12, 12)
@@ -123,8 +284,7 @@ class MainWindow(QMainWindow):
 
         config_row.addWidget(sync_box, 1)
 
-        # Batch Box
-        batch_box = QGroupBox("批量离线配置 (Batch API)")
+        batch_box = QGroupBox("批量离线 (Batch API)")
         batch_layout = QFormLayout(batch_box)
         batch_layout.setSpacing(8)
         batch_layout.setContentsMargins(12, 16, 12, 12)
@@ -157,10 +317,8 @@ class MainWindow(QMainWindow):
         batch_layout.addRow("Batch 思考程度：", self.batch_thinking_combo)
 
         config_row.addWidget(batch_box, 1)
+        layout.addLayout(config_row, 1)
 
-        layout.addLayout(config_row)
-
-        # Save config row
         save_layout = QHBoxLayout()
         save_layout.addStretch()
         self.save_config_btn = QPushButton("保存参数配置")
@@ -169,91 +327,21 @@ class MainWindow(QMainWindow):
         save_layout.addWidget(self.save_config_btn)
         layout.addLayout(save_layout)
 
-        # Connect model change signal to dynamically toggle thinking level
-        self.batch_model_combo.currentTextChanged.connect(self._on_batch_model_changed)
-        self.batch_thinking_combo.currentIndexChanged.connect(self._on_batch_thinking_changed)
+        self.tab_widget.addTab(tab, "配置")
 
-        # Actions row
-        action_layout = QHBoxLayout()
-        self.doctor_btn = QPushButton("检查项目（doctor）")
-        self.doctor_btn.setObjectName("doctor_btn")
-        self.doctor_btn.clicked.connect(self._on_run_doctor)
-        action_layout.addWidget(self.doctor_btn)
+    def _build_log_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 16, 12, 12)
+        layout.setSpacing(10)
 
-        self.api_btn = QPushButton("管理 API Key")
-        self.api_btn.setObjectName("api_btn")
-        self.api_btn.clicked.connect(self._on_manage_api_keys)
-        action_layout.addWidget(self.api_btn)
-
-        self.translate_btn = QPushButton("开始翻译任务")
-        self.translate_btn.setObjectName("translate_btn")
-        self.translate_btn.clicked.connect(self._on_start_translation)
-        action_layout.addWidget(self.translate_btn)
-
-        self.resume_btn = QPushButton("继续最新任务")
-        self.resume_btn.clicked.connect(self._on_resume_translation)
-        action_layout.addWidget(self.resume_btn)
-
-        self.kill_btn = QPushButton("停止当前任务")
-        self.kill_btn.setObjectName("kill_btn")
-        self.kill_btn.clicked.connect(self._on_kill)
-        self.kill_btn.setEnabled(False)
-        action_layout.addWidget(self.kill_btn)
-
-        action_layout.addStretch()
-        layout.addLayout(action_layout)
-
-        # Doctor summary
-        doctor_summary_box = QGroupBox("项目检查摘要")
-        doctor_summary_layout = QVBoxLayout(doctor_summary_box)
-        doctor_summary_layout.setSpacing(6)
-        doctor_summary_layout.setContentsMargins(12, 16, 12, 12)
-
-        self.doctor_status_label = QLabel()
-        self.doctor_status_label.setObjectName("doctor_status_label")
-        doctor_summary_layout.addWidget(self.doctor_status_label)
-
-        self.doctor_message_label = QLabel()
-        self.doctor_message_label.setWordWrap(True)
-        doctor_summary_layout.addWidget(self.doctor_message_label)
-
-        self.doctor_facts_label = QLabel()
-        self.doctor_facts_label.setWordWrap(True)
-        self.doctor_facts_label.setObjectName("doctor_facts_label")
-        doctor_summary_layout.addWidget(self.doctor_facts_label)
-
-        self.doctor_findings_view = QTextEdit()
-        self.doctor_findings_view.setReadOnly(True)
-        self.doctor_findings_view.setMaximumHeight(92)
-        self.doctor_findings_view.setObjectName("doctor_findings_view")
-        doctor_summary_layout.addWidget(self.doctor_findings_view)
-
-        layout.addWidget(doctor_summary_box)
-
-        # Translation workflow summary
-        workflow_box = QGroupBox("翻译任务进度")
-        workflow_layout = QVBoxLayout(workflow_box)
-        workflow_layout.setSpacing(6)
-        workflow_layout.setContentsMargins(12, 16, 12, 12)
-
-        self.workflow_status_label = QLabel()
-        self.workflow_status_label.setObjectName("workflow_status_label")
-        workflow_layout.addWidget(self.workflow_status_label)
-
-        self.workflow_message_label = QLabel()
-        self.workflow_message_label.setWordWrap(True)
-        workflow_layout.addWidget(self.workflow_message_label)
-
-        self.workflow_facts_label = QLabel()
-        self.workflow_facts_label.setWordWrap(True)
-        self.workflow_facts_label.setObjectName("workflow_facts_label")
-        workflow_layout.addWidget(self.workflow_facts_label)
-
-        layout.addWidget(workflow_box)
-
-        # Output
-        out_label = QLabel("诊断 / 任务输出（来自命令行）")
-        layout.addWidget(out_label)
+        log_hint = QLabel(
+            "此处显示 doctor 与翻译任务的原始终端输出。"
+            "开始翻译任务时会自动切换到此页；检查项目时留在工作台即可查看摘要。"
+        )
+        log_hint.setWordWrap(True)
+        log_hint.setObjectName("config_hint_label")
+        layout.addWidget(log_hint)
 
         self.log_view = QTextEdit()
         self.log_view.setReadOnly(True)
@@ -261,24 +349,10 @@ class MainWindow(QMainWindow):
         self.log_view.setObjectName("log_view")
         layout.addWidget(self.log_view, 1)
 
-        # Connect runner
-        self.runner.line_ready.connect(self._on_cli_line_ready)
-        self.runner.finished.connect(self._on_finished)
-        self.runner.error.connect(self._on_runner_error)
+        self.tab_widget.addTab(tab, "诊断日志")
 
-        self._refresh_project_label()
-        self._load_config_to_ui()
-        self._set_doctor_summary(idle_summary())
-        self._set_workflow_summary(
-            "idle",
-            "尚未开始翻译任务",
-            "运行项目检查后，可以开始基础 Batch 翻译流程。",
-        )
-
-        # Status
-        self.statusBar().showMessage(
-            "图形界面是可选组件；核心命令行不受影响。"
-        )
+    def _focus_log_tab(self) -> None:
+        self.tab_widget.setCurrentWidget(self.log_view.parentWidget())
 
     # --- UI actions ---
 
@@ -310,49 +384,50 @@ class MainWindow(QMainWindow):
             )
             self._append_log(f"项目目录已设置为：{directory}")
 
-    def _masked_key(self, key: str) -> str:
-        stripped = key.strip()
-        if not stripped:
-            return "(none)"
-        suffix = stripped[-4:] if len(stripped) > 4 else "****"
-        return f"********{suffix}"
+    def _refresh_api_status(self) -> None:
+        count, source = self.state.get_api_key_status()
+        file_keys = self.state.load_api_keys()
+
+        if count == 0:
+            message = "当前状态：尚未配置有效 API Key。"
+        elif source == "environment":
+            message = f"当前状态：已通过环境变量配置 {count} 个有效 Key（只读）。"
+            if file_keys:
+                message += f" 本地文件另保存了 {len(file_keys)} 条 Key 记录。"
+        else:
+            masked = "、".join(mask_api_key(key) for key in file_keys if key.strip())
+            message = f"当前状态：已保存 {len(file_keys)} 个 Key（有效 {count} 个）。"
+            if masked:
+                message += f"\n{masked}"
+
+        self.api_status_label.setText(message)
+
+    def _on_tab_changed(self, index: int) -> None:
+        if self.tab_widget.widget(index) is self._config_tab:
+            self._refresh_api_status()
 
     def _on_manage_api_keys(self):
-        keys = self.state.load_api_keys()
-        current = keys[0] if keys else ""
+        env_count, env_source = self.state.get_api_key_status()
+        env_key_count = env_count if env_source == "environment" else 0
 
-        text, ok = QInputDialog.getText(
+        dialog = ApiKeyDialog(
             self,
-            "API Key",
-            "当前第一个 Key："
-            f"{self._masked_key(current)}\n"
-            f"已配置 Key 数量：{len(keys)}\n\n"
-            "输入新的 Key 会替换第一个 Key。\n"
-            "留空则保持现有 Key 不变。",
-            QLineEdit.EchoMode.Password,
-            "",
+            keys=self.state.load_api_keys(),
+            env_key_count=env_key_count,
         )
-        if ok:
-            replacement = text.strip()
-            if not replacement:
-                self._append_log("API Key 未修改。")
-                return
+        if dialog.exec() != ApiKeyDialog.DialogCode.Accepted:
+            return
 
-            new_keys = list(keys)
-            if new_keys:
-                new_keys[0] = replacement
-            else:
-                new_keys = [replacement]
-            try:
-                self.state.save_api_keys(new_keys)
-            except ValueError as exc:
-                QMessageBox.warning(self, "无法更新 API Key", str(exc))
-                self._append_log(f"更新 api_keys.json 失败：{exc}")
-                return
-            self._append_log(
-                f"API Key 已更新（当前数量：{len(new_keys)}）。"
-                "其他已配置 Key 已保留。"
-            )
+        new_keys = dialog.result_keys()
+        try:
+            self.state.save_api_keys(new_keys)
+        except ValueError as exc:
+            QMessageBox.warning(self, "无法更新 API Key", str(exc))
+            self._append_log(f"更新 api_keys.json 失败：{exc}")
+            return
+
+        self._refresh_api_status()
+        self._append_log(f"API Key 已保存（当前数量：{len(new_keys)}）。")
 
     def _refresh_project_label(self):
         root = self.state.get_game_root()
@@ -391,6 +466,7 @@ class MainWindow(QMainWindow):
             return
 
         self.log_view.clear()
+        self._focus_log_tab()
         self._workflow = TranslationWorkflow.start_new()
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
@@ -423,6 +499,7 @@ class MainWindow(QMainWindow):
             return
 
         self.log_view.clear()
+        self._focus_log_tab()
         self._workflow = TranslationWorkflow.resume_manifest(str(latest_manifest), manifest)
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
@@ -523,7 +600,8 @@ class MainWindow(QMainWindow):
             self._doctor_output_lines.append(message)
         elif self._active_command == "translation_workflow":
             self._workflow_step_output_lines.append(message)
-        self.statusBar().showMessage("任务运行失败，请查看命令行输出。", 6000)
+        self._focus_log_tab()
+        self.statusBar().showMessage("任务运行失败，请查看诊断日志。", 6000)
 
     def _on_finished(self, exit_code: int):
         self._append_log(f"\n[进程已结束，退出码：{exit_code}]")
@@ -572,7 +650,7 @@ class MainWindow(QMainWindow):
         self._workflow = None
         self._set_task_running(False)
         if update.status == "failed":
-            self.statusBar().showMessage("翻译任务失败，请查看命令行输出。", 8000)
+            self.statusBar().showMessage("翻译任务失败，请查看诊断日志。", 8000)
         elif update.status == "waiting":
             self.statusBar().showMessage("Batch 任务仍在处理，可稍后继续最新任务。", 8000)
         else:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -32,6 +32,15 @@ from PySide6.QtWidgets import (
 )
 
 from .api_key_dialog import ApiKeyDialog, mask_api_key
+from .check_report import (
+    WritebackSummary,
+    idle_writeback_summary,
+    running_writeback_summary,
+    stale_writeback_summary,
+    summarize_apply_output,
+    summarize_check_output,
+    summarize_manifest_writeback,
+)
 from .cli_runner import CliRunner
 from .doctor_report import (
     DoctorSummary,
@@ -60,6 +69,8 @@ class MainWindow(QMainWindow):
         self._doctor_output_lines: list[str] = []
         self._workflow: TranslationWorkflow | None = None
         self._workflow_step_output_lines: list[str] = []
+        self._apply_output_lines: list[str] = []
+        self._writeback_manifest_path = ""
 
         central = QWidget()
         self.setCentralWidget(central)
@@ -101,6 +112,7 @@ class MainWindow(QMainWindow):
             "尚未开始翻译任务",
             "运行项目检查后，可以开始基础 Batch 翻译流程。",
         )
+        self._refresh_writeback_from_latest_manifest()
 
         # Status
         self.statusBar().showMessage(
@@ -167,6 +179,41 @@ class MainWindow(QMainWindow):
         actions_layout.addLayout(secondary_layout)
 
         layout.addWidget(actions_box)
+
+        writeback_box = QGroupBox("检查结果与写回")
+        writeback_layout = QVBoxLayout(writeback_box)
+        writeback_layout.setSpacing(6)
+        writeback_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.writeback_status_label = QLabel()
+        self.writeback_status_label.setObjectName("writeback_status_label")
+        writeback_layout.addWidget(self.writeback_status_label)
+
+        self.writeback_message_label = QLabel()
+        self.writeback_message_label.setWordWrap(True)
+        writeback_layout.addWidget(self.writeback_message_label)
+
+        self.writeback_facts_label = QLabel()
+        self.writeback_facts_label.setWordWrap(True)
+        self.writeback_facts_label.setObjectName("writeback_facts_label")
+        writeback_layout.addWidget(self.writeback_facts_label)
+
+        self.writeback_findings_view = QTextEdit()
+        self.writeback_findings_view.setReadOnly(True)
+        self.writeback_findings_view.setMaximumHeight(88)
+        self.writeback_findings_view.setObjectName("writeback_findings_view")
+        writeback_layout.addWidget(self.writeback_findings_view)
+
+        writeback_actions = QHBoxLayout()
+        self.apply_btn = QPushButton("写回翻译")
+        self.apply_btn.setObjectName("apply_btn")
+        self.apply_btn.clicked.connect(self._on_apply_writeback)
+        self.apply_btn.setEnabled(False)
+        writeback_actions.addWidget(self.apply_btn)
+        writeback_actions.addStretch()
+        writeback_layout.addLayout(writeback_actions)
+
+        layout.addWidget(writeback_box)
 
         status_row = QHBoxLayout()
         status_row.setSpacing(16)
@@ -382,6 +429,8 @@ class MainWindow(QMainWindow):
                 "项目已切换",
                 "翻译任务状态已清空；请先针对新项目重新检查。",
             )
+            self._writeback_manifest_path = ""
+            self._set_writeback_summary(stale_writeback_summary())
             self._append_log(f"项目目录已设置为：{directory}")
 
     def _refresh_api_status(self) -> None:
@@ -467,6 +516,8 @@ class MainWindow(QMainWindow):
 
         self.log_view.clear()
         self._focus_log_tab()
+        self._writeback_manifest_path = ""
+        self._set_writeback_summary(stale_writeback_summary())
         self._workflow = TranslationWorkflow.start_new()
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
@@ -510,6 +561,53 @@ class MainWindow(QMainWindow):
     def _on_kill(self):
         self.runner.kill()
 
+    def _on_apply_writeback(self):
+        if not self._writeback_manifest_path:
+            QMessageBox.information(self, "无法写回", "没有可写回的 manifest；请先完成 check。")
+            return
+
+        summary = self._current_writeback_summary()
+        if not summary.can_apply:
+            QMessageBox.information(
+                self,
+                "当前不能写回",
+                summary.message or "只有 safe 的 check 结果才允许写回。",
+            )
+            return
+
+        confirm_lines = [
+            "即将把翻译写回项目 .rpy 文件。",
+            "写回前请确认已在副本或备份上验证。",
+            "",
+            *summary.facts,
+        ]
+        if summary.findings:
+            confirm_lines.extend(["", "待处理问题：", *[f"- {item}" for item in summary.findings]])
+
+        reply = QMessageBox.question(
+            self,
+            "确认写回翻译",
+            "\n".join(confirm_lines),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.log_view.clear()
+        self._focus_log_tab()
+        self._active_command = "apply"
+        self._apply_output_lines = []
+        self._set_writeback_summary(running_writeback_summary())
+        self._append_log(
+            f"=== 正在写回：gemini_translate_batch.py apply {self._writeback_manifest_path} ===\n"
+        )
+        self._set_task_running(True)
+        self.runner.run(
+            self.state.get_batch_script_path(),
+            ["apply", self._writeback_manifest_path],
+        )
+
     # --- Runner callbacks ---
 
     def _on_cli_line_ready(self, text: str):
@@ -517,6 +615,8 @@ class MainWindow(QMainWindow):
             self._doctor_output_lines.append(text)
         elif self._active_command == "translation_workflow":
             self._workflow_step_output_lines.append(text)
+        elif self._active_command == "apply":
+            self._apply_output_lines.append(text)
         self._append_log(text)
 
     def _append_log(self, text: str):
@@ -532,6 +632,7 @@ class MainWindow(QMainWindow):
         self.translate_btn.setEnabled(not running)
         self.resume_btn.setEnabled(not running)
         self.save_config_btn.setEnabled(not running)
+        self.apply_btn.setEnabled(not running and self._current_writeback_summary().can_apply)
         self.kill_btn.setEnabled(running)
 
     def _set_workflow_summary(
@@ -576,6 +677,74 @@ class MainWindow(QMainWindow):
         self._append_log(f"\n=== {step.heading}：gemini_translate_batch.py {' '.join(step.args)} ===\n")
         self.runner.run(self.state.get_batch_script_path(), step.args)
 
+    def _current_writeback_summary(self) -> WritebackSummary:
+        return getattr(self, "_writeback_summary", idle_writeback_summary())
+
+    def _set_writeback_summary(self, summary: WritebackSummary) -> None:
+        self._writeback_summary = summary
+        self._writeback_manifest_path = summary.manifest_path
+        self.writeback_status_label.setText(summary.heading)
+        self.writeback_status_label.setProperty("status", summary.status)
+        self.writeback_status_label.style().unpolish(self.writeback_status_label)
+        self.writeback_status_label.style().polish(self.writeback_status_label)
+        self.writeback_message_label.setText(summary.message)
+        self.writeback_facts_label.setText("\n".join(summary.facts))
+        if summary.findings:
+            self.writeback_findings_view.setPlainText(
+                "\n".join(f"- {finding}" for finding in summary.findings)
+            )
+        elif summary.status in {"idle", "running"}:
+            self.writeback_findings_view.setPlainText("等待检查结果。")
+        elif summary.status == "stale":
+            self.writeback_findings_view.setPlainText("请针对当前任务重新运行 check。")
+        elif summary.status == "safe":
+            self.writeback_findings_view.setPlainText("未发现阻止写回的问题。")
+        elif summary.status == "applied":
+            self.writeback_findings_view.setPlainText("写回已完成。")
+        else:
+            self.writeback_findings_view.setPlainText("请查看诊断日志了解详情。")
+        if not self.kill_btn.isEnabled():
+            self.apply_btn.setEnabled(summary.can_apply)
+
+    def _refresh_writeback_from_latest_manifest(self) -> None:
+        latest_manifest = self.state.get_latest_manifest_path()
+        if latest_manifest is None:
+            self._set_writeback_summary(idle_writeback_summary())
+            return
+        try:
+            manifest = self.state.load_resume_manifest(latest_manifest)
+        except ValueError:
+            self._set_writeback_summary(idle_writeback_summary())
+            return
+
+        summary = summarize_manifest_writeback(manifest)
+        if summary is None:
+            self._set_writeback_summary(idle_writeback_summary())
+            return
+        self._set_writeback_summary(summary)
+
+    def _update_writeback_from_check(
+        self,
+        output: str,
+        exit_code: int,
+        manifest_path: str,
+    ) -> None:
+        already_applied = False
+        if manifest_path:
+            try:
+                manifest = self.state.load_manifest_file(manifest_path)
+                already_applied = bool(manifest.get("applied_at"))
+            except ValueError:
+                pass
+        self._set_writeback_summary(
+            summarize_check_output(
+                output,
+                exit_code,
+                manifest_path=manifest_path,
+                already_applied=already_applied,
+            )
+        )
+
     def _set_doctor_summary(self, summary: DoctorSummary):
         self.doctor_status_label.setText(summary.heading)
         self.doctor_status_label.setProperty("status", summary.status)
@@ -600,6 +769,8 @@ class MainWindow(QMainWindow):
             self._doctor_output_lines.append(message)
         elif self._active_command == "translation_workflow":
             self._workflow_step_output_lines.append(message)
+        elif self._active_command == "apply":
+            self._apply_output_lines.append(message)
         self._focus_log_tab()
         self.statusBar().showMessage("任务运行失败，请查看诊断日志。", 6000)
 
@@ -626,6 +797,21 @@ class MainWindow(QMainWindow):
             self._on_workflow_step_finished(exit_code)
             return
 
+        if self._active_command == "apply":
+            summary = summarize_apply_output(
+                "\n".join(self._apply_output_lines),
+                exit_code,
+                manifest_path=self._writeback_manifest_path,
+            )
+            self._set_writeback_summary(summary)
+            self._active_command = ""
+            self._set_task_running(False)
+            if exit_code == 0:
+                self.statusBar().showMessage("翻译写回完成。", 6000)
+            else:
+                self.statusBar().showMessage("翻译写回失败，请查看诊断日志。", 8000)
+            return
+
         self._set_task_running(False)
 
     def _on_workflow_step_finished(self, exit_code: int):
@@ -634,10 +820,11 @@ class MainWindow(QMainWindow):
             self._set_task_running(False)
             return
 
-        update = self._workflow.complete_current_step(
-            exit_code,
-            "\n".join(self._workflow_step_output_lines),
-        )
+        step_output = "\n".join(self._workflow_step_output_lines)
+        manifest_path = self._workflow.manifest_path
+        update = self._workflow.complete_current_step(exit_code, step_output)
+        if "Safety status:" in step_output:
+            self._update_writeback_from_check(step_output, exit_code, manifest_path)
         self._set_workflow_update(update)
         self._workflow_step_output_lines = []
 

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -298,8 +298,8 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
 def idle_writeback_summary() -> WritebackSummary:
     return WritebackSummary(
         status="idle",
-        heading="尚未检查结果",
-        message="完成翻译任务并运行 check 后，这里会显示是否可以写回。",
+        heading="等待翻译完成",
+        message="翻译任务跑完 check 后，这里会显示是否可以写回。",
         facts=[],
         findings=[],
         can_apply=False,

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -1,0 +1,328 @@
+"""User-facing summaries for GUI check/apply commands."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WritebackSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+    can_apply: bool
+    manifest_path: str = ""
+
+
+def _parse_int_field(output: str, prefix: str) -> int | None:
+    match = re.search(rf"^\s*{re.escape(prefix)}\s*(-?\d+)\s*$", output, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def _parse_line_value(output: str, prefix: str) -> str:
+    pattern = re.compile(rf"^\s*{re.escape(prefix)}\s*(.+?)\s*$", re.MULTILINE)
+    match = pattern.search(output)
+    return match.group(1).strip() if match else ""
+
+
+def extract_safety_status(output: str) -> str:
+    return _parse_line_value(output, "Safety status:")
+
+
+def parse_check_output(output: str) -> dict[str, object]:
+    parsed: dict[str, object] = {
+        "safety_status": extract_safety_status(output),
+        "findings": [],
+    }
+    for field, key in (
+        ("Pending files:", "pending_files"),
+        ("Pending lines:", "pending_lines"),
+        ("Failure items:", "failure_items"),
+        ("Recoverable valid items:", "valid_items"),
+    ):
+        value = _parse_int_field(output, field)
+        if value is not None:
+            parsed[key] = value
+
+    report_path = _parse_line_value(output, "Check failure report:")
+    if report_path:
+        parsed["check_failure_report"] = report_path
+
+    current_section = ""
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line in {"Warn reasons:", "Block reasons:"}:
+            current_section = line[:-1].lower().replace(" reasons", "")
+            continue
+        if current_section and line.startswith("- "):
+            parsed.setdefault("findings", []).append(f"[{current_section}] {line[2:].strip()}")
+            continue
+        if line and not line.startswith("- "):
+            current_section = ""
+
+    return parsed
+
+
+def summarize_check_output(
+    output: str,
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+    already_applied: bool = False,
+) -> WritebackSummary:
+    if exit_code != 0:
+        return WritebackSummary(
+            status="failed",
+            heading="结果检查失败",
+            message="check 没有正常完成，请查看诊断日志。",
+            facts=[f"Manifest：{manifest_path}"] if manifest_path else [],
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    parsed = parse_check_output(output)
+    safety = parsed.get("safety_status")
+    safety_text = safety if isinstance(safety, str) else ""
+
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(f"Manifest：{manifest_path}")
+
+    pending_files = parsed.get("pending_files")
+    pending_lines = parsed.get("pending_lines")
+    if isinstance(pending_files, int) and isinstance(pending_lines, int):
+        facts.append(f"将影响 {pending_files} 个文件，约 {pending_lines} 处译文行")
+
+    failure_items = parsed.get("failure_items")
+    if isinstance(failure_items, int):
+        facts.append(f"失败项：{failure_items}")
+
+    if isinstance(parsed.get("check_failure_report"), str):
+        facts.append(f"检查报告：{parsed['check_failure_report']}")
+
+    findings = [
+        finding
+        for finding in parsed.get("findings", [])
+        if isinstance(finding, str) and finding.strip()
+    ]
+
+    if already_applied:
+        return WritebackSummary(
+            status="applied",
+            heading="翻译已写回",
+            message="该任务已经执行过 apply，不会再次写回。",
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    if safety_text == "safe":
+        return WritebackSummary(
+            status="safe",
+            heading="可以写回翻译",
+            message="检查结果为 safe。写回前请确认已备份项目，apply 会修改 .rpy 文件。",
+            facts=facts,
+            findings=findings,
+            can_apply=True,
+            manifest_path=manifest_path,
+        )
+
+    if safety_text == "warn":
+        return WritebackSummary(
+            status="warn",
+            heading="需要先处理问题",
+            message="检查结果为 warn，不应写回。请查看问题后重试、repair 或重新检查。",
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    if safety_text == "block":
+        return WritebackSummary(
+            status="block",
+            heading="当前不能写回",
+            message="检查结果为 block，不能写回。请修复源文件漂移或重新生成任务后再检查。",
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    return WritebackSummary(
+        status="unknown",
+        heading="检查结果不明确",
+        message="未能识别安全状态，请查看诊断日志后重新运行 check。",
+        facts=facts,
+        findings=findings,
+        can_apply=False,
+        manifest_path=manifest_path,
+    )
+
+
+def summarize_apply_output(
+    output: str,
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+) -> WritebackSummary:
+    if exit_code != 0:
+        return WritebackSummary(
+            status="failed",
+            heading="写回失败",
+            message="apply 没有正常完成。请查看诊断日志与 apply_failure_report。",
+            facts=[fact for fact in (f"Manifest：{manifest_path}",) if manifest_path],
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(f"Manifest：{manifest_path}")
+
+    applied_files = _parse_int_field(output, "Applied files:")
+    applied_lines = _parse_int_field(output, "Applied lines:")
+    if isinstance(applied_files, int) and isinstance(applied_lines, int):
+        facts.append(f"已写回 {applied_files} 个文件，{applied_lines} 处译文行")
+
+    failures_logged = _parse_int_field(output, "Failures logged:")
+    if isinstance(failures_logged, int) and failures_logged > 0:
+        facts.append(f"失败日志条目：{failures_logged}")
+
+    return WritebackSummary(
+        status="applied",
+        heading="翻译写回完成",
+        message="apply 已完成。建议在游戏中抽查关键剧情文本。",
+        facts=facts,
+        findings=[],
+        can_apply=False,
+        manifest_path=manifest_path,
+    )
+
+
+def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummary | None:
+    manifest_path = manifest.get("_manifest_path")
+    if not isinstance(manifest_path, str) or not manifest_path.strip():
+        manifest_path = ""
+
+    if manifest.get("applied_at"):
+        apply_summary = manifest.get("apply_summary")
+        facts: list[str] = []
+        if manifest_path:
+            facts.append(f"Manifest：{manifest_path}")
+        if isinstance(apply_summary, dict):
+            applied_files = apply_summary.get("applied_files")
+            applied_lines = apply_summary.get("applied_lines")
+            if isinstance(applied_files, int) and isinstance(applied_lines, int):
+                facts.append(f"已写回 {applied_files} 个文件，{applied_lines} 处译文行")
+        return WritebackSummary(
+            status="applied",
+            heading="翻译已写回",
+            message="该任务已经执行过 apply。",
+            facts=facts,
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    last_summary = manifest.get("last_check_summary")
+    if not isinstance(last_summary, dict):
+        return None
+
+    safety = last_summary.get("safety_level")
+    safety_text = safety if isinstance(safety, str) else ""
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(f"Manifest：{manifest_path}")
+
+    pending_files = last_summary.get("pending_files")
+    pending_lines = last_summary.get("pending_lines")
+    if isinstance(pending_files, int) and isinstance(pending_lines, int):
+        facts.append(f"将影响 {pending_files} 个文件，约 {pending_lines} 处译文行")
+
+    failure_items = last_summary.get("failure_items")
+    if isinstance(failure_items, int):
+        facts.append(f"失败项：{failure_items}")
+
+    report_path = manifest.get("last_check_report_path")
+    if isinstance(report_path, str) and report_path.strip():
+        facts.append(f"检查报告：{report_path}")
+
+    findings: list[str] = []
+    safety_reasons = last_summary.get("safety_reasons")
+    if isinstance(safety_reasons, dict):
+        for level in ("warn", "block"):
+            reasons = safety_reasons.get(level)
+            if isinstance(reasons, dict):
+                for name, count in sorted(reasons.items()):
+                    findings.append(f"[{level}] {name}: {count}")
+
+    if safety_text == "safe":
+        return WritebackSummary(
+            status="safe",
+            heading="可以写回翻译",
+            message="最近一次 check 为 safe。写回前请确认已备份项目。",
+            facts=facts,
+            findings=findings,
+            can_apply=True,
+            manifest_path=manifest_path,
+        )
+    if safety_text == "warn":
+        return WritebackSummary(
+            status="warn",
+            heading="需要先处理问题",
+            message="最近一次 check 为 warn，不应写回。",
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+    if safety_text == "block":
+        return WritebackSummary(
+            status="block",
+            heading="当前不能写回",
+            message="最近一次 check 为 block，不能写回。",
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+    return None
+
+
+def idle_writeback_summary() -> WritebackSummary:
+    return WritebackSummary(
+        status="idle",
+        heading="尚未检查结果",
+        message="完成翻译任务并运行 check 后，这里会显示是否可以写回。",
+        facts=[],
+        findings=[],
+        can_apply=False,
+    )
+
+
+def stale_writeback_summary() -> WritebackSummary:
+    return WritebackSummary(
+        status="stale",
+        heading="写回状态已过期",
+        message="项目或任务已切换；请针对当前任务重新检查后再决定是否写回。",
+        facts=[],
+        findings=[],
+        can_apply=False,
+    )
+
+
+def running_writeback_summary() -> WritebackSummary:
+    return WritebackSummary(
+        status="running",
+        heading="正在写回翻译",
+        message="正在运行 apply；完成后这里会显示写回摘要。",
+        facts=[],
+        findings=[],
+        can_apply=False,
+    )

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -64,8 +64,13 @@ class ProjectState:
                 pass
         return None
 
-    def load_resume_manifest(self, manifest_path: str | Path) -> dict[str, Any]:
+    def load_manifest_file(self, manifest_path: str | Path) -> dict[str, Any]:
         manifest = self._read_json_object(Path(manifest_path), "batch manifest")
+        manifest["_manifest_path"] = str(Path(manifest_path))
+        return manifest
+
+    def load_resume_manifest(self, manifest_path: str | Path) -> dict[str, Any]:
+        manifest = self.load_manifest_file(manifest_path)
         mode = manifest.get("mode", "translation")
         if mode != "translation":
             raise ValueError("最新任务不是基础翻译任务，不能在这里继续。")

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -370,6 +370,71 @@ QLabel#workflow_facts_label {
     color: #334155;
 }
 
+QLabel#writeback_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#writeback_status_label[status="idle"],
+QLabel#writeback_status_label[status="running"] {
+    color: #2563eb;
+}
+
+QLabel#writeback_status_label[status="safe"] {
+    color: #15803d;
+}
+
+QLabel#writeback_status_label[status="applied"] {
+    color: #15803d;
+}
+
+QLabel#writeback_status_label[status="warn"],
+QLabel#writeback_status_label[status="stale"] {
+    color: #b45309;
+}
+
+QLabel#writeback_status_label[status="block"],
+QLabel#writeback_status_label[status="failed"],
+QLabel#writeback_status_label[status="unknown"] {
+    color: #b91c1c;
+}
+
+QLabel#writeback_facts_label {
+    color: #334155;
+}
+
+QTextEdit#writeback_findings_view {
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    color: #334155;
+    padding: 8px;
+}
+
+QPushButton#apply_btn {
+    background-color: #15803d;
+    border: 1px solid #15803d;
+    color: #ffffff;
+    font-weight: 600;
+    min-width: 108px;
+}
+
+QPushButton#apply_btn:hover {
+    background-color: #166534;
+    border-color: #166534;
+}
+
+QPushButton#apply_btn:pressed {
+    background-color: #14532d;
+    border-color: #14532d;
+}
+
+QPushButton#apply_btn:disabled {
+    background-color: #f1f5f9;
+    border-color: #e2e8f0;
+    color: #cbd5e1;
+}
+
 QTextEdit#doctor_findings_view {
     background-color: #f8fafc;
     border: 1px solid #e2e8f0;

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -13,10 +13,115 @@ QWidget {
 
 /* Header style */
 #header_label {
-    font-size: 16px;
+    font-size: 18px;
     font-weight: 700;
     color: #1e3a8a;
-    padding-bottom: 4px;
+    padding-bottom: 2px;
+}
+
+#subtitle_label,
+#config_hint_label {
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+}
+
+/* Dialogs are top-level windows; set an explicit light surface so Windows
+   dark mode does not leak through when only QMainWindow is themed. */
+QDialog,
+QDialog#api_key_dialog {
+    background-color: #ffffff;
+    color: #0f172a;
+}
+
+QDialog QLabel {
+    background-color: transparent;
+    color: #475569;
+}
+
+QDialog#api_key_dialog QDialogButtonBox QPushButton {
+    min-width: 88px;
+}
+
+#api_status_label {
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    color: #334155;
+    font-size: 12px;
+    padding: 10px 12px;
+}
+
+QLineEdit#api_key_input {
+    background-color: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    color: #0f172a;
+    padding: 6px 10px;
+    min-height: 20px;
+}
+
+QLineEdit#api_key_input:focus {
+    border-color: #2563eb;
+}
+
+QListWidget#api_key_list {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    color: #334155;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+    padding: 4px;
+}
+
+QListWidget#api_key_list QAbstractItemView {
+    background-color: #ffffff;
+    color: #334155;
+    selection-background-color: #dbeafe;
+    selection-color: #1e3a8a;
+}
+
+QListWidget#api_key_list::item {
+    padding: 6px 8px;
+}
+
+QListWidget#api_key_list::item:selected {
+    background-color: #dbeafe;
+    color: #1e3a8a;
+}
+
+/* Tab widget */
+QTabWidget#main_tabs::pane {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background-color: #ffffff;
+    top: -1px;
+}
+
+QTabWidget#main_tabs > QTabBar::tab {
+    background-color: #f1f5f9;
+    border: 1px solid #e2e8f0;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 9px 22px;
+    margin-right: 4px;
+    color: #64748b;
+    font-weight: 500;
+    min-width: 72px;
+}
+
+QTabWidget#main_tabs > QTabBar::tab:selected {
+    background-color: #ffffff;
+    color: #2563eb;
+    font-weight: 600;
+}
+
+QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
+    background-color: #e2e8f0;
+    color: #334155;
 }
 
 /* Project Path Frame styling */
@@ -129,6 +234,7 @@ QPushButton#translate_btn {
     border: 1px solid #2563eb;
     color: #ffffff;
     font-weight: 600;
+    min-width: 108px;
 }
 
 QPushButton#save_config_btn:hover,
@@ -145,6 +251,31 @@ QPushButton#api_btn:pressed,
 QPushButton#translate_btn:pressed {
     background-color: #1e40af;
     border-color: #1e40af;
+}
+
+/* Secondary Action Buttons */
+QPushButton#secondary_btn {
+    background-color: #ffffff;
+    border: 1px solid #cbd5e1;
+    color: #475569;
+    font-weight: 500;
+    min-width: 108px;
+}
+
+QPushButton#secondary_btn:hover {
+    background-color: #f8fafc;
+    border-color: #94a3b8;
+    color: #0f172a;
+}
+
+QPushButton#secondary_btn:pressed {
+    background-color: #f1f5f9;
+}
+
+QPushButton#secondary_btn:disabled {
+    background-color: #f1f5f9;
+    border-color: #e2e8f0;
+    color: #cbd5e1;
 }
 
 /* Danger Action Button */
@@ -249,19 +380,33 @@ QTextEdit#doctor_findings_view {
 
 /* ScrollBar Styling */
 QScrollBar:vertical {
-    background-color: #0f172a;
-    width: 12px;
+    background-color: #f1f5f9;
+    width: 10px;
     margin: 0px;
 }
 
+QTextEdit#log_view QScrollBar:vertical {
+    background-color: #0f172a;
+    width: 12px;
+}
+
 QScrollBar::handle:vertical {
-    background-color: #334155;
+    background-color: #cbd5e1;
     min-height: 20px;
-    border-radius: 6px;
-    border: 2px solid #0f172a;
+    border-radius: 5px;
+    border: 2px solid #f1f5f9;
 }
 
 QScrollBar::handle:vertical:hover {
+    background-color: #94a3b8;
+}
+
+QTextEdit#log_view QScrollBar::handle:vertical {
+    background-color: #334155;
+    border: 2px solid #0f172a;
+}
+
+QTextEdit#log_view QScrollBar::handle:vertical:hover {
     background-color: #475569;
 }
 

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -370,6 +370,19 @@ QLabel#workflow_facts_label {
     color: #334155;
 }
 
+QFrame#workflow_separator {
+    color: #e2e8f0;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+QLabel#workflow_section_label {
+    color: #2563eb;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
 QLabel#writeback_status_label {
     font-size: 15px;
     font-weight: 700;

--- a/tests/test_gui_api_key_dialog.py
+++ b/tests/test_gui_api_key_dialog.py
@@ -1,0 +1,32 @@
+import unittest
+
+from gui_qt.api_key_dialog import commit_pending_key, mask_api_key
+
+
+class GuiApiKeyDialogTests(unittest.TestCase):
+    def test_mask_api_key_hides_middle_and_keeps_suffix(self):
+        self.assertEqual(mask_api_key("abcdefghijklmnop"), "********mnop")
+        self.assertEqual(mask_api_key("ab"), "************")
+        self.assertEqual(mask_api_key("   "), "(空)")
+
+    def test_commit_pending_key_keeps_existing_list_when_input_empty(self):
+        keys, error = commit_pending_key(["existing"], "   ")
+
+        self.assertIsNone(error)
+        self.assertEqual(keys, ["existing"])
+
+    def test_commit_pending_key_appends_new_value(self):
+        keys, error = commit_pending_key(["existing"], "  new-key  ")
+
+        self.assertIsNone(error)
+        self.assertEqual(keys, ["existing", "new-key"])
+
+    def test_commit_pending_key_rejects_duplicate(self):
+        keys, error = commit_pending_key(["existing"], "existing")
+
+        self.assertEqual(error, "duplicate")
+        self.assertEqual(keys, ["existing"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_api_key_dialog.py
+++ b/tests/test_gui_api_key_dialog.py
@@ -1,6 +1,6 @@
 import unittest
 
-from gui_qt.api_key_dialog import commit_pending_key, mask_api_key
+from gui_qt.api_key_helpers import commit_pending_key, mask_api_key
 
 
 class GuiApiKeyDialogTests(unittest.TestCase):
@@ -26,6 +26,12 @@ class GuiApiKeyDialogTests(unittest.TestCase):
 
         self.assertEqual(error, "duplicate")
         self.assertEqual(keys, ["existing"])
+
+    def test_commit_pending_key_detects_whitespace_variant_duplicate(self):
+        keys, error = commit_pending_key(["key123 "], "key123")
+
+        self.assertEqual(error, "duplicate")
+        self.assertEqual(keys, ["key123 "])
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -47,6 +47,27 @@ class GuiCheckReportTests(unittest.TestCase):
         self.assertEqual(parsed["failure_items"], 2)
         self.assertTrue(any("source_mismatch" in finding for finding in parsed["findings"]))
 
+    def test_summarize_check_output_nonzero_exit_blocks_apply(self):
+        summary = summarize_check_output(
+            CHECK_OUTPUT_SAFE,
+            exit_code=1,
+            manifest_path="C:\\pkg\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertFalse(summary.can_apply)
+
+    def test_summarize_check_output_already_applied_blocks_apply(self):
+        summary = summarize_check_output(
+            CHECK_OUTPUT_SAFE,
+            exit_code=0,
+            manifest_path="C:\\pkg\\manifest.json",
+            already_applied=True,
+        )
+
+        self.assertEqual(summary.status, "applied")
+        self.assertFalse(summary.can_apply)
+
     def test_summarize_safe_check_enables_apply(self):
         summary = summarize_check_output(
             CHECK_OUTPUT_SAFE,

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -1,0 +1,110 @@
+import unittest
+
+from gui_qt.check_report import (
+    parse_check_output,
+    summarize_apply_output,
+    summarize_check_output,
+    summarize_manifest_writeback,
+)
+
+
+CHECK_OUTPUT_SAFE = """
+Pending files: 2
+Pending lines: 18
+Failure items: 0
+Recoverable valid items: 18
+Safety status: safe
+Check failure report: C:\\pkg\\check_failures.jsonl
+"""
+
+CHECK_OUTPUT_WARN = """
+Pending files: 1
+Pending lines: 4
+Failure items: 2
+Safety status: warn
+Warn reasons:
+- source_mismatch: 2
+Check failure report: C:\\pkg\\check_failures.jsonl
+"""
+
+APPLY_OUTPUT = """
+Safety status: safe
+Pending files: 2
+Pending lines: 18
+Applied files: 2
+Applied lines: 18
+Failures logged: 0
+"""
+
+
+class GuiCheckReportTests(unittest.TestCase):
+    def test_parse_check_output_extracts_counts_and_reasons(self):
+        parsed = parse_check_output(CHECK_OUTPUT_WARN)
+
+        self.assertEqual(parsed["safety_status"], "warn")
+        self.assertEqual(parsed["pending_files"], 1)
+        self.assertEqual(parsed["pending_lines"], 4)
+        self.assertEqual(parsed["failure_items"], 2)
+        self.assertTrue(any("source_mismatch" in finding for finding in parsed["findings"]))
+
+    def test_summarize_safe_check_enables_apply(self):
+        summary = summarize_check_output(
+            CHECK_OUTPUT_SAFE,
+            exit_code=0,
+            manifest_path="C:\\pkg\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "safe")
+        self.assertTrue(summary.can_apply)
+        self.assertIn("2 个文件", "\n".join(summary.facts))
+
+    def test_summarize_warn_check_blocks_apply(self):
+        summary = summarize_check_output(CHECK_OUTPUT_WARN, exit_code=0)
+
+        self.assertEqual(summary.status, "warn")
+        self.assertFalse(summary.can_apply)
+        self.assertTrue(summary.findings)
+
+    def test_summarize_apply_output_marks_completed(self):
+        summary = summarize_apply_output(
+            APPLY_OUTPUT,
+            exit_code=0,
+            manifest_path="C:\\pkg\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "applied")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("已写回 2 个文件", "\n".join(summary.facts))
+
+    def test_summarize_manifest_writeback_from_last_check(self):
+        summary = summarize_manifest_writeback(
+            {
+                "_manifest_path": "C:\\pkg\\manifest.json",
+                "last_check_summary": {
+                    "safety_level": "safe",
+                    "pending_files": 3,
+                    "pending_lines": 12,
+                    "failure_items": 0,
+                },
+            }
+        )
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.status, "safe")
+        self.assertTrue(summary.can_apply)
+
+    def test_summarize_manifest_writeback_after_apply(self):
+        summary = summarize_manifest_writeback(
+            {
+                "_manifest_path": "C:\\pkg\\manifest.json",
+                "applied_at": "2026-06-18T12:00:00",
+                "apply_summary": {"applied_files": 1, "applied_lines": 5},
+            }
+        )
+
+        self.assertEqual(summary.status, "applied")
+        self.assertFalse(summary.can_apply)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR continues the optional PySide6 workbench toward issue #42 PR 5:

- reorganize the shell into **工作台 / 配置 / 诊断日志** tabs
- replace the cramped API Key `QInputDialog` with a dedicated dialog (add/remove, masked list, pending-key save fix)
- add a **检查结果与写回** panel on the workbench
- parse `check` / `apply` CLI output into user-facing `safe / warn / block` summaries
- enable **写回翻译** only after a `safe` check, with a backup confirmation dialog
- restore writeback state from the latest manifest on startup

Apply still runs through the existing CLI (`gemini_translate_batch.py apply <manifest>`) and follows the current `check -> apply` safety contract. No `--force` entry is exposed in the GUI.

## Scope notes

Included on this branch (stacked for review convenience):

1. Workbench tab layout + API key management polish
2. Check result summary + safe apply writeback (PR 5)

Still out of scope here (PR 6 / later):

- advanced diagnostics page
- repair / retry orchestration
- final README / `docs/gui_workbench.md` acceptance docs

Refs #42

## Validation

- `python -m unittest -q tests.test_gui_check_report tests.test_gui_api_key_dialog tests.test_gui_translation_workflow tests.test_gui_project_state tests.test_gui_doctor_report tests.test_gui_app_config`
- `python -m py_compile gui_qt\app.py gui_qt\check_report.py gui_qt\api_key_dialog.py`
- `python -m unittest discover -s tests -q` (287 tests OK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API key dialog with masked key display, add/remove, and Save/Cancel commit behavior with duplicate detection.
  * Refreshed the GUI into a 3-tab layout and enhanced the writeback/apply workflow with safety-based guidance and apply gating.
* **UI/Style**
  * Updated theme styling for tabs, dialogs (including the API key dialog), buttons, and writeback/diagnostics panels.
* **Tests**
  * Added unit tests for API key masking/commit and check/apply/writeback summarization logic.
* **Refactor**
  * Centralized manifest loading and improved resume/writeback state refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->