### PR TITLE
Add GUI bootstrap entry points for RAG and source index

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -631,9 +631,9 @@ class MainWindow(QMainWindow):
         self._active_command = "bootstrap_rag"
         self._bootstrap_output_lines = []
         self._set_bootstrap_summary(running_bootstrap_summary("rag"))
-        self._append_log("=== 正在运行：gemini_translate_batch.py bootstrap-rag ===\n")
+        self._append_log("=== 正在运行：gemini_translate_batch.py bootstrap-rag --skip-prepare ===\n")
         self._set_task_running(True)
-        self.runner.run(self.state.get_batch_script_path(), ["bootstrap-rag"])
+        self.runner.run(self.state.get_batch_script_path(), ["bootstrap-rag", "--skip-prepare"])
 
     def _on_bootstrap_source_index(self) -> None:
         if not self.state.get_game_root():
@@ -653,10 +653,13 @@ class MainWindow(QMainWindow):
         self._bootstrap_output_lines = []
         self._set_bootstrap_summary(running_bootstrap_summary("source_index"))
         self._append_log(
-            "=== 正在运行：gemini_translate_batch.py bootstrap-source-index ===\n"
+            "=== 正在运行：gemini_translate_batch.py bootstrap-source-index --skip-prepare ===\n"
         )
         self._set_task_running(True)
-        self.runner.run(self.state.get_batch_script_path(), ["bootstrap-source-index"])
+        self.runner.run(
+            self.state.get_batch_script_path(),
+            ["bootstrap-source-index", "--skip-prepare"],
+        )
 
     def _on_start_translation(self):
         if not self.state.get_game_root():

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -105,8 +105,8 @@ class MainWindow(QMainWindow):
         header = QLabel("Ren'Py Translation Lab · 图形工作台")
         header.setObjectName("header_label")
         subtitle = QLabel(
-            "先环境检查，再开始翻译；翻译完成后的写回状态显示在右侧任务卡片内。"
-            "详细日志请切换到「诊断日志」页。"
+            "工作台只保留项目检查与翻译主流程；预建库、模型与 API 配置在「配置」页。"
+            "详细日志请切换到「诊断日志」。"
         )
         subtitle.setObjectName("subtitle_label")
         subtitle.setWordWrap(True)
@@ -208,55 +208,6 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(actions_box)
 
-        bootstrap_box = QGroupBox("预建上下文库")
-        bootstrap_layout = QVBoxLayout(bootstrap_box)
-        bootstrap_layout.setSpacing(8)
-        bootstrap_layout.setContentsMargins(12, 16, 12, 12)
-
-        bootstrap_hint = QLabel(
-            "翻译前可先预建本地向量库：RAG 库利用已有译文保持术语一致；"
-            "原文索引适合译文较少、需要剧情上下文的项目。"
-            "请先在配置页启用对应选项并保存，再运行预建。"
-        )
-        bootstrap_hint.setWordWrap(True)
-        bootstrap_hint.setObjectName("config_hint_label")
-        bootstrap_layout.addWidget(bootstrap_hint)
-
-        bootstrap_actions = QHBoxLayout()
-        bootstrap_actions.setSpacing(10)
-        self.bootstrap_rag_btn = QPushButton("预建 RAG 库")
-        self.bootstrap_rag_btn.setObjectName("secondary_btn")
-        self.bootstrap_rag_btn.clicked.connect(self._on_bootstrap_rag)
-        bootstrap_actions.addWidget(self.bootstrap_rag_btn)
-
-        self.bootstrap_source_index_btn = QPushButton("预建原文索引")
-        self.bootstrap_source_index_btn.setObjectName("secondary_btn")
-        self.bootstrap_source_index_btn.clicked.connect(self._on_bootstrap_source_index)
-        bootstrap_actions.addWidget(self.bootstrap_source_index_btn)
-        bootstrap_actions.addStretch()
-        bootstrap_layout.addLayout(bootstrap_actions)
-
-        self.bootstrap_status_label = QLabel()
-        self.bootstrap_status_label.setObjectName("bootstrap_status_label")
-        bootstrap_layout.addWidget(self.bootstrap_status_label)
-
-        self.bootstrap_message_label = QLabel()
-        self.bootstrap_message_label.setWordWrap(True)
-        bootstrap_layout.addWidget(self.bootstrap_message_label)
-
-        self.bootstrap_facts_label = QLabel()
-        self.bootstrap_facts_label.setWordWrap(True)
-        self.bootstrap_facts_label.setObjectName("bootstrap_facts_label")
-        bootstrap_layout.addWidget(self.bootstrap_facts_label)
-
-        self.bootstrap_findings_view = QTextEdit()
-        self.bootstrap_findings_view.setReadOnly(True)
-        self.bootstrap_findings_view.setMaximumHeight(72)
-        self.bootstrap_findings_view.setObjectName("bootstrap_findings_view")
-        bootstrap_layout.addWidget(self.bootstrap_findings_view)
-
-        layout.addWidget(bootstrap_box)
-
         status_row = QHBoxLayout()
         status_row.setSpacing(16)
 
@@ -280,7 +231,7 @@ class MainWindow(QMainWindow):
 
         self.doctor_findings_view = QTextEdit()
         self.doctor_findings_view.setReadOnly(True)
-        self.doctor_findings_view.setMaximumHeight(110)
+        self.doctor_findings_view.setMaximumHeight(88)
         self.doctor_findings_view.setObjectName("doctor_findings_view")
         doctor_summary_layout.addWidget(self.doctor_findings_view)
 
@@ -328,7 +279,7 @@ class MainWindow(QMainWindow):
 
         self.writeback_findings_view = QTextEdit()
         self.writeback_findings_view.setReadOnly(True)
-        self.writeback_findings_view.setMaximumHeight(72)
+        self.writeback_findings_view.setMaximumHeight(60)
         self.writeback_findings_view.setObjectName("writeback_findings_view")
         workflow_layout.addWidget(self.writeback_findings_view)
 
@@ -406,8 +357,8 @@ class MainWindow(QMainWindow):
         context_layout.setContentsMargins(12, 16, 12, 12)
 
         context_hint = QLabel(
-            "RAG 记忆库使用已有译文；原文索引只使用 TL 模板中的原文。"
-            "预建命令不会修改 .rpy 文件，也不会创建 Batch package。"
+            "启用后先保存配置，再运行下方预建按钮。"
+            "RAG 使用已有译文；原文索引只使用 TL 模板原文；均不修改 .rpy 文件。"
         )
         context_hint.setWordWrap(True)
         context_hint.setObjectName("config_hint_label")
@@ -425,6 +376,39 @@ class MainWindow(QMainWindow):
             "开始翻译 build 时自动暖 RAG 库（batch.rag.bootstrap_on_build）"
         )
         context_layout.addWidget(self.bootstrap_on_build_cb)
+
+        bootstrap_actions = QHBoxLayout()
+        bootstrap_actions.setSpacing(10)
+        self.bootstrap_rag_btn = QPushButton("预建 RAG 库")
+        self.bootstrap_rag_btn.setObjectName("secondary_btn")
+        self.bootstrap_rag_btn.clicked.connect(self._on_bootstrap_rag)
+        bootstrap_actions.addWidget(self.bootstrap_rag_btn)
+
+        self.bootstrap_source_index_btn = QPushButton("预建原文索引")
+        self.bootstrap_source_index_btn.setObjectName("secondary_btn")
+        self.bootstrap_source_index_btn.clicked.connect(self._on_bootstrap_source_index)
+        bootstrap_actions.addWidget(self.bootstrap_source_index_btn)
+        bootstrap_actions.addStretch()
+        context_layout.addLayout(bootstrap_actions)
+
+        self.bootstrap_status_label = QLabel()
+        self.bootstrap_status_label.setObjectName("bootstrap_status_label")
+        context_layout.addWidget(self.bootstrap_status_label)
+
+        self.bootstrap_message_label = QLabel()
+        self.bootstrap_message_label.setWordWrap(True)
+        context_layout.addWidget(self.bootstrap_message_label)
+
+        self.bootstrap_facts_label = QLabel()
+        self.bootstrap_facts_label.setWordWrap(True)
+        self.bootstrap_facts_label.setObjectName("bootstrap_facts_label")
+        context_layout.addWidget(self.bootstrap_facts_label)
+
+        self.bootstrap_findings_view = QTextEdit()
+        self.bootstrap_findings_view.setReadOnly(True)
+        self.bootstrap_findings_view.setMaximumHeight(56)
+        self.bootstrap_findings_view.setObjectName("bootstrap_findings_view")
+        context_layout.addWidget(self.bootstrap_findings_view)
 
         layout.addWidget(context_box)
 
@@ -643,11 +627,12 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "RAG 未启用",
-                "请先在配置页启用 Batch RAG 记忆库，并点击「保存参数配置」。",
+                "请先启用 Batch RAG 记忆库，并点击「保存参数配置」。",
             )
             return
 
         self.log_view.clear()
+        self._focus_log_tab()
         self._active_command = "bootstrap_rag"
         self._bootstrap_output_lines = []
         self._set_bootstrap_summary(running_bootstrap_summary("rag"))
@@ -663,11 +648,12 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "原文索引未启用",
-                "请先在配置页启用 Batch 原文索引，并点击「保存参数配置」。",
+                "请先启用 Batch 原文索引，并点击「保存参数配置」。",
             )
             return
 
         self.log_view.clear()
+        self._focus_log_tab()
         self._active_command = "bootstrap_source_index"
         self._bootstrap_output_lines = []
         self._set_bootstrap_summary(running_bootstrap_summary("source_index"))

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QLineEdit,
     QComboBox,
+    QCheckBox,
     QFrame,
     QFormLayout,
     QTabWidget,
@@ -33,6 +34,15 @@ from PySide6.QtWidgets import (
 
 from .api_key_dialog import ApiKeyDialog
 from .api_key_helpers import mask_api_key
+from .bootstrap_report import (
+    BootstrapSummary,
+    idle_bootstrap_summary,
+    read_batch_context_flags,
+    running_bootstrap_summary,
+    stale_bootstrap_summary,
+    summarize_rag_bootstrap_output,
+    summarize_source_index_bootstrap_output,
+)
 from .check_report import (
     WritebackSummary,
     idle_writeback_summary,
@@ -83,6 +93,7 @@ class MainWindow(QMainWindow):
         self._workflow: TranslationWorkflow | None = None
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
+        self._bootstrap_output_lines: list[str] = []
         self._writeback_manifest_path = ""
 
         central = QWidget()
@@ -129,6 +140,7 @@ class MainWindow(QMainWindow):
             "完成环境检查后，可以开始基础 Batch 翻译流程。",
         )
         self._refresh_writeback_from_latest_manifest()
+        self._set_bootstrap_summary(idle_bootstrap_summary())
 
         # Status
         self.statusBar().showMessage(
@@ -195,6 +207,55 @@ class MainWindow(QMainWindow):
         actions_layout.addLayout(secondary_layout)
 
         layout.addWidget(actions_box)
+
+        bootstrap_box = QGroupBox("预建上下文库")
+        bootstrap_layout = QVBoxLayout(bootstrap_box)
+        bootstrap_layout.setSpacing(8)
+        bootstrap_layout.setContentsMargins(12, 16, 12, 12)
+
+        bootstrap_hint = QLabel(
+            "翻译前可先预建本地向量库：RAG 库利用已有译文保持术语一致；"
+            "原文索引适合译文较少、需要剧情上下文的项目。"
+            "请先在配置页启用对应选项并保存，再运行预建。"
+        )
+        bootstrap_hint.setWordWrap(True)
+        bootstrap_hint.setObjectName("config_hint_label")
+        bootstrap_layout.addWidget(bootstrap_hint)
+
+        bootstrap_actions = QHBoxLayout()
+        bootstrap_actions.setSpacing(10)
+        self.bootstrap_rag_btn = QPushButton("预建 RAG 库")
+        self.bootstrap_rag_btn.setObjectName("secondary_btn")
+        self.bootstrap_rag_btn.clicked.connect(self._on_bootstrap_rag)
+        bootstrap_actions.addWidget(self.bootstrap_rag_btn)
+
+        self.bootstrap_source_index_btn = QPushButton("预建原文索引")
+        self.bootstrap_source_index_btn.setObjectName("secondary_btn")
+        self.bootstrap_source_index_btn.clicked.connect(self._on_bootstrap_source_index)
+        bootstrap_actions.addWidget(self.bootstrap_source_index_btn)
+        bootstrap_actions.addStretch()
+        bootstrap_layout.addLayout(bootstrap_actions)
+
+        self.bootstrap_status_label = QLabel()
+        self.bootstrap_status_label.setObjectName("bootstrap_status_label")
+        bootstrap_layout.addWidget(self.bootstrap_status_label)
+
+        self.bootstrap_message_label = QLabel()
+        self.bootstrap_message_label.setWordWrap(True)
+        bootstrap_layout.addWidget(self.bootstrap_message_label)
+
+        self.bootstrap_facts_label = QLabel()
+        self.bootstrap_facts_label.setWordWrap(True)
+        self.bootstrap_facts_label.setObjectName("bootstrap_facts_label")
+        bootstrap_layout.addWidget(self.bootstrap_facts_label)
+
+        self.bootstrap_findings_view = QTextEdit()
+        self.bootstrap_findings_view.setReadOnly(True)
+        self.bootstrap_findings_view.setMaximumHeight(72)
+        self.bootstrap_findings_view.setObjectName("bootstrap_findings_view")
+        bootstrap_layout.addWidget(self.bootstrap_findings_view)
+
+        layout.addWidget(bootstrap_box)
 
         status_row = QHBoxLayout()
         status_row.setSpacing(16)
@@ -339,6 +400,34 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(api_box)
 
+        context_box = QGroupBox("Batch 上下文")
+        context_layout = QVBoxLayout(context_box)
+        context_layout.setSpacing(8)
+        context_layout.setContentsMargins(12, 16, 12, 12)
+
+        context_hint = QLabel(
+            "RAG 记忆库使用已有译文；原文索引只使用 TL 模板中的原文。"
+            "预建命令不会修改 .rpy 文件，也不会创建 Batch package。"
+        )
+        context_hint.setWordWrap(True)
+        context_hint.setObjectName("config_hint_label")
+        context_layout.addWidget(context_hint)
+
+        self.rag_enabled_cb = QCheckBox("启用 Batch RAG 记忆库（batch.rag.enabled）")
+        context_layout.addWidget(self.rag_enabled_cb)
+
+        self.source_index_enabled_cb = QCheckBox(
+            "启用 Batch 原文索引（batch.source_index.enabled）"
+        )
+        context_layout.addWidget(self.source_index_enabled_cb)
+
+        self.bootstrap_on_build_cb = QCheckBox(
+            "开始翻译 build 时自动暖 RAG 库（batch.rag.bootstrap_on_build）"
+        )
+        context_layout.addWidget(self.bootstrap_on_build_cb)
+
+        layout.addWidget(context_box)
+
         config_row = QHBoxLayout()
         config_row.setSpacing(16)
 
@@ -468,6 +557,7 @@ class MainWindow(QMainWindow):
             )
             self._writeback_manifest_path = ""
             self._set_writeback_summary(stale_writeback_summary())
+            self._set_bootstrap_summary(stale_bootstrap_summary())
             self._append_log(f"项目目录已设置为：{directory}")
 
     def _refresh_api_status(self) -> None:
@@ -541,6 +631,51 @@ class MainWindow(QMainWindow):
         script = self.state.get_batch_script_path()
         # Run with no extra args — it will pick up translator_config.json
         self.runner.run(script, ["doctor"])
+
+    def _saved_batch_context_flags(self) -> dict[str, bool]:
+        return read_batch_context_flags(self.state.load_translator_config())
+
+    def _on_bootstrap_rag(self) -> None:
+        if not self.state.get_game_root():
+            QMessageBox.information(self, "请先选择项目", "请先选择游戏的 work 目录。")
+            return
+        if not self._saved_batch_context_flags()["rag_enabled"]:
+            QMessageBox.information(
+                self,
+                "RAG 未启用",
+                "请先在配置页启用 Batch RAG 记忆库，并点击「保存参数配置」。",
+            )
+            return
+
+        self.log_view.clear()
+        self._active_command = "bootstrap_rag"
+        self._bootstrap_output_lines = []
+        self._set_bootstrap_summary(running_bootstrap_summary("rag"))
+        self._append_log("=== 正在运行：gemini_translate_batch.py bootstrap-rag ===\n")
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), ["bootstrap-rag"])
+
+    def _on_bootstrap_source_index(self) -> None:
+        if not self.state.get_game_root():
+            QMessageBox.information(self, "请先选择项目", "请先选择游戏的 work 目录。")
+            return
+        if not self._saved_batch_context_flags()["source_index_enabled"]:
+            QMessageBox.information(
+                self,
+                "原文索引未启用",
+                "请先在配置页启用 Batch 原文索引，并点击「保存参数配置」。",
+            )
+            return
+
+        self.log_view.clear()
+        self._active_command = "bootstrap_source_index"
+        self._bootstrap_output_lines = []
+        self._set_bootstrap_summary(running_bootstrap_summary("source_index"))
+        self._append_log(
+            "=== 正在运行：gemini_translate_batch.py bootstrap-source-index ===\n"
+        )
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), ["bootstrap-source-index"])
 
     def _on_start_translation(self):
         if not self.state.get_game_root():
@@ -654,6 +789,8 @@ class MainWindow(QMainWindow):
             self._workflow_step_output_lines.append(text)
         elif self._active_command == "apply":
             self._apply_output_lines.append(text)
+        elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
+            self._bootstrap_output_lines.append(text)
         self._append_log(text)
 
     def _append_log(self, text: str):
@@ -670,6 +807,8 @@ class MainWindow(QMainWindow):
         self.resume_btn.setEnabled(not running)
         self.save_config_btn.setEnabled(not running)
         self.apply_btn.setEnabled(not running and self._current_writeback_summary().can_apply)
+        self.bootstrap_rag_btn.setEnabled(not running)
+        self.bootstrap_source_index_btn.setEnabled(not running)
         self.kill_btn.setEnabled(running)
 
     def _set_workflow_summary(
@@ -782,6 +921,26 @@ class MainWindow(QMainWindow):
             )
         )
 
+    def _set_bootstrap_summary(self, summary: BootstrapSummary) -> None:
+        self.bootstrap_status_label.setText(summary.heading)
+        self.bootstrap_status_label.setProperty("status", summary.status)
+        self.bootstrap_status_label.style().unpolish(self.bootstrap_status_label)
+        self.bootstrap_status_label.style().polish(self.bootstrap_status_label)
+        self.bootstrap_message_label.setText(summary.message)
+        self.bootstrap_facts_label.setText("\n".join(summary.facts))
+        if summary.findings:
+            self.bootstrap_findings_view.setPlainText(
+                "\n".join(f"- {finding}" for finding in summary.findings)
+            )
+        elif summary.status in {"idle", "running"}:
+            self.bootstrap_findings_view.setPlainText("预建完成后，这里会显示扫描与写入摘要。")
+        elif summary.status == "stale":
+            self.bootstrap_findings_view.setPlainText("请针对当前项目重新运行预建库。")
+        elif summary.status == "ready":
+            self.bootstrap_findings_view.setPlainText("预建库已就绪，可以开始翻译任务。")
+        else:
+            self.bootstrap_findings_view.setPlainText("请查看诊断日志了解详情。")
+
     def _set_doctor_summary(self, summary: DoctorSummary):
         self.doctor_status_label.setText(summary.heading)
         self.doctor_status_label.setProperty("status", summary.status)
@@ -808,6 +967,8 @@ class MainWindow(QMainWindow):
             self._workflow_step_output_lines.append(message)
         elif self._active_command == "apply":
             self._apply_output_lines.append(message)
+        elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
+            self._bootstrap_output_lines.append(message)
         self._focus_log_tab()
         self.statusBar().showMessage("任务运行失败，请查看诊断日志。", 6000)
 
@@ -847,6 +1008,38 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("翻译写回完成。", 6000)
             else:
                 self.statusBar().showMessage("翻译写回失败，请查看诊断日志。", 8000)
+            return
+
+        if self._active_command == "bootstrap_rag":
+            summary = summarize_rag_bootstrap_output(
+                "\n".join(self._bootstrap_output_lines),
+                exit_code,
+            )
+            self._set_bootstrap_summary(summary)
+            self._active_command = ""
+            self._set_task_running(False)
+            if exit_code == 0 and summary.status == "ready":
+                self.statusBar().showMessage("RAG 预建完成。", 6000)
+            elif exit_code == 0:
+                self.statusBar().showMessage("RAG 预建已结束，请查看摘要。", 6000)
+            else:
+                self.statusBar().showMessage("RAG 预建失败，请查看诊断日志。", 8000)
+            return
+
+        if self._active_command == "bootstrap_source_index":
+            summary = summarize_source_index_bootstrap_output(
+                "\n".join(self._bootstrap_output_lines),
+                exit_code,
+            )
+            self._set_bootstrap_summary(summary)
+            self._active_command = ""
+            self._set_task_running(False)
+            if exit_code == 0 and summary.status == "ready":
+                self.statusBar().showMessage("原文索引预建完成。", 6000)
+            elif exit_code == 0:
+                self.statusBar().showMessage("原文索引预建已结束，请查看摘要。", 6000)
+            else:
+                self.statusBar().showMessage("原文索引预建失败，请查看诊断日志。", 8000)
             return
 
         self._set_task_running(False)
@@ -1043,6 +1236,10 @@ class MainWindow(QMainWindow):
             batch_config = self._config_section(config, "batch")
             sync_rag_config = self._config_section(sync_config, "rag")
             batch_rag_config = self._config_section(batch_config, "rag")
+            context_flags = read_batch_context_flags(config)
+            self.rag_enabled_cb.setChecked(context_flags["rag_enabled"])
+            self.source_index_enabled_cb.setChecked(context_flags["source_index_enabled"])
+            self.bootstrap_on_build_cb.setChecked(context_flags["bootstrap_on_build"])
             self._batch_thinking_config_has_key = "thinking_level" in batch_config
 
             # Populate sync model
@@ -1111,6 +1308,11 @@ class MainWindow(QMainWindow):
             batch_config = self._ensure_config_section(config, "batch")
             sync_rag_config = self._ensure_config_section(sync_config, "rag")
             batch_rag_config = self._ensure_config_section(batch_config, "rag")
+            batch_source_index_config = self._ensure_config_section(batch_config, "source_index")
+
+            batch_rag_config["enabled"] = self.rag_enabled_cb.isChecked()
+            batch_rag_config["bootstrap_on_build"] = self.bootstrap_on_build_cb.isChecked()
+            batch_source_index_config["enabled"] = self.source_index_enabled_cb.isChecked()
 
             sync_model = self.sync_model_combo.currentText().strip()
             sync_config["model"] = sync_model

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -25,12 +25,10 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QGroupBox,
     QLineEdit,
-    QComboBox,
     QCheckBox,
     QFrame,
     QFormLayout,
     QScrollArea,
-    QTabWidget,
 )
 
 from .api_key_dialog import ApiKeyDialog
@@ -71,6 +69,7 @@ from .theme_helpers import (
     write_gui_theme_to_config,
 )
 from .translation_workflow import TranslationWorkflow, WorkflowUpdate
+from .widget_helpers import NoWheelComboBox, NoWheelTabWidget
 
 
 class MainWindow(QMainWindow):
@@ -107,7 +106,7 @@ class MainWindow(QMainWindow):
         header.setObjectName("header_label")
         root_layout.addWidget(header)
 
-        self.tab_widget = QTabWidget()
+        self.tab_widget = NoWheelTabWidget()
         self.tab_widget.setObjectName("main_tabs")
         root_layout.addWidget(self.tab_widget, 1)
 
@@ -192,7 +191,7 @@ class MainWindow(QMainWindow):
         action_row.addWidget(self.kill_btn)
         layout.addLayout(action_row)
 
-        self.workbench_status_tabs = QTabWidget()
+        self.workbench_status_tabs = NoWheelTabWidget()
         self.workbench_status_tabs.setObjectName("workbench_status_tabs")
 
         doctor_tab = QWidget()
@@ -392,7 +391,7 @@ class MainWindow(QMainWindow):
         sync_layout.setSpacing(8)
         sync_layout.setContentsMargins(12, 16, 12, 12)
 
-        self.sync_model_combo = QComboBox()
+        self.sync_model_combo = NoWheelComboBox()
         self.sync_model_combo.addItems([
             "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
@@ -404,7 +403,7 @@ class MainWindow(QMainWindow):
         ])
         sync_layout.addRow("翻译模型：", self.sync_model_combo)
 
-        self.sync_embedding_combo = QComboBox()
+        self.sync_embedding_combo = NoWheelComboBox()
         self.sync_embedding_combo.addItems([
             "gemini-embedding-2",
             "gemini-embedding-001",
@@ -418,7 +417,7 @@ class MainWindow(QMainWindow):
         batch_layout.setSpacing(8)
         batch_layout.setContentsMargins(12, 16, 12, 12)
 
-        self.batch_model_combo = QComboBox()
+        self.batch_model_combo = NoWheelComboBox()
         self.batch_model_combo.addItems([
             "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
@@ -430,14 +429,14 @@ class MainWindow(QMainWindow):
         ])
         batch_layout.addRow("翻译模型：", self.batch_model_combo)
 
-        self.batch_embedding_combo = QComboBox()
+        self.batch_embedding_combo = NoWheelComboBox()
         self.batch_embedding_combo.addItems([
             "gemini-embedding-2",
             "gemini-embedding-001",
         ])
         batch_layout.addRow("RAG 向量模型：", self.batch_embedding_combo)
 
-        self.batch_thinking_combo = QComboBox()
+        self.batch_thinking_combo = NoWheelComboBox()
         self.batch_thinking_combo.addItem("（不启用）", "")
         self.batch_thinking_combo.addItem("最小 (minimal)", "minimal")
         self.batch_thinking_combo.addItem("低 (low)", "low")
@@ -452,7 +451,7 @@ class MainWindow(QMainWindow):
         appearance_layout = QFormLayout(appearance_box)
         appearance_layout.setSpacing(8)
         appearance_layout.setContentsMargins(12, 16, 12, 12)
-        self.theme_combo = QComboBox()
+        self.theme_combo = NoWheelComboBox()
         self.theme_combo.addItem("跟随系统", THEME_SYSTEM)
         self.theme_combo.addItem("浅色", "light")
         self.theme_combo.addItem("深色", "dark")
@@ -1107,7 +1106,7 @@ class MainWindow(QMainWindow):
             or "thinking_level" in batch_config
         )
 
-    def _set_combo_value(self, combo: QComboBox, value: Any):
+    def _set_combo_value(self, combo: NoWheelComboBox, value: Any):
         value = self._config_string(value)
         if not value:
             combo.setCurrentIndex(-1)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
@@ -196,6 +196,7 @@ class MainWindow(QMainWindow):
         self.workbench_status_tabs.setObjectName("workbench_status_tabs")
 
         doctor_tab = QWidget()
+        self._style_themed_surface(doctor_tab)
         doctor_layout = QVBoxLayout(doctor_tab)
         doctor_layout.setContentsMargins(12, 12, 12, 12)
         doctor_layout.setSpacing(6)
@@ -218,6 +219,7 @@ class MainWindow(QMainWindow):
         self.workbench_status_tabs.addTab(doctor_tab, "环境检查")
 
         workflow_tab = QWidget()
+        self._style_themed_surface(workflow_tab)
         workflow_layout = QVBoxLayout(workflow_tab)
         workflow_layout.setContentsMargins(12, 12, 12, 12)
         workflow_layout.setSpacing(6)
@@ -235,6 +237,7 @@ class MainWindow(QMainWindow):
         self.workbench_status_tabs.addTab(workflow_tab, "翻译进度")
 
         writeback_tab = QWidget()
+        self._style_themed_surface(writeback_tab)
         writeback_layout = QVBoxLayout(writeback_tab)
         writeback_layout.setContentsMargins(12, 12, 12, 12)
         writeback_layout.setSpacing(6)
@@ -269,17 +272,29 @@ class MainWindow(QMainWindow):
 
         self.tab_widget.addTab(tab, "工作台")
 
+    def _style_themed_surface(self, widget: QWidget) -> None:
+        widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+
     def _build_config_tab(self) -> None:
         tab = QWidget()
+        tab.setObjectName("config_tab")
+        self._style_themed_surface(tab)
         self._config_tab = tab
         outer_layout = QVBoxLayout(tab)
         outer_layout.setContentsMargins(0, 0, 0, 0)
 
         scroll = QScrollArea()
+        scroll.setObjectName("config_scroll")
+        self._style_themed_surface(scroll)
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
+        viewport = scroll.viewport()
+        viewport.setObjectName("config_scroll_viewport")
+        self._style_themed_surface(viewport)
 
         content = QWidget()
+        content.setObjectName("config_scroll_content")
+        self._style_themed_surface(content)
         layout = QVBoxLayout(content)
         layout.setContentsMargins(12, 16, 12, 12)
         layout.setSpacing(14)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -29,6 +29,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QFrame,
     QFormLayout,
+    QScrollArea,
     QTabWidget,
 )
 
@@ -104,14 +105,7 @@ class MainWindow(QMainWindow):
 
         header = QLabel("Ren'Py Translation Lab · 图形工作台")
         header.setObjectName("header_label")
-        subtitle = QLabel(
-            "工作台只保留项目检查与翻译主流程；预建库、模型与 API 配置在「配置」页。"
-            "详细日志请切换到「诊断日志」。"
-        )
-        subtitle.setObjectName("subtitle_label")
-        subtitle.setWordWrap(True)
         root_layout.addWidget(header)
-        root_layout.addWidget(subtitle)
 
         self.tab_widget = QTabWidget()
         self.tab_widget.setObjectName("main_tabs")
@@ -172,117 +166,93 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(project_frame)
 
-        actions_box = QGroupBox("操作")
-        actions_layout = QVBoxLayout(actions_box)
-        actions_layout.setSpacing(10)
-        actions_layout.setContentsMargins(12, 16, 12, 12)
-
-        primary_layout = QHBoxLayout()
-        primary_layout.setSpacing(10)
+        action_row = QHBoxLayout()
+        action_row.setSpacing(10)
         self.doctor_btn = QPushButton("环境检查")
         self.doctor_btn.setObjectName("doctor_btn")
         self.doctor_btn.clicked.connect(self._on_run_doctor)
-        primary_layout.addWidget(self.doctor_btn)
+        action_row.addWidget(self.doctor_btn)
 
-        self.translate_btn = QPushButton("开始翻译任务")
+        self.translate_btn = QPushButton("开始翻译")
         self.translate_btn.setObjectName("translate_btn")
         self.translate_btn.clicked.connect(self._on_start_translation)
-        primary_layout.addWidget(self.translate_btn)
-        primary_layout.addStretch()
-        actions_layout.addLayout(primary_layout)
+        action_row.addWidget(self.translate_btn)
 
-        secondary_layout = QHBoxLayout()
-        secondary_layout.setSpacing(10)
-        self.resume_btn = QPushButton("继续最新任务")
+        self.resume_btn = QPushButton("继续任务")
         self.resume_btn.setObjectName("secondary_btn")
         self.resume_btn.clicked.connect(self._on_resume_translation)
-        secondary_layout.addWidget(self.resume_btn)
-        secondary_layout.addStretch()
+        action_row.addWidget(self.resume_btn)
 
-        self.kill_btn = QPushButton("停止当前任务")
+        action_row.addStretch()
+
+        self.kill_btn = QPushButton("停止")
         self.kill_btn.setObjectName("kill_btn")
         self.kill_btn.clicked.connect(self._on_kill)
         self.kill_btn.setEnabled(False)
-        secondary_layout.addWidget(self.kill_btn)
-        actions_layout.addLayout(secondary_layout)
+        action_row.addWidget(self.kill_btn)
+        layout.addLayout(action_row)
 
-        layout.addWidget(actions_box)
+        self.workbench_status_tabs = QTabWidget()
+        self.workbench_status_tabs.setObjectName("workbench_status_tabs")
 
-        status_row = QHBoxLayout()
-        status_row.setSpacing(16)
-
-        doctor_summary_box = QGroupBox("环境检查 (doctor)")
-        doctor_summary_layout = QVBoxLayout(doctor_summary_box)
-        doctor_summary_layout.setSpacing(6)
-        doctor_summary_layout.setContentsMargins(12, 16, 12, 12)
-
+        doctor_tab = QWidget()
+        doctor_layout = QVBoxLayout(doctor_tab)
+        doctor_layout.setContentsMargins(12, 12, 12, 12)
+        doctor_layout.setSpacing(6)
         self.doctor_status_label = QLabel()
         self.doctor_status_label.setObjectName("doctor_status_label")
-        doctor_summary_layout.addWidget(self.doctor_status_label)
-
+        doctor_layout.addWidget(self.doctor_status_label)
         self.doctor_message_label = QLabel()
         self.doctor_message_label.setWordWrap(True)
-        doctor_summary_layout.addWidget(self.doctor_message_label)
-
+        doctor_layout.addWidget(self.doctor_message_label)
         self.doctor_facts_label = QLabel()
         self.doctor_facts_label.setWordWrap(True)
         self.doctor_facts_label.setObjectName("doctor_facts_label")
-        doctor_summary_layout.addWidget(self.doctor_facts_label)
+        doctor_layout.addWidget(self.doctor_facts_label)
+        self.doctor_details_label = QLabel()
+        self.doctor_details_label.setWordWrap(True)
+        self.doctor_details_label.setObjectName("config_hint_label")
+        self.doctor_details_label.setVisible(False)
+        doctor_layout.addWidget(self.doctor_details_label)
+        doctor_layout.addStretch()
+        self.workbench_status_tabs.addTab(doctor_tab, "环境检查")
 
-        self.doctor_findings_view = QTextEdit()
-        self.doctor_findings_view.setReadOnly(True)
-        self.doctor_findings_view.setMaximumHeight(88)
-        self.doctor_findings_view.setObjectName("doctor_findings_view")
-        doctor_summary_layout.addWidget(self.doctor_findings_view)
-
-        status_row.addWidget(doctor_summary_box, 1)
-
-        workflow_box = QGroupBox("翻译任务")
-        workflow_layout = QVBoxLayout(workflow_box)
+        workflow_tab = QWidget()
+        workflow_layout = QVBoxLayout(workflow_tab)
+        workflow_layout.setContentsMargins(12, 12, 12, 12)
         workflow_layout.setSpacing(6)
-        workflow_layout.setContentsMargins(12, 16, 12, 12)
-
         self.workflow_status_label = QLabel()
         self.workflow_status_label.setObjectName("workflow_status_label")
         workflow_layout.addWidget(self.workflow_status_label)
-
         self.workflow_message_label = QLabel()
         self.workflow_message_label.setWordWrap(True)
         workflow_layout.addWidget(self.workflow_message_label)
-
         self.workflow_facts_label = QLabel()
         self.workflow_facts_label.setWordWrap(True)
         self.workflow_facts_label.setObjectName("workflow_facts_label")
         workflow_layout.addWidget(self.workflow_facts_label)
+        workflow_layout.addStretch()
+        self.workbench_status_tabs.addTab(workflow_tab, "翻译进度")
 
-        workflow_separator = QFrame()
-        workflow_separator.setFrameShape(QFrame.Shape.HLine)
-        workflow_separator.setObjectName("workflow_separator")
-        workflow_layout.addWidget(workflow_separator)
-
-        writeback_heading = QLabel("写回翻译")
-        writeback_heading.setObjectName("workflow_section_label")
-        workflow_layout.addWidget(writeback_heading)
-
+        writeback_tab = QWidget()
+        writeback_layout = QVBoxLayout(writeback_tab)
+        writeback_layout.setContentsMargins(12, 12, 12, 12)
+        writeback_layout.setSpacing(6)
         self.writeback_status_label = QLabel()
         self.writeback_status_label.setObjectName("writeback_status_label")
-        workflow_layout.addWidget(self.writeback_status_label)
-
+        writeback_layout.addWidget(self.writeback_status_label)
         self.writeback_message_label = QLabel()
         self.writeback_message_label.setWordWrap(True)
-        workflow_layout.addWidget(self.writeback_message_label)
-
+        writeback_layout.addWidget(self.writeback_message_label)
         self.writeback_facts_label = QLabel()
         self.writeback_facts_label.setWordWrap(True)
         self.writeback_facts_label.setObjectName("writeback_facts_label")
-        workflow_layout.addWidget(self.writeback_facts_label)
-
-        self.writeback_findings_view = QTextEdit()
-        self.writeback_findings_view.setReadOnly(True)
-        self.writeback_findings_view.setMaximumHeight(60)
-        self.writeback_findings_view.setObjectName("writeback_findings_view")
-        workflow_layout.addWidget(self.writeback_findings_view)
-
+        writeback_layout.addWidget(self.writeback_facts_label)
+        self.writeback_details_label = QLabel()
+        self.writeback_details_label.setWordWrap(True)
+        self.writeback_details_label.setObjectName("config_hint_label")
+        self.writeback_details_label.setVisible(False)
+        writeback_layout.addWidget(self.writeback_details_label)
         writeback_actions = QHBoxLayout()
         self.apply_btn = QPushButton("写回翻译")
         self.apply_btn.setObjectName("apply_btn")
@@ -290,38 +260,29 @@ class MainWindow(QMainWindow):
         self.apply_btn.setEnabled(False)
         writeback_actions.addWidget(self.apply_btn)
         writeback_actions.addStretch()
-        workflow_layout.addLayout(writeback_actions)
+        writeback_layout.addLayout(writeback_actions)
+        writeback_layout.addStretch()
+        self.workbench_status_tabs.addTab(writeback_tab, "写回")
 
-        status_row.addWidget(workflow_box, 1)
-        layout.addLayout(status_row, 1)
+        self.workbench_status_tabs.setCurrentIndex(1)
+        layout.addWidget(self.workbench_status_tabs, 1)
 
         self.tab_widget.addTab(tab, "工作台")
 
     def _build_config_tab(self) -> None:
         tab = QWidget()
         self._config_tab = tab
-        layout = QVBoxLayout(tab)
+        outer_layout = QVBoxLayout(tab)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+
+        content = QWidget()
+        layout = QVBoxLayout(content)
         layout.setContentsMargins(12, 16, 12, 12)
         layout.setSpacing(14)
-
-        appearance_box = QGroupBox("外观")
-        appearance_layout = QFormLayout(appearance_box)
-        appearance_layout.setSpacing(8)
-        appearance_layout.setContentsMargins(12, 16, 12, 12)
-
-        appearance_hint = QLabel("默认跟随系统深浅色；也可手动选择浅色或深色主题。")
-        appearance_hint.setWordWrap(True)
-        appearance_hint.setObjectName("config_hint_label")
-        appearance_layout.addRow(appearance_hint)
-
-        self.theme_combo = QComboBox()
-        self.theme_combo.addItem("跟随系统", THEME_SYSTEM)
-        self.theme_combo.addItem("浅色", "light")
-        self.theme_combo.addItem("深色", "dark")
-        self.theme_combo.currentIndexChanged.connect(self._on_theme_changed)
-        appearance_layout.addRow("主题：", self.theme_combo)
-
-        layout.addWidget(appearance_box)
 
         api_box = QGroupBox("API Key")
         api_layout = QVBoxLayout(api_box)
@@ -364,17 +325,13 @@ class MainWindow(QMainWindow):
         context_hint.setObjectName("config_hint_label")
         context_layout.addWidget(context_hint)
 
-        self.rag_enabled_cb = QCheckBox("启用 Batch RAG 记忆库（batch.rag.enabled）")
+        self.rag_enabled_cb = QCheckBox("启用 RAG 记忆库")
         context_layout.addWidget(self.rag_enabled_cb)
 
-        self.source_index_enabled_cb = QCheckBox(
-            "启用 Batch 原文索引（batch.source_index.enabled）"
-        )
+        self.source_index_enabled_cb = QCheckBox("启用原文索引")
         context_layout.addWidget(self.source_index_enabled_cb)
 
-        self.bootstrap_on_build_cb = QCheckBox(
-            "开始翻译 build 时自动暖 RAG 库（batch.rag.bootstrap_on_build）"
-        )
+        self.bootstrap_on_build_cb = QCheckBox("开始翻译时自动暖 RAG 库")
         context_layout.addWidget(self.bootstrap_on_build_cb)
 
         bootstrap_actions = QHBoxLayout()
@@ -404,11 +361,11 @@ class MainWindow(QMainWindow):
         self.bootstrap_facts_label.setObjectName("bootstrap_facts_label")
         context_layout.addWidget(self.bootstrap_facts_label)
 
-        self.bootstrap_findings_view = QTextEdit()
-        self.bootstrap_findings_view.setReadOnly(True)
-        self.bootstrap_findings_view.setMaximumHeight(56)
-        self.bootstrap_findings_view.setObjectName("bootstrap_findings_view")
-        context_layout.addWidget(self.bootstrap_findings_view)
+        self.bootstrap_details_label = QLabel()
+        self.bootstrap_details_label.setWordWrap(True)
+        self.bootstrap_details_label.setObjectName("config_hint_label")
+        self.bootstrap_details_label.setVisible(False)
+        context_layout.addWidget(self.bootstrap_details_label)
 
         layout.addWidget(context_box)
 
@@ -476,6 +433,18 @@ class MainWindow(QMainWindow):
         config_row.addWidget(batch_box, 1)
         layout.addLayout(config_row, 1)
 
+        appearance_box = QGroupBox("外观")
+        appearance_layout = QFormLayout(appearance_box)
+        appearance_layout.setSpacing(8)
+        appearance_layout.setContentsMargins(12, 16, 12, 12)
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItem("跟随系统", THEME_SYSTEM)
+        self.theme_combo.addItem("浅色", "light")
+        self.theme_combo.addItem("深色", "dark")
+        self.theme_combo.currentIndexChanged.connect(self._on_theme_changed)
+        appearance_layout.addRow("主题：", self.theme_combo)
+        layout.addWidget(appearance_box)
+
         save_layout = QHBoxLayout()
         save_layout.addStretch()
         self.save_config_btn = QPushButton("保存参数配置")
@@ -484,6 +453,8 @@ class MainWindow(QMainWindow):
         save_layout.addWidget(self.save_config_btn)
         layout.addLayout(save_layout)
 
+        scroll.setWidget(content)
+        outer_layout.addWidget(scroll)
         self.tab_widget.addTab(tab, "配置")
 
     def _build_log_tab(self) -> None:
@@ -492,10 +463,7 @@ class MainWindow(QMainWindow):
         layout.setContentsMargins(12, 16, 12, 12)
         layout.setSpacing(10)
 
-        log_hint = QLabel(
-            "此处显示 doctor 与翻译任务的原始终端输出。"
-            "开始翻译任务时会自动切换到此页；检查项目时留在工作台即可查看摘要。"
-        )
+        log_hint = QLabel("原始终端输出；翻译、预建库与写回任务运行时会自动切换到此页。")
         log_hint.setWordWrap(True)
         log_hint.setObjectName("config_hint_label")
         layout.addWidget(log_hint)
@@ -510,6 +478,18 @@ class MainWindow(QMainWindow):
 
     def _focus_log_tab(self) -> None:
         self.tab_widget.setCurrentWidget(self.log_view.parentWidget())
+
+    def _focus_workbench_status_tab(self, index: int) -> None:
+        if 0 <= index < self.workbench_status_tabs.count():
+            self.workbench_status_tabs.setCurrentIndex(index)
+
+    def _set_details_label(self, label: QLabel, findings: list[str]) -> None:
+        if findings:
+            label.setText("\n".join(f"- {item}" for item in findings))
+            label.setVisible(True)
+        else:
+            label.setText("")
+            label.setVisible(False)
 
     # --- UI actions ---
 
@@ -608,6 +588,7 @@ class MainWindow(QMainWindow):
         self.log_view.clear()
         self._active_command = "doctor"
         self._doctor_output_lines = []
+        self._focus_workbench_status_tab(0)
         self._set_doctor_summary(running_summary())
         self._append_log("=== 正在运行：gemini_translate_batch.py doctor ===\n")
         self._set_task_running(True)
@@ -679,6 +660,7 @@ class MainWindow(QMainWindow):
         self._workflow = TranslationWorkflow.start_new()
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
+        self._focus_workbench_status_tab(1)
         self._append_log("=== 正在运行：基础 Batch 翻译流程 ===\n")
         self._set_task_running(True)
         self._run_workflow_current_step()
@@ -712,6 +694,7 @@ class MainWindow(QMainWindow):
         self._workflow = TranslationWorkflow.resume_manifest(str(latest_manifest), manifest)
         self._active_command = "translation_workflow"
         self._workflow_step_output_lines = []
+        self._focus_workbench_status_tab(1)
         self._append_log("=== 正在继续最新 Batch 翻译任务 ===\n")
         self._set_task_running(True)
         self._run_workflow_current_step()
@@ -756,6 +739,7 @@ class MainWindow(QMainWindow):
         self._focus_log_tab()
         self._active_command = "apply"
         self._apply_output_lines = []
+        self._focus_workbench_status_tab(2)
         self._set_writeback_summary(running_writeback_summary())
         self._append_log(
             f"=== 正在写回：gemini_translate_batch.py apply {self._writeback_manifest_path} ===\n"
@@ -851,20 +835,7 @@ class MainWindow(QMainWindow):
         self.writeback_status_label.style().polish(self.writeback_status_label)
         self.writeback_message_label.setText(summary.message)
         self.writeback_facts_label.setText("\n".join(summary.facts))
-        if summary.findings:
-            self.writeback_findings_view.setPlainText(
-                "\n".join(f"- {finding}" for finding in summary.findings)
-            )
-        elif summary.status in {"idle", "running"}:
-            self.writeback_findings_view.setPlainText("翻译任务完成 check 后，这里会显示写回建议。")
-        elif summary.status == "stale":
-            self.writeback_findings_view.setPlainText("请针对当前任务重新完成翻译与 check。")
-        elif summary.status == "safe":
-            self.writeback_findings_view.setPlainText("未发现阻止写回的问题。")
-        elif summary.status == "applied":
-            self.writeback_findings_view.setPlainText("写回已完成。")
-        else:
-            self.writeback_findings_view.setPlainText("请查看诊断日志了解详情。")
+        self._set_details_label(self.writeback_details_label, summary.findings)
         if not self.kill_btn.isEnabled():
             self.apply_btn.setEnabled(summary.can_apply)
 
@@ -898,14 +869,15 @@ class MainWindow(QMainWindow):
                 already_applied = bool(manifest.get("applied_at"))
             except ValueError:
                 pass
-        self._set_writeback_summary(
-            summarize_check_output(
-                output,
-                exit_code,
-                manifest_path=manifest_path,
-                already_applied=already_applied,
-            )
+        summary = summarize_check_output(
+            output,
+            exit_code,
+            manifest_path=manifest_path,
+            already_applied=already_applied,
         )
+        self._set_writeback_summary(summary)
+        if summary.status not in {"idle", "running", "stale"}:
+            self._focus_workbench_status_tab(2)
 
     def _set_bootstrap_summary(self, summary: BootstrapSummary) -> None:
         self.bootstrap_status_label.setText(summary.heading)
@@ -914,18 +886,7 @@ class MainWindow(QMainWindow):
         self.bootstrap_status_label.style().polish(self.bootstrap_status_label)
         self.bootstrap_message_label.setText(summary.message)
         self.bootstrap_facts_label.setText("\n".join(summary.facts))
-        if summary.findings:
-            self.bootstrap_findings_view.setPlainText(
-                "\n".join(f"- {finding}" for finding in summary.findings)
-            )
-        elif summary.status in {"idle", "running"}:
-            self.bootstrap_findings_view.setPlainText("预建完成后，这里会显示扫描与写入摘要。")
-        elif summary.status == "stale":
-            self.bootstrap_findings_view.setPlainText("请针对当前项目重新运行预建库。")
-        elif summary.status == "ready":
-            self.bootstrap_findings_view.setPlainText("预建库已就绪，可以开始翻译任务。")
-        else:
-            self.bootstrap_findings_view.setPlainText("请查看诊断日志了解详情。")
+        self._set_details_label(self.bootstrap_details_label, summary.findings)
 
     def _set_doctor_summary(self, summary: DoctorSummary):
         self.doctor_status_label.setText(summary.heading)
@@ -934,16 +895,7 @@ class MainWindow(QMainWindow):
         self.doctor_status_label.style().polish(self.doctor_status_label)
         self.doctor_message_label.setText(summary.message)
         self.doctor_facts_label.setText("\n".join(summary.facts))
-        if summary.findings:
-            self.doctor_findings_view.setPlainText(
-                "\n".join(f"- {finding}" for finding in summary.findings)
-            )
-        elif summary.status in {"idle", "running"}:
-            self.doctor_findings_view.setPlainText("等待项目检查结果。")
-        elif summary.status == "stale":
-            self.doctor_findings_view.setPlainText("请重新运行项目检查。")
-        else:
-            self.doctor_findings_view.setPlainText("未发现需要处理的事项。")
+        self._set_details_label(self.doctor_details_label, summary.findings)
 
     def _on_runner_error(self, message: str):
         self._append_log(message)

--- a/gui_qt/bootstrap_report.py
+++ b/gui_qt/bootstrap_report.py
@@ -1,0 +1,285 @@
+"""User-facing summaries for GUI bootstrap-rag / bootstrap-source-index commands."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BootstrapSummary:
+    kind: str
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+
+
+RAG_SUMMARY_HEADER = "RAG bootstrap summary:"
+SOURCE_INDEX_SUMMARY_HEADER = "Source Index bootstrap final summary:"
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def read_batch_context_flags(config: dict[str, Any]) -> dict[str, bool]:
+    batch = config.get("batch")
+    if not isinstance(batch, dict):
+        batch = {}
+    rag = batch.get("rag")
+    if not isinstance(rag, dict):
+        rag = {}
+    source_index = batch.get("source_index")
+    if not isinstance(source_index, dict):
+        source_index = {}
+    return {
+        "rag_enabled": coerce_bool(rag.get("enabled"), False),
+        "source_index_enabled": coerce_bool(source_index.get("enabled"), False),
+        "bootstrap_on_build": coerce_bool(rag.get("bootstrap_on_build"), True),
+    }
+
+
+def _parse_summary_values(output: str, header: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    in_section = False
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line == header:
+            in_section = True
+            continue
+        if in_section and line.startswith("- "):
+            match = re.match(r"-\s*([a-z_]+):\s*(.*)$", line)
+            if match:
+                values[match.group(1)] = match.group(2).strip()
+            continue
+        if in_section and not line.startswith("- "):
+            break
+    return values
+
+
+def _parse_int_field(values: dict[str, str], key: str, default: int = 0) -> int:
+    raw = values.get(key, "")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _format_fact_values(values: dict[str, str], keys: tuple[str, ...]) -> list[str]:
+    facts: list[str] = []
+    for key in keys:
+        if key in values:
+            facts.append(f"{key}：{values[key]}")
+    return facts
+
+
+def idle_bootstrap_summary() -> BootstrapSummary:
+    return BootstrapSummary(
+        kind="",
+        status="idle",
+        heading="尚未预建上下文库",
+        message="如果项目已有部分译文，可先预建 RAG 库；如果译文很少，可预建原文索引。",
+        facts=[],
+        findings=[],
+    )
+
+
+def running_bootstrap_summary(kind: str) -> BootstrapSummary:
+    if kind == "source_index":
+        return BootstrapSummary(
+            kind=kind,
+            status="running",
+            heading="正在预建原文索引",
+            message="正在扫描 TL 模板原文并生成 source embedding，请稍候。",
+            facts=[],
+            findings=[],
+        )
+    return BootstrapSummary(
+        kind=kind or "rag",
+        status="running",
+        heading="正在预建 RAG 库",
+        message="正在扫描已有译文并生成 RAG history store，请稍候。",
+        facts=[],
+        findings=[],
+    )
+
+
+def stale_bootstrap_summary() -> BootstrapSummary:
+    return BootstrapSummary(
+        kind="",
+        status="stale",
+        heading="预建状态已过期",
+        message="项目或配置已切换，请针对当前项目重新运行预建库。",
+        facts=[],
+        findings=[],
+    )
+
+
+def summarize_rag_bootstrap_output(output: str, exit_code: int) -> BootstrapSummary:
+    if "RAG is disabled" in output:
+        return BootstrapSummary(
+            kind="rag",
+            status="warning",
+            heading="RAG 未启用",
+            message="请先在配置页启用 Batch RAG 并保存参数配置，再运行预建 RAG 库。",
+            facts=[],
+            findings=[],
+        )
+
+    values = _parse_summary_values(output, RAG_SUMMARY_HEADER)
+    facts = _format_fact_values(
+        values,
+        (
+            "store_dir",
+            "scan_scope",
+            "files_scanned",
+            "scanned",
+            "embedded",
+            "upserted",
+            "history_records_before",
+            "history_records_after",
+            "external_seed_records",
+        ),
+    )
+    findings: list[str] = []
+    if values.get("error"):
+        findings.append(values["error"])
+
+    if exit_code != 0:
+        return BootstrapSummary(
+            kind="rag",
+            status="failed",
+            heading="RAG 预建失败",
+            message="预建 RAG 库未成功完成，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+        )
+
+    if values.get("error"):
+        return BootstrapSummary(
+            kind="rag",
+            status="failed",
+            heading="RAG 预建失败",
+            message="预建过程中出现错误，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+        )
+
+    scanned = _parse_int_field(values, "scanned")
+    upserted = _parse_int_field(values, "upserted")
+    embedded = _parse_int_field(values, "embedded")
+    external_seed_records = _parse_int_field(values, "external_seed_records")
+    if scanned == 0 and external_seed_records == 0:
+        return BootstrapSummary(
+            kind="rag",
+            status="warning",
+            heading="RAG 预建完成（无新记录）",
+            message="未扫描到可写入的译文记录。若项目尚无 TL 译文，可先翻译一部分或导入 seed JSONL。",
+            facts=facts,
+            findings=findings,
+        )
+
+    if upserted > 0 or embedded > 0 or external_seed_records > 0:
+        return BootstrapSummary(
+            kind="rag",
+            status="ready",
+            heading="RAG 预建完成",
+            message="本地 RAG history store 已刷新，可以开始翻译任务。",
+            facts=facts,
+            findings=findings,
+        )
+
+    return BootstrapSummary(
+        kind="rag",
+        status="ready",
+        heading="RAG 预建完成",
+        message="预建流程已完成；如需更新记忆库，可在译文变更后再次运行。",
+        facts=facts,
+        findings=findings,
+    )
+
+
+def summarize_source_index_bootstrap_output(output: str, exit_code: int) -> BootstrapSummary:
+    values = _parse_summary_values(output, SOURCE_INDEX_SUMMARY_HEADER)
+    facts = _format_fact_values(
+        values,
+        (
+            "store_dir",
+            "files_scanned",
+            "scanned",
+            "embedded",
+            "upserted",
+            "reused_embeddings",
+            "stale_count",
+            "pruned",
+            "history_records_before",
+            "history_records_after",
+        ),
+    )
+    findings: list[str] = []
+    if values.get("error"):
+        findings.append(values["error"])
+
+    if exit_code != 0:
+        return BootstrapSummary(
+            kind="source_index",
+            status="failed",
+            heading="原文索引预建失败",
+            message="预建 source-only index 未成功完成，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+        )
+
+    if values.get("error"):
+        return BootstrapSummary(
+            kind="source_index",
+            status="failed",
+            heading="原文索引预建失败",
+            message="预建过程中出现错误，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+        )
+
+    scanned = _parse_int_field(values, "scanned")
+    upserted = _parse_int_field(values, "upserted")
+    embedded = _parse_int_field(values, "embedded")
+    if scanned == 0:
+        return BootstrapSummary(
+            kind="source_index",
+            status="warning",
+            heading="原文索引预建完成（无新记录）",
+            message="未扫描到可索引的原文片段。请确认 TL 模板已生成且项目路径正确。",
+            facts=facts,
+            findings=findings,
+        )
+
+    if upserted > 0 or embedded > 0:
+        return BootstrapSummary(
+            kind="source_index",
+            status="ready",
+            heading="原文索引预建完成",
+            message="source-only index 已刷新，后续 Batch build 可检索相关剧情原文。",
+            facts=facts,
+            findings=findings,
+        )
+
+    return BootstrapSummary(
+        kind="source_index",
+        status="ready",
+        heading="原文索引预建完成",
+        message="索引库已是最新状态，无需新增 embedding。",
+        facts=facts,
+        findings=findings,
+    )

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -124,6 +124,31 @@ QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
     color: #334155;
 }
 
+QTabWidget#workbench_status_tabs::pane {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background-color: #ffffff;
+    top: -1px;
+}
+
+QTabWidget#workbench_status_tabs > QTabBar::tab {
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 7px 16px;
+    margin-right: 3px;
+    color: #64748b;
+    font-weight: 500;
+}
+
+QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
+    background-color: #ffffff;
+    color: #2563eb;
+    font-weight: 600;
+}
+
 /* Project Path Frame styling */
 #project_frame {
     background-color: #ffffff;

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -416,6 +416,41 @@ QLabel#writeback_facts_label {
     color: #334155;
 }
 
+QLabel#bootstrap_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#bootstrap_status_label[status="idle"],
+QLabel#bootstrap_status_label[status="running"] {
+    color: #2563eb;
+}
+
+QLabel#bootstrap_status_label[status="ready"] {
+    color: #15803d;
+}
+
+QLabel#bootstrap_status_label[status="warning"],
+QLabel#bootstrap_status_label[status="stale"] {
+    color: #b45309;
+}
+
+QLabel#bootstrap_status_label[status="failed"] {
+    color: #b91c1c;
+}
+
+QLabel#bootstrap_facts_label {
+    color: #334155;
+}
+
+QTextEdit#bootstrap_findings_view {
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    color: #334155;
+    padding: 8px;
+}
+
 QTextEdit#writeback_findings_view {
     background-color: #f8fafc;
     border: 1px solid #e2e8f0;

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -100,6 +100,14 @@ QTabWidget#main_tabs::pane {
     top: -1px;
 }
 
+QWidget#config_tab,
+QScrollArea#config_scroll,
+QWidget#config_scroll_viewport,
+QWidget#config_scroll_content {
+    background-color: #ffffff;
+    border: none;
+}
+
 QTabWidget#main_tabs > QTabBar::tab {
     background-color: #f1f5f9;
     border: 1px solid #e2e8f0;
@@ -129,6 +137,10 @@ QTabWidget#workbench_status_tabs::pane {
     border-radius: 8px;
     background-color: #ffffff;
     top: -1px;
+}
+
+QTabWidget#workbench_status_tabs QWidget {
+    background-color: #ffffff;
 }
 
 QTabWidget#workbench_status_tabs > QTabBar::tab {

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -100,6 +100,14 @@ QTabWidget#main_tabs::pane {
     top: -1px;
 }
 
+QWidget#config_tab,
+QScrollArea#config_scroll,
+QWidget#config_scroll_viewport,
+QWidget#config_scroll_content {
+    background-color: #1e293b;
+    border: none;
+}
+
 QTabWidget#main_tabs > QTabBar::tab {
     background-color: #0f172a;
     border: 1px solid #334155;
@@ -129,6 +137,10 @@ QTabWidget#workbench_status_tabs::pane {
     border-radius: 8px;
     background-color: #1e293b;
     top: -1px;
+}
+
+QTabWidget#workbench_status_tabs QWidget {
+    background-color: #1e293b;
 }
 
 QTabWidget#workbench_status_tabs > QTabBar::tab {

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -416,6 +416,41 @@ QLabel#writeback_facts_label {
     color: #cbd5e1;
 }
 
+QLabel#bootstrap_status_label {
+    font-size: 15px;
+    font-weight: 700;
+}
+
+QLabel#bootstrap_status_label[status="idle"],
+QLabel#bootstrap_status_label[status="running"] {
+    color: #60a5fa;
+}
+
+QLabel#bootstrap_status_label[status="ready"] {
+    color: #4ade80;
+}
+
+QLabel#bootstrap_status_label[status="warning"],
+QLabel#bootstrap_status_label[status="stale"] {
+    color: #fbbf24;
+}
+
+QLabel#bootstrap_status_label[status="failed"] {
+    color: #f87171;
+}
+
+QLabel#bootstrap_facts_label {
+    color: #cbd5e1;
+}
+
+QTextEdit#bootstrap_findings_view {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #cbd5e1;
+    padding: 8px;
+}
+
 QTextEdit#writeback_findings_view {
     background-color: #0f172a;
     border: 1px solid #334155;

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -124,6 +124,31 @@ QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
     color: #e2e8f0;
 }
 
+QTabWidget#workbench_status_tabs::pane {
+    border: 1px solid #334155;
+    border-radius: 8px;
+    background-color: #1e293b;
+    top: -1px;
+}
+
+QTabWidget#workbench_status_tabs > QTabBar::tab {
+    background-color: #0f172a;
+    border: 1px solid #334155;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 7px 16px;
+    margin-right: 3px;
+    color: #94a3b8;
+    font-weight: 500;
+}
+
+QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
+    background-color: #1e293b;
+    color: #60a5fa;
+    font-weight: 600;
+}
+
 /* Project Path Frame styling */
 #project_frame {
     background-color: #1e293b;

--- a/gui_qt/widget_helpers.py
+++ b/gui_qt/widget_helpers.py
@@ -21,3 +21,4 @@ class NoWheelTabWidget(QTabWidget):
 
     def wheelEvent(self, event: QWheelEvent) -> None:
         event.ignore()
+        return

--- a/gui_qt/widget_helpers.py
+++ b/gui_qt/widget_helpers.py
@@ -6,13 +6,14 @@ from PySide6.QtWidgets import QComboBox, QTabWidget
 
 
 class NoWheelComboBox(QComboBox):
-    """Ignore mouse-wheel changes unless the combo already has keyboard focus."""
+    """Ignore mouse-wheel selection changes unless the dropdown list is open."""
 
     def wheelEvent(self, event: QWheelEvent) -> None:
-        if not self.hasFocus():
-            event.ignore()
+        popup = self.view()
+        if popup is not None and popup.isVisible():
+            super().wheelEvent(event)
             return
-        super().wheelEvent(event)
+        event.ignore()
 
 
 class NoWheelTabWidget(QTabWidget):

--- a/gui_qt/widget_helpers.py
+++ b/gui_qt/widget_helpers.py
@@ -1,0 +1,22 @@
+"""Small Qt widget subclasses for safer desktop UX."""
+from __future__ import annotations
+
+from PySide6.QtGui import QWheelEvent
+from PySide6.QtWidgets import QComboBox, QTabWidget
+
+
+class NoWheelComboBox(QComboBox):
+    """Ignore mouse-wheel changes unless the combo already has keyboard focus."""
+
+    def wheelEvent(self, event: QWheelEvent) -> None:
+        if not self.hasFocus():
+            event.ignore()
+            return
+        super().wheelEvent(event)
+
+
+class NoWheelTabWidget(QTabWidget):
+    """Ignore mouse-wheel tab switching; use clicks to change tabs."""
+
+    def wheelEvent(self, event: QWheelEvent) -> None:
+        event.ignore()

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 try:
     from gui_qt.app import MainWindow
@@ -97,6 +98,67 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         )
 
         self.assertIsNone(thinking_level)
+
+    def _prepare_bootstrap_window(self, config):
+        class FakeRunner:
+            def __init__(self):
+                self.calls = []
+
+            def run(self, script, args):
+                self.calls.append((script, args))
+
+        class FakeState:
+            def get_game_root(self):
+                return Path("C:/Game/work")
+
+            def get_batch_script_path(self):
+                return Path("C:/tool/gemini_translate_batch.py")
+
+            def load_translator_config(self):
+                return config
+
+        self.window.state = FakeState()
+        self.window.runner = FakeRunner()
+        self.window.log_view = type("FakeLogView", (), {"clear": lambda _self: None})()
+        self.window._focus_log_tab = lambda: None
+        self.window._set_bootstrap_summary = lambda _summary: None
+        self.window._append_log = lambda _text: None
+        self.window._set_task_running = lambda _running: None
+        return self.window.runner
+
+    def test_bootstrap_rag_uses_skip_prepare(self):
+        runner = self._prepare_bootstrap_window(
+            {"batch": {"rag": {"enabled": True}}}
+        )
+
+        self.window._on_bootstrap_rag()
+
+        self.assertEqual(
+            runner.calls,
+            [
+                (
+                    Path("C:/tool/gemini_translate_batch.py"),
+                    ["bootstrap-rag", "--skip-prepare"],
+                )
+            ],
+        )
+
+    def test_bootstrap_source_index_uses_skip_prepare(self):
+        runner = self._prepare_bootstrap_window(
+            {"batch": {"source_index": {"enabled": True}}}
+        )
+
+        self.window._on_bootstrap_source_index()
+
+        self.assertEqual(
+            runner.calls,
+            [
+                (
+                    Path("C:/tool/gemini_translate_batch.py"),
+                    ["bootstrap-source-index", "--skip-prepare"],
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_bootstrap_report.py
+++ b/tests/test_gui_bootstrap_report.py
@@ -56,7 +56,7 @@ RAG bootstrap summary:
 """
         summary = summarize_rag_bootstrap_output(output, 0)
         self.assertEqual(summary.status, "ready")
-        self.assertIn("store_dir：logs/rag_store/demo", summary.facts)
+        self.assertIn("store_dir\uFF1Alogs/rag_store/demo", summary.facts)
 
     def test_summarize_rag_bootstrap_output_marks_empty_scan_as_warning(self):
         output = """

--- a/tests/test_gui_bootstrap_report.py
+++ b/tests/test_gui_bootstrap_report.py
@@ -1,0 +1,95 @@
+import unittest
+
+from gui_qt.bootstrap_report import (
+    coerce_bool,
+    idle_bootstrap_summary,
+    read_batch_context_flags,
+    summarize_rag_bootstrap_output,
+    summarize_source_index_bootstrap_output,
+)
+
+
+class GuiBootstrapReportTests(unittest.TestCase):
+    def test_coerce_bool_accepts_common_literals(self):
+        self.assertTrue(coerce_bool("true", False))
+        self.assertTrue(coerce_bool("ON", False))
+        self.assertFalse(coerce_bool("off", True))
+        self.assertTrue(coerce_bool(True, False))
+
+    def test_read_batch_context_flags_defaults(self):
+        flags = read_batch_context_flags({})
+        self.assertFalse(flags["rag_enabled"])
+        self.assertFalse(flags["source_index_enabled"])
+        self.assertTrue(flags["bootstrap_on_build"])
+
+    def test_read_batch_context_flags_reads_nested_config(self):
+        flags = read_batch_context_flags(
+            {
+                "batch": {
+                    "rag": {"enabled": True, "bootstrap_on_build": False},
+                    "source_index": {"enabled": True},
+                }
+            }
+        )
+        self.assertTrue(flags["rag_enabled"])
+        self.assertTrue(flags["source_index_enabled"])
+        self.assertFalse(flags["bootstrap_on_build"])
+
+    def test_summarize_rag_bootstrap_output_marks_disabled(self):
+        summary = summarize_rag_bootstrap_output(
+            "RAG is disabled. Enable batch.rag.enabled=true before bootstrapping.\n",
+            0,
+        )
+        self.assertEqual(summary.status, "warning")
+        self.assertEqual(summary.kind, "rag")
+
+    def test_summarize_rag_bootstrap_output_marks_success(self):
+        output = """
+RAG bootstrap summary:
+- store_dir: logs/rag_store/demo
+- files_scanned: 2
+- scanned: 5
+- embedded: 3
+- upserted: 3
+- history_records_before: 0
+- history_records_after: 3
+"""
+        summary = summarize_rag_bootstrap_output(output, 0)
+        self.assertEqual(summary.status, "ready")
+        self.assertIn("store_dir：logs/rag_store/demo", summary.facts)
+
+    def test_summarize_rag_bootstrap_output_marks_empty_scan_as_warning(self):
+        output = """
+RAG bootstrap summary:
+- files_scanned: 0
+- scanned: 0
+- upserted: 0
+"""
+        summary = summarize_rag_bootstrap_output(output, 0)
+        self.assertEqual(summary.status, "warning")
+
+    def test_summarize_source_index_bootstrap_output_marks_failure(self):
+        summary = summarize_source_index_bootstrap_output("TL dir does not exist", 1)
+        self.assertEqual(summary.status, "failed")
+
+    def test_summarize_source_index_bootstrap_output_marks_success(self):
+        output = """
+Source Index bootstrap final summary:
+- store_dir: logs/source_index_store/demo
+- files_scanned: 1
+- scanned: 4
+- embedded: 2
+- upserted: 2
+- history_records_after: 4
+"""
+        summary = summarize_source_index_bootstrap_output(output, 0)
+        self.assertEqual(summary.status, "ready")
+        self.assertEqual(summary.kind, "source_index")
+
+    def test_idle_bootstrap_summary_is_idle(self):
+        summary = idle_bootstrap_summary()
+        self.assertEqual(summary.status, "idle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds graphical entry points for the CLI prebuild/bootstrap workflow described in `docs/context_systems.md`.

## Changes

**Config tab — Batch 上下文**
- `batch.rag.enabled`
- `batch.source_index.enabled`
- `batch.rag.bootstrap_on_build`
- Saved with existing「保存参数配置」flow

**Workbench — 预建上下文库**
- **预建 RAG 库** → `gemini_translate_batch.py bootstrap-rag`
- **预建原文索引** → `gemini_translate_batch.py bootstrap-source-index`
- Parses CLI summary output into user-facing status/facts
- Requires the corresponding option to be enabled and saved in config before running

**New modules**
- `gui_qt/bootstrap_report.py`
- `tests/test_gui_bootstrap_report.py` (9 tests)

## Validation

- `python -m unittest discover -s tests -q` → 306 tests OK

Refs #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Batch 上下文”** section with checkboxes for Batch RAG, source-index, and **bootstrap on build**, plus buttons to pre-build both components.
  * Added a dedicated **pre-build status panel** with idle/running/stale and completion outcomes, including summarized facts and findings.
  * Persisted these batch-context settings in the app configuration.
* **Refactor**
  * Refreshed the workbench status area into tabbed cards and auto-switches based on the current action.
* **Style**
  * Applied light/dark styling for the new bootstrap panel and improved scrolling/tab interactions (no mouse-wheel switching).
* **Tests**
  * Added unit tests for bootstrap summary parsing and batch-context flag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->