### PR TITLE
fix(gui): clarify skipped work-directory bootstrap copy

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2110,7 +2110,7 @@ class MainWindow(QMainWindow):
                     self.state.set_game_root(summary.work_dir)
                     self._refresh_project_label()
                 except ValueError as exc:
-                    self._append_log(f"更新 translator_config.json 失败：{exc}")
+                    self._append_log(f"未能保存项目路径：{exc}")
                     game_root_update_failed = True
                     summary = with_game_root_persist_warning(summary)
             self._set_doctor_summary(work_bootstrap_to_doctor_summary(summary))
@@ -2118,7 +2118,7 @@ class MainWindow(QMainWindow):
             self._set_task_running(False)
             if game_root_update_failed:
                 self.statusBar().showMessage(
-                    "工作目录已复制，但更新 game_root 失败，请查看诊断日志。",
+                    "工作目录已复制，但项目路径未保存，请查看诊断日志。",
                     8000,
                 )
             elif exit_code == 0 and summary.status == "ready":

--- a/gui_qt/work_bootstrap_report.py
+++ b/gui_qt/work_bootstrap_report.py
@@ -10,6 +10,25 @@ from .summary_helpers import append_unique_fact, extend_facts_with_notices
 
 WORK_BOOTSTRAP_HEADER = "Work bootstrap summary:"
 
+_WORK_BOOTSTRAP_MESSAGE_TRANSLATIONS = {
+    "work directory already exists and is not empty": (
+        "如需重新初始化，请先手动清空或移除工作目录。"
+    ),
+}
+
+
+def _translate_work_bootstrap_message(message: str) -> str:
+    text = message.strip()
+    if not text:
+        return ""
+    if text in _WORK_BOOTSTRAP_MESSAGE_TRANSLATIONS:
+        return _WORK_BOOTSTRAP_MESSAGE_TRANSLATIONS[text]
+    if "work directory already exists and is not empty" in text:
+        return _WORK_BOOTSTRAP_MESSAGE_TRANSLATIONS[
+            "work directory already exists and is not empty"
+        ]
+    return text
+
 
 @dataclass(frozen=True)
 class WorkBootstrapSummary:
@@ -64,15 +83,17 @@ def summarize_work_bootstrap_output(output: str, exit_code: int) -> WorkBootstra
 
     facts: list[str] = []
     if work_dir:
-        append_unique_fact(facts, f"work 目录：{work_dir}")
+        append_unique_fact(facts, f"工作目录：{work_dir}")
     if files_copied and files_copied != "0":
         append_unique_fact(facts, f"复制文件数：{files_copied}")
     if game_root_updated:
-        append_unique_fact(facts, "已自动将 game_root 更新为 work 目录")
+        append_unique_fact(facts, "已自动将项目路径更新为工作目录")
 
     findings: list[str] = []
     if message and status == "skipped":
-        findings.append(message)
+        translated = _translate_work_bootstrap_message(message)
+        if translated and translated != message:
+            findings.append(translated)
 
     if exit_code != 0:
         return WorkBootstrapSummary(
@@ -81,9 +102,9 @@ def summarize_work_bootstrap_output(output: str, exit_code: int) -> WorkBootstra
             message="命令未正常完成，请查看诊断日志。",
             facts=extend_facts_with_notices(
                 facts,
-                findings or ["请确认存在 original/game，且 work 目录不存在或为空。"],
+                findings or ["请确认存在 original/game，且工作目录不存在或为空。"],
             ),
-            findings=findings or ["请确认存在 original/game，且 work 目录不存在或为空。"],
+            findings=findings or ["请确认存在 original/game，且工作目录不存在或为空。"],
             work_dir=work_dir,
             game_root_updated=False,
         )
@@ -101,11 +122,15 @@ def summarize_work_bootstrap_output(output: str, exit_code: int) -> WorkBootstra
         )
 
     if status == "skipped":
-        skip_notices = findings or [message or "如需重新初始化，请先手动清空或移除 work 目录。"]
+        skip_notice = (
+            _translate_work_bootstrap_message(message)
+            or "如需重新初始化，请先手动清空或移除工作目录。"
+        )
+        skip_notices = findings or [skip_notice]
         return WorkBootstrapSummary(
             status="warning",
-            heading="未准备工作目录",
-            message="work 目录已存在且非空，未做任何修改。",
+            heading="工作目录已存在",
+            message="工作目录已存在且非空，未做任何修改。",
             facts=extend_facts_with_notices(facts, skip_notices),
             findings=skip_notices,
             work_dir=work_dir,
@@ -135,7 +160,7 @@ def summarize_work_bootstrap_output(output: str, exit_code: int) -> WorkBootstra
 
 
 def with_game_root_persist_warning(summary: WorkBootstrapSummary) -> WorkBootstrapSummary:
-    notice = "未能更新 translator_config.json 中的 game_root，请手动切换到 work 目录。"
+    notice = "未能保存项目路径到配置文件，请手动切换到工作目录。"
     return WorkBootstrapSummary(
         status="warning",
         heading="工作目录已复制，但路径未保存",

--- a/gui_qt/work_bootstrap_report.py
+++ b/gui_qt/work_bootstrap_report.py
@@ -164,7 +164,7 @@ def with_game_root_persist_warning(summary: WorkBootstrapSummary) -> WorkBootstr
     return WorkBootstrapSummary(
         status="warning",
         heading="工作目录已复制，但路径未保存",
-        message="文件已复制到 work/game，但未能将 game_root 写入配置文件。",
+        message="工作目录已复制，但未能保存项目路径到配置文件。",
         facts=extend_facts_with_notices(summary.facts, [notice]),
         findings=[notice],
         work_dir=summary.work_dir,

--- a/tests/test_gui_work_bootstrap_report.py
+++ b/tests/test_gui_work_bootstrap_report.py
@@ -28,16 +28,31 @@ class GuiWorkBootstrapReportTests(unittest.TestCase):
         self.assertTrue(any("复制文件数：42" in fact for fact in summary.facts))
 
     def test_summarize_skipped_bootstrap_output(self):
-        output = BOOTSTRAP_OUTPUT.replace("status: created", "status: skipped").replace(
-            "Copied 42 files",
-            "work directory already exists and is not empty",
-        )
+        output = """
+Work bootstrap summary:
+- status: skipped
+- project_root: C:\\Games\\Example
+- work_dir: C:\\Games\\Example\\work
+- source_game_dir: C:\\Games\\Example\\original\\game
+- files_copied: 0
+- game_root_updated: False
+- message: work directory already exists and is not empty
+"""
 
         summary = summarize_work_bootstrap_output(output, exit_code=0)
 
         self.assertEqual(summary.status, "warning")
+        self.assertEqual(summary.heading, "工作目录已存在")
         self.assertIn("非空", summary.message)
-        self.assertTrue(any(fact.startswith("注意：") for fact in summary.facts))
+        self.assertNotIn("work 目录", summary.message)
+        self.assertTrue(any(fact.startswith("工作目录：") for fact in summary.facts))
+        self.assertTrue(
+            any(
+                fact.startswith("注意：") and "重新初始化" in fact
+                for fact in summary.facts
+            )
+        )
+        self.assertFalse(any("work directory already exists" in fact for fact in summary.facts))
         self.assertFalse(any(fact.startswith("- ") for fact in summary.facts))
 
     def test_work_bootstrap_to_doctor_summary_preserves_heading(self):


### PR DESCRIPTION
## Summary

Fix misleading GUI copy when `bootstrap-work` is skipped because the work directory already exists.

## Problem

- Heading said **未准备工作目录** even though the directory already exists (skipped, not failed).
- Facts duplicated the CLI English string `work directory already exists and is not empty`.
- Mixed `work 目录` jargon with Chinese user-facing text.

## Changes

- Heading → **工作目录已存在**
- Message/facts use **工作目录** consistently
- Translate known CLI skip messages to Chinese follow-up guidance
- Update `test_gui_work_bootstrap_report.py` skipped fixture

## Tests

```bash
python -m unittest tests.test_gui_work_bootstrap_report -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化工作目录相关的中文提示与汇总文案：在“已存在且非空”等跳过场景下，避免直接展示原始英文提示，并统一为“工作目录/项目路径”口径。
  * 更新项目路径保存失败时的用户提示与状态栏信息，强调“工作目录已复制，但项目路径未保存”。
* **Tests**
  * 强化并更新跳过场景的用例：改为内联构造输出数据，细化对 heading/message/facts 的断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->