### PR TITLE
Add GUI light/dark theme with system follow default

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1001,7 +1001,11 @@ class MainWindow(QMainWindow):
     def _apply_theme(self) -> None:
         if self._qt_app is None:
             return
-        apply_theme(self._qt_app, self._resources_dir, self._theme_preference)
+        try:
+            apply_theme(self._qt_app, self._resources_dir, self._theme_preference)
+        except OSError as exc:
+            self.statusBar().showMessage("主题样式加载失败，已保留当前样式。", 6000)
+            self._append_log(f"加载主题样式失败：{exc}")
 
     def _set_theme_preference(self, preference: str, *, persist: bool) -> None:
         self._theme_preference = normalize_theme_preference(preference)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -51,18 +51,30 @@ from .doctor_report import (
     summarize_doctor_output,
 )
 from .project_state import ProjectState
+from .theme import apply_theme
+from .theme_helpers import (
+    DEFAULT_THEME_PREFERENCE,
+    THEME_SYSTEM,
+    normalize_theme_preference,
+    read_gui_theme_from_config,
+    write_gui_theme_to_config,
+)
 from .translation_workflow import TranslationWorkflow, WorkflowUpdate
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, *, qt_app: QApplication | None = None, resources_dir: Path | None = None):
         super().__init__()
         self.setWindowTitle("Ren'Py Translation Lab - 图形工作台（实验版）")
         self.resize(1100, 720)
 
         self.state = ProjectState()
+        self._qt_app = qt_app
+        self._resources_dir = resources_dir or Path(__file__).resolve().parent / "resources"
+        self._theme_preference = DEFAULT_THEME_PREFERENCE
         self.runner = CliRunner()
         self._loading_config_to_ui = False
+        self._loading_theme_to_ui = False
         self._updating_batch_thinking_combo = False
         self._batch_thinking_config_has_key = False
         self._batch_thinking_user_changed = False
@@ -279,6 +291,25 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(12, 16, 12, 12)
         layout.setSpacing(14)
+
+        appearance_box = QGroupBox("外观")
+        appearance_layout = QFormLayout(appearance_box)
+        appearance_layout.setSpacing(8)
+        appearance_layout.setContentsMargins(12, 16, 12, 12)
+
+        appearance_hint = QLabel("默认跟随系统深浅色；也可手动选择浅色或深色主题。")
+        appearance_hint.setWordWrap(True)
+        appearance_hint.setObjectName("config_hint_label")
+        appearance_layout.addRow(appearance_hint)
+
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItem("跟随系统", THEME_SYSTEM)
+        self.theme_combo.addItem("浅色", "light")
+        self.theme_combo.addItem("深色", "dark")
+        self.theme_combo.currentIndexChanged.connect(self._on_theme_changed)
+        appearance_layout.addRow("主题：", self.theme_combo)
+
+        layout.addWidget(appearance_box)
 
         api_box = QGroupBox("API Key")
         api_layout = QVBoxLayout(api_box)
@@ -956,10 +987,54 @@ class MainWindow(QMainWindow):
         finally:
             self._updating_batch_thinking_combo = False
 
+    def _load_theme_to_ui(self, config: dict[str, Any]) -> None:
+        theme = read_gui_theme_from_config(config)
+        self._theme_preference = theme
+        self._loading_theme_to_ui = True
+        try:
+            idx = self.theme_combo.findData(theme)
+            if idx >= 0:
+                self.theme_combo.setCurrentIndex(idx)
+        finally:
+            self._loading_theme_to_ui = False
+
+    def _apply_theme(self) -> None:
+        if self._qt_app is None:
+            return
+        apply_theme(self._qt_app, self._resources_dir, self._theme_preference)
+
+    def _set_theme_preference(self, preference: str, *, persist: bool) -> None:
+        self._theme_preference = normalize_theme_preference(preference)
+        self._apply_theme()
+        if not persist:
+            return
+        try:
+            config = self.state.load_translator_config()
+            write_gui_theme_to_config(config, self._theme_preference)
+            self.state.save_translator_config(config)
+            self._append_log(f"外观主题已保存：{self._theme_preference}。")
+        except Exception as exc:
+            QMessageBox.warning(self, "保存主题失败", str(exc))
+            self._append_log(f"保存主题失败：{exc}")
+
+    def _on_theme_changed(self, _index: int) -> None:
+        if self._loading_config_to_ui or self._loading_theme_to_ui:
+            return
+        preference = self.theme_combo.currentData()
+        if not isinstance(preference, str):
+            return
+        self._set_theme_preference(preference, persist=True)
+
+    def _on_system_color_scheme_changed(self, _scheme: object) -> None:
+        if self._theme_preference != THEME_SYSTEM:
+            return
+        self._apply_theme()
+
     def _load_config_to_ui(self):
         self._loading_config_to_ui = True
         try:
             config = self.state.load_translator_config()
+            self._load_theme_to_ui(config)
             sync_config = self._config_section(config, "sync")
             batch_config = self._config_section(config, "batch")
             sync_rag_config = self._config_section(sync_config, "rag")
@@ -1068,13 +1143,21 @@ def run_app(argv: list[str] | None = None) -> int:
         argv = sys.argv
 
     app = QApplication(argv)
-    qss_path = Path(__file__).resolve().parent / "resources" / "app.qss"
-    if qss_path.exists():
-        try:
-            app.setStyleSheet(qss_path.read_text(encoding="utf-8"))
-        except OSError as exc:
-            print(f"警告：无法加载 GUI 样式表：{exc}")
-    win = MainWindow()
+    resources_dir = Path(__file__).resolve().parent / "resources"
+    bootstrap_state = ProjectState()
+    try:
+        bootstrap_config = bootstrap_state.load_translator_config()
+        theme_preference = read_gui_theme_from_config(bootstrap_config)
+    except Exception as exc:
+        print(f"警告：无法读取主题配置，将使用系统跟随：{exc}")
+        theme_preference = DEFAULT_THEME_PREFERENCE
+    try:
+        apply_theme(app, resources_dir, theme_preference)
+    except OSError as exc:
+        print(f"警告：无法加载 GUI 样式表：{exc}")
+
+    win = MainWindow(qt_app=app, resources_dir=resources_dir)
+    app.styleHints().colorSchemeChanged.connect(win._on_system_color_scheme_changed)
     win.show()
     return app.exec()
 

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -1,0 +1,499 @@
+/* Premium Slate Dark Theme for the GUI Workbench */
+
+/* Global Window styling */
+QMainWindow {
+    background-color: #0f172a;
+}
+
+QWidget {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 13px;
+    color: #f1f5f9;
+}
+
+/* Header style */
+#header_label {
+    font-size: 18px;
+    font-weight: 700;
+    color: #93c5fd;
+    padding-bottom: 2px;
+}
+
+#subtitle_label,
+#config_hint_label {
+    color: #94a3b8;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+}
+
+/* Dialogs are top-level windows; set an explicit surface so native OS chrome
+   does not leak through when only QMainWindow is themed. */
+QDialog,
+QDialog#api_key_dialog {
+    background-color: #1e293b;
+    color: #f1f5f9;
+}
+
+QDialog QLabel {
+    background-color: transparent;
+    color: #cbd5e1;
+}
+
+QDialog#api_key_dialog QDialogButtonBox QPushButton {
+    min-width: 88px;
+}
+
+#api_status_label {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #cbd5e1;
+    font-size: 12px;
+    padding: 10px 12px;
+}
+
+QLineEdit#api_key_input {
+    background-color: #0f172a;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    color: #f1f5f9;
+    padding: 6px 10px;
+    min-height: 20px;
+}
+
+QLineEdit#api_key_input:focus {
+    border-color: #3b82f6;
+}
+
+QListWidget#api_key_list {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #cbd5e1;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+    padding: 4px;
+}
+
+QListWidget#api_key_list QAbstractItemView {
+    background-color: #0f172a;
+    color: #cbd5e1;
+    selection-background-color: #1e40af;
+    selection-color: #dbeafe;
+}
+
+QListWidget#api_key_list::item {
+    padding: 6px 8px;
+}
+
+QListWidget#api_key_list::item:selected {
+    background-color: #1e40af;
+    color: #dbeafe;
+}
+
+/* Tab widget */
+QTabWidget#main_tabs::pane {
+    border: 1px solid #334155;
+    border-radius: 8px;
+    background-color: #1e293b;
+    top: -1px;
+}
+
+QTabWidget#main_tabs > QTabBar::tab {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 9px 22px;
+    margin-right: 4px;
+    color: #94a3b8;
+    font-weight: 500;
+    min-width: 72px;
+}
+
+QTabWidget#main_tabs > QTabBar::tab:selected {
+    background-color: #1e293b;
+    color: #60a5fa;
+    font-weight: 600;
+}
+
+QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
+    background-color: #334155;
+    color: #e2e8f0;
+}
+
+/* Project Path Frame styling */
+#project_frame {
+    background-color: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 8px;
+}
+
+#project_path_edit {
+    background-color: #0f172a;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    color: #e2e8f0;
+    padding: 6px 10px;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+}
+
+/* GroupBox styling */
+QGroupBox {
+    background-color: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    margin-top: 16px;
+    font-weight: 600;
+    color: #f1f5f9;
+    padding-top: 24px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 12px;
+    top: 6px;
+    background-color: #1e293b;
+    padding: 0 6px;
+    color: #60a5fa;
+    font-size: 13px;
+}
+
+/* Form layout labels */
+QLabel {
+    color: #cbd5e1;
+    font-weight: 500;
+}
+
+/* Input Elements (ComboBox) styling */
+QComboBox {
+    background-color: #0f172a;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    color: #f1f5f9;
+    padding: 5px 10px;
+    min-height: 20px;
+}
+
+QComboBox:hover {
+    border-color: #60a5fa;
+}
+
+QComboBox:focus {
+    border-color: #3b82f6;
+}
+
+QComboBox:disabled {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #64748b;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 24px;
+}
+
+/* Default Buttons styling */
+QPushButton {
+    background-color: #1e293b;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    color: #e2e8f0;
+    font-weight: 500;
+    padding: 8px 16px;
+    min-height: 18px;
+}
+
+QPushButton:hover {
+    background-color: #334155;
+    border-color: #64748b;
+    color: #f8fafc;
+}
+
+QPushButton:pressed {
+    background-color: #0f172a;
+}
+
+QPushButton:disabled {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #64748b;
+}
+
+/* Primary Action Buttons */
+QPushButton#save_config_btn,
+QPushButton#doctor_btn,
+QPushButton#api_btn,
+QPushButton#translate_btn {
+    background-color: #2563eb;
+    border: 1px solid #2563eb;
+    color: #ffffff;
+    font-weight: 600;
+    min-width: 108px;
+}
+
+QPushButton#save_config_btn:hover,
+QPushButton#doctor_btn:hover,
+QPushButton#api_btn:hover,
+QPushButton#translate_btn:hover {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+}
+
+QPushButton#save_config_btn:pressed,
+QPushButton#doctor_btn:pressed,
+QPushButton#api_btn:pressed,
+QPushButton#translate_btn:pressed {
+    background-color: #1d4ed8;
+    border-color: #1d4ed8;
+}
+
+/* Secondary Action Buttons */
+QPushButton#secondary_btn {
+    background-color: #1e293b;
+    border: 1px solid #475569;
+    color: #cbd5e1;
+    font-weight: 500;
+    min-width: 108px;
+}
+
+QPushButton#secondary_btn:hover {
+    background-color: #334155;
+    border-color: #64748b;
+    color: #f8fafc;
+}
+
+QPushButton#secondary_btn:pressed {
+    background-color: #0f172a;
+}
+
+QPushButton#secondary_btn:disabled {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #64748b;
+}
+
+/* Danger Action Button */
+QPushButton#kill_btn {
+    background-color: #ef4444;
+    border: 1px solid #ef4444;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+QPushButton#kill_btn:hover {
+    background-color: #f87171;
+    border-color: #f87171;
+}
+
+QPushButton#kill_btn:pressed {
+    background-color: #dc2626;
+    border-color: #dc2626;
+}
+
+QPushButton#kill_btn:disabled {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #64748b;
+}
+
+/* Log View (QTextEdit) terminal styling */
+QTextEdit#log_view {
+    background-color: #020617;
+    border: 1px solid #1e293b;
+    border-radius: 8px;
+    color: #e2e8f0;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+    padding: 12px;
+}
+
+QLabel#doctor_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#doctor_status_label[status="idle"],
+QLabel#doctor_status_label[status="running"] {
+    color: #60a5fa;
+}
+
+QLabel#doctor_status_label[status="ready"] {
+    color: #4ade80;
+}
+
+QLabel#doctor_status_label[status="warning"] {
+    color: #fbbf24;
+}
+
+QLabel#doctor_status_label[status="stale"] {
+    color: #fbbf24;
+}
+
+QLabel#doctor_status_label[status="blocked"] {
+    color: #f87171;
+}
+
+QLabel#doctor_facts_label {
+    color: #cbd5e1;
+}
+
+QLabel#workflow_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#workflow_status_label[status="idle"],
+QLabel#workflow_status_label[status="running"] {
+    color: #60a5fa;
+}
+
+QLabel#workflow_status_label[status="done"] {
+    color: #4ade80;
+}
+
+QLabel#workflow_status_label[status="waiting"],
+QLabel#workflow_status_label[status="stale"] {
+    color: #fbbf24;
+}
+
+QLabel#workflow_status_label[status="failed"] {
+    color: #f87171;
+}
+
+QLabel#workflow_facts_label {
+    color: #cbd5e1;
+}
+
+QFrame#workflow_separator {
+    color: #334155;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+QLabel#workflow_section_label {
+    color: #60a5fa;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+QLabel#writeback_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#writeback_status_label[status="idle"],
+QLabel#writeback_status_label[status="running"] {
+    color: #60a5fa;
+}
+
+QLabel#writeback_status_label[status="safe"] {
+    color: #4ade80;
+}
+
+QLabel#writeback_status_label[status="applied"] {
+    color: #4ade80;
+}
+
+QLabel#writeback_status_label[status="warn"],
+QLabel#writeback_status_label[status="stale"] {
+    color: #fbbf24;
+}
+
+QLabel#writeback_status_label[status="block"],
+QLabel#writeback_status_label[status="failed"],
+QLabel#writeback_status_label[status="unknown"] {
+    color: #f87171;
+}
+
+QLabel#writeback_facts_label {
+    color: #cbd5e1;
+}
+
+QTextEdit#writeback_findings_view {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #cbd5e1;
+    padding: 8px;
+}
+
+QPushButton#apply_btn {
+    background-color: #15803d;
+    border: 1px solid #15803d;
+    color: #ffffff;
+    font-weight: 600;
+    min-width: 108px;
+}
+
+QPushButton#apply_btn:hover {
+    background-color: #22c55e;
+    border-color: #22c55e;
+}
+
+QPushButton#apply_btn:pressed {
+    background-color: #166534;
+    border-color: #166534;
+}
+
+QPushButton#apply_btn:disabled {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #64748b;
+}
+
+QTextEdit#doctor_findings_view {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #cbd5e1;
+    padding: 8px;
+}
+
+/* ScrollBar Styling */
+QScrollBar:vertical {
+    background-color: #1e293b;
+    width: 10px;
+    margin: 0px;
+}
+
+QTextEdit#log_view QScrollBar:vertical {
+    background-color: #020617;
+    width: 12px;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #475569;
+    min-height: 20px;
+    border-radius: 5px;
+    border: 2px solid #1e293b;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #64748b;
+}
+
+QTextEdit#log_view QScrollBar::handle:vertical {
+    background-color: #334155;
+    border: 2px solid #020617;
+}
+
+QTextEdit#log_view QScrollBar::handle:vertical:hover {
+    background-color: #475569;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0px;
+}
+
+QScrollBar::add-page:vertical,
+QScrollBar::sub-page:vertical {
+    background: none;
+}

--- a/gui_qt/theme.py
+++ b/gui_qt/theme.py
@@ -1,0 +1,44 @@
+"""Qt integration for applying GUI theme stylesheets."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
+
+from .theme_helpers import (
+    resolve_effective_theme,
+    theme_stylesheet_filename,
+)
+
+
+def system_prefers_dark(app: QApplication) -> bool | None:
+    scheme = app.styleHints().colorScheme()
+    if scheme == Qt.ColorScheme.Dark:
+        return True
+    if scheme == Qt.ColorScheme.Light:
+        return False
+    return None
+
+
+def load_theme_stylesheet(resources_dir: Path, effective_theme: str) -> str:
+    filename = theme_stylesheet_filename(effective_theme)
+    path = resources_dir / filename
+    if not path.exists() and effective_theme == "dark":
+        path = resources_dir / "app.qss"
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def apply_theme(app: QApplication, resources_dir: Path, preference: str) -> str:
+    effective = resolve_effective_theme(
+        preference,
+        system_is_dark=system_prefers_dark(app),
+    )
+    stylesheet = load_theme_stylesheet(resources_dir, effective)
+    if stylesheet:
+        app.setStyleSheet(stylesheet)
+    else:
+        app.setStyleSheet("")
+    return effective

--- a/gui_qt/theme_helpers.py
+++ b/gui_qt/theme_helpers.py
@@ -1,0 +1,51 @@
+"""Pure helpers for GUI theme preference resolution (no Qt dependency)."""
+from __future__ import annotations
+
+from typing import Any
+
+THEME_SYSTEM = "system"
+THEME_LIGHT = "light"
+THEME_DARK = "dark"
+
+VALID_THEME_PREFERENCES = frozenset({THEME_SYSTEM, THEME_LIGHT, THEME_DARK})
+DEFAULT_THEME_PREFERENCE = THEME_SYSTEM
+
+
+def normalize_theme_preference(value: Any) -> str:
+    if isinstance(value, str):
+        cleaned = value.strip().lower()
+        if cleaned in VALID_THEME_PREFERENCES:
+            return cleaned
+    return DEFAULT_THEME_PREFERENCE
+
+
+def resolve_effective_theme(preference: Any, *, system_is_dark: bool | None = None) -> str:
+    normalized = normalize_theme_preference(preference)
+    if normalized == THEME_LIGHT:
+        return THEME_LIGHT
+    if normalized == THEME_DARK:
+        return THEME_DARK
+    if system_is_dark is True:
+        return THEME_DARK
+    return THEME_LIGHT
+
+
+def theme_stylesheet_filename(effective_theme: str) -> str:
+    if effective_theme == THEME_DARK:
+        return "app_dark.qss"
+    return "app.qss"
+
+
+def read_gui_theme_from_config(config: dict[str, Any]) -> str:
+    gui = config.get("gui")
+    if not isinstance(gui, dict):
+        return DEFAULT_THEME_PREFERENCE
+    return normalize_theme_preference(gui.get("theme"))
+
+
+def write_gui_theme_to_config(config: dict[str, Any], preference: Any) -> None:
+    gui = config.get("gui")
+    if not isinstance(gui, dict):
+        gui = {}
+        config["gui"] = gui
+    gui["theme"] = normalize_theme_preference(preference)

--- a/tests/test_gui_theme_helpers.py
+++ b/tests/test_gui_theme_helpers.py
@@ -1,0 +1,53 @@
+import unittest
+
+from gui_qt.theme_helpers import (
+    DEFAULT_THEME_PREFERENCE,
+    THEME_DARK,
+    THEME_LIGHT,
+    THEME_SYSTEM,
+    normalize_theme_preference,
+    read_gui_theme_from_config,
+    resolve_effective_theme,
+    theme_stylesheet_filename,
+    write_gui_theme_to_config,
+)
+
+
+class GuiThemeHelperTests(unittest.TestCase):
+    def test_normalize_theme_preference_defaults_to_system(self):
+        self.assertEqual(normalize_theme_preference(None), THEME_SYSTEM)
+        self.assertEqual(normalize_theme_preference("  "), THEME_SYSTEM)
+        self.assertEqual(normalize_theme_preference("invalid"), THEME_SYSTEM)
+
+    def test_normalize_theme_preference_accepts_known_values(self):
+        self.assertEqual(normalize_theme_preference("LIGHT"), THEME_LIGHT)
+        self.assertEqual(normalize_theme_preference(" dark "), THEME_DARK)
+        self.assertEqual(normalize_theme_preference("system"), THEME_SYSTEM)
+
+    def test_resolve_effective_theme_honors_explicit_preference(self):
+        self.assertEqual(resolve_effective_theme(THEME_LIGHT, system_is_dark=True), THEME_LIGHT)
+        self.assertEqual(resolve_effective_theme(THEME_DARK, system_is_dark=False), THEME_DARK)
+
+    def test_resolve_effective_theme_follows_system_when_requested(self):
+        self.assertEqual(resolve_effective_theme(THEME_SYSTEM, system_is_dark=True), THEME_DARK)
+        self.assertEqual(resolve_effective_theme(THEME_SYSTEM, system_is_dark=False), THEME_LIGHT)
+        self.assertEqual(resolve_effective_theme(THEME_SYSTEM, system_is_dark=None), THEME_LIGHT)
+
+    def test_theme_stylesheet_filename_maps_effective_theme(self):
+        self.assertEqual(theme_stylesheet_filename(THEME_LIGHT), "app.qss")
+        self.assertEqual(theme_stylesheet_filename(THEME_DARK), "app_dark.qss")
+
+    def test_read_gui_theme_from_config_defaults_to_system(self):
+        self.assertEqual(read_gui_theme_from_config({}), DEFAULT_THEME_PREFERENCE)
+        self.assertEqual(read_gui_theme_from_config({"gui": "bad"}), DEFAULT_THEME_PREFERENCE)
+
+    def test_write_gui_theme_to_config_preserves_other_gui_fields(self):
+        config = {"gui": {"theme": "light", "other": 1}, "sync": {"model": "x"}}
+        write_gui_theme_to_config(config, " dark ")
+        self.assertEqual(config["gui"]["theme"], THEME_DARK)
+        self.assertEqual(config["gui"]["other"], 1)
+        self.assertEqual(config["sync"]["model"], "x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds appearance controls to the optional PySide6 workbench:

- **Default:** follow system light/dark via `QStyleHints.colorScheme()`
- **Manual:** light or dark override from the config tab
- **Persistence:** `translator_config.json` → `gui.theme` (`system` / `light` / `dark`)

## Changes

- `gui_qt/theme_helpers.py` — pure preference resolution (CI-friendly tests)
- `gui_qt/theme.py` — Qt stylesheet loading and application
- `gui_qt/resources/app_dark.qss` — dark Slate companion to existing `app.qss`
- Config tab **外观** group with immediate apply + auto-save
- Listens for `colorSchemeChanged` while preference is `system`

Refs #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime theme selection in Appearance settings (Light, Dark, Follow system) with preferences saved across sessions.
  * Introduced a refreshed “Premium Slate Dark” theme styling for the GUI.

* **Bug Fixes**
  * Improved config/UI synchronization for theme changes to avoid conflicting updates.
  * When set to “Follow system,” the app now re-applies the theme automatically as the system color scheme changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->