### PR TITLE
feat(gui): retry package preview and confirmation (#94)

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -692,46 +692,77 @@ class MainWindow(QMainWindow):
         except ValueError:
             return None
 
-    def _remediation_ready(self, summary: WritebackSummary) -> bool:
+    def _remediation_ready(
+        self,
+        summary: WritebackSummary,
+        *,
+        manifest: dict[str, object] | None = None,
+    ) -> bool:
         if not self._writeback_issues_ready(summary):
             return False
-        manifest = self._load_writeback_manifest()
-        if manifest is None:
+        loaded = manifest if manifest is not None else self._load_writeback_manifest()
+        if loaded is None:
             return False
         return retry_followup_allowed(
-            manifest,
+            loaded,
             parent_manifest_path=summary.manifest_path,
             confirmed_parent_paths=self._retry_followup_confirmed,
         )
 
-    def _retry_button_mode(self, summary: WritebackSummary) -> str:
+    def _retry_button_mode(
+        self,
+        summary: WritebackSummary,
+        *,
+        manifest: dict[str, object] | None = None,
+    ) -> str:
         if not self._writeback_issues_ready(summary):
             return "hidden"
-        manifest = self._load_writeback_manifest()
-        if manifest is None:
+        loaded = manifest if manifest is not None else self._load_writeback_manifest()
+        if loaded is None:
             return "hidden"
-        if existing_retry_manifest_path(manifest):
+        if existing_retry_manifest_path(loaded):
             return "view"
         eligibility = assess_retry_eligibility(
-            manifest,
+            loaded,
             manifest_path=summary.manifest_path,
         )
         return "build" if eligibility.eligible else "hidden"
 
-    def _update_retry_button(self, summary: WritebackSummary) -> None:
-        if not hasattr(self, "retry_btn"):
-            return
-        mode = self._retry_button_mode(summary)
-        running = self.kill_btn.isEnabled()
-        if mode == "hidden":
-            self.retry_btn.setVisible(False)
-            self.retry_btn.setEnabled(False)
-            return
-        self.retry_btn.setVisible(True)
-        self.retry_btn.setText(
-            "查看 retry 包" if mode == "view" else "生成 retry 包"
-        )
-        self.retry_btn.setEnabled(not running)
+    def _update_writeback_action_buttons(
+        self,
+        summary: WritebackSummary,
+        *,
+        running: bool,
+    ) -> None:
+        issues_ready = self._writeback_issues_ready(summary)
+        manifest = self._load_writeback_manifest() if issues_ready else None
+
+        if hasattr(self, "check_issues_btn"):
+            self.check_issues_btn.setEnabled(not running and issues_ready)
+
+        if hasattr(self, "retry_btn"):
+            mode = (
+                self._retry_button_mode(summary, manifest=manifest)
+                if issues_ready
+                else "hidden"
+            )
+            if mode == "hidden":
+                self.retry_btn.setVisible(False)
+                self.retry_btn.setEnabled(False)
+            else:
+                self.retry_btn.setVisible(True)
+                self.retry_btn.setText(
+                    "查看 retry 包" if mode == "view" else "生成 retry 包"
+                )
+                self.retry_btn.setEnabled(not running)
+
+        if hasattr(self, "remediation_btn"):
+            remediation_ready = (
+                self._remediation_ready(summary, manifest=manifest)
+                if issues_ready
+                else False
+            )
+            self.remediation_btn.setEnabled(not running and remediation_ready)
 
     def _show_retry_preview(
         self,
@@ -758,11 +789,10 @@ class MainWindow(QMainWindow):
         if parent_path:
             self._retry_followup_confirmed.add(parent_path)
         summary = self._current_writeback_summary()
-        self._update_retry_button(summary)
-        if hasattr(self, "remediation_btn"):
-            self.remediation_btn.setEnabled(
-                self._remediation_ready(summary) and not self.kill_btn.isEnabled()
-            )
+        self._update_writeback_action_buttons(
+            summary,
+            running=self.kill_btn.isEnabled(),
+        )
         if open_remediation_on_confirm:
             self._open_remediation_commands()
         else:
@@ -1266,14 +1296,7 @@ class MainWindow(QMainWindow):
         self.save_config_btn.setEnabled(not running)
         writeback_summary = self._current_writeback_summary()
         self.apply_btn.setEnabled(not running and writeback_summary.can_apply)
-        issues_ready = self._writeback_issues_ready(writeback_summary)
-        if hasattr(self, "check_issues_btn"):
-            self.check_issues_btn.setEnabled(not running and issues_ready)
-        self._update_retry_button(writeback_summary)
-        if hasattr(self, "remediation_btn"):
-            self.remediation_btn.setEnabled(
-                not running and self._remediation_ready(writeback_summary)
-            )
+        self._update_writeback_action_buttons(writeback_summary, running=running)
         self.bootstrap_rag_btn.setEnabled(not running)
         self.bootstrap_source_index_btn.setEnabled(not running)
         self.kill_btn.setEnabled(running)
@@ -1333,16 +1356,10 @@ class MainWindow(QMainWindow):
         self.writeback_message_label.setText(summary.message)
         self.writeback_facts_label.setText("\n".join(summary.facts))
         self._set_details_label(self.writeback_details_label, summary.findings)
-        issues_ready = self._writeback_issues_ready(summary)
-        if hasattr(self, "check_issues_btn"):
-            self.check_issues_btn.setEnabled(
-                issues_ready and not self.kill_btn.isEnabled()
-            )
-        self._update_retry_button(summary)
-        if hasattr(self, "remediation_btn"):
-            self.remediation_btn.setEnabled(
-                self._remediation_ready(summary) and not self.kill_btn.isEnabled()
-            )
+        self._update_writeback_action_buttons(
+            summary,
+            running=self.kill_btn.isEnabled(),
+        )
         if not self.kill_btn.isEnabled():
             self.apply_btn.setEnabled(summary.can_apply)
 
@@ -1467,8 +1484,6 @@ class MainWindow(QMainWindow):
             self._active_command = ""
             self._set_task_running(False)
             self._refresh_diagnostics_context()
-            summary = self._current_writeback_summary()
-            self._update_retry_button(summary)
             if result.status == "ok":
                 parent_manifest = self._load_writeback_manifest()
                 retry_path = ""

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -59,6 +59,15 @@ from .check_report import (
 from .diagnostics_context import (
     DiagnosticsContext,
     build_diagnostics_context,
+    existing_retry_manifest_path,
+)
+from .retry_preview_dialog import RetryPreviewDialog
+from .retry_report import (
+    assess_retry_eligibility,
+    build_retry_cli_args,
+    parse_build_retry_output,
+    retry_followup_allowed,
+    summarize_retry_manifest,
 )
 from .cli_runner import CliRunner
 from .doctor_report import (
@@ -109,6 +118,8 @@ class MainWindow(QMainWindow):
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
         self._bootstrap_output_lines: list[str] = []
+        self._build_retry_output_lines: list[str] = []
+        self._retry_followup_confirmed: set[str] = set()
         self._writeback_manifest_path = ""
 
         central = QWidget()
@@ -285,6 +296,12 @@ class MainWindow(QMainWindow):
         self.check_issues_btn.clicked.connect(self._open_check_issues)
         self.check_issues_btn.setEnabled(False)
         writeback_actions.addWidget(self.check_issues_btn)
+        self.retry_btn = QPushButton("生成 retry 包")
+        self.retry_btn.setObjectName("secondary_btn")
+        self.retry_btn.clicked.connect(self._on_retry_action)
+        self.retry_btn.setEnabled(False)
+        self.retry_btn.setVisible(False)
+        writeback_actions.addWidget(self.retry_btn)
         self.remediation_btn = QPushButton("补救命令")
         self.remediation_btn.setObjectName("secondary_btn")
         self.remediation_btn.clicked.connect(self._open_remediation_commands)
@@ -666,6 +683,143 @@ class MainWindow(QMainWindow):
 
     def _writeback_issues_ready(self, summary: WritebackSummary) -> bool:
         return summary.status == "warn" and bool(summary.manifest_path)
+
+    def _load_writeback_manifest(self) -> dict[str, object] | None:
+        if not self._writeback_manifest_path:
+            return None
+        try:
+            return self.state.load_manifest_file(self._writeback_manifest_path)
+        except ValueError:
+            return None
+
+    def _remediation_ready(self, summary: WritebackSummary) -> bool:
+        if not self._writeback_issues_ready(summary):
+            return False
+        manifest = self._load_writeback_manifest()
+        if manifest is None:
+            return False
+        return retry_followup_allowed(
+            manifest,
+            parent_manifest_path=summary.manifest_path,
+            confirmed_parent_paths=self._retry_followup_confirmed,
+        )
+
+    def _retry_button_mode(self, summary: WritebackSummary) -> str:
+        if not self._writeback_issues_ready(summary):
+            return "hidden"
+        manifest = self._load_writeback_manifest()
+        if manifest is None:
+            return "hidden"
+        if existing_retry_manifest_path(manifest):
+            return "view"
+        eligibility = assess_retry_eligibility(
+            manifest,
+            manifest_path=summary.manifest_path,
+        )
+        return "build" if eligibility.eligible else "hidden"
+
+    def _update_retry_button(self, summary: WritebackSummary) -> None:
+        if not hasattr(self, "retry_btn"):
+            return
+        mode = self._retry_button_mode(summary)
+        running = self.kill_btn.isEnabled()
+        if mode == "hidden":
+            self.retry_btn.setVisible(False)
+            self.retry_btn.setEnabled(False)
+            return
+        self.retry_btn.setVisible(True)
+        self.retry_btn.setText(
+            "查看 retry 包" if mode == "view" else "生成 retry 包"
+        )
+        self.retry_btn.setEnabled(not running)
+
+    def _show_retry_preview(
+        self,
+        retry_manifest_path: str,
+        *,
+        open_remediation_on_confirm: bool = False,
+    ) -> None:
+        try:
+            retry_manifest = self.state.load_manifest_file(retry_manifest_path)
+        except ValueError as exc:
+            QMessageBox.warning(self, "无法预览 retry 包", str(exc))
+            return
+
+        report = summarize_retry_manifest(
+            retry_manifest,
+            manifest_path=retry_manifest_path,
+        )
+        dialog = RetryPreviewDialog(self, report=report)
+        dialog.exec()
+        if not dialog.confirmed:
+            return
+
+        parent_path = report.parent_manifest_path or self._writeback_manifest_path
+        if parent_path:
+            self._retry_followup_confirmed.add(parent_path)
+        summary = self._current_writeback_summary()
+        self._update_retry_button(summary)
+        if hasattr(self, "remediation_btn"):
+            self.remediation_btn.setEnabled(
+                self._remediation_ready(summary) and not self.kill_btn.isEnabled()
+            )
+        if open_remediation_on_confirm:
+            self._open_remediation_commands()
+        else:
+            self.statusBar().showMessage("已确认 retry 包范围。", 3000)
+
+    def _on_retry_action(self) -> None:
+        summary = self._current_writeback_summary()
+        mode = self._retry_button_mode(summary)
+        if mode == "view":
+            manifest = self._load_writeback_manifest()
+            if manifest is None:
+                return
+            retry_path = existing_retry_manifest_path(manifest)
+            if retry_path:
+                self._show_retry_preview(retry_path)
+            return
+
+        if mode != "build" or not self._writeback_manifest_path:
+            return
+
+        manifest = self._load_writeback_manifest()
+        if manifest is None:
+            QMessageBox.warning(self, "无法生成 retry 包", "无法读取当前任务清单。")
+            return
+
+        eligibility = assess_retry_eligibility(
+            manifest,
+            manifest_path=self._writeback_manifest_path,
+        )
+        reply = QMessageBox.question(
+            self,
+            "确认生成 retry 包",
+            "\n".join(
+                [
+                    eligibility.message,
+                    "",
+                    "将运行 build-retry 生成本地 retry 包。",
+                    "GUI 不会自动提交云端任务；生成后会先预览范围。",
+                ]
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self._active_command = "build_retry"
+        self._build_retry_output_lines = []
+        self._set_task_running(True)
+        self._append_log(
+            "\n=== 正在生成 retry 包："
+            f"gemini_translate_batch.py {' '.join(build_retry_cli_args(self._writeback_manifest_path))} ===\n"
+        )
+        self.runner.run(
+            self.state.get_batch_script_path(),
+            build_retry_cli_args(self._writeback_manifest_path),
+        )
 
     def _open_check_issues(self) -> None:
         manifest_path = self._writeback_manifest_path
@@ -1091,6 +1245,8 @@ class MainWindow(QMainWindow):
             self._workflow_step_output_lines.append(text)
         elif self._active_command == "apply":
             self._apply_output_lines.append(text)
+        elif self._active_command == "build_retry":
+            self._build_retry_output_lines.append(text)
         elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
             self._bootstrap_output_lines.append(text)
         self._append_log(text)
@@ -1113,8 +1269,11 @@ class MainWindow(QMainWindow):
         issues_ready = self._writeback_issues_ready(writeback_summary)
         if hasattr(self, "check_issues_btn"):
             self.check_issues_btn.setEnabled(not running and issues_ready)
+        self._update_retry_button(writeback_summary)
         if hasattr(self, "remediation_btn"):
-            self.remediation_btn.setEnabled(not running and issues_ready)
+            self.remediation_btn.setEnabled(
+                not running and self._remediation_ready(writeback_summary)
+            )
         self.bootstrap_rag_btn.setEnabled(not running)
         self.bootstrap_source_index_btn.setEnabled(not running)
         self.kill_btn.setEnabled(running)
@@ -1179,9 +1338,10 @@ class MainWindow(QMainWindow):
             self.check_issues_btn.setEnabled(
                 issues_ready and not self.kill_btn.isEnabled()
             )
+        self._update_retry_button(summary)
         if hasattr(self, "remediation_btn"):
             self.remediation_btn.setEnabled(
-                issues_ready and not self.kill_btn.isEnabled()
+                self._remediation_ready(summary) and not self.kill_btn.isEnabled()
             )
         if not self.kill_btn.isEnabled():
             self.apply_btn.setEnabled(summary.can_apply)
@@ -1253,6 +1413,8 @@ class MainWindow(QMainWindow):
             self._workflow_step_output_lines.append(message)
         elif self._active_command == "apply":
             self._apply_output_lines.append(message)
+        elif self._active_command == "build_retry":
+            self._build_retry_output_lines.append(message)
         elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
             self._bootstrap_output_lines.append(message)
         self._focus_log_tab()
@@ -1295,6 +1457,34 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("翻译写回完成。", 6000)
             else:
                 self.statusBar().showMessage("翻译写回失败，请查看诊断日志。", 8000)
+            return
+
+        if self._active_command == "build_retry":
+            result = parse_build_retry_output(
+                "\n".join(self._build_retry_output_lines),
+                exit_code,
+            )
+            self._active_command = ""
+            self._set_task_running(False)
+            self._refresh_diagnostics_context()
+            summary = self._current_writeback_summary()
+            self._update_retry_button(summary)
+            if result.status == "ok":
+                parent_manifest = self._load_writeback_manifest()
+                retry_path = ""
+                if parent_manifest is not None:
+                    retry_path = existing_retry_manifest_path(parent_manifest)
+                if not retry_path:
+                    retry_path = result.retry_manifest_path
+                if retry_path:
+                    self._show_retry_preview(
+                        retry_path,
+                        open_remediation_on_confirm=True,
+                    )
+                self.statusBar().showMessage("retry 包已生成，请先确认预览范围。", 6000)
+            else:
+                QMessageBox.warning(self, result.heading, result.message)
+                self.statusBar().showMessage(result.heading, 6000)
             return
 
         if self._active_command == "bootstrap_rag":

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -145,7 +145,7 @@ def summarize_check_output(
         return WritebackSummary(
             status="warn",
             heading="需要先处理问题",
-            message="检查结果为需处理, 暂不应写回。可点击「查看问题清单」了解失败原因, 或「补救命令」查看 retry 参考命令; 处理后重新检查, 只有 safe 才能写回。",
+            message="检查结果为需处理, 暂不应写回。可先「查看问题清单」, 适合时「生成 retry 包」并预览范围, 或到「补救命令」查看后续步骤; 处理后重新检查, 只有 safe 才能写回。",
             facts=facts,
             findings=findings,
             can_apply=False,
@@ -288,7 +288,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
         return WritebackSummary(
             status="warn",
             heading="需要先处理问题",
-            message="最近一次检查结果为需处理, 不应写回。可点击「查看问题清单」了解失败原因, 或「补救命令」查看 retry 参考命令; 处理后重新检查, 只有 safe 才能写回。",
+            message="最近一次检查结果为需处理, 不应写回。可先「查看问题清单」, 适合时「生成 retry 包」并预览范围, 或到「补救命令」查看后续步骤; 处理后重新检查, 只有 safe 才能写回。",
             facts=facts,
             findings=findings,
             can_apply=False,

--- a/gui_qt/retry_preview_dialog.py
+++ b/gui_qt/retry_preview_dialog.py
@@ -1,0 +1,104 @@
+"""Dialog for previewing a generated retry package before follow-up steps."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .retry_report import RetryPreviewReport
+
+
+class RetryPreviewDialog(QDialog):
+    """Modal dialog that previews retry package scope and asks for confirmation."""
+
+    def __init__(self, parent: QWidget | None, *, report: RetryPreviewReport):
+        super().__init__(parent)
+        self.setObjectName("retry_preview_dialog")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setWindowTitle("retry 包预览")
+        self.setModal(True)
+        self.resize(720, 560)
+        self._report = report
+        self._confirmed = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        heading = QLabel(report.heading)
+        heading.setObjectName("writeback_status_label")
+        layout.addWidget(heading)
+
+        message = QLabel(report.message)
+        message.setWordWrap(True)
+        message.setObjectName("summary_body_label")
+        layout.addWidget(message)
+
+        if report.facts:
+            facts = QLabel("\n".join(report.facts))
+            facts.setWordWrap(True)
+            facts.setObjectName("writeback_facts_label")
+            layout.addWidget(facts)
+
+        layout.addWidget(QLabel("预览详情："))
+
+        self.detail_view = QPlainTextEdit()
+        self.detail_view.setObjectName("retry_preview_detail_view")
+        self.detail_view.setReadOnly(True)
+        self.detail_view.setPlainText("\n".join(report.detail_lines))
+        self.detail_view.setMinimumHeight(280)
+        layout.addWidget(self.detail_view)
+
+        actions = QHBoxLayout()
+        if report.retry_manifest_path:
+            copy_manifest_btn = QPushButton("复制 retry 清单路径")
+            copy_manifest_btn.setObjectName("secondary_btn")
+            copy_manifest_btn.clicked.connect(self._copy_retry_manifest_path)
+            actions.addWidget(copy_manifest_btn)
+        if report.package_dir:
+            copy_package_btn = QPushButton("复制 retry 包路径")
+            copy_package_btn.setObjectName("secondary_btn")
+            copy_package_btn.clicked.connect(self._copy_package_dir)
+            actions.addWidget(copy_package_btn)
+        actions.addStretch()
+        layout.addLayout(actions)
+
+        buttons = QDialogButtonBox()
+        confirm_btn = buttons.addButton("确认并查看补救命令", QDialogButtonBox.ButtonRole.AcceptRole)
+        close_btn = buttons.addButton("关闭", QDialogButtonBox.ButtonRole.RejectRole)
+        if confirm_btn is not None:
+            confirm_btn.setObjectName("apply_btn")
+        if close_btn is not None:
+            close_btn.setObjectName("secondary_btn")
+        buttons.accepted.connect(self._on_confirm)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    @property
+    def confirmed(self) -> bool:
+        return self._confirmed
+
+    def _on_confirm(self) -> None:
+        self._confirmed = True
+        self.accept()
+
+    def _copy_retry_manifest_path(self) -> None:
+        self._copy_text(self._report.retry_manifest_path)
+
+    def _copy_package_dir(self) -> None:
+        self._copy_text(self._report.package_dir)
+
+    def _copy_text(self, text: str) -> None:
+        from PySide6.QtGui import QGuiApplication
+
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(text)

--- a/gui_qt/retry_report.py
+++ b/gui_qt/retry_report.py
@@ -1,0 +1,234 @@
+"""Retry package eligibility, CLI parsing, and preview summaries for the GUI."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .check_failures_report import (
+    REASON_CATEGORY_REPAIR,
+    REASON_CATEGORY_RETRY,
+    build_check_issues_report,
+    reason_code_label,
+)
+from .diagnostics_context import existing_retry_manifest_path, manifest_check_safety_level
+from .user_copy import format_manifest_path_fact
+
+_MANIFEST_LINE_RE = re.compile(r"^\s*Manifest:\s*(.+?)\s*$", re.MULTILINE)
+_RETRY_PACKAGE_LINE_RE = re.compile(r"^\s*Created retry package:\s*(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class RetryEligibility:
+    eligible: bool
+    heading: str
+    message: str
+
+
+@dataclass(frozen=True)
+class BuildRetryResult:
+    status: str
+    heading: str
+    message: str
+    retry_manifest_path: str = ""
+    package_dir: str = ""
+
+
+@dataclass(frozen=True)
+class RetryPreviewReport:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    detail_lines: list[str]
+    retry_manifest_path: str
+    parent_manifest_path: str
+    package_dir: str
+    chunk_count: int
+    item_count: int
+    file_count: int
+
+
+def assess_retry_eligibility(
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+) -> RetryEligibility:
+    """Return whether the current warn state is a good candidate for build-retry."""
+    if manifest_check_safety_level(manifest) != "warn":
+        return RetryEligibility(
+            eligible=False,
+            heading="暂不适合 retry",
+            message="只有最近一次 check 为需处理时，才可能生成 retry 包。",
+        )
+
+    report = build_check_issues_report(manifest, manifest_path=manifest_path)
+    retry_count = report.category_counts.get(REASON_CATEGORY_RETRY, 0)
+    repair_count = report.category_counts.get(REASON_CATEGORY_REPAIR, 0)
+
+    if retry_count > 0:
+        return RetryEligibility(
+            eligible=True,
+            heading="可生成 retry 包",
+            message=(
+                f"检测到 {retry_count} 个适合 retry 的问题项。"
+                "生成后请先预览范围，确认后再到补救命令里手动提交任务。"
+            ),
+        )
+
+    if repair_count > 0:
+        return RetryEligibility(
+            eligible=False,
+            heading="不建议直接 retry",
+            message="当前问题更适合 repair 或人工处理，不建议直接生成 retry 包。",
+        )
+
+    return RetryEligibility(
+        eligible=False,
+        heading="不适合 retry",
+        message="当前问题属于源文件漂移、重定位失败或需重新 build/check 的类型，不应默认走 retry。",
+    )
+
+
+def parse_build_retry_output(output: str, exit_code: int) -> BuildRetryResult:
+    """Parse build-retry stdout into a structured result."""
+    if exit_code != 0:
+        return BuildRetryResult(
+            status="failed",
+            heading="生成 retry 包失败",
+            message="build-retry 没有正常完成，请查看诊断日志。",
+        )
+
+    if "No retry chunks needed." in output:
+        return BuildRetryResult(
+            status="empty",
+            heading="无需 retry",
+            message="当前没有需要重新翻译的 chunk，请回到问题清单确认原因。",
+        )
+
+    manifest_match = _MANIFEST_LINE_RE.search(output)
+    package_match = _RETRY_PACKAGE_LINE_RE.search(output)
+    retry_manifest_path = manifest_match.group(1).strip() if manifest_match else ""
+    package_dir = package_match.group(1).strip() if package_match else ""
+
+    if not retry_manifest_path:
+        return BuildRetryResult(
+            status="unknown",
+            heading="retry 包状态不明确",
+            message="命令已结束，但未能从输出中识别 retry manifest 路径，请查看诊断日志。",
+        )
+
+    return BuildRetryResult(
+        status="ok",
+        heading="retry 包已生成",
+        message="请预览 retry 范围并确认后，再到补救命令里手动执行后续步骤。",
+        retry_manifest_path=retry_manifest_path,
+        package_dir=package_dir,
+    )
+
+
+def _sorted_file_paths(files: object) -> list[str]:
+    if isinstance(files, dict):
+        return sorted(str(path) for path in files.keys() if str(path).strip())
+    return []
+
+
+def _format_reason_count_lines(reason_counts: object) -> list[str]:
+    if not isinstance(reason_counts, dict) or not reason_counts:
+        return ["- 未记录 retry 原因统计"]
+
+    lines: list[str] = []
+    for reason_code, count in sorted(reason_counts.items()):
+        if not isinstance(reason_code, str) or not reason_code.strip():
+            continue
+        if not isinstance(count, int) or count <= 0:
+            continue
+        lines.append(f"- {reason_code_label(reason_code)} ({reason_code})：{count}")
+    return lines or ["- 未记录 retry 原因统计"]
+
+
+def summarize_retry_manifest(
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+) -> RetryPreviewReport:
+    """Build a user-facing preview report from a retry child manifest."""
+    if not manifest_path:
+        raw_path = manifest.get("_manifest_path")
+        manifest_path = raw_path.strip() if isinstance(raw_path, str) else ""
+
+    parent_manifest_path = manifest.get("retry_of_manifest")
+    parent_text = parent_manifest_path.strip() if isinstance(parent_manifest_path, str) else ""
+
+    summary = manifest.get("summary")
+    chunk_count = 0
+    item_count = 0
+    file_count = 0
+    if isinstance(summary, dict):
+        if isinstance(summary.get("chunk_count"), int):
+            chunk_count = summary["chunk_count"]
+        if isinstance(summary.get("item_count"), int):
+            item_count = summary["item_count"]
+        if isinstance(summary.get("file_count"), int):
+            file_count = summary["file_count"]
+
+    package_dir = manifest.get("_package_dir")
+    if not isinstance(package_dir, str) or not package_dir.strip():
+        if manifest_path:
+            from .diagnostics_context import resolve_package_dir
+
+            package_dir = resolve_package_dir(manifest_path, manifest)
+        else:
+            package_dir = ""
+
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(format_manifest_path_fact(manifest_path))
+    if parent_text:
+        facts.append(f"父任务清单：{parent_text}")
+    if package_dir:
+        facts.append(f"retry 包目录：{package_dir}")
+    facts.append(f"影响范围：{file_count} 个文件，{chunk_count} 个 chunk，{item_count} 个条目")
+
+    reason_lines = _format_reason_count_lines(manifest.get("retry_reason_counts"))
+    file_paths = _sorted_file_paths(manifest.get("files"))
+    detail_lines = ["【retry 原因统计】", *reason_lines]
+    if file_paths:
+        detail_lines.append("")
+        detail_lines.append("【涉及文件】")
+        detail_lines.extend(f"- {path}" for path in file_paths)
+
+    return RetryPreviewReport(
+        status="ok",
+        heading="retry 包预览",
+        message=(
+            "请确认影响范围后再继续。"
+            "GUI 不会自动提交 retry 任务；确认后可到「补救命令」手动执行 submit / download / merge-retry。"
+        ),
+        facts=facts,
+        detail_lines=detail_lines,
+        retry_manifest_path=manifest_path,
+        parent_manifest_path=parent_text,
+        package_dir=package_dir if isinstance(package_dir, str) else "",
+        chunk_count=chunk_count,
+        item_count=item_count,
+        file_count=file_count,
+    )
+
+
+def retry_followup_allowed(
+    manifest: dict[str, object],
+    *,
+    parent_manifest_path: str,
+    confirmed_parent_paths: set[str] | frozenset[str],
+) -> bool:
+    """Return whether remediation commands for submit/merge may be shown as next steps."""
+    if not parent_manifest_path:
+        return False
+    if not existing_retry_manifest_path(manifest):
+        return True
+    return parent_manifest_path in confirmed_parent_paths
+
+
+def build_retry_cli_args(parent_manifest_path: str) -> list[str]:
+    """Return CLI args for build-retry; kept separate to make non-submit behavior testable."""
+    return ["build-retry", parent_manifest_path]

--- a/tests/test_gui_retry_report.py
+++ b/tests/test_gui_retry_report.py
@@ -1,0 +1,143 @@
+import unittest
+
+from gui_qt.retry_report import (
+    assess_retry_eligibility,
+    build_retry_cli_args,
+    parse_build_retry_output,
+    retry_followup_allowed,
+    summarize_retry_manifest,
+)
+
+BUILD_RETRY_OUTPUT_OK = """
+Created retry package: C:\\pkg\\retry_parts\\20260625_retry
+Retry chunks: 2
+Retry items: 5
+Failure items considered: 5
+Manifest: C:\\pkg\\retry_parts\\20260625_retry\\manifest.json
+"""
+
+RETRY_MANIFEST = {
+    "_manifest_path": r"C:\pkg\retry_parts\20260625_retry\manifest.json",
+    "retry_of_manifest": r"C:\pkg\manifest.json",
+    "summary": {
+        "file_count": 2,
+        "chunk_count": 2,
+        "item_count": 5,
+    },
+    "retry_reason_counts": {
+        "response_missing_item_id": 2,
+        "partial_result_items": 1,
+    },
+    "files": {
+        "game/tl/schinese/script.rpy": {},
+        "game/tl/schinese/common.rpy": {},
+    },
+}
+
+
+class GuiRetryReportTests(unittest.TestCase):
+    def test_assess_retry_eligibility_accepts_retry_reasons(self):
+        eligibility = assess_retry_eligibility(
+            {
+                "last_check_summary": {
+                    "safety_level": "warn",
+                    "safety_reasons": {
+                        "warn": {"response_missing_item_id": 2},
+                    },
+                },
+            }
+        )
+
+        self.assertTrue(eligibility.eligible)
+
+    def test_assess_retry_eligibility_rejects_manual_only_reasons(self):
+        eligibility = assess_retry_eligibility(
+            {
+                "last_check_summary": {
+                    "safety_level": "warn",
+                    "safety_reasons": {
+                        "block": {"source_text_mismatch": 1},
+                    },
+                },
+            }
+        )
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_assess_retry_eligibility_requires_warn(self):
+        eligibility = assess_retry_eligibility(
+            {
+                "last_check_summary": {
+                    "safety_level": "safe",
+                    "safety_reasons": {
+                        "warn": {"response_missing_item_id": 1},
+                    },
+                },
+            }
+        )
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_parse_build_retry_output_extracts_manifest_path(self):
+        result = parse_build_retry_output(BUILD_RETRY_OUTPUT_OK, exit_code=0)
+
+        self.assertEqual(result.status, "ok")
+        self.assertTrue(result.retry_manifest_path.endswith("manifest.json"))
+        self.assertIn("retry_parts", result.package_dir)
+
+    def test_parse_build_retry_output_handles_no_chunks(self):
+        result = parse_build_retry_output("No retry chunks needed.\n", exit_code=0)
+
+        self.assertEqual(result.status, "empty")
+
+    def test_summarize_retry_manifest_includes_scope_and_reasons(self):
+        report = summarize_retry_manifest(RETRY_MANIFEST)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.chunk_count, 2)
+        self.assertEqual(report.item_count, 5)
+        self.assertEqual(report.file_count, 2)
+        self.assertEqual(report.parent_manifest_path, r"C:\pkg\manifest.json")
+        self.assertTrue(any("response_missing_item_id" in line for line in report.detail_lines))
+        self.assertTrue(any("script.rpy" in line for line in report.detail_lines))
+
+    def test_retry_followup_allowed_before_and_after_confirmation(self):
+        manifest_without_retry = {"last_check_summary": {"safety_level": "warn"}}
+        manifest_with_retry = {
+            "last_check_summary": {"safety_level": "warn"},
+            "last_retry_manifest_path": r"C:\pkg\retry_parts\retry1\manifest.json",
+        }
+        parent_path = r"C:\pkg\manifest.json"
+
+        self.assertTrue(
+            retry_followup_allowed(
+                manifest_without_retry,
+                parent_manifest_path=parent_path,
+                confirmed_parent_paths=set(),
+            )
+        )
+        self.assertFalse(
+            retry_followup_allowed(
+                manifest_with_retry,
+                parent_manifest_path=parent_path,
+                confirmed_parent_paths=set(),
+            )
+        )
+        self.assertTrue(
+            retry_followup_allowed(
+                manifest_with_retry,
+                parent_manifest_path=parent_path,
+                confirmed_parent_paths={parent_path},
+            )
+        )
+
+    def test_build_retry_cli_args_only_build_retry(self):
+        self.assertEqual(
+            build_retry_cli_args(r"C:\pkg\manifest.json"),
+            ["build-retry", r"C:\pkg\manifest.json"],
+        )
+        self.assertNotIn("submit", build_retry_cli_args(r"C:\pkg\manifest.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a controlled GUI retry remediation flow on top of the #93 issue list. Users can generate a retry package from the writeback tab, preview its scope, and only then access follow-up remediation commands.

## Changes

- New `gui_qt/retry_report.py` for retry eligibility, `build-retry` output parsing, and retry manifest summaries
- New `RetryPreviewDialog` showing package path, chunk/item/file counts, reason counts, parent manifest, and involved files
- Writeback tab button:
  - **生成 retry 包** when `check=warn` and failures are retry-suitable
  - **查看 retry 包** when `last_retry_manifest_path` already exists
- Runs only `build-retry`; does **not** auto-submit retry batches
- **补救命令** stays disabled after a retry package exists until the user confirms the preview
- Updated warn copy to mention the new retry flow
- Tests in `tests/test_gui_retry_report.py`

## Safety

- Retry button hidden for manual/rebuild-only warn cases (e.g. source drift, relocation missing)
- No `submit` / `merge-retry` automation added in GUI
- Parent manifest `check/apply` gates unchanged

## Test plan

- [x] `python -m unittest tests.test_gui_retry_report tests.test_gui_check_failures_report tests.test_gui_check_report tests.test_gui_diagnostics_context -v`
- [ ] Manual: reach `check=warn`, click **生成 retry 包**, confirm preview, then open **补救命令**

Closes #94
Refs #93
Refs #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Generate retry package” to the writeback workflow, including a retry preview confirmation step before running follow-up actions.
  * Introduced a retry preview dialog to review details and copy the retry manifest path and/or package directory.
  * Added eligibility checks that control when retry and follow-up actions are available.
* **Bug Fixes**
  * Improved retry build result handling and UI state refresh after retry execution, including correct status/error capture.
* **Tests**
  * Added unit tests for retry eligibility, build-output parsing, preview summary content, follow-up rules, and retry command construction.
* **Documentation**
  * Updated user warning text for the “needs prior issue handling” state to reflect the new retry/preview/remediation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->