### PR TITLE
fix(gui): clarify doctor TL scan and pending task stats

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -6984,6 +6984,16 @@ def collect_doctor_report():
     else:
         mode = 'blocked_missing_template'
 
+    pending_task_count = 0
+    pending_file_count = 0
+    if has_tl_files:
+        try:
+            file_jobs = collect_pending_file_jobs()
+            pending_file_count = len(file_jobs)
+            pending_task_count = sum(job['task_count'] for job in file_jobs)
+        except Exception:
+            pass
+
     return {
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
@@ -7003,6 +7013,8 @@ def collect_doctor_report():
         'launcher_py': template_info.get('launcher_py', ''),
         'mode': mode,
         'counts': counts,
+        'pending_task_count': pending_task_count,
+        'pending_file_count': pending_file_count,
         'warnings': warnings,
     }
 
@@ -7036,6 +7048,12 @@ def print_doctor_report(report):
         f"new_lines={counts['new_lines']}, "
         f"commented_original_lines={counts['commented_original_lines']}"
     )
+    if report['tl_exists'] and counts['rpy_files'] > 0:
+        print(
+            '- Pending translation: '
+            f"task_count={report['pending_task_count']}, "
+            f"file_count={report['pending_file_count']}"
+        )
     if report['warnings']:
         print('Warnings:')
         for warning in report['warnings']:

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -6991,8 +6991,8 @@ def collect_doctor_report():
             file_jobs = collect_pending_file_jobs()
             pending_file_count = len(file_jobs)
             pending_task_count = sum(job['task_count'] for job in file_jobs)
-        except Exception:
-            pass
+        except Exception as exc:
+            print(f'Warning: Could not compute pending translation counts: {exc}')
 
     return {
         'base_dir': legacy.BASE_DIR,

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -37,6 +37,48 @@ def _parse_counts(raw_counts: str) -> dict[str, int]:
     return counts
 
 
+def format_tl_scan_facts(
+    counts: dict[str, int],
+    pending: dict[str, int] | None = None,
+) -> list[str]:
+    """Turn doctor TL scan counters into user-facing facts."""
+    rpy_files = int(counts.get("rpy_files", 0))
+    translate_blocks = int(counts.get("translate_blocks", 0))
+    commented_lines = int(counts.get("commented_original_lines", 0))
+    old_lines = int(counts.get("old_lines", 0))
+    new_lines = int(counts.get("new_lines", 0))
+
+    if rpy_files == 0 and translate_blocks == 0:
+        return ["TL 文件：0 个"]
+
+    facts: list[str] = [f"TL 文件：{rpy_files} 个"]
+
+    if pending is not None:
+        task_count = int(pending.get("task_count", 0))
+        file_count = int(pending.get("file_count", 0))
+        if task_count > 0:
+            facts.append(
+                f"待翻译条目：约 {task_count} 条（分布在 {file_count} 个文件中，与 build 统计一致）"
+            )
+        else:
+            facts.append("待翻译条目：0 条（当前没有需要提交到 Batch 的英文待译行）")
+
+    if commented_lines > 0:
+        facts.append(
+            f"剧情对话：{commented_lines} 条注释原文格式（主流程会翻译这类内容，不是 old/new 行）"
+        )
+    elif translate_blocks > 0:
+        facts.append(f"翻译块：{translate_blocks} 个")
+
+    if old_lines > 0 or new_lines > 0:
+        if old_lines == new_lines:
+            facts.append(f"UI 字符串：{old_lines} 条 old/new（translate strings 块）")
+        else:
+            facts.append(f"UI 字符串：old/new 行数 {old_lines}/{new_lines}（可能格式异常）")
+
+    return facts
+
+
 def parse_doctor_output(output: str) -> dict[str, object]:
     parsed: dict[str, object] = {"warnings": []}
     in_warnings = False
@@ -84,6 +126,10 @@ def parse_doctor_output(output: str) -> dict[str, object]:
             parsed["counts"] = _parse_counts(line.split(":", 1)[1])
             continue
 
+        if line.startswith("- Pending translation:"):
+            parsed["pending"] = _parse_counts(line.split(":", 1)[1])
+            continue
+
     return parsed
 
 
@@ -100,6 +146,7 @@ def summarize_doctor_output(
         if isinstance(warning, str) and warning.strip()
     ]
     counts = parsed.get("counts") if isinstance(parsed.get("counts"), dict) else {}
+    pending = parsed.get("pending") if isinstance(parsed.get("pending"), dict) else None
     mode = parsed.get("mode") if isinstance(parsed.get("mode"), str) else ""
 
     facts: list[str] = []
@@ -113,10 +160,7 @@ def summarize_doctor_output(
     if mode:
         facts.append(f"检查模式：{mode}")
     if counts:
-        rpy_files = int(counts.get("rpy_files", 0))
-        old_lines = int(counts.get("old_lines", 0))
-        new_lines = int(counts.get("new_lines", 0))
-        facts.append(f"扫描到 {rpy_files} 个 .rpy 文件，old/new 行数 {old_lines}/{new_lines}")
+        facts.extend(format_tl_scan_facts(counts, pending=pending))
 
     findings = list(warnings)
     if mode == "can_generate_template":
@@ -127,7 +171,7 @@ def summarize_doctor_output(
             )
         elif counts and int(counts.get("rpy_files", 0)) == 0:
             findings.append(
-                "翻译目录中没有可处理的 .rpy 文件；请先生成或刷新翻译模板后重新检查。"
+                "翻译目录中没有 TL 文件；请先生成或刷新翻译模板后重新检查。"
             )
     if api_key_count is not None:
         if api_key_count > 0:

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -1,6 +1,11 @@
 import unittest
 
-from gui_qt.doctor_report import parse_doctor_output, stale_summary, summarize_doctor_output
+from gui_qt.doctor_report import (
+    format_tl_scan_facts,
+    parse_doctor_output,
+    stale_summary,
+    summarize_doctor_output,
+)
 
 
 DOCTOR_OUTPUT = """
@@ -14,6 +19,7 @@ Doctor report:
 - Template generation: unavailable (no command resolved)
 - Mode: existing_tl_only
 - TL scan: rpy_files=3, translate_blocks=2, string_sections=1, old_lines=10, new_lines=10, commented_original_lines=2
+- Pending translation: task_count=5, file_count=2
 """
 
 GENERATE_TEMPLATE_OUTPUT = """
@@ -39,6 +45,8 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(parsed["tl_exists"], True)
         self.assertEqual(parsed["counts"]["rpy_files"], 3)
         self.assertEqual(parsed["counts"]["old_lines"], 10)
+        self.assertEqual(parsed["pending"]["task_count"], 5)
+        self.assertEqual(parsed["pending"]["file_count"], 2)
 
     def test_successful_existing_tl_without_api_key_is_warning(self):
         summary = summarize_doctor_output(DOCTOR_OUTPUT, exit_code=0, api_key_count=0)
@@ -54,6 +62,11 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "ready")
         self.assertEqual(summary.heading, "项目检查通过")
         self.assertTrue(any("API Key：已配置 2 个" in fact for fact in summary.facts))
+        self.assertTrue(any("TL 文件：3 个" in fact for fact in summary.facts))
+        self.assertTrue(any("待翻译条目：约 5 条" in fact for fact in summary.facts))
+        self.assertTrue(any("剧情对话：2 条" in fact for fact in summary.facts))
+        self.assertTrue(any("UI 字符串：10 条 old/new" in fact for fact in summary.facts))
+        self.assertFalse(any("old/new 行数" in fact for fact in summary.facts))
         self.assertEqual(summary.findings, [])
 
     def test_can_generate_template_without_tl_files_is_warning(self):
@@ -66,7 +79,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "warning")
         self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
         self.assertTrue(any("翻译目录尚不存在" in finding for finding in summary.findings))
-        self.assertTrue(any("扫描到 0 个 .rpy 文件" in fact for fact in summary.facts))
+        self.assertTrue(any("TL 文件：0 个" in fact for fact in summary.facts))
 
     def test_can_generate_template_with_empty_tl_dir_is_warning(self):
         output = GENERATE_TEMPLATE_OUTPUT.replace("(exists: False)", "(exists: True)")
@@ -74,7 +87,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
 
         self.assertEqual(summary.status, "warning")
-        self.assertTrue(any("没有可处理的 .rpy 文件" in finding for finding in summary.findings))
+        self.assertTrue(any("没有 TL 文件" in finding for finding in summary.findings))
 
     def test_environment_api_key_source_is_reported(self):
         summary = summarize_doctor_output(
@@ -114,6 +127,23 @@ class GuiDoctorReportTests(unittest.TestCase):
 
         self.assertEqual(summary.status, "stale")
         self.assertIn("重新运行", summary.heading)
+
+    def test_format_tl_scan_facts_separates_dialogue_and_strings(self):
+        facts = format_tl_scan_facts(
+            {
+                "rpy_files": 49,
+                "translate_blocks": 49901,
+                "commented_original_lines": 49863,
+                "old_lines": 637,
+                "new_lines": 637,
+            },
+            pending={"task_count": 48394, "file_count": 49},
+        )
+
+        self.assertIn("TL 文件：49 个", facts)
+        self.assertTrue(any("待翻译条目：约 48394 条" in fact for fact in facts))
+        self.assertTrue(any("剧情对话：49863 条" in fact for fact in facts))
+        self.assertTrue(any("UI 字符串：637 条 old/new" in fact for fact in facts))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The environment check summary previously showed only \old/new\ line counts, which mostly reflect Ren'Py \	ranslate strings\ blocks and undercount large dialogue-heavy projects.

- \doctor\ now prints \Pending translation\ using the same logic as \uild\
- GUI doctor summary separates TL file count, pending tasks, dialogue blocks (comment format), and UI old/new strings

## Test plan

- [x] \python -m unittest tests.test_gui_doctor_report -q\
- [x] Verified on Game_Burrows: ~48394 pending tasks, 49863 dialogue lines, 637 UI strings

Refs #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Doctor report now shows “Pending translation” with pending task and file counts when translation files are present.
  * Improved translation availability details for clearer status reporting.
* **Refactor**
  * Updated doctor report parsing and formatting to support the new pending-translation section and consistent “facts” output.
* **Tests**
  * Updated and extended GUI doctor report tests to verify new parsing/summarization and the updated empty-translation-directory wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->