### PR TITLE
feat(gui): structured apply failure diagnostics (#95)

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4982,6 +4982,7 @@ def check_results(target=None):
     manifest['last_check_at'] = datetime.now().isoformat(timespec='seconds')
     manifest['last_check_summary'] = summary
     manifest['last_check_report_path'] = check_report_path
+    manifest.pop('last_apply_failure_report_path', None)
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
     print(f"Manifest: {manifest['_manifest_path']}")
     print_check_summary(summary)
@@ -5085,6 +5086,7 @@ def apply_results(target=None, force=False):
         rag_apply_summary = sync_rag_store_for_jobs(rag_jobs, quality_state='batch_applied')
 
     manifest['applied_at'] = datetime.now().isoformat(timespec='seconds')
+    manifest.pop('last_apply_failure_report_path', None)
     manifest['apply_summary'] = {
         'applied_files': applied_files,
         'applied_lines': applied_lines,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -45,6 +45,11 @@ from .bootstrap_report import (
     summarize_rag_bootstrap_output,
     summarize_source_index_bootstrap_output,
 )
+from .apply_failure_dialog import ApplyFailureDialog
+from .apply_failure_report import (
+    apply_failure_report_available,
+    build_apply_failure_report,
+)
 from .check_failures_report import build_check_issues_report
 from .check_issues_dialog import CheckIssuesDialog
 from .check_report import (
@@ -302,6 +307,12 @@ class MainWindow(QMainWindow):
         self.retry_btn.setEnabled(False)
         self.retry_btn.setVisible(False)
         writeback_actions.addWidget(self.retry_btn)
+        self.apply_failure_btn = QPushButton("查看写回失败报告")
+        self.apply_failure_btn.setObjectName("secondary_btn")
+        self.apply_failure_btn.clicked.connect(self._open_apply_failure_report)
+        self.apply_failure_btn.setEnabled(False)
+        self.apply_failure_btn.setVisible(False)
+        writeback_actions.addWidget(self.apply_failure_btn)
         self.remediation_btn = QPushButton("补救命令")
         self.remediation_btn.setObjectName("secondary_btn")
         self.remediation_btn.clicked.connect(self._open_remediation_commands)
@@ -728,6 +739,37 @@ class MainWindow(QMainWindow):
         )
         return "build" if eligibility.eligible else "hidden"
 
+    def _apply_failure_report_ready(
+        self,
+        summary: WritebackSummary,
+        *,
+        manifest: dict[str, object] | None,
+    ) -> bool:
+        if summary.status == "failed" and summary.manifest_path:
+            return True
+        if manifest is None or not summary.manifest_path:
+            return False
+        return apply_failure_report_available(
+            manifest,
+            manifest_path=summary.manifest_path,
+        )
+
+    def _open_apply_failure_report(self) -> None:
+        manifest_path = self._writeback_manifest_path
+        if not manifest_path:
+            QMessageBox.warning(self, "无法查看写回失败报告", "当前没有可用的任务清单。")
+            return
+        try:
+            manifest = self.state.load_manifest_file(manifest_path)
+        except ValueError as exc:
+            QMessageBox.warning(self, "无法查看写回失败报告", str(exc))
+            return
+
+        report = build_apply_failure_report(manifest, manifest_path=manifest_path)
+        dialog = ApplyFailureDialog(self, report=report)
+        dialog.exec()
+        self.statusBar().showMessage("已查看写回失败报告。", 3000)
+
     def _update_writeback_action_buttons(
         self,
         summary: WritebackSummary,
@@ -735,10 +777,18 @@ class MainWindow(QMainWindow):
         running: bool,
     ) -> None:
         issues_ready = self._writeback_issues_ready(summary)
-        manifest = self._load_writeback_manifest() if issues_ready else None
+        manifest = self._load_writeback_manifest() if summary.manifest_path else None
 
         if hasattr(self, "check_issues_btn"):
             self.check_issues_btn.setEnabled(not running and issues_ready)
+
+        apply_failure_ready = self._apply_failure_report_ready(
+            summary,
+            manifest=manifest,
+        )
+        if hasattr(self, "apply_failure_btn"):
+            self.apply_failure_btn.setVisible(apply_failure_ready)
+            self.apply_failure_btn.setEnabled(not running and apply_failure_ready)
 
         if hasattr(self, "retry_btn"):
             mode = (

--- a/gui_qt/apply_failure_dialog.py
+++ b/gui_qt/apply_failure_dialog.py
@@ -1,0 +1,92 @@
+"""Dialog for displaying structured apply failure diagnostics."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .apply_failure_report import ApplyFailureReportView
+
+
+class ApplyFailureDialog(QDialog):
+    """Modal dialog that presents an apply failure diagnostic report."""
+
+    def __init__(self, parent: QWidget | None, *, report: ApplyFailureReportView):
+        super().__init__(parent)
+        self.setObjectName("apply_failure_dialog")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setWindowTitle("写回失败报告")
+        self.setModal(True)
+        self.resize(720, 560)
+        self._report = report
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        heading = QLabel(report.heading)
+        heading.setObjectName("writeback_status_label")
+        layout.addWidget(heading)
+
+        message = QLabel(report.message)
+        message.setWordWrap(True)
+        message.setObjectName("summary_body_label")
+        layout.addWidget(message)
+
+        if report.facts:
+            facts = QLabel("\n".join(report.facts))
+            facts.setWordWrap(True)
+            facts.setObjectName("writeback_facts_label")
+            layout.addWidget(facts)
+
+        layout.addWidget(QLabel("诊断详情："))
+
+        self.detail_view = QPlainTextEdit()
+        self.detail_view.setObjectName("apply_failure_detail_view")
+        self.detail_view.setReadOnly(True)
+        self.detail_view.setPlainText("\n".join(report.detail_lines))
+        self.detail_view.setMinimumHeight(280)
+        layout.addWidget(self.detail_view)
+
+        actions = QHBoxLayout()
+        if report.report_path:
+            copy_report_btn = QPushButton("复制报告路径")
+            copy_report_btn.setObjectName("secondary_btn")
+            copy_report_btn.clicked.connect(self._copy_report_path)
+            actions.addWidget(copy_report_btn)
+        if report.failures_path:
+            copy_failures_btn = QPushButton("复制失败明细路径")
+            copy_failures_btn.setObjectName("secondary_btn")
+            copy_failures_btn.clicked.connect(self._copy_failures_path)
+            actions.addWidget(copy_failures_btn)
+        actions.addStretch()
+        layout.addLayout(actions)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)
+        close_btn = buttons.button(QDialogButtonBox.StandardButton.Close)
+        if close_btn is not None:
+            close_btn.setText("关闭")
+        layout.addWidget(buttons)
+
+    def _copy_report_path(self) -> None:
+        self._copy_text(self._report.report_path)
+
+    def _copy_failures_path(self) -> None:
+        self._copy_text(self._report.failures_path)
+
+    def _copy_text(self, text: str) -> None:
+        from PySide6.QtGui import QGuiApplication
+
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(text)

--- a/gui_qt/apply_failure_report.py
+++ b/gui_qt/apply_failure_report.py
@@ -1,0 +1,401 @@
+"""Parse and summarize apply_failure_report.json for GUI diagnostics."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from .check_failures_report import (
+    CheckFailureItem,
+    normalize_failure_entry,
+    parse_check_failures_jsonl,
+    reason_code_label,
+    safe_preview,
+)
+from .diagnostics_context import join_directory_file, resolve_package_dir
+from .user_copy import format_manifest_path_fact, safety_level_label
+
+APPLY_REASON_CODE_LABELS = {
+    "missing_check": "缺少检查结果",
+    "stale_check_contract": "检查合约已过期",
+    "stale_check_fingerprint": "检查结果已过期",
+    "unsafe_check_status": "检查状态不安全",
+    "unsafe_apply_recheck": "写回前复检失败",
+    "unsafe_apply_revalidation": "源文件复检失败",
+    "unclassified_failure": "未分类写回失败",
+}
+
+APPLY_REASON_SUGGESTIONS = {
+    "missing_check": "请先对当前任务运行 check，确认 safe 后再尝试写回。",
+    "stale_check_contract": "检查规则已更新；请重新运行 check 生成新的检查摘要。",
+    "stale_check_fingerprint": "manifest、结果包或源文件在 check 之后有变化；请重新 check，不要重复 apply。",
+    "unsafe_check_status": "最近一次 check 不是 safe；请先处理问题并重新 check。",
+    "unsafe_apply_recheck": "写回前自动复检未通过；请查看失败条目，修复后重新 check。",
+    "unsafe_apply_revalidation": "源文件与检查结果不一致（可能已漂移）；请修复源文件后重新 build/check。",
+    "unclassified_failure": "请查看错误摘要与诊断日志，确认下一步操作。",
+}
+
+
+@dataclass(frozen=True)
+class ApplyFailureReportView:
+    status: str
+    heading: str
+    message: str
+    report_path: str
+    failures_path: str
+    reason_code: str
+    facts: list[str]
+    detail_lines: list[str]
+    failure_item_count: int
+
+
+def apply_reason_code_label(reason_code: str) -> str:
+    """Return a Chinese label for an apply failure reason code."""
+    text = str(reason_code or "").strip()
+    return APPLY_REASON_CODE_LABELS.get(text, reason_code_label(text))
+
+
+def apply_reason_suggestion(reason_code: str) -> str:
+    """Return next-step guidance for an apply failure reason code."""
+    text = str(reason_code or "").strip()
+    return APPLY_REASON_SUGGESTIONS.get(
+        text,
+        APPLY_REASON_SUGGESTIONS["unclassified_failure"],
+    )
+
+
+def resolve_apply_failure_report_path(
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+) -> str:
+    """Resolve apply_failure_report.json from manifest metadata."""
+    report_path = manifest.get("last_apply_failure_report_path")
+    if isinstance(report_path, str) and report_path.strip():
+        return report_path.strip()
+
+    package_dir = resolve_package_dir(manifest_path, manifest)
+    if package_dir:
+        return join_directory_file(package_dir, "apply_failure_report.json")
+    return ""
+
+
+def resolve_apply_failures_jsonl_path(
+    report_payload: dict[str, object],
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+) -> str:
+    """Resolve failures.jsonl path referenced by an apply failure report."""
+    failures_path = report_payload.get("failures_path")
+    if isinstance(failures_path, str) and failures_path.strip():
+        return failures_path.strip()
+
+    package_dir = resolve_package_dir(manifest_path, manifest)
+    if package_dir:
+        return join_directory_file(package_dir, "failures.jsonl")
+    return ""
+
+
+def parse_apply_failure_report_payload(payload: dict[str, object]) -> dict[str, object]:
+    """Normalize fields from apply_failure_report.json."""
+    reason_code = payload.get("reason_code")
+    reason_text = reason_code.strip() if isinstance(reason_code, str) else ""
+    if not reason_text:
+        reason_text = "unclassified_failure"
+
+    error = str(payload.get("error") or "").strip()
+    last_check_safety = payload.get("last_check_safety_level")
+    safety_text = (
+        last_check_safety.strip().lower()
+        if isinstance(last_check_safety, str) and last_check_safety.strip()
+        else ""
+    )
+
+    failure_count = payload.get("failure_count")
+    count = failure_count if isinstance(failure_count, int) else 0
+
+    summary = payload.get("summary")
+    summary_dict = summary if isinstance(summary, dict) else {}
+
+    fingerprint = payload.get("current_check_fingerprint")
+    fingerprint_dict = fingerprint if isinstance(fingerprint, dict) else {}
+
+    return {
+        "reason_code": reason_text,
+        "error": error,
+        "last_check_safety_level": safety_text,
+        "failure_count": count,
+        "summary": summary_dict,
+        "current_check_fingerprint": fingerprint_dict,
+        "timestamp": str(payload.get("timestamp") or "").strip(),
+        "last_check_at": str(payload.get("last_check_at") or "").strip(),
+        "manifest_path": str(payload.get("manifest_path") or "").strip(),
+        "failures_path": str(payload.get("failures_path") or "").strip(),
+    }
+
+
+def _default_path_exists(path: str) -> bool:
+    try:
+        return Path(path).exists()
+    except OSError:
+        return False
+
+
+def _default_read_file(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _format_fingerprint_facts(fingerprint: dict[str, object]) -> list[str]:
+    facts: list[str] = []
+    for key, label in (
+        ("pending_files", "待写回文件数"),
+        ("pending_lines", "待写回行数"),
+        ("failure_items", "失败项"),
+    ):
+        value = fingerprint.get(key)
+        if isinstance(value, int):
+            facts.append(f"当前指纹 {label}：{value}")
+    fingerprint_id = fingerprint.get("id")
+    if isinstance(fingerprint_id, str) and fingerprint_id.strip():
+        facts.append(f"当前检查指纹：{fingerprint_id.strip()}")
+    return facts
+
+
+def _format_summary_facts(summary: dict[str, object]) -> list[str]:
+    facts: list[str] = []
+    safety = summary.get("safety_level")
+    if isinstance(safety, str) and safety.strip():
+        facts.append(f"复检结果：{safety_level_label(safety.strip().lower())}")
+    for key, label in (
+        ("pending_files", "待写回文件数"),
+        ("pending_lines", "待写回行数"),
+        ("failure_items", "失败项"),
+        ("source_mismatch_items", "源文本不匹配"),
+    ):
+        value = summary.get(key)
+        if isinstance(value, int):
+            facts.append(f"{label}：{value}")
+    return facts
+
+
+def _format_failure_item_lines(
+    items: list[CheckFailureItem],
+    *,
+    omitted_count: int,
+) -> list[str]:
+    if not items:
+        return []
+
+    lines = ["", "【失败条目】"]
+    for item in items:
+        location_parts: list[str] = []
+        if item.file_rel_path:
+            location_parts.append(item.file_rel_path)
+        if item.line is not None:
+            location_parts.append(f"第 {item.line} 行")
+        if item.item_id:
+            location_parts.append(f"ID {item.item_id}")
+        location = " / ".join(location_parts) if location_parts else "位置未知"
+        lines.append(f"- [{reason_code_label(item.reason_code)}] {location}")
+        if item.error:
+            lines.append(f"  错误：{safe_preview(item.error, max_len=200)}")
+    if omitted_count > 0:
+        lines.append(f"… 另有 {omitted_count} 条未显示，请打开 failures.jsonl 查看。")
+    return lines
+
+
+def apply_failure_report_available(
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+    path_exists: Callable[[str], bool] | None = None,
+) -> bool:
+    """Return whether a structured apply failure report can be opened."""
+    if manifest.get("applied_at"):
+        return False
+    exists = path_exists or _default_path_exists
+    report_path = resolve_apply_failure_report_path(manifest, manifest_path=manifest_path)
+    if report_path and exists(report_path):
+        return True
+    stored = manifest.get("last_apply_failure_report_path")
+    return isinstance(stored, str) and bool(stored.strip())
+
+
+def build_apply_failure_report(
+    manifest: dict[str, object],
+    *,
+    manifest_path: str = "",
+    report_text: str | None = None,
+    failures_text: str | None = None,
+    path_exists: Callable[[str], bool] | None = None,
+    read_file: Callable[[str], str] | None = None,
+    max_items: int = 50,
+) -> ApplyFailureReportView:
+    """Build a structured GUI report from apply failure artifacts."""
+    exists = path_exists or _default_path_exists
+    reader = read_file or _default_read_file
+
+    if not manifest_path:
+        raw_manifest_path = manifest.get("_manifest_path")
+        manifest_path = raw_manifest_path.strip() if isinstance(raw_manifest_path, str) else ""
+
+    report_path = resolve_apply_failure_report_path(manifest, manifest_path=manifest_path)
+    facts: list[str] = []
+    if report_path:
+        facts.append(f"写回失败报告：{report_path}")
+
+    payload: dict[str, object] | None = None
+    parse_error = ""
+
+    if report_text is not None:
+        try:
+            loaded = json.loads(report_text)
+            if not isinstance(loaded, dict):
+                raise ValueError("报告根节点不是 JSON 对象。")
+            payload = parse_apply_failure_report_payload(loaded)
+        except (json.JSONDecodeError, ValueError) as exc:
+            parse_error = str(exc)
+    elif report_path and exists(report_path):
+        try:
+            loaded = json.loads(reader(report_path))
+            if not isinstance(loaded, dict):
+                raise ValueError("报告根节点不是 JSON 对象。")
+            payload = parse_apply_failure_report_payload(loaded)
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+            parse_error = str(exc)
+
+    reason_code = "unclassified_failure"
+    error_message = ""
+    failures_path = ""
+    failure_items: list[object] = []
+
+    if payload is not None:
+        reason_code = str(payload.get("reason_code") or "unclassified_failure")
+        error_message = str(payload.get("error") or "")
+        failures_path = resolve_apply_failures_jsonl_path(
+            payload,
+            manifest,
+            manifest_path=manifest_path,
+        )
+        if not failures_path:
+            failures_path = str(payload.get("failures_path") or "")
+
+        safety_text = str(payload.get("last_check_safety_level") or "")
+        if safety_text:
+            facts.append(f"最近检查：{safety_level_label(safety_text)}")
+
+        last_check_at = str(payload.get("last_check_at") or "")
+        if last_check_at:
+            facts.append(f"最近检查时间：{last_check_at}")
+
+        if manifest_path:
+            facts.append(format_manifest_path_fact(manifest_path))
+
+        summary = payload.get("summary")
+        if isinstance(summary, dict):
+            facts.extend(_format_summary_facts(summary))
+
+        fingerprint = payload.get("current_check_fingerprint")
+        if isinstance(fingerprint, dict):
+            facts.extend(_format_fingerprint_facts(fingerprint))
+
+        if failures_path:
+            facts.append(f"失败明细：{failures_path}")
+
+    if failures_text is not None:
+        try:
+            failure_items = parse_check_failures_jsonl(failures_text)
+        except ValueError as exc:
+            if not parse_error:
+                parse_error = str(exc)
+    elif failures_path and exists(failures_path):
+        try:
+            failure_items = parse_check_failures_jsonl(reader(failures_path))
+        except (OSError, UnicodeError, ValueError) as exc:
+            if not parse_error:
+                parse_error = str(exc)
+
+    normalized_items = [
+        normalize_failure_entry(item) for item in failure_items if isinstance(item, dict)
+    ]
+    omitted_count = 0
+    display_items = normalized_items
+    if len(normalized_items) > max_items:
+        display_items = normalized_items[:max_items]
+        omitted_count = len(normalized_items) - max_items
+
+    detail_lines = [
+        f"【失败原因】{apply_reason_code_label(reason_code)} ({reason_code})",
+        f"【建议处理】{apply_reason_suggestion(reason_code)}",
+    ]
+    if error_message:
+        detail_lines.append(f"【错误摘要】{safe_preview(error_message, max_len=300)}")
+    detail_lines.extend(
+        _format_failure_item_lines(display_items, omitted_count=omitted_count)
+    )
+
+    if parse_error:
+        return ApplyFailureReportView(
+            status="unreadable",
+            heading="写回失败报告无法解析",
+            message="找到了写回失败报告，但内容无法读取或解析。请打开原始报告或查看诊断日志。",
+            report_path=report_path,
+            failures_path=failures_path,
+            reason_code=reason_code,
+            facts=facts + [f"解析错误：{parse_error}"],
+            detail_lines=detail_lines or [f"解析错误：{parse_error}"],
+            failure_item_count=len(normalized_items),
+        )
+
+    if not report_path:
+        return ApplyFailureReportView(
+            status="missing_report",
+            heading="未找到写回失败报告",
+            message="任务清单中没有记录写回失败报告路径。请查看诊断日志中的 apply 输出。",
+            report_path="",
+            failures_path="",
+            reason_code=reason_code,
+            facts=facts,
+            detail_lines=["未找到 apply_failure_report.json。"],
+            failure_item_count=0,
+        )
+
+    if report_text is None and not exists(report_path):
+        return ApplyFailureReportView(
+            status="missing_report",
+            heading="写回失败报告不可用",
+            message="写回失败报告路径已记录，但文件当前不存在。请重新尝试 apply 或查看诊断日志。",
+            report_path=report_path,
+            failures_path=failures_path,
+            reason_code=reason_code,
+            facts=facts,
+            detail_lines=[f"报告路径：{report_path}"],
+            failure_item_count=len(normalized_items),
+        )
+
+    if payload is None:
+        return ApplyFailureReportView(
+            status="empty",
+            heading="写回失败报告为空",
+            message="写回失败报告存在，但没有可识别的内容。",
+            report_path=report_path,
+            failures_path=failures_path,
+            reason_code=reason_code,
+            facts=facts,
+            detail_lines=["报告文件中没有可展示的内容。"],
+            failure_item_count=0,
+        )
+
+    return ApplyFailureReportView(
+        status="ok",
+        heading="写回失败诊断",
+        message="写回未完成。请按建议处理问题后重新 check，不要重复 apply。",
+        report_path=report_path,
+        failures_path=failures_path,
+        reason_code=reason_code,
+        facts=facts,
+        detail_lines=detail_lines,
+        failure_item_count=len(normalized_items),
+    )

--- a/gui_qt/apply_failure_report.py
+++ b/gui_qt/apply_failure_report.py
@@ -247,7 +247,8 @@ def build_apply_failure_report(
         facts.append(f"写回失败报告：{report_path}")
 
     payload: dict[str, object] | None = None
-    parse_error = ""
+    report_parse_error = ""
+    failures_parse_error = ""
 
     if report_text is not None:
         try:
@@ -256,7 +257,7 @@ def build_apply_failure_report(
                 raise ValueError("报告根节点不是 JSON 对象。")
             payload = parse_apply_failure_report_payload(loaded)
         except (json.JSONDecodeError, ValueError) as exc:
-            parse_error = str(exc)
+            report_parse_error = str(exc)
     elif report_path and exists(report_path):
         try:
             loaded = json.loads(reader(report_path))
@@ -264,7 +265,7 @@ def build_apply_failure_report(
                 raise ValueError("报告根节点不是 JSON 对象。")
             payload = parse_apply_failure_report_payload(loaded)
         except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
-            parse_error = str(exc)
+            report_parse_error = str(exc)
 
     reason_code = "unclassified_failure"
     error_message = ""
@@ -308,14 +309,12 @@ def build_apply_failure_report(
         try:
             failure_items = parse_check_failures_jsonl(failures_text)
         except ValueError as exc:
-            if not parse_error:
-                parse_error = str(exc)
+            failures_parse_error = str(exc)
     elif failures_path and exists(failures_path):
         try:
             failure_items = parse_check_failures_jsonl(reader(failures_path))
         except (OSError, UnicodeError, ValueError) as exc:
-            if not parse_error:
-                parse_error = str(exc)
+            failures_parse_error = str(exc)
 
     normalized_items = [
         normalize_failure_entry(item) for item in failure_items if isinstance(item, dict)
@@ -336,7 +335,13 @@ def build_apply_failure_report(
         _format_failure_item_lines(display_items, omitted_count=omitted_count)
     )
 
-    if parse_error:
+    if failures_parse_error:
+        facts.append(f"失败明细解析错误：{failures_parse_error}")
+        detail_lines.append(
+            f"【失败明细】无法解析 failures.jsonl：{failures_parse_error}"
+        )
+
+    if report_parse_error:
         return ApplyFailureReportView(
             status="unreadable",
             heading="写回失败报告无法解析",
@@ -344,8 +349,8 @@ def build_apply_failure_report(
             report_path=report_path,
             failures_path=failures_path,
             reason_code=reason_code,
-            facts=facts + [f"解析错误：{parse_error}"],
-            detail_lines=detail_lines or [f"解析错误：{parse_error}"],
+            facts=facts + [f"解析错误：{report_parse_error}"],
+            detail_lines=detail_lines or [f"解析错误：{report_parse_error}"],
             failure_item_count=len(normalized_items),
         )
 

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -184,7 +184,7 @@ def summarize_apply_output(
         return WritebackSummary(
             status="failed",
             heading="写回失败",
-            message="写回没有正常完成。请查看诊断日志与写回失败报告。",
+            message="写回没有正常完成。可点击「查看写回失败报告」了解原因，或查看诊断日志。",
             facts=[format_manifest_path_fact(manifest_path)] if manifest_path else [],
             findings=[],
             can_apply=False,
@@ -234,6 +234,20 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
             status="applied",
             heading="翻译已写回",
             message="该任务已经写回过。",
+            facts=facts,
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    apply_failure_path = manifest.get("last_apply_failure_report_path")
+    if isinstance(apply_failure_path, str) and apply_failure_path.strip():
+        facts = [format_manifest_path_fact(manifest_path)] if manifest_path else []
+        facts.append(f"写回失败报告：{apply_failure_path.strip()}")
+        return WritebackSummary(
+            status="failed",
+            heading="写回失败",
+            message="最近一次写回未成功。可点击「查看写回失败报告」了解原因，处理后再重新 check。",
             facts=facts,
             findings=[],
             can_apply=False,

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1513,10 +1513,15 @@ class BatchRepairRegressionTests(unittest.TestCase):
             final_script = target_file.read_text(encoding='utf-8')
             saved_manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
 
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.check_results(str(manifest_path))
+            rechecked_manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+
         self.assertEqual(final_script, changed_line)
         update_progress.assert_not_called()
         append_failures.assert_called_once()
         self.assertIn('last_apply_failure_report_path', saved_manifest)
+        self.assertNotIn('last_apply_failure_report_path', rechecked_manifest)
 
     def test_apply_results_rejects_already_applied_manifest_without_force(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_gui_apply_failure_report.py
+++ b/tests/test_gui_apply_failure_report.py
@@ -1,0 +1,131 @@
+import json
+import unittest
+
+from gui_qt.apply_failure_report import (
+    APPLY_REASON_SUGGESTIONS,
+    apply_failure_report_available,
+    apply_reason_code_label,
+    build_apply_failure_report,
+    parse_apply_failure_report_payload,
+)
+
+SAMPLE_REPORT = {
+    "timestamp": "2026-06-25T13:00:00",
+    "status": "block",
+    "reason_code": "stale_check_fingerprint",
+    "error": "Manifest or results changed after the last check. Run check again before apply.",
+    "manifest_path": r"C:\pkg\manifest.json",
+    "last_check_at": "2026-06-25T12:50:00",
+    "last_check_safety_level": "safe",
+    "current_check_fingerprint": {
+        "id": "fp-123",
+        "pending_files": 2,
+        "pending_lines": 18,
+        "failure_items": 1,
+    },
+    "summary": {
+        "safety_level": "block",
+        "pending_files": 2,
+        "pending_lines": 18,
+        "failure_items": 1,
+        "source_mismatch_items": 1,
+    },
+    "failure_count": 1,
+    "failures_path": r"C:\pkg\failures.jsonl",
+}
+
+SAMPLE_FAILURES_JSONL = "\n".join(
+    [
+        json.dumps(
+            {
+                "reason_code": "source_text_mismatch",
+                "status": "block",
+                "file_rel_path": "game/tl/schinese/script.rpy",
+                "line": 12,
+                "item_id": "item-1",
+                "error": "Source text mismatch",
+            },
+            ensure_ascii=False,
+        )
+    ]
+)
+
+
+class GuiApplyFailureReportTests(unittest.TestCase):
+    def test_apply_reason_code_label_covers_known_codes(self):
+        self.assertEqual(
+            apply_reason_code_label("stale_check_fingerprint"),
+            "检查结果已过期",
+        )
+        self.assertIn(
+            "重新 check",
+            APPLY_REASON_SUGGESTIONS["stale_check_fingerprint"],
+        )
+
+    def test_parse_apply_failure_report_payload_normalizes_fields(self):
+        parsed = parse_apply_failure_report_payload(SAMPLE_REPORT)
+
+        self.assertEqual(parsed["reason_code"], "stale_check_fingerprint")
+        self.assertEqual(parsed["last_check_safety_level"], "safe")
+        self.assertEqual(parsed["failure_count"], 1)
+
+    def test_build_apply_failure_report_from_text_and_failures(self):
+        manifest = {
+            "_manifest_path": r"C:\pkg\manifest.json",
+            "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+        }
+
+        report = build_apply_failure_report(
+            manifest,
+            manifest_path=r"C:\pkg\manifest.json",
+            report_text=json.dumps(SAMPLE_REPORT, ensure_ascii=False),
+            failures_text=SAMPLE_FAILURES_JSONL,
+        )
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.reason_code, "stale_check_fingerprint")
+        self.assertEqual(report.failure_item_count, 1)
+        self.assertTrue(any("stale_check_fingerprint" in line for line in report.detail_lines))
+        self.assertTrue(any("script.rpy" in line for line in report.detail_lines))
+        self.assertTrue(any("最近检查" in fact for fact in report.facts))
+
+    def test_build_apply_failure_report_missing_file(self):
+        manifest = {
+            "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+        }
+
+        report = build_apply_failure_report(
+            manifest,
+            path_exists=lambda _path: False,
+        )
+
+        self.assertEqual(report.status, "missing_report")
+
+    def test_apply_failure_report_available_respects_applied_manifest(self):
+        manifest = {
+            "applied_at": "2026-06-25T12:00:00",
+            "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+        }
+
+        self.assertFalse(
+            apply_failure_report_available(
+                manifest,
+                path_exists=lambda _path: True,
+            )
+        )
+
+    def test_apply_failure_report_available_when_report_exists(self):
+        manifest = {
+            "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+        }
+
+        self.assertTrue(
+            apply_failure_report_available(
+                manifest,
+                path_exists=lambda path: path.endswith("apply_failure_report.json"),
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_apply_failure_report.py
+++ b/tests/test_gui_apply_failure_report.py
@@ -89,6 +89,26 @@ class GuiApplyFailureReportTests(unittest.TestCase):
         self.assertTrue(any("script.rpy" in line for line in report.detail_lines))
         self.assertTrue(any("最近检查" in fact for fact in report.facts))
 
+    def test_build_apply_failure_report_keeps_valid_report_when_failures_unreadable(self):
+        manifest = {
+            "_manifest_path": r"C:\pkg\manifest.json",
+            "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+        }
+
+        report = build_apply_failure_report(
+            manifest,
+            manifest_path=r"C:\pkg\manifest.json",
+            report_text=json.dumps(SAMPLE_REPORT, ensure_ascii=False),
+            failures_text="not valid jsonl",
+        )
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.reason_code, "stale_check_fingerprint")
+        self.assertTrue(any("失败明细解析错误" in fact for fact in report.facts))
+        self.assertTrue(
+            any("无法解析 failures.jsonl" in line for line in report.detail_lines)
+        )
+
     def test_build_apply_failure_report_missing_file(self):
         manifest = {
             "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -153,6 +153,17 @@ class GuiCheckReportTests(unittest.TestCase):
             {
                 "_manifest_path": r"C:\pkg\manifest.json",
                 "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+            }
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("查看写回失败报告", summary.message)
+
+    def test_summarize_manifest_writeback_after_apply_failure_and_recheck(self):
+        summary = summarize_manifest_writeback(
+            {
+                "_manifest_path": r"C:\pkg\manifest.json",
                 "last_check_summary": {
                     "safety_level": "safe",
                     "pending_files": 2,
@@ -161,9 +172,8 @@ class GuiCheckReportTests(unittest.TestCase):
             }
         )
 
-        self.assertEqual(summary.status, "failed")
-        self.assertFalse(summary.can_apply)
-        self.assertIn("查看写回失败报告", summary.message)
+        self.assertEqual(summary.status, "safe")
+        self.assertTrue(summary.can_apply)
 
     def test_summarize_manifest_writeback_after_apply(self):
         summary = summarize_manifest_writeback(

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -148,6 +148,23 @@ class GuiCheckReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "safe")
         self.assertTrue(summary.can_apply)
 
+    def test_summarize_manifest_writeback_after_apply_failure(self):
+        summary = summarize_manifest_writeback(
+            {
+                "_manifest_path": r"C:\pkg\manifest.json",
+                "last_apply_failure_report_path": r"C:\pkg\apply_failure_report.json",
+                "last_check_summary": {
+                    "safety_level": "safe",
+                    "pending_files": 2,
+                    "pending_lines": 10,
+                },
+            }
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("查看写回失败报告", summary.message)
+
     def test_summarize_manifest_writeback_after_apply(self):
         summary = summarize_manifest_writeback(
             {


### PR DESCRIPTION
## Summary

Adds structured **apply failure diagnostics** to the GUI writeback tab. When `apply` exits non-zero or a manifest retains `last_apply_failure_report_path`, users can open a dedicated report instead of only reading raw logs.

## Changes

- New `gui_qt/apply_failure_report.py` to parse `apply_failure_report.json` and optional `failures.jsonl`
- Chinese labels and next-step guidance for stale check, unsafe check, source revalidation, missing check, etc.
- New `ApplyFailureDialog` with facts, detail text, and copy-path actions
- Writeback tab **「查看写回失败报告」** button when apply failed or a stored report exists
- `summarize_manifest_writeback` surfaces persisted apply-failure state on reload
- Tests in `tests/test_gui_apply_failure_report.py`

## Safety

- No `apply --force` entry
- Does not bypass `check=safe` gates
- Does not auto-fix source drift

## Test plan

- [x] `python -m unittest tests.test_gui_apply_failure_report tests.test_gui_check_report -v`
- [ ] Manual: trigger apply failure (e.g. source drift), open **查看写回失败报告**

Closes #95
Refs #93
Refs #94
Refs #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “查看写回失败报告” button to the writeback tab, opening a structured diagnostics dialog when a failure report is available.
  * The dialog includes summary, diagnosis details, and one-click copying of report paths (when present).
* **Bug Fixes**
  * Updated writeback failure summaries to focus on the most recent failure and guide users to the report.
* **Tests**
  * Added coverage for parsing/building failure reports, availability rules, and writeback summary behavior after recorded apply failures.
* **Chores**
  * Cleared stale “last apply failure report” markers during translation flows to avoid outdated report prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->