### PR TITLE
Improve GUI hint text sizes and diagnostics splitter default

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -212,6 +212,7 @@ class MainWindow(QMainWindow):
         doctor_layout.addWidget(self.doctor_status_label)
         self.doctor_message_label = QLabel()
         self.doctor_message_label.setWordWrap(True)
+        self.doctor_message_label.setObjectName("summary_body_label")
         doctor_layout.addWidget(self.doctor_message_label)
         self.doctor_facts_label = QLabel()
         self.doctor_facts_label.setWordWrap(True)
@@ -235,6 +236,7 @@ class MainWindow(QMainWindow):
         workflow_layout.addWidget(self.workflow_status_label)
         self.workflow_message_label = QLabel()
         self.workflow_message_label.setWordWrap(True)
+        self.workflow_message_label.setObjectName("summary_body_label")
         workflow_layout.addWidget(self.workflow_message_label)
         self.workflow_facts_label = QLabel()
         self.workflow_facts_label.setWordWrap(True)
@@ -253,6 +255,7 @@ class MainWindow(QMainWindow):
         writeback_layout.addWidget(self.writeback_status_label)
         self.writeback_message_label = QLabel()
         self.writeback_message_label.setWordWrap(True)
+        self.writeback_message_label.setObjectName("summary_body_label")
         writeback_layout.addWidget(self.writeback_message_label)
         self.writeback_facts_label = QLabel()
         self.writeback_facts_label.setWordWrap(True)
@@ -376,6 +379,7 @@ class MainWindow(QMainWindow):
 
         self.bootstrap_message_label = QLabel()
         self.bootstrap_message_label.setWordWrap(True)
+        self.bootstrap_message_label.setObjectName("summary_body_label")
         context_layout.addWidget(self.bootstrap_message_label)
 
         self.bootstrap_facts_label = QLabel()
@@ -536,6 +540,7 @@ class MainWindow(QMainWindow):
         context_layout.addWidget(self.diagnostics_status_label)
         self.diagnostics_message_label = QLabel()
         self.diagnostics_message_label.setWordWrap(True)
+        self.diagnostics_message_label.setObjectName("summary_body_label")
         context_layout.addWidget(self.diagnostics_message_label)
 
         facts_frame = QFrame()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -78,6 +78,11 @@ from .theme_helpers import (
 from .translation_workflow import TranslationWorkflow, WorkflowUpdate
 from .widget_helpers import NoWheelComboBox, NoWheelTabWidget
 
+# Diagnostics splitter: idle favors task context; running tasks expand the log.
+_DIAGNOSTICS_IDLE_CONTEXT_PX = 420
+_DIAGNOSTICS_IDLE_LOG_PX = 180
+_DIAGNOSTICS_RUNNING_CONTEXT_RATIO = 0.32
+
 
 class MainWindow(QMainWindow):
     def __init__(self, *, qt_app: QApplication | None = None, resources_dir: Path | None = None):
@@ -624,13 +629,13 @@ class MainWindow(QMainWindow):
         self.log_view.setReadOnly(True)
         self.log_view.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
         self.log_view.setObjectName("log_view")
-        self.log_view.setMinimumHeight(160)
+        self.log_view.setMinimumHeight(120)
         log_panel_layout.addWidget(self.log_view, 1)
         splitter.addWidget(log_panel)
 
-        splitter.setStretchFactor(0, 2)
-        splitter.setStretchFactor(1, 3)
-        splitter.setSizes([280, 420])
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([_DIAGNOSTICS_IDLE_CONTEXT_PX, _DIAGNOSTICS_IDLE_LOG_PX])
 
         layout.addWidget(splitter, 1)
         self.tab_widget.addTab(tab, "诊断日志")
@@ -639,7 +644,8 @@ class MainWindow(QMainWindow):
         if self._diagnostics_tab is not None:
             self.tab_widget.setCurrentWidget(self._diagnostics_tab)
         total = max(sum(self.diagnostics_splitter.sizes()), 1)
-        self.diagnostics_splitter.setSizes([int(total * 0.32), int(total * 0.68)])
+        context_size = int(total * _DIAGNOSTICS_RUNNING_CONTEXT_RATIO)
+        self.diagnostics_splitter.setSizes([context_size, total - context_size])
 
     def _focus_workbench_status_tab(self, index: int) -> None:
         if 0 <= index < self.workbench_status_tabs.count():

--- a/gui_qt/font_helpers.py
+++ b/gui_qt/font_helpers.py
@@ -17,6 +17,12 @@ MONO_FONT_SELECTORS = (
 UI_FONT_FILENAME = "HarmonyOS_Sans_SC_Regular.ttf"
 MONO_FONT_FILENAME = "LXGWWenKaiMonoGB-Regular.ttf"
 
+# Hint / body copy sizes (px). Keep in sync with app.qss and app_dark.qss.
+UI_FONT_SIZE_HINT_PX = 15
+UI_FONT_SIZE_BODY_PX = 14
+UI_FONT_SIZE_SECTION_PX = 14
+UI_FONT_SIZE_MONO_BODY_PX = 13
+
 
 @dataclass(frozen=True)
 class GuiFontFamilies:

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -22,9 +22,16 @@ QWidget {
 #subtitle_label,
 #config_hint_label {
     color: #64748b;
-    font-size: 12px;
+    font-size: 15px;
     font-weight: 400;
-    line-height: 1.4;
+    line-height: 1.45;
+}
+
+QLabel#summary_body_label {
+    color: #475569;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.45;
 }
 
 /* Dialogs are top-level windows; set an explicit light surface so Windows
@@ -49,7 +56,7 @@ QDialog#api_key_dialog QDialogButtonBox QPushButton {
     border: 1px solid #e2e8f0;
     border-radius: 6px;
     color: #334155;
-    font-size: 12px;
+    font-size: 14px;
     padding: 10px 12px;
 }
 
@@ -158,7 +165,7 @@ QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
 
 QLabel#diagnostics_section_label {
     color: #475569;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
 }
 
@@ -189,7 +196,7 @@ QFrame#diagnostics_facts_frame {
 QLabel#diagnostics_facts_label {
     color: #334155;
     font-family: "Consolas", "Courier New", monospace;
-    font-size: 12px;
+    font-size: 13px;
 }
 
 QLineEdit#diagnostics_command_edit,
@@ -483,6 +490,7 @@ QLabel#doctor_status_label[status="blocked"] {
 
 QLabel#doctor_facts_label {
     color: #334155;
+    font-size: 14px;
 }
 
 QLabel#workflow_status_label {
@@ -510,6 +518,7 @@ QLabel#workflow_status_label[status="failed"] {
 
 QLabel#workflow_facts_label {
     color: #334155;
+    font-size: 14px;
 }
 
 QFrame#workflow_separator {
@@ -520,7 +529,7 @@ QFrame#workflow_separator {
 
 QLabel#workflow_section_label {
     color: #2563eb;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     margin-top: 2px;
 }
@@ -556,6 +565,7 @@ QLabel#writeback_status_label[status="unknown"] {
 
 QLabel#writeback_facts_label {
     color: #334155;
+    font-size: 14px;
 }
 
 QLabel#bootstrap_status_label {
@@ -583,6 +593,7 @@ QLabel#bootstrap_status_label[status="failed"] {
 
 QLabel#bootstrap_facts_label {
     color: #334155;
+    font-size: 14px;
 }
 
 QTextEdit#bootstrap_findings_view {
@@ -590,6 +601,7 @@ QTextEdit#bootstrap_findings_view {
     border: 1px solid #e2e8f0;
     border-radius: 6px;
     color: #334155;
+    font-size: 14px;
     padding: 8px;
 }
 
@@ -598,6 +610,7 @@ QTextEdit#writeback_findings_view {
     border: 1px solid #e2e8f0;
     border-radius: 6px;
     color: #334155;
+    font-size: 14px;
     padding: 8px;
 }
 
@@ -630,6 +643,7 @@ QTextEdit#doctor_findings_view {
     border: 1px solid #e2e8f0;
     border-radius: 6px;
     color: #334155;
+    font-size: 14px;
     padding: 8px;
 }
 

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -22,9 +22,16 @@ QWidget {
 #subtitle_label,
 #config_hint_label {
     color: #94a3b8;
-    font-size: 12px;
+    font-size: 15px;
     font-weight: 400;
-    line-height: 1.4;
+    line-height: 1.45;
+}
+
+QLabel#summary_body_label {
+    color: #cbd5e1;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.45;
 }
 
 /* Dialogs are top-level windows; set an explicit surface so native OS chrome
@@ -49,7 +56,7 @@ QDialog#api_key_dialog QDialogButtonBox QPushButton {
     border: 1px solid #334155;
     border-radius: 6px;
     color: #cbd5e1;
-    font-size: 12px;
+    font-size: 14px;
     padding: 10px 12px;
 }
 
@@ -158,7 +165,7 @@ QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
 
 QLabel#diagnostics_section_label {
     color: #94a3b8;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
 }
 
@@ -189,7 +196,7 @@ QFrame#diagnostics_facts_frame {
 QLabel#diagnostics_facts_label {
     color: #cbd5e1;
     font-family: "Consolas", "Courier New", monospace;
-    font-size: 12px;
+    font-size: 13px;
 }
 
 QLineEdit#diagnostics_command_edit,
@@ -483,6 +490,7 @@ QLabel#doctor_status_label[status="blocked"] {
 
 QLabel#doctor_facts_label {
     color: #cbd5e1;
+    font-size: 14px;
 }
 
 QLabel#workflow_status_label {
@@ -510,6 +518,7 @@ QLabel#workflow_status_label[status="failed"] {
 
 QLabel#workflow_facts_label {
     color: #cbd5e1;
+    font-size: 14px;
 }
 
 QFrame#workflow_separator {
@@ -520,7 +529,7 @@ QFrame#workflow_separator {
 
 QLabel#workflow_section_label {
     color: #60a5fa;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     margin-top: 2px;
 }
@@ -556,6 +565,7 @@ QLabel#writeback_status_label[status="unknown"] {
 
 QLabel#writeback_facts_label {
     color: #cbd5e1;
+    font-size: 14px;
 }
 
 QLabel#bootstrap_status_label {
@@ -583,6 +593,7 @@ QLabel#bootstrap_status_label[status="failed"] {
 
 QLabel#bootstrap_facts_label {
     color: #cbd5e1;
+    font-size: 14px;
 }
 
 QTextEdit#bootstrap_findings_view {
@@ -590,6 +601,7 @@ QTextEdit#bootstrap_findings_view {
     border: 1px solid #334155;
     border-radius: 6px;
     color: #cbd5e1;
+    font-size: 14px;
     padding: 8px;
 }
 
@@ -598,6 +610,7 @@ QTextEdit#writeback_findings_view {
     border: 1px solid #334155;
     border-radius: 6px;
     color: #cbd5e1;
+    font-size: 14px;
     padding: 8px;
 }
 
@@ -630,6 +643,7 @@ QTextEdit#doctor_findings_view {
     border: 1px solid #334155;
     border-radius: 6px;
     color: #cbd5e1;
+    font-size: 14px;
     padding: 8px;
 }
 


### PR DESCRIPTION
## Summary

Polish GUI readability and diagnostics layout per user feedback. Does not change translation core behavior.

Refs #42

## Changes

### Hint and summary text sizes

- Bump gray hint copy (`config_hint_label`): 12px → **15px**
- Add `summary_body_label` for status message lines (doctor / workflow / writeback / bootstrap / diagnostics): **14px**
- Bump facts lists, findings views, API status, and section labels to **14px**
- Diagnostics monospace facts: 12px → **13px**
- Buttons, tabs, status headings, and CLI log monospace areas keep existing sizes

### Diagnostics tab splitter (idle default)

- Default split favors task context: ~**70% / 30%** (was ~40% / 60%)
- Stretch factors: context **3** : log **1** (context grows faster on resize)
- Log panel minimum height: 160px → **120px**
- **Unchanged:** running tasks still call `_focus_log_tab()` to expand the log (~68%)

## Verification

```powershell
python -m gui_qt
```

- Config / diagnostics hint text should read larger than before
- Diagnostics tab idle: upper context area taller, lower log shorter
- Start a CLI task: log area still auto-expands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout spacing for diagnostics display when idle and during task execution.
  * Enhanced typography with larger font sizes across UI labels and text areas for better readability in both light and dark themes.
  * Standardized appearance of status message labels throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->