### PR TITLE
GUI: speed up startup and refresh for large batch manifests

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1232,11 +1232,38 @@ class MainWindow(QMainWindow):
                 selected_manifest_path = self._split_status_selected_manifest_path
                 QTimer.singleShot(
                     0,
-                    lambda: self._render_split_status_entries(
+                    lambda entries=entries,
+                    selected_manifest_path=selected_manifest_path,
+                    profile_key=current_profile_key: self._deferred_render_split_status_entries(
                         entries,
                         selected_manifest_path=selected_manifest_path,
+                        expected_profile_key=profile_key,
                     ),
                 )
+
+    def _deferred_render_split_status_entries(
+        self,
+        entries: list[SplitManifestEntry],
+        *,
+        selected_manifest_path: str,
+        expected_profile_key: tuple[int, int],
+    ) -> None:
+        if not hasattr(self, "split_status_table") or not self.split_status_table.isVisible():
+            return
+        if not self._split_status_entries:
+            return
+        if list(self._split_status_entries) != entries:
+            return
+        if self._split_status_selected_manifest_path != selected_manifest_path:
+            return
+        profile = self._split_status_table_profile()
+        current_profile_key = (max(1, profile["groups"]), profile["job_chars"])
+        if current_profile_key != expected_profile_key:
+            return
+        self._render_split_status_entries(
+            entries,
+            selected_manifest_path=selected_manifest_path,
+        )
 
     def _update_split_status_job_column_texts(self, profile: dict[str, int]) -> None:
         if not hasattr(self, "split_status_table"):
@@ -1736,7 +1763,7 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage(message, 3000)
 
     def _on_clear_log(self) -> None:
-        self.log_view.clear()
+        self._clear_log_view()
         self.statusBar().showMessage("诊断日志已清空。", 3000)
 
     def _resolve_diagnostics_manifest_path(self) -> str | None:
@@ -2709,7 +2736,7 @@ class MainWindow(QMainWindow):
             )
             return
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._active_command = "doctor"
         self._doctor_output_lines = []
         self._focus_workbench_status_tab(0)
@@ -2731,7 +2758,7 @@ class MainWindow(QMainWindow):
             )
             return
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._active_command = "bootstrap_work"
         self._work_bootstrap_output_lines = []
         self._workflow_progress = create_workflow_progress_state("work_bootstrap")
@@ -2794,7 +2821,7 @@ class MainWindow(QMainWindow):
             log_heading = "gemini_translate_batch.py bootstrap-source-index --skip-prepare"
             running_summary = running_bootstrap_summary("source_index")
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._active_command = command
         self._bootstrap_output_lines = []
@@ -2853,7 +2880,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "无法开始任务", spec.not_implemented_message)
             return
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._writeback_manifest_path = ""
         if spec.supports_translation_writeback:
@@ -2908,7 +2935,7 @@ class MainWindow(QMainWindow):
                 anchor_manifest_path=str(latest_manifest),
             )
             if split_workflow.current_step() is not None:
-                self.log_view.clear()
+                self._clear_log_view()
                 self._focus_log_tab()
                 self._workflow = split_workflow
                 self._refresh_diagnostics_context()
@@ -2950,7 +2977,7 @@ class MainWindow(QMainWindow):
         only_query = self._resume_button_is_query_mode()
         workflow.only_query = only_query
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._workflow = workflow
         self._refresh_diagnostics_context()
@@ -2993,7 +3020,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "没有待提交拆分包", "当前拆分组没有尚未提交的包。")
             return
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._workflow = workflow
         self._refresh_diagnostics_context()
@@ -3046,7 +3073,7 @@ class MainWindow(QMainWindow):
             return
 
         manifest_path = self._writeback_manifest_path
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._active_command = "apply"
         self._apply_output_lines = []
@@ -3101,7 +3128,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "无法写回订正", "没有可写回的订正任务记录。")
             return
 
-        self.log_view.clear()
+        self._clear_log_view()
         self._focus_log_tab()
         self._active_command = "apply_revision"
         self._apply_revision_output_lines = []
@@ -3222,6 +3249,16 @@ class MainWindow(QMainWindow):
                 self._apply_bootstrap_progress_ui()
             else:
                 self._apply_workflow_progress_ui()
+
+    def _clear_log_view(self) -> None:
+        pending = getattr(self, "_pending_log_lines", None)
+        if pending is not None:
+            pending.clear()
+        timer = getattr(self, "_log_flush_timer", None)
+        if timer is not None and timer.isActive():
+            timer.stop()
+        if hasattr(self, "log_view"):
+            self.log_view.clear()
 
     def _append_log(self, text: str) -> None:
         line = text.rstrip("\n")

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -12,8 +12,6 @@ import re
 from pathlib import Path
 from typing import Any
 
-import translator_runtime as runtime
-
 from PySide6.QtCore import QEvent, Qt, QTimer
 from PySide6.QtGui import QBrush, QColor, QGuiApplication
 from PySide6.QtWidgets import (
@@ -43,6 +41,7 @@ from PySide6.QtWidgets import (
     QSizePolicy,
 )
 
+from .path_utils import canonical_abs_path, normalize_context_storage_location
 from .api_key_dialog import ApiKeyDialog
 from .api_key_helpers import mask_api_key
 from .bootstrap_report import (
@@ -163,14 +162,40 @@ _DIAGNOSTICS_IDLE_LOG_PX = 180
 _DIAGNOSTICS_RUNNING_CONTEXT_RATIO = 0.32
 
 
+_LOG_FLUSH_INTERVAL_MS = 80
+_LAYOUT_SYNC_DEBOUNCE_MS = 32
+_UI_PROGRESS_FLUSH_INTERVAL_MS = 100
+
+
 class MainWindow(QMainWindow):
-    def __init__(self, *, qt_app: QApplication | None = None, resources_dir: Path | None = None):
+    def __init__(
+        self,
+        *,
+        qt_app: QApplication | None = None,
+        resources_dir: Path | None = None,
+        project_state: ProjectState | None = None,
+    ):
         super().__init__()
         self.setWindowTitle("Ren'Py Translation Lab - 图形工作台")
         self.setMinimumSize(960, 640)
         self.resize(960, 760)
 
-        self.state = ProjectState()
+        self.state = project_state or ProjectState()
+        self._diagnostics_context_fingerprint: tuple[object, ...] | None = None
+        self._pending_log_lines: list[str] = []
+        self._workflow_progress_dirty = False
+        self._log_flush_timer = QTimer(self)
+        self._log_flush_timer.setSingleShot(True)
+        self._log_flush_timer.setInterval(_LOG_FLUSH_INTERVAL_MS)
+        self._log_flush_timer.timeout.connect(self._flush_pending_log_lines)
+        self._progress_flush_timer = QTimer(self)
+        self._progress_flush_timer.setSingleShot(True)
+        self._progress_flush_timer.setInterval(_UI_PROGRESS_FLUSH_INTERVAL_MS)
+        self._progress_flush_timer.timeout.connect(self._flush_throttled_progress_ui)
+        self._layout_sync_timer = QTimer(self)
+        self._layout_sync_timer.setSingleShot(True)
+        self._layout_sync_timer.setInterval(_LAYOUT_SYNC_DEBOUNCE_MS)
+        self._layout_sync_timer.timeout.connect(self._sync_layout_sizes)
         self._qt_app = qt_app
         self._resources_dir = resources_dir or Path(__file__).resolve().parent / "resources"
         self._theme_preference = DEFAULT_THEME_PREFERENCE
@@ -184,6 +209,7 @@ class MainWindow(QMainWindow):
         self._doctor_output_lines: list[str] = []
         self._workflow = None
         self._split_status_entries: list[SplitManifestEntry] = []
+        self._split_status_selected_manifest_path = ""
         self._work_mode = WorkMode.BATCH_TRANSLATION
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
@@ -239,13 +265,18 @@ class MainWindow(QMainWindow):
         self._refresh_api_status()
         self._load_config_to_ui()
         self._set_doctor_summary(idle_summary())
-        self._apply_work_mode_ui(refresh_manifest_writeback=True)
-        self._refresh_diagnostics_context()
+        QTimer.singleShot(0, self._deferred_startup_refresh)
         QTimer.singleShot(0, self._sync_work_mode_hint_height)
 
         # Status
         self.statusBar().showMessage(
             "图形界面是可选组件；核心命令行不受影响。"
+        )
+
+    def _deferred_startup_refresh(self) -> None:
+        self._apply_work_mode_ui(
+            refresh_manifest_writeback=True,
+            refresh_diagnostics=True,
         )
 
     def eventFilter(self, watched: Any, event: QEvent) -> bool:
@@ -286,7 +317,7 @@ class MainWindow(QMainWindow):
 
     def resizeEvent(self, event: QEvent) -> None:
         super().resizeEvent(event)
-        self._sync_layout_sizes()
+        self._layout_sync_timer.start()
 
     def _sync_layout_sizes(self) -> None:
         if not hasattr(self, "doctor_message_label") or not hasattr(self, "workbench_status_tabs"):
@@ -1031,7 +1062,7 @@ class MainWindow(QMainWindow):
     def _same_manifest_path(self, left: str, right: str) -> bool:
         if not left or not right:
             return False
-        return runtime.canonical_abs_path(left).lower() == runtime.canonical_abs_path(right).lower()
+        return canonical_abs_path(left).lower() == canonical_abs_path(right).lower()
 
     def _split_entries_for_manifest(
         self,
@@ -1079,6 +1110,7 @@ class MainWindow(QMainWindow):
         selected_manifest_path: str = "",
     ) -> None:
         self._split_status_entries = list(entries)
+        self._split_status_selected_manifest_path = selected_manifest_path
         if not hasattr(self, "split_status_table"):
             return
         if not entries:
@@ -1190,7 +1222,41 @@ class MainWindow(QMainWindow):
             and self.split_status_table.isVisible()
             and self._split_status_entries
         ):
-            QTimer.singleShot(0, self._refresh_split_status_ui)
+            if (
+                previous_profile_key is not None
+                and current_profile_key[0] == previous_profile_key[0]
+            ):
+                self._update_split_status_job_column_texts(profile)
+            else:
+                entries = list(self._split_status_entries)
+                selected_manifest_path = self._split_status_selected_manifest_path
+                QTimer.singleShot(
+                    0,
+                    lambda: self._render_split_status_entries(
+                        entries,
+                        selected_manifest_path=selected_manifest_path,
+                    ),
+                )
+
+    def _update_split_status_job_column_texts(self, profile: dict[str, int]) -> None:
+        if not hasattr(self, "split_status_table"):
+            return
+        group_count = max(1, profile["groups"])
+        rows = self.split_status_table.rowCount()
+        if rows <= 0:
+            return
+        for index, entry in enumerate(self._split_status_entries):
+            group_index = index // rows
+            row = index % rows
+            base_column = group_index * 6
+            if base_column + 4 >= self.split_status_table.columnCount():
+                continue
+            self._set_split_table_item(
+                row,
+                base_column + 4,
+                self._split_job_text(entry, profile["job_chars"]),
+                tooltip=entry.job_name or entry.manifest_path,
+            )
 
     def _render_split_status_entry(
         self,
@@ -1373,8 +1439,7 @@ class MainWindow(QMainWindow):
             return
         self._workflow = None
         self._workflow_step_output_lines = []
-        self._refresh_workflow_from_latest_manifest()
-        self._refresh_writeback_from_latest_manifest()
+        self._refresh_manifest_derived_ui(refresh_writeback=True)
         writeback_summary = self._current_writeback_summary()
         if writeback_summary.status not in {"idle", "running", "stale"}:
             self._focus_workbench_status_tab(2)
@@ -1698,7 +1763,49 @@ class MainWindow(QMainWindow):
         except ValueError:
             return None
 
-    def _refresh_diagnostics_context(self) -> None:
+    def _refresh_manifest_derived_ui(
+        self,
+        *,
+        refresh_writeback: bool = False,
+        refresh_diagnostics: bool = False,
+    ) -> None:
+        spec = work_mode_spec(self._current_work_mode())
+        game_root = self.state.get_game_root()
+        latest_manifest = None
+        manifest = None
+
+        needs_manifest = (
+            (spec.supports_resume and not self.kill_btn.isEnabled())
+            or refresh_writeback
+            or refresh_diagnostics
+        )
+        if needs_manifest and game_root is not None and spec.manifest_mode is not None:
+            latest_manifest, manifest = self.state.load_latest_resume_manifest_for_mode(
+                game_root,
+                spec.mode,
+            )
+
+        self._refresh_workflow_from_latest_manifest(
+            latest_manifest=latest_manifest,
+            manifest=manifest,
+        )
+        if refresh_writeback:
+            self._refresh_writeback_from_latest_manifest(
+                latest_manifest=latest_manifest,
+                manifest=manifest,
+            )
+        if refresh_diagnostics:
+            self._refresh_diagnostics_context(
+                latest_manifest_path=latest_manifest,
+                manifest=manifest,
+            )
+
+    def _refresh_diagnostics_context(
+        self,
+        *,
+        latest_manifest_path: Path | str | None = None,
+        manifest: dict[str, object] | None = None,
+    ) -> None:
         spec = work_mode_spec(self._current_work_mode())
         if spec.mode == WorkMode.SYNC_TRANSLATION:
             context = sync_diagnostics_context(
@@ -1710,18 +1817,23 @@ class MainWindow(QMainWindow):
 
         uses_batch_manifest = spec.manifest_mode is not None
         game_root = self.state.get_game_root()
-        latest_manifest = (
-            self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
-            if (uses_batch_manifest and game_root is not None)
-            else None
-        )
+        latest_manifest = latest_manifest_path
+        if latest_manifest is None and uses_batch_manifest and game_root is not None:
+            latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                game_root,
+                spec.mode,
+            )
         if self._workflow is not None and self._workflow.manifest_path:
             manifest_path = self._workflow.manifest_path
         elif self._writeback_manifest_path:
             manifest_path = self._writeback_manifest_path
         else:
             manifest_path = str(latest_manifest) if latest_manifest is not None else None
-        manifest = self._load_diagnostics_manifest(manifest_path)
+        if manifest is None or (
+            manifest_path
+            and str(manifest.get("_manifest_path", "")) != str(manifest_path)
+        ):
+            manifest = self._load_diagnostics_manifest(manifest_path)
         context = build_diagnostics_context(
             latest_manifest_path=str(latest_manifest) if latest_manifest is not None else None,
             manifest=manifest,
@@ -1732,6 +1844,19 @@ class MainWindow(QMainWindow):
         self._set_diagnostics_context(context)
 
     def _set_diagnostics_context(self, context: DiagnosticsContext) -> None:
+        fingerprint = (
+            context.status,
+            context.heading,
+            context.message,
+            tuple(context.facts),
+            tuple((entry.label, entry.path) for entry in context.paths),
+            tuple((command.label, command.command) for command in context.commands),
+            context.manifest_json_preview,
+        )
+        if self._diagnostics_context_fingerprint == fingerprint:
+            return
+        self._diagnostics_context_fingerprint = fingerprint
+
         self.diagnostics_status_label.setText(context.heading)
         self.diagnostics_status_label.setProperty("status", context.status)
         self.diagnostics_status_label.style().unpolish(self.diagnostics_status_label)
@@ -1893,7 +2018,12 @@ class MainWindow(QMainWindow):
     def _resume_button_is_query_mode(self) -> bool:
         return hasattr(self, "resume_btn") and self.resume_btn.text() == "查询云端状态"
 
-    def _apply_work_mode_ui(self, *, refresh_manifest_writeback: bool = False) -> None:
+    def _apply_work_mode_ui(
+        self,
+        *,
+        refresh_manifest_writeback: bool = False,
+        refresh_diagnostics: bool = False,
+    ) -> None:
         spec = work_mode_spec(self._current_work_mode())
         self._update_timeline_steps(spec.mode)
         self.timeline.setVisible(False)
@@ -1914,9 +2044,13 @@ class MainWindow(QMainWindow):
         else:
             hint = spec.not_implemented_message
         self.work_mode_hint_label.setText(hint)
-        self._refresh_workflow_from_latest_manifest()
-        if refresh_manifest_writeback:
-            self._refresh_writeback_from_latest_manifest()
+        if refresh_manifest_writeback or refresh_diagnostics:
+            self._refresh_manifest_derived_ui(
+                refresh_writeback=refresh_manifest_writeback,
+                refresh_diagnostics=refresh_diagnostics,
+            )
+        else:
+            self._refresh_workflow_from_latest_manifest()
         running = self.kill_btn.isEnabled()
         bootstrap_ready = self._bootstrap_task_ready(spec)
         self.translate_btn.setEnabled(spec.implemented and bootstrap_ready and not running)
@@ -2004,7 +2138,12 @@ class MainWindow(QMainWindow):
             spec.idle_workflow_message,
         )
 
-    def _refresh_workflow_from_latest_manifest(self) -> None:
+    def _refresh_workflow_from_latest_manifest(
+        self,
+        *,
+        latest_manifest: Path | str | None = None,
+        manifest: dict[str, object] | None = None,
+    ) -> None:
         if self.kill_btn.isEnabled():
             return
         spec = work_mode_spec(self._current_work_mode())
@@ -2017,19 +2156,24 @@ class MainWindow(QMainWindow):
             self._refresh_workflow_idle_summary()
             return
 
-        latest_manifest = self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
+        if latest_manifest is None:
+            latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                game_root,
+                spec.mode,
+            )
         if latest_manifest is None:
             self._refresh_workflow_idle_summary()
             return
 
-        try:
-            manifest = self.state.load_resume_manifest(
-                latest_manifest,
-                work_mode=spec.mode,
-            )
-        except ValueError:
-            self._refresh_workflow_idle_summary()
-            return
+        if manifest is None:
+            try:
+                manifest = self.state.load_resume_manifest(
+                    latest_manifest,
+                    work_mode=spec.mode,
+                )
+            except ValueError:
+                self._refresh_workflow_idle_summary()
+                return
 
         job_state = manifest.get("job_state")
         job_state_text = job_state if isinstance(job_state, str) else ""
@@ -2270,26 +2414,32 @@ class MainWindow(QMainWindow):
             summary.facts,
         )
 
-    def _refresh_writeback_from_latest_manifest(self) -> None:
+    def _refresh_writeback_from_latest_manifest(
+        self,
+        *,
+        latest_manifest: Path | str | None = None,
+        manifest: dict[str, object] | None = None,
+    ) -> None:
         spec = work_mode_spec(self._current_work_mode())
         game_root = self.state.get_game_root()
         if spec.mode == WorkMode.REVISION:
-            latest_manifest = (
-                self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
-                if game_root is not None
-                else None
-            )
+            if latest_manifest is None and game_root is not None:
+                latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                    game_root,
+                    spec.mode,
+                )
             if latest_manifest is None:
                 self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
                 return
-            try:
-                manifest = self.state.load_resume_manifest(
-                    latest_manifest,
-                    work_mode=spec.mode,
-                )
-            except ValueError:
-                self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
-                return
+            if manifest is None:
+                try:
+                    manifest = self.state.load_resume_manifest(
+                        latest_manifest,
+                        work_mode=spec.mode,
+                    )
+                except ValueError:
+                    self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
+                    return
             summary = summarize_revision_writeback_from_manifest(manifest)
             if summary is None:
                 self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
@@ -2297,22 +2447,23 @@ class MainWindow(QMainWindow):
             self._set_writeback_summary(summary)
             return
         if spec.mode == WorkMode.KEYWORD_EXTRACTION:
-            latest_manifest = (
-                self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
-                if game_root is not None
-                else None
-            )
+            if latest_manifest is None and game_root is not None:
+                latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                    game_root,
+                    spec.mode,
+                )
             if latest_manifest is None:
                 self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
                 return
-            try:
-                manifest = self.state.load_resume_manifest(
-                    latest_manifest,
-                    work_mode=spec.mode,
-                )
-            except ValueError:
-                self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
-                return
+            if manifest is None:
+                try:
+                    manifest = self.state.load_resume_manifest(
+                        latest_manifest,
+                        work_mode=spec.mode,
+                    )
+                except ValueError:
+                    self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
+                    return
             summary = summarize_keyword_result_from_manifest(manifest)
             if summary is None:
                 self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
@@ -2324,29 +2475,34 @@ class MainWindow(QMainWindow):
             self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
             return
 
-        latest_manifest = (
-            self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
-            if game_root is not None
-            else None
-        )
+        if latest_manifest is None and game_root is not None:
+            latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                game_root,
+                spec.mode,
+            )
         if latest_manifest is None:
             self._set_writeback_summary(idle_writeback_summary())
             return
-        try:
-            manifest = self.state.load_resume_manifest(
-                latest_manifest,
-                work_mode=spec.mode,
-            )
-        except ValueError:
-            self._set_writeback_summary(idle_writeback_summary())
-            return
+        if manifest is None:
+            try:
+                manifest = self.state.load_resume_manifest(
+                    latest_manifest,
+                    work_mode=spec.mode,
+                )
+            except ValueError:
+                self._set_writeback_summary(idle_writeback_summary())
+                return
 
         summary = summarize_manifest_writeback(manifest)
         if summary is None:
             self._set_writeback_summary(idle_writeback_summary())
             return
         self._set_writeback_summary(summary)
-        self._refresh_split_status_ui(manifest_path=str(latest_manifest), manifest=manifest)
+        if not getattr(self, "_split_status_entries", []):
+            self._refresh_split_status_ui(
+                manifest_path=str(latest_manifest),
+                manifest=manifest,
+            )
 
     # --- UI actions ---
 
@@ -3013,7 +3169,7 @@ class MainWindow(QMainWindow):
                 text,
                 self._workflow_progress,
             )
-            self._apply_workflow_progress_ui()
+            self._schedule_progress_ui_flush()
         elif self._active_command == "apply":
             self._apply_output_lines.append(text)
         elif self._active_command == "apply_revision":
@@ -3030,25 +3186,66 @@ class MainWindow(QMainWindow):
                     text,
                     self._bootstrap_progress,
                 )
-                self._apply_bootstrap_progress_ui()
+                self._schedule_progress_ui_flush()
             elif self._active_command == "bootstrap_rag":
                 self._workflow_progress = update_workflow_progress_from_line(
                     text,
                     self._workflow_progress,
                 )
-                self._apply_bootstrap_progress_ui()
+                self._schedule_progress_ui_flush()
         elif self._active_command == "bootstrap_work":
             self._work_bootstrap_output_lines.append(text)
             self._workflow_progress = update_workflow_progress_from_line(
                 text,
                 self._workflow_progress,
             )
-            self._apply_workflow_progress_ui()
+            self._schedule_progress_ui_flush()
         self._append_log(text)
 
-    def _append_log(self, text: str):
-        self.log_view.append(text.rstrip("\n"))
-        # scroll to bottom
+    def _schedule_progress_ui_flush(self) -> None:
+        self._workflow_progress_dirty = True
+        timer = getattr(self, "_progress_flush_timer", None)
+        if timer is None:
+            self._flush_throttled_progress_ui()
+            return
+        if not timer.isActive():
+            timer.start()
+
+    def _flush_throttled_progress_ui(self) -> None:
+        if not self._workflow_progress_dirty:
+            return
+        self._workflow_progress_dirty = False
+        if self._active_command == "bootstrap_source_index":
+            self._apply_bootstrap_progress_ui()
+        elif self._active_command in {"bootstrap_rag", "bootstrap_work", "translation_workflow"}:
+            if self._active_command == "bootstrap_rag":
+                self._apply_bootstrap_progress_ui()
+            else:
+                self._apply_workflow_progress_ui()
+
+    def _append_log(self, text: str) -> None:
+        line = text.rstrip("\n")
+        if not line:
+            return
+        pending = getattr(self, "_pending_log_lines", None)
+        timer = getattr(self, "_log_flush_timer", None)
+        if pending is None or timer is None:
+            if hasattr(self, "log_view"):
+                self.log_view.append(line)
+                scrollbar = self.log_view.verticalScrollBar()
+                scrollbar.setValue(scrollbar.maximum())
+            return
+        pending.append(line)
+        if not timer.isActive():
+            timer.start()
+
+    def _flush_pending_log_lines(self) -> None:
+        if not self._pending_log_lines or not hasattr(self, "log_view"):
+            self._pending_log_lines = []
+            return
+        lines = self._pending_log_lines
+        self._pending_log_lines = []
+        self.log_view.append("\n".join(lines))
         scrollbar = self.log_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
@@ -3672,7 +3869,7 @@ class MainWindow(QMainWindow):
             self.source_index_enabled_cb.setChecked(context_flags["source_index_enabled"])
             self.bootstrap_on_build_cb.setChecked(context_flags["bootstrap_on_build"])
             storage_config = self._config_section(config, "context_storage")
-            storage_location = runtime._normalize_context_storage_location(
+            storage_location = normalize_context_storage_location(
                 storage_config.get("location", config.get("context_storage_location", ""))
             )
             self.context_storage_game_cb.setChecked(storage_location == "game")
@@ -3806,9 +4003,9 @@ def run_app(argv: list[str] | None = None) -> int:
 
     app = QApplication(argv)
     resources_dir = Path(__file__).resolve().parent / "resources"
-    bootstrap_state = ProjectState()
+    project_state = ProjectState()
     try:
-        bootstrap_config = bootstrap_state.load_translator_config()
+        bootstrap_config = project_state.load_translator_config()
         theme_preference = read_gui_theme_from_config(bootstrap_config)
     except Exception as exc:
         print(f"警告：无法读取主题配置，将使用系统跟随：{exc}")
@@ -3818,7 +4015,11 @@ def run_app(argv: list[str] | None = None) -> int:
     except OSError as exc:
         print(f"警告：无法加载 GUI 样式表：{exc}")
 
-    win = MainWindow(qt_app=app, resources_dir=resources_dir)
+    win = MainWindow(
+        qt_app=app,
+        resources_dir=resources_dir,
+        project_state=project_state,
+    )
     app.styleHints().colorSchemeChanged.connect(win._on_system_color_scheme_changed)
     win.show()
     return app.exec()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1268,7 +1268,6 @@ class MainWindow(QMainWindow):
     def _update_split_status_job_column_texts(self, profile: dict[str, int]) -> None:
         if not hasattr(self, "split_status_table"):
             return
-        group_count = max(1, profile["groups"])
         rows = self.split_status_table.rowCount()
         if rows <= 0:
             return

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -122,8 +122,14 @@ def manifest_for_preview(manifest: dict[str, object]) -> dict[str, object]:
 
     files = manifest.get("files")
     chunks = manifest.get("chunks")
+    summary = manifest.get("summary")
     file_count = len(files) if isinstance(files, dict) else 0
     chunk_count = len(chunks) if isinstance(chunks, list) else 0
+    if isinstance(summary, dict):
+        if not file_count and isinstance(summary.get("file_count"), int):
+            file_count = summary["file_count"]
+        if not chunk_count and isinstance(summary.get("chunk_count"), int):
+            chunk_count = summary["chunk_count"]
     if file_count or chunk_count:
         preview["_preview_note"] = (
             f"预览已省略条目明细（{chunk_count} 块 / {file_count} 个文件）"

--- a/gui_qt/manifest_lite.py
+++ b/gui_qt/manifest_lite.py
@@ -1,0 +1,227 @@
+"""Lightweight batch manifest readers for the GUI shell.
+
+Full batch manifests can embed very large ``chunks`` arrays (tens of MB).
+The GUI only needs header / summary / writeback metadata, so we read the
+manifest head and tail instead of parsing the entire JSON object.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_CHUNKS_MARKER_RE = re.compile(r'"chunks"\s*:\s*\[')
+_HEAD_READ_BYTES = 262_144
+_TAIL_READ_BYTES = 524_288
+
+_TAIL_OBJECT_KEYS = (
+    "last_check_summary",
+    "apply_summary",
+    "split_children",
+    "split_from_manifest",
+)
+_TAIL_SCALAR_KEYS = (
+    "applied_at",
+    "next_split_manifest_path",
+    "last_apply_failure_report_path",
+    "last_check_report_path",
+    "retry_of_manifest",
+    "last_retry_manifest_path",
+    "last_check_at",
+    "last_check",
+)
+
+# Manifests larger than this are treated as "heavy" for GUI resume/summary reads.
+HEAVY_MANIFEST_BYTE_THRESHOLD = 256_000
+
+
+def manifest_should_use_lite_reader(path: str | Path) -> bool:
+    try:
+        return Path(path).stat().st_size >= HEAVY_MANIFEST_BYTE_THRESHOLD
+    except OSError:
+        return False
+
+
+def read_manifest_index_fields(path: str | Path) -> dict[str, Any]:
+    """Read only the fields needed to index manifests by mode and project."""
+    try:
+        with Path(path).open("rb") as handle:
+            head = handle.read(8192).decode("utf-8-sig", errors="replace")
+    except OSError:
+        return {}
+
+    result: dict[str, Any] = {}
+    for key in ("mode", "base_dir"):
+        value = _extract_quoted_field(head, key)
+        if value is not None:
+            result[key] = value
+    return result
+
+
+def read_manifest_lite(path: str | Path) -> dict[str, Any]:
+    """Load manifest metadata without parsing the heavy ``chunks`` array."""
+    manifest_path = Path(path)
+    try:
+        size = manifest_path.stat().st_size
+    except OSError:
+        return {}
+    if size <= 0:
+        return {}
+
+    if size < HEAVY_MANIFEST_BYTE_THRESHOLD:
+        try:
+            raw = manifest_path.read_text(encoding="utf-8-sig")
+        except OSError:
+            return {}
+        return _read_json_object(raw)
+
+    try:
+        with manifest_path.open("rb") as handle:
+            head = handle.read(min(_HEAD_READ_BYTES, size)).decode("utf-8-sig", errors="replace")
+            if size > _TAIL_READ_BYTES:
+                handle.seek(size - _TAIL_READ_BYTES)
+                tail = handle.read().decode("utf-8-sig", errors="replace")
+            else:
+                tail = head
+    except OSError:
+        return {}
+
+    if '"chunks"' not in head and '"chunks"' not in tail:
+        return _read_json_object(head if size <= _HEAD_READ_BYTES else head + tail)
+
+    result: dict[str, Any] = {}
+    marker = _CHUNKS_MARKER_RE.search(head)
+    if marker is not None:
+        head_part = head[: marker.start()].rstrip().rstrip(",")
+        head_obj = _read_json_object(head_part + "}")
+        if head_obj:
+            result.update(head_obj)
+    else:
+        head_obj = _read_json_object(head.rstrip().rstrip(","))
+        if head_obj:
+            result.update(head_obj)
+
+    result.update(_extract_tail_fields(tail))
+    return result
+
+
+def _extract_tail_fields(tail: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in _TAIL_OBJECT_KEYS:
+        value = _extract_json_value_after_key(tail, key)
+        if value is not None:
+            result[key] = value
+    for key in _TAIL_SCALAR_KEYS:
+        if key in result:
+            continue
+        value = _extract_scalar_field(tail, key)
+        if value is not None:
+            result[key] = value
+    return result
+
+
+def _extract_scalar_field(text: str, key: str) -> Any | None:
+    match = re.search(
+        rf'"{re.escape(key)}"\s*:\s*("((?:\\.|[^"\\])*)"|(true|false|null))',
+        text,
+    )
+    if not match:
+        return None
+    if match.group(2) is not None:
+        return _decode_json_string(match.group(2))
+    raw = match.group(3)
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    return None
+
+
+def _extract_quoted_field(text: str, key: str) -> str | None:
+    match = re.search(rf'"{re.escape(key)}"\s*:\s*"((?:\\.|[^"\\])*)"', text)
+    if not match:
+        return None
+    return _decode_json_string(match.group(1))
+
+
+def _extract_json_value_after_key(text: str, key: str) -> Any | None:
+    marker = re.search(rf'"{re.escape(key)}"\s*:\s*', text)
+    if not marker:
+        return None
+    index = marker.end()
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if index >= len(text):
+        return None
+
+    opener = text[index]
+    if opener == "{":
+        end = _skip_balanced(text, index, "{", "}")
+    elif opener == "[":
+        end = _skip_balanced(text, index, "[", "]")
+    elif opener == '"':
+        end = _skip_json_string(text, index) + 1
+    else:
+        end_match = re.match(r"[^,\n}]+", text[index:])
+        if not end_match:
+            return None
+        end = index + end_match.end()
+
+    snippet = text[index:end]
+    try:
+        return json.loads(snippet)
+    except json.JSONDecodeError:
+        return None
+
+
+def _decode_json_string(raw: str) -> str:
+    try:
+        decoded = json.loads(f'"{raw}"')
+    except json.JSONDecodeError:
+        return raw
+    return decoded if isinstance(decoded, str) else raw
+
+
+def _read_json_object(raw: str) -> dict[str, Any]:
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _skip_balanced(text: str, start: int, open_char: str, close_char: str) -> int:
+    depth = 0
+    index = start
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == '"':
+            index = _skip_json_string(text, index)
+            index += 1
+            continue
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return length
+
+
+def _skip_json_string(text: str, start: int) -> int:
+    index = start + 1
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == '"':
+            return index
+        index += 1
+    return length

--- a/gui_qt/manifest_lite.py
+++ b/gui_qt/manifest_lite.py
@@ -12,8 +12,21 @@ from pathlib import Path
 from typing import Any
 
 _CHUNKS_MARKER_RE = re.compile(r'"chunks"\s*:\s*\[')
+_CHUNKS_MARKER_BYTES = b'"chunks"'
 _HEAD_READ_BYTES = 262_144
 _TAIL_READ_BYTES = 524_288
+
+_HEAD_SCALAR_KEYS = (
+    "mode",
+    "base_dir",
+    "display_name",
+    "job_name",
+    "job_state",
+    "job_error",
+    "result_jsonl_path",
+    "retry_of_manifest",
+)
+_HEAD_INT_KEYS = ("split_index", "split_total")
 
 _TAIL_OBJECT_KEYS = (
     "last_check_summary",
@@ -72,37 +85,84 @@ def read_manifest_lite(path: str | Path) -> dict[str, Any]:
     if size < HEAVY_MANIFEST_BYTE_THRESHOLD:
         try:
             raw = manifest_path.read_text(encoding="utf-8-sig")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             return {}
         return _read_json_object(raw)
 
+    marker_offset = _locate_chunks_marker(manifest_path)
     try:
         with manifest_path.open("rb") as handle:
-            head = handle.read(min(_HEAD_READ_BYTES, size)).decode("utf-8-sig", errors="replace")
-            if size > _TAIL_READ_BYTES:
-                handle.seek(size - _TAIL_READ_BYTES)
+            if marker_offset is not None:
+                head_limit = marker_offset
+                head = handle.read(head_limit).decode("utf-8-sig", errors="replace")
+                handle.seek(marker_offset)
                 tail = handle.read().decode("utf-8-sig", errors="replace")
             else:
-                tail = head
-    except OSError:
+                head_limit = min(_HEAD_READ_BYTES, size)
+                head = handle.read(head_limit).decode("utf-8-sig", errors="replace")
+                if size > _TAIL_READ_BYTES:
+                    handle.seek(size - _TAIL_READ_BYTES)
+                    tail = handle.read().decode("utf-8-sig", errors="replace")
+                elif head_limit < size:
+                    tail = handle.read().decode("utf-8-sig", errors="replace")
+                else:
+                    tail = head
+    except (OSError, UnicodeDecodeError):
         return {}
 
-    if '"chunks"' not in head and '"chunks"' not in tail:
-        return _read_json_object(head if size <= _HEAD_READ_BYTES else head + tail)
-
     result: dict[str, Any] = {}
-    marker = _CHUNKS_MARKER_RE.search(head)
-    if marker is not None:
-        head_part = head[: marker.start()].rstrip().rstrip(",")
-        head_obj = _read_json_object(head_part + "}")
-        if head_obj:
-            result.update(head_obj)
-    else:
+    if marker_offset is not None:
+        marker = _CHUNKS_MARKER_RE.search(head)
+        if marker is not None:
+            head_part = head[: marker.start()].rstrip().rstrip(",")
+            head_obj = _read_json_object(head_part + "}")
+            if head_obj:
+                result.update(head_obj)
+        else:
+            result.update(_extract_sparse_head_fields(head))
+    elif '"chunks"' not in head and '"chunks"' not in tail:
         head_obj = _read_json_object(head.rstrip().rstrip(","))
         if head_obj:
             result.update(head_obj)
+        else:
+            result.update(_extract_sparse_head_fields(head))
+    else:
+        result.update(_extract_sparse_head_fields(head))
 
     result.update(_extract_tail_fields(tail))
+    result.pop("chunks", None)
+    return result
+
+
+def _locate_chunks_marker(path: Path) -> int | None:
+    with path.open("rb") as handle:
+        offset = 0
+        carry = b""
+        while True:
+            block = handle.read(1024 * 1024)
+            if not block:
+                return None
+            haystack = carry + block
+            idx = haystack.find(_CHUNKS_MARKER_BYTES)
+            if idx >= 0:
+                return offset - len(carry) + idx
+            carry = haystack[-(len(_CHUNKS_MARKER_BYTES) - 1) :] if len(_CHUNKS_MARKER_BYTES) > 1 else b""
+            offset += len(block)
+
+
+def _extract_sparse_head_fields(head: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in _HEAD_SCALAR_KEYS:
+        value = _extract_quoted_field(head, key)
+        if value is not None:
+            result[key] = value
+    for key in _HEAD_INT_KEYS:
+        match = re.search(rf'"{re.escape(key)}"\s*:\s*(\d+)', head)
+        if match:
+            result[key] = int(match.group(1))
+    summary = _extract_json_value_after_key(head, "summary")
+    if isinstance(summary, dict):
+        result["summary"] = summary
     return result
 
 

--- a/gui_qt/path_utils.py
+++ b/gui_qt/path_utils.py
@@ -1,0 +1,43 @@
+"""Lightweight path helpers for the GUI shell.
+
+Kept separate from ``translator_runtime`` so importing the GUI does not pull
+in the full translation runtime dependency chain.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def canonical_abs_path(path: str | Path) -> str:
+    """Return a stable absolute path (long path on Windows, not 8.3 short names)."""
+    if not path:
+        return ""
+    abs_path = os.path.abspath(str(path))
+    try:
+        return str(Path(abs_path).resolve(strict=False))
+    except OSError:
+        return abs_path
+
+
+def resolve_effective_game_root(game_root: str | Path) -> str:
+    """Prefer nested work/ when game_root points at a project-root layout."""
+    normalized = canonical_abs_path(game_root)
+    if os.path.basename(normalized).lower() == "work":
+        return normalized
+
+    nested_work = os.path.join(normalized, "work")
+    original_game = os.path.join(normalized, "original", "game")
+    if os.path.isdir(nested_work) and os.path.isdir(original_game):
+        return canonical_abs_path(nested_work)
+    return normalized
+
+
+def normalize_context_storage_location(value: object) -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower().replace("-", "_")
+        if normalized in {"game", "game_dir", "game_directory"}:
+            return "game"
+        if normalized in {"tool", "project", "repo", "repository", "internal"}:
+            return "tool"
+    return "tool"

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -16,7 +16,12 @@ import os
 from pathlib import Path
 from typing import Any
 
-import translator_runtime as runtime
+from .manifest_lite import (
+    manifest_should_use_lite_reader,
+    read_manifest_index_fields,
+    read_manifest_lite,
+)
+from .path_utils import canonical_abs_path, resolve_effective_game_root
 
 
 class ProjectState:
@@ -36,6 +41,7 @@ class ProjectState:
 
         self._game_root: Path | None = None
         self._game_root_redirect_from: Path | None = None
+        self._manifest_file_cache: dict[str, tuple[int, dict[str, Any]]] = {}
         self._load_game_root_from_config()
 
     # --- Path helpers ---
@@ -92,12 +98,14 @@ class ProjectState:
         # immediately even when the broader history index is cached.
         latest = self.get_latest_manifest_path()
         if latest is not None:
-            try:
-                manifest = self.load_manifest_file(latest)
-            except ValueError:
-                return None
+            manifest = read_manifest_index_fields(latest)
             if self._manifest_matches(manifest, expected_mode, normalized_game_root):
                 return latest
+            try:
+                if latest.stat().st_size > 0 and not manifest:
+                    return None
+            except OSError:
+                return None
 
         for _, path, actual_mode, base_dir in self._manifest_history_index():
             if not self._manifest_mode_matches(actual_mode, expected_mode):
@@ -110,6 +118,34 @@ class ProjectState:
     def invalidate_manifest_history_cache(self) -> None:
         self._manifest_history_cache_signature = None
         self._manifest_history_entries = None
+
+    def invalidate_manifest_file_cache(
+        self,
+        manifest_path: str | Path | None = None,
+    ) -> None:
+        if manifest_path is None:
+            self._manifest_file_cache.clear()
+            return
+        self._manifest_file_cache.pop(self._manifest_cache_key(Path(manifest_path)), None)
+
+    def load_latest_resume_manifest_for_mode(
+        self,
+        game_root: Path | None,
+        work_mode: Any,
+    ) -> tuple[Path | None, dict[str, Any] | None]:
+        if game_root is None:
+            return None, None
+        manifest_path = self.get_latest_manifest_path_for_mode(game_root, work_mode)
+        if manifest_path is None:
+            return None, None
+        try:
+            manifest = self.load_resume_manifest(
+                manifest_path,
+                work_mode=work_mode,
+            )
+        except ValueError:
+            return manifest_path, None
+        return manifest_path, manifest
 
     def _manifest_history_index(self) -> list[tuple[int, Path, str, str]]:
         logs_dir = self.get_logs_dir()
@@ -127,7 +163,9 @@ class ProjectState:
                 path = Path(root) / "manifest.json"
                 try:
                     stat = path.stat()
-                    manifest = self.load_manifest_file(path)
+                    manifest = read_manifest_index_fields(path)
+                    if not manifest:
+                        continue
                     actual_mode = manifest.get("mode", "translation")
                     actual_text = actual_mode.strip() if isinstance(actual_mode, str) else "translation"
                     base_dir = manifest.get("base_dir")
@@ -184,9 +222,37 @@ class ProjectState:
             return actual_text in {"", "translation"}
         return actual_text == expected_mode
 
-    def load_manifest_file(self, manifest_path: str | Path) -> dict[str, Any]:
-        manifest = self._read_json_object(Path(manifest_path), "batch manifest")
-        manifest["_manifest_path"] = str(Path(manifest_path))
+    def load_manifest_file(
+        self,
+        manifest_path: str | Path,
+        *,
+        lite: bool | None = None,
+    ) -> dict[str, Any]:
+        path = Path(manifest_path)
+        cache_key = self._manifest_cache_key(path)
+        mtime_ns = self._manifest_mtime_ns(path)
+        if mtime_ns is not None:
+            cached = self._manifest_file_cache.get(cache_key)
+            if cached is not None and cached[0] == mtime_ns:
+                return cached[1]
+
+        use_lite = (
+            manifest_should_use_lite_reader(path)
+            if lite is None
+            else lite
+        )
+        if use_lite:
+            if not path.exists():
+                manifest: dict[str, Any] = {}
+            else:
+                manifest = read_manifest_lite(path)
+                if not manifest and path.stat().st_size > 0:
+                    raise ValueError(f"Failed to read batch manifest: {path}")
+        else:
+            manifest = self._read_json_object(path, "batch manifest")
+        manifest["_manifest_path"] = str(path)
+        if mtime_ns is not None:
+            self._manifest_file_cache[cache_key] = (mtime_ns, manifest)
         return manifest
 
     def load_resume_manifest(
@@ -208,8 +274,17 @@ class ProjectState:
         )
         return manifest
 
+    def _manifest_cache_key(self, path: Path) -> str:
+        return self._normalized_path_text(path)
+
+    def _manifest_mtime_ns(self, path: Path) -> int | None:
+        try:
+            return path.stat().st_mtime_ns
+        except OSError:
+            return None
+
     def _normalized_path_text(self, path: str | Path) -> str:
-        return os.path.normcase(runtime.canonical_abs_path(str(path)))
+        return os.path.normcase(canonical_abs_path(str(path)))
 
     def _resolve_api_keys_path(self) -> Path:
         root_api_keys = self.tool_root / "api_keys.json"
@@ -282,7 +357,7 @@ class ProjectState:
     def normalize_game_root(self, path: str | Path) -> tuple[Path, bool]:
         """Resolve project-root selections to nested work/ when that directory exists."""
         original = self._path_without_resolve(path)
-        effective = Path(runtime.canonical_abs_path(runtime.resolve_effective_game_root(str(original))))
+        effective = Path(canonical_abs_path(resolve_effective_game_root(str(original))))
         adjusted = self._normalized_path_text(original) != self._normalized_path_text(effective)
         return effective, adjusted
 
@@ -327,7 +402,7 @@ class ProjectState:
     def _save_game_root_to_config(self, game_root: Path) -> None:
         """Update only the game_root key, preserve everything else."""
         data = self._read_json_object(self.config_path, "translator_config.json")
-        data["game_root"] = runtime.canonical_abs_path(str(game_root))
+        data["game_root"] = canonical_abs_path(str(game_root))
         self._write_json_object(self.config_path, data)
 
     # --- Config helpers (api_keys + translator_config) ---

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -126,7 +126,10 @@ class ProjectState:
         if manifest_path is None:
             self._manifest_file_cache.clear()
             return
-        self._manifest_file_cache.pop(self._manifest_cache_key(Path(manifest_path)), None)
+        prefix = self._normalized_path_text(Path(manifest_path)) + "::"
+        for key in list(self._manifest_file_cache):
+            if key.startswith(prefix):
+                del self._manifest_file_cache[key]
 
     def load_latest_resume_manifest_for_mode(
         self,
@@ -229,30 +232,35 @@ class ProjectState:
         lite: bool | None = None,
     ) -> dict[str, Any]:
         path = Path(manifest_path)
-        cache_key = self._manifest_cache_key(path)
-        mtime_ns = self._manifest_mtime_ns(path)
-        if mtime_ns is not None:
-            cached = self._manifest_file_cache.get(cache_key)
-            if cached is not None and cached[0] == mtime_ns:
-                return cached[1]
+        if not path.exists():
+            manifest: dict[str, Any] = {"_manifest_path": str(path)}
+            return manifest
+
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            raise ValueError(f"Failed to read batch manifest: {path}") from exc
 
         use_lite = (
             manifest_should_use_lite_reader(path)
             if lite is None
             else lite
         )
+        cache_key = self._manifest_cache_key(path, lite=use_lite)
+        mtime_ns = stat.st_mtime_ns
+        cached = self._manifest_file_cache.get(cache_key)
+        if cached is not None and cached[0] == mtime_ns:
+            return cached[1]
+
+        file_size = stat.st_size
         if use_lite:
-            if not path.exists():
-                manifest: dict[str, Any] = {}
-            else:
-                manifest = read_manifest_lite(path)
-                if not manifest and path.stat().st_size > 0:
-                    raise ValueError(f"Failed to read batch manifest: {path}")
+            manifest = read_manifest_lite(path)
+            if not manifest and file_size > 0:
+                raise ValueError(f"Failed to read batch manifest: {path}")
         else:
             manifest = self._read_json_object(path, "batch manifest")
         manifest["_manifest_path"] = str(path)
-        if mtime_ns is not None:
-            self._manifest_file_cache[cache_key] = (mtime_ns, manifest)
+        self._manifest_file_cache[cache_key] = (mtime_ns, manifest)
         return manifest
 
     def load_resume_manifest(
@@ -274,14 +282,9 @@ class ProjectState:
         )
         return manifest
 
-    def _manifest_cache_key(self, path: Path) -> str:
-        return self._normalized_path_text(path)
-
-    def _manifest_mtime_ns(self, path: Path) -> int | None:
-        try:
-            return path.stat().st_mtime_ns
-        except OSError:
-            return None
+    def _manifest_cache_key(self, path: Path, *, lite: bool) -> str:
+        mode = "lite" if lite else "full"
+        return f"{self._normalized_path_text(path)}::{mode}"
 
     def _normalized_path_text(self, path: str | Path) -> str:
         return os.path.normcase(canonical_abs_path(str(path)))

--- a/gui_qt/split_batch.py
+++ b/gui_qt/split_batch.py
@@ -1,12 +1,12 @@
 """Helpers for displaying and selecting split batch manifests in the GUI."""
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .manifest_lite import read_manifest_lite
 from .user_copy import job_state_label, safety_level_label
 
 
@@ -39,9 +39,8 @@ class SplitManifestEntry:
 
 def read_json_object(path: str | Path) -> dict[str, Any]:
     try:
-        raw = Path(path).read_text(encoding="utf-8-sig")
-        data = json.loads(raw or "{}")
-    except (OSError, json.JSONDecodeError):
+        data = read_manifest_lite(path)
+    except OSError:
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/gui_qt/split_batch.py
+++ b/gui_qt/split_batch.py
@@ -1,6 +1,7 @@
 """Helpers for displaying and selecting split batch manifests in the GUI."""
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,7 +41,7 @@ class SplitManifestEntry:
 def read_json_object(path: str | Path) -> dict[str, Any]:
     try:
         data = read_manifest_lite(path)
-    except OSError:
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/gui_qt/theme.py
+++ b/gui_qt/theme.py
@@ -16,6 +16,12 @@ _STYLESHEET_CACHE: dict[tuple[str, str], str] = {}
 _FONT_CACHE: dict[str, GuiFontFamilies] = {}
 
 
+def clear_theme_caches() -> None:
+    """Reset module-level caches; primarily intended for test isolation."""
+    _STYLESHEET_CACHE.clear()
+    _FONT_CACHE.clear()
+
+
 def system_prefers_dark(app: QApplication) -> bool | None:
     scheme = app.styleHints().colorScheme()
     if scheme == Qt.ColorScheme.Dark:

--- a/gui_qt/theme.py
+++ b/gui_qt/theme.py
@@ -8,17 +8,17 @@ from PySide6.QtWidgets import QApplication
 
 from .font_helpers import GuiFontFamilies, build_font_stylesheet, load_gui_fonts
 from .theme_helpers import (
+    clear_stylesheet_cache,
+    load_theme_stylesheet,
     resolve_effective_theme,
-    theme_stylesheet_filename,
 )
 
-_STYLESHEET_CACHE: dict[tuple[str, str], str] = {}
 _FONT_CACHE: dict[str, GuiFontFamilies] = {}
 
 
 def clear_theme_caches() -> None:
     """Reset module-level caches; primarily intended for test isolation."""
-    _STYLESHEET_CACHE.clear()
+    clear_stylesheet_cache()
     _FONT_CACHE.clear()
 
 
@@ -29,24 +29,6 @@ def system_prefers_dark(app: QApplication) -> bool | None:
     if scheme == Qt.ColorScheme.Light:
         return False
     return None
-
-
-def load_theme_stylesheet(resources_dir: Path, effective_theme: str) -> str:
-    cache_key = (str(resources_dir.resolve()), effective_theme)
-    cached = _STYLESHEET_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
-
-    filename = theme_stylesheet_filename(effective_theme)
-    path = resources_dir / filename
-    if not path.exists() and effective_theme == "dark":
-        path = resources_dir / "app.qss"
-    if not path.exists():
-        stylesheet = ""
-    else:
-        stylesheet = path.read_text(encoding="utf-8")
-    _STYLESHEET_CACHE[cache_key] = stylesheet
-    return stylesheet
 
 
 def cached_gui_fonts(resources_dir: Path) -> GuiFontFamilies:

--- a/gui_qt/theme.py
+++ b/gui_qt/theme.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
-from .font_helpers import build_font_stylesheet, load_gui_fonts
+from .font_helpers import GuiFontFamilies, build_font_stylesheet, load_gui_fonts
 from .theme_helpers import (
     resolve_effective_theme,
     theme_stylesheet_filename,
 )
+
+_STYLESHEET_CACHE: dict[tuple[str, str], str] = {}
+_FONT_CACHE: dict[str, GuiFontFamilies] = {}
 
 
 def system_prefers_dark(app: QApplication) -> bool | None:
@@ -23,13 +26,31 @@ def system_prefers_dark(app: QApplication) -> bool | None:
 
 
 def load_theme_stylesheet(resources_dir: Path, effective_theme: str) -> str:
+    cache_key = (str(resources_dir.resolve()), effective_theme)
+    cached = _STYLESHEET_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     filename = theme_stylesheet_filename(effective_theme)
     path = resources_dir / filename
     if not path.exists() and effective_theme == "dark":
         path = resources_dir / "app.qss"
     if not path.exists():
-        return ""
-    return path.read_text(encoding="utf-8")
+        stylesheet = ""
+    else:
+        stylesheet = path.read_text(encoding="utf-8")
+    _STYLESHEET_CACHE[cache_key] = stylesheet
+    return stylesheet
+
+
+def cached_gui_fonts(resources_dir: Path) -> GuiFontFamilies:
+    cache_key = str(resources_dir.resolve())
+    cached = _FONT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    fonts = load_gui_fonts(resources_dir)
+    _FONT_CACHE[cache_key] = fonts
+    return fonts
 
 
 def apply_theme(app: QApplication, resources_dir: Path, preference: str) -> str:
@@ -38,7 +59,7 @@ def apply_theme(app: QApplication, resources_dir: Path, preference: str) -> str:
         system_is_dark=system_prefers_dark(app),
     )
     stylesheet = load_theme_stylesheet(resources_dir, effective)
-    font_stylesheet = build_font_stylesheet(load_gui_fonts(resources_dir))
+    font_stylesheet = build_font_stylesheet(cached_gui_fonts(resources_dir))
     if font_stylesheet:
         stylesheet = f"{font_stylesheet}\n{stylesheet}"
     if stylesheet:

--- a/gui_qt/theme_helpers.py
+++ b/gui_qt/theme_helpers.py
@@ -1,6 +1,7 @@
 """Pure helpers for GUI theme preference resolution (no Qt dependency)."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 THEME_SYSTEM = "system"
@@ -49,3 +50,29 @@ def write_gui_theme_to_config(config: dict[str, Any], preference: Any) -> None:
         gui = {}
         config["gui"] = gui
     gui["theme"] = normalize_theme_preference(preference)
+
+
+_STYLESHEET_CACHE: dict[tuple[str, str], str] = {}
+
+
+def clear_stylesheet_cache() -> None:
+    """Reset stylesheet cache; primarily intended for test isolation."""
+    _STYLESHEET_CACHE.clear()
+
+
+def load_theme_stylesheet(resources_dir: Path, effective_theme: str) -> str:
+    cache_key = (str(resources_dir.resolve()), effective_theme)
+    cached = _STYLESHEET_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    filename = theme_stylesheet_filename(effective_theme)
+    path = resources_dir / filename
+    if not path.exists() and effective_theme == "dark":
+        path = resources_dir / "app.qss"
+    if not path.exists():
+        stylesheet = ""
+    else:
+        stylesheet = path.read_text(encoding="utf-8")
+    _STYLESHEET_CACHE[cache_key] = stylesheet
+    return stylesheet

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -52,6 +52,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window.workflow_progress_bar = FakeProgressBar()
         self.window.workflow_facts_label = FakeLabel()
         self.window._append_log = lambda text: None
+        self.window._progress_flush_timer = None
 
         self.window._on_cli_line_ready("[2/4] sync-key")
 

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -66,6 +66,36 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             "Manifest: C:/dummy/manifest.json\n当前请求：sync-key",
         )
 
+    def test_clear_log_view_flushes_pending_buffer(self):
+        class FakeLogView:
+            def __init__(self):
+                self.lines: list[str] = []
+
+            def append(self, text: str) -> None:
+                self.lines.append(text)
+
+            def clear(self) -> None:
+                self.lines.clear()
+
+            def verticalScrollBar(self):
+                class Bar:
+                    def setValue(self, _value: int) -> None:
+                        return None
+
+                    @property
+                    def maximum(self) -> int:
+                        return 0
+
+                return Bar()
+
+        self.window.log_view = FakeLogView()
+        self.window._pending_log_lines = ["stale line"]
+        self.window._log_flush_timer = None
+
+        self.window._clear_log_view()
+
+        self.assertEqual(self.window._pending_log_lines, [])
+        self.assertEqual(self.window.log_view.lines, [])
 
     def test_short_job_name_compacts_batch_ids(self):
         job_name = "batches/l10v1nppy30lvv2cbzbhedje4oqnqlzedlve"

--- a/tests/test_gui_manifest_lite.py
+++ b/tests/test_gui_manifest_lite.py
@@ -35,6 +35,35 @@ class GuiManifestLiteTests(unittest.TestCase):
             self.assertEqual(lite.get("applied_at"), "2026-06-30T12:00:00")
             self.assertNotIn("chunks", lite)
 
+    def test_read_manifest_lite_skips_chunks_beyond_head_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            head = {
+                "mode": "translation",
+                "base_dir": "C:/game/work",
+                "job_name": "batches/late-chunks",
+                "job_state": "JOB_STATE_SUCCEEDED",
+                "summary": {"item_count": 9, "chunk_count": 2, "file_count": 1},
+                "files": {"a.rpy": {"path": "C:/game/work/a.rpy"}},
+            }
+            tail = {
+                "last_check_summary": {"safety_level": "warn"},
+                "applied_at": "2026-06-30T13:00:00",
+            }
+            padding = "p" * 300_000
+            payload = {**head, "padding": padding, "chunks": [{"key": "chunk-1"}], **tail}
+            path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+            lite = read_manifest_lite(path)
+
+            self.assertEqual(lite.get("mode"), "translation")
+            self.assertEqual(lite.get("base_dir"), "C:/game/work")
+            self.assertEqual(lite.get("job_state"), "JOB_STATE_SUCCEEDED")
+            self.assertEqual(lite.get("summary", {}).get("item_count"), 9)
+            self.assertEqual(lite.get("last_check_summary", {}).get("safety_level"), "warn")
+            self.assertEqual(lite.get("applied_at"), "2026-06-30T13:00:00")
+            self.assertNotIn("chunks", lite)
+
     def test_read_manifest_index_fields_reads_only_header(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "manifest.json"

--- a/tests/test_gui_manifest_lite.py
+++ b/tests/test_gui_manifest_lite.py
@@ -1,0 +1,61 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from gui_qt.manifest_lite import (
+    read_manifest_index_fields,
+    read_manifest_lite,
+)
+
+
+class GuiManifestLiteTests(unittest.TestCase):
+    def test_read_manifest_lite_skips_heavy_chunks_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            payload = {
+                "mode": "translation",
+                "base_dir": "C:/game/work",
+                "job_name": "batches/demo",
+                "job_state": "JOB_STATE_SUCCEEDED",
+                "summary": {"item_count": 12, "chunk_count": 3, "file_count": 2},
+                "files": {"a.rpy": {"path": "C:/game/work/a.rpy"}},
+                "chunks": [{"key": f"chunk-{index}", "payload": "x" * 96} for index in range(4000)],
+                "last_check_summary": {"safety_level": "safe", "pending_lines": 12},
+                "applied_at": "2026-06-30T12:00:00",
+            }
+            path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+            lite = read_manifest_lite(path)
+
+            self.assertEqual(lite.get("mode"), "translation")
+            self.assertEqual(lite.get("job_state"), "JOB_STATE_SUCCEEDED")
+            self.assertEqual(lite.get("summary", {}).get("item_count"), 12)
+            self.assertEqual(lite.get("last_check_summary", {}).get("safety_level"), "safe")
+            self.assertEqual(lite.get("applied_at"), "2026-06-30T12:00:00")
+            self.assertNotIn("chunks", lite)
+
+    def test_read_manifest_index_fields_reads_only_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "mode": "keyword_extraction",
+                        "base_dir": "C:/game/work",
+                        "chunks": [{"key": "ignored"}],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            fields = read_manifest_index_fields(path)
+
+            self.assertEqual(fields.get("mode"), "keyword_extraction")
+            self.assertEqual(fields.get("base_dir"), "C:/game/work")
+            self.assertNotIn("chunks", fields)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -25,6 +25,7 @@ class GuiProjectStateTests(unittest.TestCase):
         state.config_path = root / "translator_config.json"
         state._game_root = None
         state._game_root_redirect_from = None
+        state._manifest_file_cache = {}
         return state
 
     def test_save_api_keys_preserves_existing_unknown_fields(self):
@@ -582,24 +583,71 @@ class GuiProjectStateTests(unittest.TestCase):
 
             state.get_logs_dir = lambda: logs_dir
             state._normalized_path_text = lambda p: os.path.normcase(os.path.abspath(p))
-            original_load_manifest_file = state.load_manifest_file
-            loaded_paths = []
-
-            def recording_load_manifest_file(path):
-                loaded_paths.append(Path(path))
-                return original_load_manifest_file(path)
-
-            state.load_manifest_file = recording_load_manifest_file
             game_root = Path("C:/correct/project")
 
-            first = state.get_latest_manifest_path_for_mode(game_root, WorkMode.KEYWORD_EXTRACTION)
-            first_read_count = len(loaded_paths)
-            second = state.get_latest_manifest_path_for_mode(game_root, WorkMode.KEYWORD_EXTRACTION)
+            first = state.get_latest_manifest_path_for_mode(
+                game_root,
+                WorkMode.KEYWORD_EXTRACTION,
+            )
+            first_index = state._manifest_history_index()
+            second = state.get_latest_manifest_path_for_mode(
+                game_root,
+                WorkMode.KEYWORD_EXTRACTION,
+            )
+            second_index = state._manifest_history_index()
 
             self.assertEqual(Path(first).resolve(), manifest.resolve())
             self.assertEqual(Path(second).resolve(), manifest.resolve())
-            self.assertGreater(first_read_count, 0)
-            self.assertEqual(len(loaded_paths), first_read_count)
+            self.assertIs(first_index, second_index)
+
+    def test_load_manifest_file_reuses_mtime_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"mode": "translation", "base_dir": "C:/game/work"}),
+                encoding="utf-8",
+            )
+
+            read_calls = {"count": 0}
+            original_read = state._read_json_object
+
+            def counting_read(path, description):
+                read_calls["count"] += 1
+                return original_read(path, description)
+
+            with patch.object(state, "_read_json_object", side_effect=counting_read):
+                first = state.load_manifest_file(manifest)
+                second = state.load_manifest_file(manifest)
+
+            self.assertEqual(first.get("mode"), "translation")
+            self.assertIs(second, first)
+            self.assertEqual(read_calls["count"], 1)
+
+    def test_invalidate_manifest_file_cache_forces_reload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"mode": "translation", "base_dir": "C:/game/work"}),
+                encoding="utf-8",
+            )
+
+            read_calls = {"count": 0}
+            original_read = state._read_json_object
+
+            def counting_read(path, description):
+                read_calls["count"] += 1
+                return original_read(path, description)
+
+            with patch.object(state, "_read_json_object", side_effect=counting_read):
+                state.load_manifest_file(manifest)
+                state.invalidate_manifest_file_cache(manifest)
+                state.load_manifest_file(manifest)
+
+            self.assertEqual(read_calls["count"], 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -649,5 +649,43 @@ class GuiProjectStateTests(unittest.TestCase):
 
             self.assertEqual(read_calls["count"], 2)
 
+    def test_load_manifest_file_keeps_lite_and_full_cache_separate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            manifest = root / "manifest.json"
+            payload = {
+                "mode": "translation",
+                "base_dir": "C:/game/work",
+                "padding": "x" * 300_000,
+                "chunks": [{"key": "chunk-1"}],
+                "last_check_summary": {"safety_level": "safe"},
+            }
+            manifest.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+            lite = state.load_manifest_file(manifest, lite=True)
+            full = state.load_manifest_file(manifest, lite=False)
+
+            self.assertNotIn("chunks", lite)
+            self.assertIn("chunks", full)
+            self.assertIsNot(lite, full)
+
+    def test_invalidate_manifest_file_cache_clears_lite_and_full(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"mode": "translation", "base_dir": "C:/game/work"}),
+                encoding="utf-8",
+            )
+
+            first = state.load_manifest_file(manifest)
+            state.invalidate_manifest_file_cache(manifest)
+            second = state.load_manifest_file(manifest)
+
+            self.assertEqual(first.get("mode"), "translation")
+            self.assertIsNot(second, first)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_theme_cache.py
+++ b/tests/test_gui_theme_cache.py
@@ -2,20 +2,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from gui_qt.theme import clear_theme_caches, load_theme_stylesheet
+from gui_qt.theme_helpers import clear_stylesheet_cache, load_theme_stylesheet
 
 
 class GuiThemeCacheTests(unittest.TestCase):
     def tearDown(self) -> None:
-        clear_theme_caches()
+        clear_stylesheet_cache()
 
-    def test_clear_theme_caches_allows_stylesheet_reload(self):
+    def test_clear_stylesheet_cache_allows_stylesheet_reload(self):
         with tempfile.TemporaryDirectory() as tmp:
             resources = Path(tmp)
             (resources / "app.qss").write_text("QWidget { color: red; }", encoding="utf-8")
 
             first = load_theme_stylesheet(resources, "light")
-            clear_theme_caches()
+            clear_stylesheet_cache()
             (resources / "app.qss").write_text("QWidget { color: blue; }", encoding="utf-8")
             second = load_theme_stylesheet(resources, "light")
 

--- a/tests/test_gui_theme_cache.py
+++ b/tests/test_gui_theme_cache.py
@@ -1,0 +1,27 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gui_qt.theme import clear_theme_caches, load_theme_stylesheet
+
+
+class GuiThemeCacheTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        clear_theme_caches()
+
+    def test_clear_theme_caches_allows_stylesheet_reload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resources = Path(tmp)
+            (resources / "app.qss").write_text("QWidget { color: red; }", encoding="utf-8")
+
+            first = load_theme_stylesheet(resources, "light")
+            clear_theme_caches()
+            (resources / "app.qss").write_text("QWidget { color: blue; }", encoding="utf-8")
+            second = load_theme_stylesheet(resources, "light")
+
+            self.assertIn("red", first)
+            self.assertIn("blue", second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Batch manifests can embed very large `chunks` arrays (tens of MB). The GUI was fully parsing them on startup, when indexing job history, and again when resizing the split-batch status table.

This change makes those paths lightweight and avoids duplicate work during a single refresh cycle.

## Changes

- **manifest_lite**: read manifest head/tail metadata without parsing `chunks`
- **ProjectState**: mtime-based manifest file cache; lightweight index fields for `latest_manifest.txt` validation
- **Refresh coordination**: workflow, writeback, and diagnostics share one latest-manifest load on startup
- **Split-batch table**: reuse in-memory entries on resize; only re-truncate job column text when column profile changes
- **path_utils**: GUI no longer imports `translator_runtime` at module load
- **UI responsiveness**: batched log append, throttled progress updates, debounced layout sync, diagnostics rebuild shortcut
- **Startup**: deferred manifest-derived UI refresh; shared `ProjectState`; cached QSS/fonts

## Testing

```
python -m unittest discover -s tests -p test_gui*.py -q
```

326 tests passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 提升了清单相关界面的加载与刷新效率，减少大文件带来的卡顿。
  * 日志、进度条和部分界面更新改为批量刷新，操作更流畅。
  * 主题与字体加载增加缓存，切换界面时响应更快。

* **Bug 修复**
  * 优化了诊断信息的刷新时机，减少重复渲染和不必要的更新。
  * 改进了路径与清单匹配方式，提升项目状态识别稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->