### PR TITLE
fix(gui): stop inner tab bar shifting on selection

### DIFF
--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -160,7 +160,6 @@ QTabWidget#diagnostics_inner_tabs > QTabBar::tab {
 QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
     background-color: #ffffff;
     color: #2563eb;
-    font-weight: 600;
 }
 
 QLabel#diagnostics_section_label {
@@ -270,7 +269,6 @@ QTabWidget#workbench_status_tabs > QTabBar::tab {
 QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
     background-color: #ffffff;
     color: #2563eb;
-    font-weight: 600;
 }
 
 /* Project Path Frame styling */

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -160,7 +160,6 @@ QTabWidget#diagnostics_inner_tabs > QTabBar::tab {
 QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
     background-color: #1e293b;
     color: #60a5fa;
-    font-weight: 600;
 }
 
 QLabel#diagnostics_section_label {
@@ -270,7 +269,6 @@ QTabWidget#workbench_status_tabs > QTabBar::tab {
 QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
     background-color: #1e293b;
     color: #60a5fa;
-    font-weight: 600;
 }
 
 /* Project Path Frame styling */


### PR DESCRIPTION
## Summary

Inner workbench and diagnostics tabs jumped horizontally when switching pages because the selected tab used font-weight 600 while unselected tabs used 500, changing label width.

This removes the selected-state font-weight bump and keeps selection indicated by background and text color only.

## Test plan

- [x] Launch GUI and switch workbench inner tabs (环境检查 / 翻译进度 / 写回); tab bar stays stable
- [x] Switch diagnostics inner tabs (任务上下文 / 命令参考 / 任务清单); tab bar stays stable
- [x] Verify in both light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab styling so selected tabs in the diagnostics and workbench areas no longer appear bold in both light and dark themes.
  * Kept the selected tab background and text colors unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->