### PR TITLE
fix(gui): polish user-facing Chinese copy

### DIFF
--- a/gui_qt/api_key_dialog.py
+++ b/gui_qt/api_key_dialog.py
@@ -41,7 +41,7 @@ class ApiKeyDialog(QDialog):
         layout.setSpacing(12)
 
         intro = QLabel(
-            "Key 仅保存在本地 api_keys.json，不会上传或代理。"
+            "密钥仅保存在本地配置文件中，不会上传或代理。"
             "可添加多个 Key；删除选中项后点击「保存」生效。"
         )
         intro.setWordWrap(True)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -75,7 +75,8 @@ from .theme_helpers import (
     read_gui_theme_from_config,
     write_gui_theme_to_config,
 )
-from .translation_workflow import TranslationWorkflow, WorkflowUpdate
+from .translation_workflow import TranslationWorkflow
+from .user_copy import format_manifest_path_fact, WorkflowUpdate
 from .widget_helpers import NoWheelComboBox, NoWheelTabWidget
 
 # Diagnostics splitter: idle favors task context; running tasks expand the log.
@@ -142,7 +143,7 @@ class MainWindow(QMainWindow):
         self._set_workflow_summary(
             "idle",
             "尚未开始翻译任务",
-            "完成环境检查后，可以开始基础 Batch 翻译流程。",
+            "完成环境检查后，可以开始批量翻译流程。",
         )
         self._refresh_writeback_from_latest_manifest()
         self._set_bootstrap_summary(idle_bootstrap_summary())
@@ -320,8 +321,8 @@ class MainWindow(QMainWindow):
         api_layout.setContentsMargins(12, 16, 12, 12)
 
         api_hint = QLabel(
-            "翻译任务需要 Gemini API Key。Key 保存在本地 api_keys.json，"
-            "不会上传或代理。也可通过环境变量 GEMINI_API_KEY 配置。"
+            "翻译任务需要 Gemini API 密钥。密钥保存在本地配置文件中，"
+            "不会上传或代理。也可通过环境变量配置。"
         )
         api_hint.setWordWrap(True)
         api_hint.setObjectName("config_hint_label")
@@ -342,7 +343,7 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(api_box)
 
-        context_box = QGroupBox("Batch 上下文")
+        context_box = QGroupBox("批量上下文")
         context_layout = QVBoxLayout(context_box)
         context_layout.setSpacing(8)
         context_layout.setContentsMargins(12, 16, 12, 12)
@@ -403,7 +404,7 @@ class MainWindow(QMainWindow):
         config_row = QHBoxLayout()
         config_row.setSpacing(16)
 
-        sync_box = QGroupBox("同步翻译 (Sync API)")
+        sync_box = QGroupBox("同步翻译")
         sync_layout = QFormLayout(sync_box)
         sync_layout.setSpacing(8)
         sync_layout.setContentsMargins(12, 16, 12, 12)
@@ -429,7 +430,7 @@ class MainWindow(QMainWindow):
 
         config_row.addWidget(sync_box, 1)
 
-        batch_box = QGroupBox("批量离线 (Batch API)")
+        batch_box = QGroupBox("批量离线翻译")
         batch_layout = QFormLayout(batch_box)
         batch_layout.setSpacing(8)
         batch_layout.setContentsMargins(12, 16, 12, 12)
@@ -455,11 +456,11 @@ class MainWindow(QMainWindow):
 
         self.batch_thinking_combo = NoWheelComboBox()
         self.batch_thinking_combo.addItem("（不启用）", "")
-        self.batch_thinking_combo.addItem("最小 (minimal)", "minimal")
-        self.batch_thinking_combo.addItem("低 (low)", "low")
-        self.batch_thinking_combo.addItem("中 (medium)", "medium")
-        self.batch_thinking_combo.addItem("高 (high)", "high")
-        batch_layout.addRow("Batch 思考程度：", self.batch_thinking_combo)
+        self.batch_thinking_combo.addItem("最小", "minimal")
+        self.batch_thinking_combo.addItem("低", "low")
+        self.batch_thinking_combo.addItem("中", "medium")
+        self.batch_thinking_combo.addItem("高", "high")
+        batch_layout.addRow("思考程度：", self.batch_thinking_combo)
 
         config_row.addWidget(batch_box, 1)
         layout.addLayout(config_row, 1)
@@ -499,7 +500,7 @@ class MainWindow(QMainWindow):
         toolbar = QHBoxLayout()
         toolbar.setSpacing(8)
         diag_hint = QLabel(
-            "上方切换任务上下文、CLI 命令与 Manifest；下方始终显示原始输出。"
+            "上方可查看任务上下文、命令参考与任务清单；下方显示原始命令输出。"
             "任务运行时会自动切到此页并放大日志区域。"
         )
         diag_hint.setWordWrap(True)
@@ -585,7 +586,7 @@ class MainWindow(QMainWindow):
         commands_layout = QVBoxLayout(commands_content)
         commands_layout.setContentsMargins(12, 12, 12, 12)
         commands_layout.setSpacing(8)
-        commands_hint = QLabel("复制后在终端运行；命令使用当前 Python 解释器与真实脚本路径。")
+        commands_hint = QLabel("复制后在终端运行；命令使用当前解释器与脚本路径。")
         commands_hint.setWordWrap(True)
         commands_hint.setObjectName("config_hint_label")
         commands_layout.addWidget(commands_hint)
@@ -597,14 +598,14 @@ class MainWindow(QMainWindow):
         commands_layout.addStretch()
         commands_scroll.setWidget(commands_content)
         commands_outer.addWidget(commands_scroll)
-        self.diagnostics_inner_tabs.addTab(commands_tab, "CLI 命令")
+        self.diagnostics_inner_tabs.addTab(commands_tab, "命令参考")
 
         manifest_tab = QWidget()
         self._style_themed_surface(manifest_tab)
         manifest_layout = QVBoxLayout(manifest_tab)
         manifest_layout.setContentsMargins(12, 12, 12, 12)
         manifest_layout.setSpacing(8)
-        manifest_hint = QLabel("只读 JSON 预览；为控制体积已省略 chunks / files 大字段。")
+        manifest_hint = QLabel("只读预览；大段条目明细已省略。")
         manifest_hint.setWordWrap(True)
         manifest_hint.setObjectName("config_hint_label")
         manifest_layout.addWidget(manifest_hint)
@@ -613,7 +614,7 @@ class MainWindow(QMainWindow):
         self.diagnostics_manifest_preview.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
         self.diagnostics_manifest_preview.setObjectName("diagnostics_manifest_preview")
         manifest_layout.addWidget(self.diagnostics_manifest_preview, 1)
-        self.diagnostics_inner_tabs.addTab(manifest_tab, "Manifest")
+        self.diagnostics_inner_tabs.addTab(manifest_tab, "任务清单")
 
         splitter.addWidget(self.diagnostics_inner_tabs)
 
@@ -622,7 +623,7 @@ class MainWindow(QMainWindow):
         log_panel_layout = QVBoxLayout(log_panel)
         log_panel_layout.setContentsMargins(0, 4, 0, 0)
         log_panel_layout.setSpacing(6)
-        log_title = QLabel("原始 CLI 输出")
+        log_title = QLabel("原始命令输出")
         log_title.setObjectName("diagnostics_section_label")
         log_panel_layout.addWidget(log_title)
         self.log_view = QTextEdit()
@@ -769,7 +770,7 @@ class MainWindow(QMainWindow):
                 row_layout.addWidget(copy_btn)
                 self.diagnostics_commands_layout.addWidget(row_host)
         else:
-            placeholder = QLabel("开始翻译任务后，这里会出现可复制的手动 CLI 命令。")
+            placeholder = QLabel("开始翻译任务后，这里会出现可复制的手动命令。")
             placeholder.setWordWrap(True)
             placeholder.setObjectName("config_hint_label")
             self.diagnostics_commands_layout.addWidget(placeholder)
@@ -869,7 +870,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self, "请先选择项目",
                 "请先选择游戏的 work 目录。\n"
-                "项目检查（doctor）会读取 translator_config.json 中的 game_root。"
+                "环境检查会读取本地配置中的项目路径。"
             )
             return
 
@@ -896,7 +897,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "RAG 未启用",
-                "请先启用 Batch RAG 记忆库，并点击「保存参数配置」。",
+                "请先启用批量记忆库，并点击「保存参数配置」。",
             )
             return
 
@@ -917,7 +918,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "原文索引未启用",
-                "请先启用 Batch 原文索引，并点击「保存参数配置」。",
+                "请先启用批量原文索引，并点击「保存参数配置」。",
             )
             return
 
@@ -970,7 +971,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "没有可继续的任务",
-                "未找到 latest manifest；请先开始一个翻译任务。",
+                "未找到最近任务清单；请先开始一个翻译任务。",
             )
             return
 
@@ -996,7 +997,7 @@ class MainWindow(QMainWindow):
 
     def _on_apply_writeback(self):
         if not self._writeback_manifest_path:
-            QMessageBox.information(self, "无法写回", "没有可写回的 manifest；请先完成 check。")
+            QMessageBox.information(self, "无法写回", "没有可写回的任务；请先完成结果检查。")
             return
 
         summary = self._current_writeback_summary()
@@ -1004,7 +1005,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "当前不能写回",
-                summary.message or "只有 safe 的 check 结果才允许写回。",
+                summary.message or "只有检查结果为可写回时才允许写回。",
             )
             return
 
@@ -1109,7 +1110,7 @@ class MainWindow(QMainWindow):
 
         facts = []
         if self._workflow.manifest_path:
-            facts.append(f"Manifest：{self._workflow.manifest_path}")
+            facts.append(format_manifest_path_fact(self._workflow.manifest_path))
         self._workflow_step_output_lines = []
         self._set_workflow_summary("running", step.heading, step.message, facts)
         self._append_log(f"\n=== {step.heading}：gemini_translate_batch.py {' '.join(step.args)} ===\n")
@@ -1302,7 +1303,7 @@ class MainWindow(QMainWindow):
         if update.status == "failed":
             self.statusBar().showMessage("翻译任务失败，请查看诊断日志。", 8000)
         elif update.status == "waiting":
-            self.statusBar().showMessage("Batch 任务仍在处理，可稍后继续最新任务。", 8000)
+            self.statusBar().showMessage("批量任务仍在处理，可稍后继续最新任务。", 8000)
         else:
             self.statusBar().showMessage("翻译任务流程完成。", 6000)
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -75,8 +75,8 @@ from .theme_helpers import (
     read_gui_theme_from_config,
     write_gui_theme_to_config,
 )
-from .translation_workflow import TranslationWorkflow
-from .user_copy import format_manifest_path_fact, WorkflowUpdate
+from .translation_workflow import TranslationWorkflow, WorkflowUpdate
+from .user_copy import format_manifest_path_fact
 from .widget_helpers import NoWheelComboBox, NoWheelTabWidget
 
 # Diagnostics splitter: idle favors task context; running tasks expand the log.

--- a/gui_qt/bootstrap_report.py
+++ b/gui_qt/bootstrap_report.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+
+from .user_copy import format_bootstrap_fact
 from typing import Any
 
 
@@ -81,7 +83,7 @@ def _format_fact_values(values: dict[str, str], keys: tuple[str, ...]) -> list[s
     facts: list[str] = []
     for key in keys:
         if key in values:
-            facts.append(f"{key}：{values[key]}")
+            facts.append(format_bootstrap_fact(key, values[key]))
     return facts
 
 
@@ -102,7 +104,7 @@ def running_bootstrap_summary(kind: str) -> BootstrapSummary:
             kind=kind,
             status="running",
             heading="正在预建原文索引",
-            message="正在扫描 TL 模板原文并生成 source embedding，请稍候。",
+            message="正在扫描翻译模板原文并生成向量索引，请稍候。",
             facts=[],
             findings=[],
         )
@@ -110,7 +112,7 @@ def running_bootstrap_summary(kind: str) -> BootstrapSummary:
         kind=kind or "rag",
         status="running",
         heading="正在预建 RAG 库",
-        message="正在扫描已有译文并生成 RAG history store，请稍候。",
+        message="正在扫描已有译文并更新记忆库，请稍候。",
         facts=[],
         findings=[],
     )
@@ -186,7 +188,7 @@ def summarize_rag_bootstrap_output(output: str, exit_code: int) -> BootstrapSumm
             kind="rag",
             status="warning",
             heading="RAG 预建完成（无新记录）",
-            message="未扫描到可写入的译文记录。若项目尚无 TL 译文，可先翻译一部分或导入 seed JSONL。",
+            message="未扫描到可写入的译文记录。若项目尚无译文，可先翻译一部分。",
             facts=facts,
             findings=findings,
         )
@@ -196,7 +198,7 @@ def summarize_rag_bootstrap_output(output: str, exit_code: int) -> BootstrapSumm
             kind="rag",
             status="ready",
             heading="RAG 预建完成",
-            message="本地 RAG history store 已刷新，可以开始翻译任务。",
+            message="记忆库已刷新，可以开始翻译任务。",
             facts=facts,
             findings=findings,
         )
@@ -237,7 +239,7 @@ def summarize_source_index_bootstrap_output(output: str, exit_code: int) -> Boot
             kind="source_index",
             status="failed",
             heading="原文索引预建失败",
-            message="预建 source-only index 未成功完成，请查看诊断日志。",
+            message="预建原文索引未成功完成，请查看诊断日志。",
             facts=facts,
             findings=findings,
         )
@@ -260,7 +262,7 @@ def summarize_source_index_bootstrap_output(output: str, exit_code: int) -> Boot
             kind="source_index",
             status="warning",
             heading="原文索引预建完成（无新记录）",
-            message="未扫描到可索引的原文片段。请确认 TL 模板已生成且项目路径正确。",
+            message="未扫描到可索引的原文片段。请确认翻译模板已生成且项目路径正确。",
             facts=facts,
             findings=findings,
         )
@@ -270,7 +272,7 @@ def summarize_source_index_bootstrap_output(output: str, exit_code: int) -> Boot
             kind="source_index",
             status="ready",
             heading="原文索引预建完成",
-            message="source-only index 已刷新，后续 Batch build 可检索相关剧情原文。",
+            message="原文索引已刷新，后续翻译时可检索相关剧情原文。",
             facts=facts,
             findings=findings,
         )
@@ -279,7 +281,7 @@ def summarize_source_index_bootstrap_output(output: str, exit_code: int) -> Boot
         kind="source_index",
         status="ready",
         heading="原文索引预建完成",
-        message="索引库已是最新状态，无需新增 embedding。",
+        message="索引库已是最新状态，无需新增向量。",
         facts=facts,
         findings=findings,
     )

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -69,9 +69,9 @@ def parse_check_output(output: str) -> dict[str, object]:
 
 def _format_check_finding(finding: str) -> str:
     if finding.startswith("[warn] "):
-        return f"[需处理] {finding[7:]}"
+        return f"[{safety_level_label('warn')}] {finding[7:]}"
     if finding.startswith("[block] "):
-        return f"[禁止写回] {finding[8:]}"
+        return f"[{safety_level_label('block')}] {finding[8:]}"
     return finding
 
 

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from .user_copy import format_manifest_path_fact, safety_level_label
+
 
 @dataclass(frozen=True)
 class WritebackSummary:
@@ -65,6 +67,14 @@ def parse_check_output(output: str) -> dict[str, object]:
     return parsed
 
 
+def _format_check_finding(finding: str) -> str:
+    if finding.startswith("[warn] "):
+        return f"[需处理] {finding[7:]}"
+    if finding.startswith("[block] "):
+        return f"[禁止写回] {finding[8:]}"
+    return finding
+
+
 def summarize_check_output(
     output: str,
     exit_code: int,
@@ -76,8 +86,8 @@ def summarize_check_output(
         return WritebackSummary(
             status="failed",
             heading="结果检查失败",
-            message="check 没有正常完成，请查看诊断日志。",
-            facts=[f"Manifest：{manifest_path}"] if manifest_path else [],
+            message="结果检查没有正常完成，请查看诊断日志。",
+            facts=[format_manifest_path_fact(manifest_path)] if manifest_path else [],
             findings=[],
             can_apply=False,
             manifest_path=manifest_path,
@@ -89,7 +99,7 @@ def summarize_check_output(
 
     facts: list[str] = []
     if manifest_path:
-        facts.append(f"Manifest：{manifest_path}")
+        facts.append(format_manifest_path_fact(manifest_path))
 
     pending_files = parsed.get("pending_files")
     pending_lines = parsed.get("pending_lines")
@@ -104,7 +114,7 @@ def summarize_check_output(
         facts.append(f"检查报告：{parsed['check_failure_report']}")
 
     findings = [
-        finding
+        _format_check_finding(finding)
         for finding in parsed.get("findings", [])
         if isinstance(finding, str) and finding.strip()
     ]
@@ -113,7 +123,7 @@ def summarize_check_output(
         return WritebackSummary(
             status="applied",
             heading="翻译已写回",
-            message="该任务已经执行过 apply，不会再次写回。",
+            message="该任务已经写回过，不会再次写回。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -124,7 +134,7 @@ def summarize_check_output(
         return WritebackSummary(
             status="safe",
             heading="可以写回翻译",
-            message="检查结果为 safe。写回前请确认已备份项目，apply 会修改 .rpy 文件。",
+            message="检查结果为可写回。写回前请确认已备份项目，写回会修改游戏脚本。",
             facts=facts,
             findings=findings,
             can_apply=True,
@@ -135,7 +145,7 @@ def summarize_check_output(
         return WritebackSummary(
             status="warn",
             heading="需要先处理问题",
-            message="检查结果为 warn，不应写回。请查看问题后重试、repair 或重新检查。",
+            message="检查结果为需处理，暂不应写回。请查看问题后重试、修复或重新检查。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -146,7 +156,7 @@ def summarize_check_output(
         return WritebackSummary(
             status="block",
             heading="当前不能写回",
-            message="检查结果为 block，不能写回。请修复源文件漂移或重新生成任务后再检查。",
+            message="检查结果为禁止写回。请修复源文件变化或重新生成任务后再检查。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -156,7 +166,7 @@ def summarize_check_output(
     return WritebackSummary(
         status="unknown",
         heading="检查结果不明确",
-        message="未能识别安全状态，请查看诊断日志后重新运行 check。",
+        message="未能识别检查结果，请查看诊断日志后重新检查。",
         facts=facts,
         findings=findings,
         can_apply=False,
@@ -174,8 +184,8 @@ def summarize_apply_output(
         return WritebackSummary(
             status="failed",
             heading="写回失败",
-            message="apply 没有正常完成。请查看诊断日志与 apply_failure_report。",
-            facts=[fact for fact in (f"Manifest：{manifest_path}",) if manifest_path],
+            message="写回没有正常完成。请查看诊断日志与写回失败报告。",
+            facts=[fact for fact in (format_manifest_path_fact(manifest_path),) if manifest_path],
             findings=[],
             can_apply=False,
             manifest_path=manifest_path,
@@ -183,7 +193,7 @@ def summarize_apply_output(
 
     facts: list[str] = []
     if manifest_path:
-        facts.append(f"Manifest：{manifest_path}")
+        facts.append(format_manifest_path_fact(manifest_path))
 
     applied_files = _parse_int_field(output, "Applied files:")
     applied_lines = _parse_int_field(output, "Applied lines:")
@@ -197,7 +207,7 @@ def summarize_apply_output(
     return WritebackSummary(
         status="applied",
         heading="翻译写回完成",
-        message="apply 已完成。建议在游戏中抽查关键剧情文本。",
+        message="写回已完成。建议在游戏中抽查关键剧情文本。",
         facts=facts,
         findings=[],
         can_apply=False,
@@ -214,7 +224,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
         apply_summary = manifest.get("apply_summary")
         facts: list[str] = []
         if manifest_path:
-            facts.append(f"Manifest：{manifest_path}")
+            facts.append(format_manifest_path_fact(manifest_path))
         if isinstance(apply_summary, dict):
             applied_files = apply_summary.get("applied_files")
             applied_lines = apply_summary.get("applied_lines")
@@ -223,7 +233,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
         return WritebackSummary(
             status="applied",
             heading="翻译已写回",
-            message="该任务已经执行过 apply。",
+            message="该任务已经写回过。",
             facts=facts,
             findings=[],
             can_apply=False,
@@ -238,7 +248,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
     safety_text = safety if isinstance(safety, str) else ""
     facts: list[str] = []
     if manifest_path:
-        facts.append(f"Manifest：{manifest_path}")
+        facts.append(format_manifest_path_fact(manifest_path))
 
     pending_files = last_summary.get("pending_files")
     pending_lines = last_summary.get("pending_lines")
@@ -260,13 +270,15 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
             reasons = safety_reasons.get(level)
             if isinstance(reasons, dict):
                 for name, count in sorted(reasons.items()):
-                    findings.append(f"[{level}] {name}: {count}")
+                    findings.append(
+                        f"[{safety_level_label(level)}] {name}: {count}"
+                    )
 
     if safety_text == "safe":
         return WritebackSummary(
             status="safe",
             heading="可以写回翻译",
-            message="最近一次 check 为 safe。写回前请确认已备份项目。",
+            message="最近一次检查结果为可写回。写回前请确认已备份项目。",
             facts=facts,
             findings=findings,
             can_apply=True,
@@ -276,7 +288,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
         return WritebackSummary(
             status="warn",
             heading="需要先处理问题",
-            message="最近一次 check 为 warn，不应写回。",
+            message="最近一次检查结果为需处理，不应写回。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -286,7 +298,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
         return WritebackSummary(
             status="block",
             heading="当前不能写回",
-            message="最近一次 check 为 block，不能写回。",
+            message="最近一次检查结果为禁止写回。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -299,7 +311,7 @@ def idle_writeback_summary() -> WritebackSummary:
     return WritebackSummary(
         status="idle",
         heading="等待翻译完成",
-        message="翻译任务跑完 check 后，这里会显示是否可以写回。",
+        message="翻译完成并检查结果后，这里会显示是否可以写回。",
         facts=[],
         findings=[],
         can_apply=False,
@@ -321,7 +333,7 @@ def running_writeback_summary() -> WritebackSummary:
     return WritebackSummary(
         status="running",
         heading="正在写回翻译",
-        message="正在运行 apply；完成后这里会显示写回摘要。",
+        message="正在写回；完成后这里会显示写回摘要。",
         facts=[],
         findings=[],
         can_apply=False,

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -185,7 +185,7 @@ def summarize_apply_output(
             status="failed",
             heading="写回失败",
             message="写回没有正常完成。请查看诊断日志与写回失败报告。",
-            facts=[fact for fact in (format_manifest_path_fact(manifest_path),) if manifest_path],
+            facts=[format_manifest_path_fact(manifest_path)] if manifest_path else [],
             findings=[],
             can_apply=False,
             manifest_path=manifest_path,

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -8,6 +8,15 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
+from .user_copy import (
+    format_job_fact,
+    format_job_state_fact,
+    format_manifest_path_fact,
+    format_package_dir_fact,
+    format_safety_fact,
+    manifest_mode_label,
+)
+
 
 @dataclass(frozen=True)
 class DiagnosticsPathEntry:
@@ -117,7 +126,7 @@ def manifest_for_preview(manifest: dict[str, object]) -> dict[str, object]:
     chunk_count = len(chunks) if isinstance(chunks, list) else 0
     if file_count or chunk_count:
         preview["_preview_note"] = (
-            f"chunks/files omitted from preview ({chunk_count} chunks, {file_count} files)"
+            f"预览已省略条目明细（{chunk_count} 块 / {file_count} 个文件）"
         )
     return preview
 
@@ -230,7 +239,7 @@ def build_cli_commands(
     if not manifest.get("applied_at"):
         commands.append(
             DiagnosticsCommand(
-                label="写回翻译（仅 safe）",
+                label="写回翻译（仅可写回）",
                 command=format_cli_command(
                     python_exe,
                     batch_script_path,
@@ -245,27 +254,27 @@ def build_cli_commands(
 def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> list[str]:
     facts: list[str] = []
     if manifest_path:
-        facts.append(f"Manifest：{manifest_path}")
+        facts.append(format_manifest_path_fact(manifest_path))
 
     package_dir = resolve_package_dir(manifest_path, manifest)
     if package_dir:
-        facts.append(f"Package：{package_dir}")
+        facts.append(format_package_dir_fact(package_dir))
 
     job_name = manifest.get("job_name")
     if isinstance(job_name, str) and job_name.strip():
-        facts.append(f"Job：{job_name.strip()}")
+        facts.append(format_job_fact(job_name.strip()))
     else:
-        facts.append("Job：尚未提交")
+        facts.append("云端任务：尚未提交")
 
     job_state = manifest.get("job_state")
     if isinstance(job_state, str) and job_state.strip():
-        facts.append(f"Job 状态：{job_state.strip()}")
+        facts.append(format_job_state_fact(job_state.strip()))
 
     last_summary = manifest.get("last_check_summary")
     if isinstance(last_summary, dict):
         safety = last_summary.get("safety_level")
         if isinstance(safety, str) and safety.strip():
-            facts.append(f"最近检查：{safety.strip()}")
+            facts.append(format_safety_fact(safety.strip(), prefix="最近检查"))
 
     applied_at = manifest.get("applied_at")
     if isinstance(applied_at, str) and applied_at.strip():
@@ -277,7 +286,7 @@ def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> lis
 
     mode = manifest.get("mode")
     if isinstance(mode, str) and mode.strip():
-        facts.append(f"模式：{mode.strip()}")
+        facts.append(f"任务类型：{manifest_mode_label(mode.strip())}")
 
     return facts
 
@@ -286,7 +295,7 @@ def idle_diagnostics_context() -> DiagnosticsContext:
     return DiagnosticsContext(
         status="idle",
         heading="暂无任务上下文",
-        message="完成 build 或开始翻译后，这里会显示 manifest、package、job 和可复制命令。",
+        message="开始翻译后，这里会显示任务清单、翻译包、云端任务和可复制命令。",
         facts=[],
         paths=[],
         commands=[],
@@ -320,9 +329,9 @@ def build_diagnostics_context(
         if manifest_path and exists(manifest_path):
             return DiagnosticsContext(
                 status="warning",
-                heading="无法读取 manifest",
-                message="找到了 manifest 路径，但内容未能加载。请查看下方原始日志。",
-                facts=[f"Manifest：{manifest_path}"],
+                heading="无法读取任务清单",
+                message="找到了任务清单路径，但内容未能加载。请查看下方原始日志。",
+                facts=[format_manifest_path_fact(manifest_path)],
                 paths=[],
                 commands=[],
                 manifest_json_preview="",
@@ -334,7 +343,7 @@ def build_diagnostics_context(
 
     latest_pointer = join_directory_file(logs_dir, "latest_manifest.txt")
     if exists(latest_pointer):
-        facts.append(f"Latest 指针：{latest_pointer}")
+        facts.append(f"最近任务指针：{latest_pointer}")
 
     paths = collect_existing_report_paths(package_dir, manifest, path_exists=exists)
     commands = build_cli_commands(
@@ -346,13 +355,13 @@ def build_diagnostics_context(
     preview = format_manifest_json_preview(manifest)
 
     status = "ready"
-    message = "以下为 latest manifest 对应的内部路径与手动 CLI 命令。"
+    message = "以下为当前任务清单对应的路径与可手动运行的命令。"
     if manifest_path and latest_manifest_path:
         if _canonical_compare_path(manifest_path) != _canonical_compare_path(
             latest_manifest_path
         ):
             status = "warning"
-            message = "活动 manifest 与 latest 指针不一致；下方预览以当前加载的 manifest 为准。"
+            message = "当前任务与最近任务指针不一致；下方预览以当前加载的任务清单为准。"
 
     return DiagnosticsContext(
         status=status,

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -1,4 +1,5 @@
 """User-facing summaries for the GUI doctor command."""
+# ruff: noqa: RUF001
 from __future__ import annotations
 
 import re
@@ -147,8 +148,10 @@ def summarize_doctor_output(
         for warning in parsed.get("warnings", [])
         if isinstance(warning, str) and warning.strip()
     ]
-    counts = parsed.get("counts") if isinstance(parsed.get("counts"), dict) else {}
-    pending = parsed.get("pending") if isinstance(parsed.get("pending"), dict) else None
+    counts_value = parsed.get("counts")
+    counts = counts_value if isinstance(counts_value, dict) else {}
+    pending_value = parsed.get("pending")
+    pending = pending_value if isinstance(pending_value, dict) else None
     mode = parsed.get("mode") if isinstance(parsed.get("mode"), str) else ""
 
     facts: list[str] = []

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from .user_copy import doctor_mode_label, translate_doctor_warning
+
 
 @dataclass(frozen=True)
 class DoctorSummary:
@@ -16,7 +18,7 @@ class DoctorSummary:
 
 MODE_MESSAGES = {
     "can_generate_template": "Ren'Py 模板生成环境可用；如翻译模板尚不存在，需要先生成或刷新模板。",
-    "existing_tl_only": "已有翻译文件可处理；模板生成环境不可用，后续依赖现有 TL 文件。",
+    "existing_tl_only": "已有翻译文件可处理；模板生成环境不可用，后续依赖现有翻译文件。",
     "blocked_missing_template": "缺少可处理的翻译文件，也无法自动生成模板。",
 }
 
@@ -49,9 +51,9 @@ def format_tl_scan_facts(
     new_lines = int(counts.get("new_lines", 0))
 
     if rpy_files == 0 and translate_blocks == 0:
-        return ["TL 文件：0 个"]
+        return ["翻译文件：0 个"]
 
-    facts: list[str] = [f"TL 文件：{rpy_files} 个"]
+    facts: list[str] = [f"翻译文件：{rpy_files} 个"]
 
     if pending is not None:
         task_count = int(pending.get("task_count", 0))
@@ -64,17 +66,17 @@ def format_tl_scan_facts(
             facts.append("待翻译条目：0 条（当前没有需要提交到 Batch 的英文待译行）")
 
     if commented_lines > 0:
-        facts.append(
-            f"剧情对话：{commented_lines} 条注释原文格式（主流程会翻译这类内容，不是 old/new 行）"
-        )
+        facts.append(f"剧情对话：{commented_lines} 条")
     elif translate_blocks > 0:
         facts.append(f"翻译块：{translate_blocks} 个")
 
     if old_lines > 0 or new_lines > 0:
         if old_lines == new_lines:
-            facts.append(f"UI 字符串：{old_lines} 条 old/new（translate strings 块）")
+            facts.append(f"界面字符串：{old_lines} 条")
         else:
-            facts.append(f"UI 字符串：old/new 行数 {old_lines}/{new_lines}（可能格式异常）")
+            facts.append(
+                f"界面字符串：原文 {old_lines} 条，译文 {new_lines} 条（可能格式异常）"
+            )
 
     return facts
 
@@ -141,7 +143,7 @@ def summarize_doctor_output(
 ) -> DoctorSummary:
     parsed = parse_doctor_output(output)
     warnings = [
-        warning
+        translate_doctor_warning(warning)
         for warning in parsed.get("warnings", [])
         if isinstance(warning, str) and warning.strip()
     ]
@@ -158,7 +160,7 @@ def summarize_doctor_output(
     if parsed.get("language"):
         facts.append(f"目标语言：{parsed['language']}")
     if mode:
-        facts.append(f"检查模式：{mode}")
+        facts.append(f"检查模式：{doctor_mode_label(mode)}")
     if counts:
         facts.extend(format_tl_scan_facts(counts, pending=pending))
 
@@ -166,27 +168,27 @@ def summarize_doctor_output(
     if mode == "can_generate_template":
         if parsed.get("tl_exists") is False:
             findings.append(
-                "翻译目录尚不存在；doctor 可以生成模板，但还没有可检查的 TL 文件。"
+                "翻译目录尚不存在；可以生成模板，但还没有可检查的翻译文件。"
                 "请先生成或刷新翻译模板后重新检查。"
             )
         elif counts and int(counts.get("rpy_files", 0)) == 0:
             findings.append(
-                "翻译目录中没有 TL 文件；请先生成或刷新翻译模板后重新检查。"
+                "翻译目录中没有翻译文件；请先生成或刷新翻译模板后重新检查。"
             )
     if api_key_count is not None:
         if api_key_count > 0:
             if api_key_source == "environment":
-                facts.append(f"API Key：已通过环境变量配置 {api_key_count} 个")
+                facts.append(f"API 密钥：已通过环境变量配置 {api_key_count} 个")
             else:
-                facts.append(f"API Key：已配置 {api_key_count} 个")
+                facts.append(f"API 密钥：已配置 {api_key_count} 个")
         else:
-            findings.append("尚未配置 API Key；doctor 不调用 Gemini，但后续翻译任务需要 API Key。")
+            findings.append("尚未配置 API 密钥；环境检查不调用模型，但翻译任务需要密钥。")
 
     if exit_code != 0:
         return DoctorSummary(
             status="blocked",
             heading="项目检查失败",
-            message="命令行检查没有正常完成，请查看下方诊断输出。",
+            message="环境检查没有正常完成，请查看诊断日志。",
             facts=facts,
             findings=findings,
         )
@@ -215,7 +217,7 @@ def running_summary() -> DoctorSummary:
     return DoctorSummary(
         status="running",
         heading="正在检查项目",
-        message="正在运行 doctor；完成后这里会显示可读摘要。",
+        message="正在运行环境检查；完成后这里会显示摘要。",
         facts=[],
         findings=[],
     )
@@ -225,7 +227,7 @@ def idle_summary() -> DoctorSummary:
     return DoctorSummary(
         status="idle",
         heading="尚未运行项目检查",
-        message="选择游戏 work 目录后运行 doctor。",
+        message="选择游戏 work 目录后点击「环境检查」。",
         facts=[],
         findings=[],
     )
@@ -235,7 +237,7 @@ def stale_summary() -> DoctorSummary:
     return DoctorSummary(
         status="stale",
         heading="项目已切换，请重新运行检查",
-        message="当前摘要已清空；请针对新的 work 目录重新运行 doctor。",
+        message="当前摘要已清空；请针对新的 work 目录重新运行环境检查。",
         facts=[],
         findings=[],
     )

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -7,6 +7,14 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+
+from .user_copy import (
+    format_job_state_fact,
+    format_manifest_path_fact,
+    format_safety_fact,
+    job_state_label,
+    safety_level_label,
+)
 from pathlib import PurePosixPath, PureWindowsPath
 
 
@@ -35,9 +43,9 @@ class WorkflowUpdate:
 
 
 STEP_TEXT = {
-    "build": ("正在准备翻译内容", "正在扫描待翻译文本并生成 Batch 请求包。"),
-    "submit": ("正在提交翻译任务", "正在上传请求文件并创建 Batch 任务。"),
-    "status": ("正在刷新任务状态", "正在向 Batch API 查询当前处理状态。"),
+    "build": ("正在准备翻译内容", "正在扫描待翻译文本并生成批量请求包。"),
+    "submit": ("正在提交翻译任务", "正在上传请求文件并创建云端批量任务。"),
+    "status": ("正在刷新任务状态", "正在查询云端任务处理状态。"),
     "download": ("正在获取翻译结果", "任务已完成，正在下载结果文件。"),
     "check": ("正在检查翻译结果", "正在校验结果是否可以进入写回前预览。"),
 }
@@ -164,40 +172,43 @@ class TranslationWorkflow:
             if "download" not in self._pending_steps:
                 self._pending_steps[:0] = ["download", "check"]
             return self._continue_or_finish(
-                extra_facts=[f"Batch 状态：{state}"],
+                extra_facts=[format_job_state_fact(state)],
             )
         if state in TERMINAL_FAILURE_STATES:
             self._pending_steps.clear()
             return WorkflowUpdate(
                 status="failed",
-                heading="Batch 任务没有成功完成",
-                message=f"当前状态为 {state}，请查看原始输出后重试或重新生成任务。",
-                facts=self._facts([f"Batch 状态：{state}"]),
+                heading="批量任务没有成功完成",
+                message=f"当前状态为 {job_state_label(state)}，请查看原始输出后重试或重新生成任务。",
+                facts=self._facts([format_job_state_fact(state)]),
             )
 
         self._pending_steps.clear()
         state_text = state or "未知"
         return WorkflowUpdate(
             status="waiting",
-            heading="Batch 任务仍在处理",
+            heading="批量任务仍在处理",
             message="稍后可以继续刷新最新任务状态；任务成功后再下载并检查结果。",
-            facts=self._facts([f"Batch 状态：{state_text}"]),
+            facts=self._facts([format_job_state_fact(state_text)]),
         )
 
     def _finish_check(self, output: str) -> WorkflowUpdate:
         safety = extract_safety_status(output)
         if safety == "safe":
             heading = "翻译结果检查通过"
-            message = "结果为 safe，可以进入后续写回前预览。"
+            message = "检查结果为可写回，可以进入写回前确认。"
         elif safety in {"warn", "block"}:
             heading = "翻译结果需要处理"
-            message = f"结果为 {safety}，普通流程不应写回；请先查看问题并重试或修复。"
+            message = (
+                f"检查结果为 {safety_level_label(safety)}，普通流程不应写回；"
+                "请先查看问题并重试或修复。"
+            )
         else:
             heading = "翻译结果检查完成"
             message = "未能识别安全状态，请查看原始输出。"
 
         self._pending_steps.clear()
-        facts = self._facts([f"安全状态：{safety or '未知'}"])
+        facts = self._facts([format_safety_fact(safety or "", prefix="检查结果")])
         return WorkflowUpdate(status="done", heading=heading, message=message, facts=facts)
 
     def _continue_or_finish(self, extra_facts: list[str] | None = None) -> WorkflowUpdate:
@@ -225,7 +236,7 @@ class TranslationWorkflow:
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:
         facts: list[str] = []
         if self.manifest_path:
-            facts.append(f"Manifest：{self.manifest_path}")
+            facts.append(format_manifest_path_fact(self.manifest_path))
         if extra_facts:
             facts.extend(extra_facts)
         return facts

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -88,7 +88,7 @@ def job_state_label(state: str) -> str:
 
 def manifest_mode_label(mode: str) -> str:
     text = str(mode or "").strip()
-    return MANIFEST_MODE_LABELS.get(text, text or text)
+    return MANIFEST_MODE_LABELS.get(text, text or "未知")
 
 
 def format_manifest_path_fact(path: str) -> str:

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -1,0 +1,130 @@
+"""Shared Chinese labels and copy helpers for GUI summaries."""
+from __future__ import annotations
+
+SAFETY_LEVEL_LABELS = {
+    "safe": "可写回",
+    "warn": "需处理",
+    "block": "禁止写回",
+}
+
+DOCTOR_MODE_LABELS = {
+    "can_generate_template": "可生成翻译模板",
+    "existing_tl_only": "仅处理已有翻译文件",
+    "blocked_missing_template": "缺少模板且无法生成",
+}
+
+JOB_STATE_LABELS = {
+    "JOB_STATE_SUCCEEDED": "已完成",
+    "JOB_STATE_FAILED": "失败",
+    "JOB_STATE_CANCELLED": "已取消",
+    "JOB_STATE_EXPIRED": "已过期",
+    "JOB_STATE_PENDING": "排队中",
+    "JOB_STATE_RUNNING": "处理中",
+}
+
+MANIFEST_MODE_LABELS = {
+    "translation": "普通翻译",
+    "revision": "订正",
+    "keyword_extraction": "关键词提取",
+}
+
+BOOTSTRAP_FIELD_LABELS = {
+    "store_dir": "存储目录",
+    "scan_scope": "扫描范围",
+    "files_scanned": "扫描文件数",
+    "scanned": "扫描条目",
+    "embedded": "生成向量数",
+    "upserted": "写入记录数",
+    "reused_embeddings": "复用向量数",
+    "stale_count": "过期记录数",
+    "pruned": "清理记录数",
+    "history_records_before": "更新前记录数",
+    "history_records_after": "更新后记录数",
+    "external_seed_records": "外部种子记录数",
+}
+
+DOCTOR_WARNING_TRANSLATIONS: tuple[tuple[str, str], ...] = (
+    (
+        "old/new line counts differ; string translation blocks may be malformed.",
+        "界面字符串块的原文/译文行数不一致，格式可能异常。",
+    ),
+    (
+        "Dialogue translation blocks do not include source comments; revision/RAG source pairing may be limited.",
+        "部分对话块缺少原文注释，订正与记忆库配对可能受限。",
+    ),
+    (
+        "No TL files and no Ren'Py SDK/game launcher found; template generation is required.",
+        "没有翻译文件，也未找到 Ren'Py SDK；需要先生成翻译模板。",
+    ),
+    (
+        "Ren'Py SDK/game launcher not found; existing TL files can still be processed.",
+        "未找到 Ren'Py SDK，但仍可处理已有翻译文件。",
+    ),
+    (
+        "No TL files and custom template command is unavailable; template generation is required.",
+        "没有翻译文件，且自定义模板命令不可用；需要先生成翻译模板。",
+    ),
+    (
+        "Custom template command is unavailable; existing TL files can still be processed.",
+        "自定义模板命令不可用，但仍可处理已有翻译文件。",
+    ),
+)
+
+
+def safety_level_label(level: str) -> str:
+    text = str(level or "").strip().lower()
+    return SAFETY_LEVEL_LABELS.get(text, level or "未知")
+
+
+def doctor_mode_label(mode: str) -> str:
+    text = str(mode or "").strip()
+    return DOCTOR_MODE_LABELS.get(text, text or "未知")
+
+
+def job_state_label(state: str) -> str:
+    text = str(state or "").strip()
+    return JOB_STATE_LABELS.get(text, text or "未知")
+
+
+def manifest_mode_label(mode: str) -> str:
+    text = str(mode or "").strip()
+    return MANIFEST_MODE_LABELS.get(text, text or text)
+
+
+def format_manifest_path_fact(path: str) -> str:
+    return f"任务清单：{path}"
+
+
+def format_package_dir_fact(path: str) -> str:
+    return f"翻译包：{path}"
+
+
+def format_job_fact(job_name: str) -> str:
+    return f"云端任务：{job_name}"
+
+
+def format_job_state_fact(state: str) -> str:
+    return f"任务状态：{job_state_label(state)}"
+
+
+def format_safety_fact(level: str, *, prefix: str = "检查结果") -> str:
+    return f"{prefix}：{safety_level_label(level)}"
+
+
+def translate_doctor_warning(warning: str) -> str:
+    text = warning.strip()
+    for source, translated in DOCTOR_WARNING_TRANSLATIONS:
+        if text == source:
+            return translated
+    if text.startswith("Found ") and "legacy manifest" in text:
+        return "检测到旧版任务清单，将使用兼容模式继续处理。"
+    if text.startswith("Custom template command cannot be rendered:"):
+        return "自定义模板命令无法解析，请检查配置。"
+    if text.startswith("RAG store contains legacy ID format keys."):
+        return "记忆库含有旧版键格式，下次写回时会自动迁移。"
+    return text
+
+
+def format_bootstrap_fact(key: str, value: str) -> str:
+    label = BOOTSTRAP_FIELD_LABELS.get(key, key)
+    return f"{label}：{value}"

--- a/tests/test_gui_bootstrap_report.py
+++ b/tests/test_gui_bootstrap_report.py
@@ -56,7 +56,7 @@ RAG bootstrap summary:
 """
         summary = summarize_rag_bootstrap_output(output, 0)
         self.assertEqual(summary.status, "ready")
-        self.assertIn("store_dir\uFF1Alogs/rag_store/demo", summary.facts)
+        self.assertIn("存储目录：logs/rag_store/demo", summary.facts)
 
     def test_summarize_rag_bootstrap_output_marks_empty_scan_as_warning(self):
         output = """

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -83,7 +83,7 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
             manifest={"job_name": "jobs/abc", "applied_at": "2026-01-01T00:00:00"},
         )
         labels = [command.label for command in commands]
-        self.assertNotIn("写回翻译（仅 safe）", labels)
+        self.assertNotIn("写回翻译（仅可写回）", labels)
 
     def test_build_diagnostics_context_idle_without_manifest(self):
         context = build_diagnostics_context(
@@ -122,7 +122,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
             path_exists=path_exists,
         )
         self.assertEqual(context.status, "ready")
-        self.assertTrue(any("Manifest" in fact for fact in context.facts))
+        self.assertTrue(any("任务清单：" in fact for fact in context.facts))
+        self.assertTrue(any("最近检查：可写回" in fact for fact in context.facts))
         self.assertTrue(any(entry.label == "Batch 请求" for entry in context.paths))
         self.assertTrue(context.commands)
         self.assertIn('"mode": "translation"', context.manifest_json_preview)

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -54,18 +54,18 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "warning")
         self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
         self.assertIn("已有翻译文件", summary.message)
-        self.assertTrue(any("API Key" in finding for finding in summary.findings))
+        self.assertTrue(any("API" in finding for finding in summary.findings))
 
     def test_successful_clean_report_is_ready(self):
         summary = summarize_doctor_output(DOCTOR_OUTPUT, exit_code=0, api_key_count=2)
 
         self.assertEqual(summary.status, "ready")
         self.assertEqual(summary.heading, "项目检查通过")
-        self.assertTrue(any("API Key：已配置 2 个" in fact for fact in summary.facts))
-        self.assertTrue(any("TL 文件：3 个" in fact for fact in summary.facts))
+        self.assertTrue(any("API 密钥：已配置 2 个" in fact for fact in summary.facts))
+        self.assertTrue(any("翻译文件：3 个" in fact for fact in summary.facts))
         self.assertTrue(any("待翻译条目：约 5 条" in fact for fact in summary.facts))
         self.assertTrue(any("剧情对话：2 条" in fact for fact in summary.facts))
-        self.assertTrue(any("UI 字符串：10 条 old/new" in fact for fact in summary.facts))
+        self.assertTrue(any("界面字符串：10 条" in fact for fact in summary.facts))
         self.assertFalse(any("old/new 行数" in fact for fact in summary.facts))
         self.assertEqual(summary.findings, [])
 
@@ -79,7 +79,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "warning")
         self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
         self.assertTrue(any("翻译目录尚不存在" in finding for finding in summary.findings))
-        self.assertTrue(any("TL 文件：0 个" in fact for fact in summary.facts))
+        self.assertTrue(any("翻译文件：0 个" in fact for fact in summary.facts))
 
     def test_can_generate_template_with_empty_tl_dir_is_warning(self):
         output = GENERATE_TEMPLATE_OUTPUT.replace("(exists: False)", "(exists: True)")
@@ -87,7 +87,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
 
         self.assertEqual(summary.status, "warning")
-        self.assertTrue(any("没有 TL 文件" in finding for finding in summary.findings))
+        self.assertTrue(any("没有翻译文件" in finding for finding in summary.findings))
 
     def test_environment_api_key_source_is_reported(self):
         summary = summarize_doctor_output(
@@ -112,7 +112,7 @@ class GuiDoctorReportTests(unittest.TestCase):
 
         self.assertEqual(summary.status, "blocked")
         self.assertEqual(summary.heading, "项目检查失败")
-        self.assertIn("命令行检查没有正常完成", summary.message)
+        self.assertIn("环境检查没有正常完成", summary.message)
 
     def test_doctor_warnings_are_preserved(self):
         output = DOCTOR_OUTPUT + "\nWarnings:\n- old/new line counts differ; string translation blocks may be malformed.\n"
@@ -120,7 +120,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
 
         self.assertEqual(summary.status, "warning")
-        self.assertTrue(any("old/new line counts differ" in finding for finding in summary.findings))
+        self.assertTrue(any("界面字符串块" in finding for finding in summary.findings))
 
     def test_stale_summary_marks_previous_result_invalid(self):
         summary = stale_summary()
@@ -140,10 +140,10 @@ class GuiDoctorReportTests(unittest.TestCase):
             pending={"task_count": 48394, "file_count": 49},
         )
 
-        self.assertIn("TL 文件：49 个", facts)
+        self.assertIn("翻译文件：49 个", facts)
         self.assertTrue(any("待翻译条目：约 48394 条" in fact for fact in facts))
         self.assertTrue(any("剧情对话：49863 条" in fact for fact in facts))
-        self.assertTrue(any("UI 字符串：637 条 old/new" in fact for fact in facts))
+        self.assertTrue(any("界面字符串：637 条" in fact for fact in facts))
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_translation_workflow.py
+++ b/tests/test_gui_translation_workflow.py
@@ -64,7 +64,7 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
         update = workflow.complete_current_step(0, "State: JOB_STATE_RUNNING\n")
 
         self.assertEqual(update.status, "waiting")
-        self.assertTrue(any("JOB_STATE_RUNNING" in fact for fact in update.facts))
+        self.assertTrue(any("任务状态：处理中" in fact for fact in update.facts))
         self.assertIsNone(workflow.current_step())
 
     def test_resume_unsubmitted_manifest_starts_from_submit(self):
@@ -96,7 +96,7 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
 
         check_update = workflow.complete_current_step(0, "Safety status: safe\n")
         self.assertEqual(check_update.status, "done")
-        self.assertIn("safe", check_update.facts[-1])
+        self.assertIn("可写回", check_update.facts[-1])
         self.assertIsNone(workflow.current_step())
 
     def test_check_warn_is_done_but_not_writeback_ready(self):

--- a/tests/test_gui_user_copy.py
+++ b/tests/test_gui_user_copy.py
@@ -40,7 +40,7 @@ class GuiUserCopyTests(unittest.TestCase):
         self.assertEqual(manifest_mode_label("custom_mode"), "custom_mode")
 
     def test_format_bootstrap_fact_passthrough_unknown_key(self):
-        self.assertEqual(format_bootstrap_fact("unknown_key", "42"), "unknown_key：42")
+        self.assertEqual(format_bootstrap_fact("unknown_key", "42"), "unknown_key：42")  # noqa: RUF001
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_user_copy.py
+++ b/tests/test_gui_user_copy.py
@@ -1,0 +1,38 @@
+import unittest
+
+from gui_qt.user_copy import (
+    doctor_mode_label,
+    format_manifest_path_fact,
+    job_state_label,
+    safety_level_label,
+    translate_doctor_warning,
+)
+
+
+class GuiUserCopyTests(unittest.TestCase):
+    def test_safety_level_label_maps_known_values(self):
+        self.assertEqual(safety_level_label("safe"), "可写回")
+        self.assertEqual(safety_level_label("warn"), "需处理")
+        self.assertEqual(safety_level_label("block"), "禁止写回")
+
+    def test_doctor_mode_label_maps_known_values(self):
+        self.assertEqual(doctor_mode_label("can_generate_template"), "可生成翻译模板")
+
+    def test_job_state_label_maps_known_values(self):
+        self.assertEqual(job_state_label("JOB_STATE_SUCCEEDED"), "已完成")
+
+    def test_format_manifest_path_fact_uses_chinese_label(self):
+        self.assertEqual(
+            format_manifest_path_fact(r"C:\jobs\manifest.json"),
+            r"任务清单：C:\jobs\manifest.json",
+        )
+
+    def test_translate_doctor_warning_maps_known_message(self):
+        translated = translate_doctor_warning(
+            "old/new line counts differ; string translation blocks may be malformed."
+        )
+        self.assertIn("界面字符串块", translated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_user_copy.py
+++ b/tests/test_gui_user_copy.py
@@ -17,11 +17,23 @@ class GuiUserCopyTests(unittest.TestCase):
         self.assertEqual(safety_level_label("warn"), "需处理")
         self.assertEqual(safety_level_label("block"), "禁止写回")
 
+    def test_safety_level_label_case_insensitive(self):
+        self.assertEqual(safety_level_label("Safe"), "可写回")
+        self.assertEqual(safety_level_label("WARN"), "需处理")
+        self.assertEqual(safety_level_label("Block"), "禁止写回")
+
     def test_doctor_mode_label_maps_known_values(self):
         self.assertEqual(doctor_mode_label("can_generate_template"), "可生成翻译模板")
+        self.assertEqual(doctor_mode_label("existing_tl_only"), "仅处理已有翻译文件")
+        self.assertEqual(doctor_mode_label("blocked_missing_template"), "缺少模板且无法生成")
 
     def test_job_state_label_maps_known_values(self):
         self.assertEqual(job_state_label("JOB_STATE_SUCCEEDED"), "已完成")
+        self.assertEqual(job_state_label("JOB_STATE_FAILED"), "失败")
+        self.assertEqual(job_state_label("JOB_STATE_CANCELLED"), "已取消")
+        self.assertEqual(job_state_label("JOB_STATE_EXPIRED"), "已过期")
+        self.assertEqual(job_state_label("JOB_STATE_PENDING"), "排队中")
+        self.assertEqual(job_state_label("JOB_STATE_RUNNING"), "处理中")
 
     def test_format_manifest_path_fact_uses_chinese_label(self):
         self.assertEqual(

--- a/tests/test_gui_user_copy.py
+++ b/tests/test_gui_user_copy.py
@@ -2,8 +2,10 @@ import unittest
 
 from gui_qt.user_copy import (
     doctor_mode_label,
+    format_bootstrap_fact,
     format_manifest_path_fact,
     job_state_label,
+    manifest_mode_label,
     safety_level_label,
     translate_doctor_warning,
 )
@@ -32,6 +34,13 @@ class GuiUserCopyTests(unittest.TestCase):
             "old/new line counts differ; string translation blocks may be malformed."
         )
         self.assertIn("界面字符串块", translated)
+
+    def test_manifest_mode_label_falls_back_for_empty_and_unknown(self):
+        self.assertEqual(manifest_mode_label(""), "未知")
+        self.assertEqual(manifest_mode_label("custom_mode"), "custom_mode")
+
+    def test_format_bootstrap_fact_passthrough_unknown_key(self):
+        self.assertEqual(format_bootstrap_fact("unknown_key", "42"), "unknown_key：42")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Localize GUI summaries and trim technical jargon for normal users.

- Add \gui_qt/user_copy.py\ for shared labels (safe/warn/block, job states, doctor warnings, bootstrap field names)
- Diagnostics: \Manifest\ → 任务清单, \CLI 命令\ → 命令参考; 翻译包 / 云端任务 / 最近任务指针
- Writeback / workflow: 可写回 / 需处理 / 禁止写回 instead of bare safe/warn/block
- Doctor: Chinese mode labels, translated warnings, simplified scan facts (works with pending stats when #86 lands)
- Config hints shortened; model names and raw command output unchanged

## Test plan

- [x] \python -m unittest discover -s tests -p test_gui*.py -q\

Refs #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **UI/UX Improvements**
  * Updated the API key dialog hint to reference a local configuration file while keeping the privacy reassurance.
  * Refreshed and standardized user-facing Chinese wording across the workbench, diagnostics, doctor, bootstrap, and translation workflow—improving clarity for manifest paths, job states, safety/doctor results, and empty/waiting/failed states.
  * Simplified some workflow UI text (including batch “thinking level” display) and improved placeholder/idle guidance.

* **Testing**
  * Updated GUI tests to match the revised localized text and standardized displayed facts, including added coverage for shared label/formatter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->