### PR TITLE
perf(gui): split-status delegate buttons and manifest lite tail fix

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1569,24 +1569,12 @@ class MainWindow(QMainWindow):
         else:
             self._refresh_split_status_ui(manifest_path=manifest_path)
         self._refresh_writeback_for_manifest_path(manifest_path)
-        QTimer.singleShot(
-            0,
-            lambda path=manifest_path: self._deferred_select_split_manifest_refresh(path),
-        )
         writeback_summary = self._current_writeback_summary()
         if writeback_summary.status not in {"idle", "running", "stale"}:
             self._focus_workbench_status_tab(2)
         else:
             self._focus_workbench_status_tab(1)
         self.statusBar().showMessage("已选择拆分包；可继续下载、检查或写回。", 5000)
-
-    def _deferred_select_split_manifest_refresh(self, manifest_path: str) -> None:
-        if not self._same_manifest_path(
-            manifest_path,
-            self._split_status_selected_manifest_path,
-        ):
-            return
-        self._refresh_workflow_from_latest_manifest()
 
     def _writeback_issues_ready(self, summary: WritebackSummary) -> bool:
         if self._uses_revision_writeback():

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -296,10 +296,12 @@ class MainWindow(QMainWindow):
                 if delegate is not None:
                     if event.type() == QEvent.Type.Leave:
                         delegate.clear_hover_state()
+                        delegate.clear_pressed_state()
                     else:
                         index = self.split_status_table.indexAt(event.position().toPoint())
                         if not index.isValid() or not is_split_action_column(index.column()):
                             delegate.clear_hover_state()
+                            delegate.clear_pressed_state()
         return super().eventFilter(watched, event)
 
     def _sync_work_mode_hint_height(self) -> None:
@@ -1085,15 +1087,18 @@ class MainWindow(QMainWindow):
         previous = self._split_status_entries
         if len(previous) != len(entries):
             return False
-        for old_entry, new_entry in zip(previous, entries):
+        for old_entry, new_entry in zip(previous, entries, strict=True):
             if (
                 old_entry.manifest_path != new_entry.manifest_path
+                or old_entry.part_label != new_entry.part_label
                 or old_entry.status_kind != new_entry.status_kind
                 or old_entry.status_label != new_entry.status_label
                 or old_entry.item_count != new_entry.item_count
                 or old_entry.chunk_count != new_entry.chunk_count
                 or old_entry.job_name != new_entry.job_name
+                or old_entry.job_state != new_entry.job_state
                 or old_entry.selectable != new_entry.selectable
+                or old_entry.needs_submit != new_entry.needs_submit
             ):
                 return False
         return True
@@ -1160,6 +1165,7 @@ class MainWindow(QMainWindow):
         delegate = getattr(self, "_split_status_action_delegate", None)
         if delegate is not None:
             delegate.clear_hover_state()
+            delegate.clear_pressed_state()
         self.split_status_table.setRowCount(rows)
         for row in range(rows):
             for column in range(self.split_status_table.columnCount()):
@@ -1569,6 +1575,16 @@ class MainWindow(QMainWindow):
         else:
             self._refresh_split_status_ui(manifest_path=manifest_path)
         self._refresh_writeback_for_manifest_path(manifest_path)
+        try:
+            selected_manifest = self.state.load_manifest_file(manifest_path, lite=True)
+        except ValueError:
+            selected_manifest = None
+        if selected_manifest is not None:
+            self._refresh_workflow_from_latest_manifest(
+                latest_manifest=manifest_path,
+                manifest=selected_manifest,
+                split_entries=self._split_status_entries or None,
+            )
         writeback_summary = self._current_writeback_summary()
         if writeback_summary.status not in {"idle", "running", "stale"}:
             self._focus_workbench_status_tab(2)
@@ -2272,6 +2288,7 @@ class MainWindow(QMainWindow):
         *,
         latest_manifest: Path | str | None = None,
         manifest: dict[str, object] | None = None,
+        split_entries: list[SplitManifestEntry] | None = None,
     ) -> None:
         if self.kill_btn.isEnabled():
             return
@@ -2343,7 +2360,8 @@ class MainWindow(QMainWindow):
         if retry_parent_text:
             facts.append(f"父任务：{retry_parent_text}")
 
-        split_entries = self._split_entries_for_manifest(str(latest_manifest), manifest)
+        if split_entries is None:
+            split_entries = self._split_entries_for_manifest(str(latest_manifest), manifest)
         facts.extend(summarize_split_entries(split_entries))
 
         is_waiting = job_state_text in ("JOB_STATE_PENDING", "JOB_STATE_RUNNING")

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -94,6 +94,8 @@ from .split_batch import (
     summarize_split_entries,
 )
 from .split_batch_workflow import SplitBatchQueueWorkflow
+from .split_status_delegate import SPLIT_ACTION_DATA_ROLE, SplitStatusActionDelegate
+from .split_status_table_helpers import is_split_action_column, split_action_item_payload
 from .retry_preview_dialog import RetryPreviewDialog
 from .retry_report import (
     assess_retry_eligibility,
@@ -282,12 +284,18 @@ class MainWindow(QMainWindow):
     def eventFilter(self, watched: Any, event: QEvent) -> bool:
         if watched is self.work_mode_hint_label and event.type() == QEvent.Type.Resize:
             self._sync_work_mode_hint_height()
-        if (
-            hasattr(self, "split_status_table")
-            and watched is self.split_status_table.viewport()
-            and event.type() == QEvent.Type.Resize
-        ):
-            self._sync_split_status_table_columns()
+        if hasattr(self, "split_status_table") and watched is self.split_status_table.viewport():
+            if event.type() == QEvent.Type.Resize:
+                self._sync_split_status_table_columns()
+            elif event.type() in {QEvent.Type.Leave, QEvent.Type.MouseMove}:
+                delegate = getattr(self, "_split_status_action_delegate", None)
+                if delegate is not None:
+                    if event.type() == QEvent.Type.Leave:
+                        delegate.clear_hover_state()
+                    else:
+                        index = self.split_status_table.indexAt(event.position().toPoint())
+                        if not index.isValid() or not is_split_action_column(index.column()):
+                            delegate.clear_hover_state()
         return super().eventFilter(watched, event)
 
     def _sync_work_mode_hint_height(self) -> None:
@@ -613,6 +621,8 @@ class MainWindow(QMainWindow):
         self.split_status_table.setMaximumHeight(360)
         self.split_status_table.verticalHeader().setVisible(False)
         self.split_status_table.viewport().installEventFilter(self)
+        self._split_status_action_delegate = SplitStatusActionDelegate(self.split_status_table)
+        self._split_status_action_delegate.select_requested.connect(self._select_split_manifest)
         split_header = self.split_status_table.horizontalHeader()
         split_header.setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
         split_header.setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)
@@ -1123,10 +1133,12 @@ class MainWindow(QMainWindow):
         profile = self._configure_split_status_table_columns()
         group_count = max(1, profile["groups"])
         rows = (len(entries) + group_count - 1) // group_count
+        delegate = getattr(self, "_split_status_action_delegate", None)
+        if delegate is not None:
+            delegate.clear_hover_state()
         self.split_status_table.setRowCount(rows)
         for row in range(rows):
             for column in range(self.split_status_table.columnCount()):
-                self.split_status_table.removeCellWidget(row, column)
                 self._set_split_table_item(row, column, "")
 
         for index, entry in enumerate(entries):
@@ -1209,7 +1221,18 @@ class MainWindow(QMainWindow):
             self.split_status_table.setColumnWidth(base + 2, profile["item_width"])
             self.split_status_table.setColumnWidth(base + 3, profile["chunk_width"])
             self.split_status_table.setColumnWidth(base + 5, profile["action_width"])
+        self._ensure_split_status_action_delegates()
         return profile
+
+    def _ensure_split_status_action_delegates(self) -> None:
+        if not hasattr(self, "split_status_table"):
+            return
+        delegate = getattr(self, "_split_status_action_delegate", None)
+        if delegate is None:
+            return
+        for column in range(self.split_status_table.columnCount()):
+            if is_split_action_column(column):
+                self.split_status_table.setItemDelegateForColumn(column, delegate)
 
     def _sync_split_status_table_columns(self) -> None:
         if not hasattr(self, "split_status_table"):
@@ -1310,24 +1333,18 @@ class MainWindow(QMainWindow):
             self._split_job_text(entry, profile["job_chars"]),
             tooltip=entry.job_name or entry.manifest_path,
         )
-        self._set_split_table_item(row, base_column + 5, "")
-        if entry.selectable:
-            select_btn = QPushButton("\u9009\u62e9")
-            select_btn.setObjectName("split_select_btn")
-            select_btn.setMinimumHeight(30)
-            select_btn.setMaximumHeight(30)
-            select_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-            select_btn.setToolTip(f"\u5207\u6362\u5230 {entry.part_label}")
-            select_btn.clicked.connect(
-                lambda _checked=False, path=entry.manifest_path: self._select_split_manifest(path)
-            )
-            cell = QWidget()
-            cell.setObjectName("split_status_action_cell")
-            cell_layout = QHBoxLayout(cell)
-            cell_layout.setContentsMargins(8, 6, 8, 6)
-            cell_layout.setSpacing(0)
-            cell_layout.addWidget(select_btn)
-            self.split_status_table.setCellWidget(row, base_column + 5, cell)
+        action_payload = split_action_item_payload(
+            selectable=entry.selectable,
+            manifest_path=entry.manifest_path,
+            part_label=entry.part_label,
+        )
+        action_item = QTableWidgetItem("")
+        action_item.setFlags(action_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+        action_item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter)
+        if action_payload is not None:
+            action_item.setData(SPLIT_ACTION_DATA_ROLE, action_payload)
+            action_item.setToolTip(f"\u5207\u6362\u5230 {entry.part_label}")
+        self.split_status_table.setItem(row, base_column + 5, action_item)
         self._apply_split_table_row_style(row, entry, base_column=base_column, is_current=is_current)
 
     def _split_job_text(self, entry: SplitManifestEntry, max_chars: int) -> str:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -278,8 +278,12 @@ class MainWindow(QMainWindow):
     def _deferred_startup_refresh(self) -> None:
         self._apply_work_mode_ui(
             refresh_manifest_writeback=True,
-            refresh_diagnostics=True,
+            refresh_diagnostics=False,
         )
+        QTimer.singleShot(0, self._deferred_startup_diagnostics_refresh)
+
+    def _deferred_startup_diagnostics_refresh(self) -> None:
+        self._refresh_manifest_derived_ui(refresh_diagnostics=True)
 
     def eventFilter(self, watched: Any, event: QEvent) -> bool:
         if watched is self.work_mode_hint_label and event.type() == QEvent.Type.Resize:
@@ -1074,6 +1078,26 @@ class MainWindow(QMainWindow):
             return False
         return canonical_abs_path(left).lower() == canonical_abs_path(right).lower()
 
+    def _split_entries_unchanged(
+        self,
+        entries: list[SplitManifestEntry],
+    ) -> bool:
+        previous = self._split_status_entries
+        if len(previous) != len(entries):
+            return False
+        for old_entry, new_entry in zip(previous, entries):
+            if (
+                old_entry.manifest_path != new_entry.manifest_path
+                or old_entry.status_kind != new_entry.status_kind
+                or old_entry.status_label != new_entry.status_label
+                or old_entry.item_count != new_entry.item_count
+                or old_entry.chunk_count != new_entry.chunk_count
+                or old_entry.job_name != new_entry.job_name
+                or old_entry.selectable != new_entry.selectable
+            ):
+                return False
+        return True
+
     def _split_entries_for_manifest(
         self,
         manifest_path: str,
@@ -1288,6 +1312,46 @@ class MainWindow(QMainWindow):
             selected_manifest_path=selected_manifest_path,
         )
 
+    def _update_split_status_selection_ui(self, selected_manifest_path: str) -> None:
+        if not hasattr(self, "split_status_table") or not self._split_status_entries:
+            return
+        rows = self.split_status_table.rowCount()
+        if rows <= 0:
+            return
+        for index, entry in enumerate(self._split_status_entries):
+            group_index = index // rows if rows else 0
+            row = index % rows if rows else 0
+            base_column = group_index * 6
+            if base_column + 5 >= self.split_status_table.columnCount():
+                continue
+            is_current = self._same_manifest_path(entry.manifest_path, selected_manifest_path)
+            part_item = self.split_status_table.item(row, base_column + 0)
+            if part_item is not None:
+                current_suffix = "\uff08\u5f53\u524d\uff09" if is_current else ""
+                part_item.setText(f"{entry.part_label}{current_suffix}")
+                font = part_item.font()
+                font.setBold(is_current)
+                part_item.setFont(font)
+            action_item = self.split_status_table.item(row, base_column + 5)
+            if action_item is None:
+                continue
+            show_action_button = entry.selectable and not is_current
+            action_payload = split_action_item_payload(
+                selectable=show_action_button,
+                manifest_path=entry.manifest_path,
+                part_label=entry.part_label,
+            )
+            if action_payload is not None:
+                action_item.setData(SPLIT_ACTION_DATA_ROLE, action_payload)
+                action_item.setToolTip(f"\u5207\u6362\u5230 {entry.part_label}")
+            else:
+                action_item.setData(SPLIT_ACTION_DATA_ROLE, None)
+                action_item.setToolTip("")
+            model_index = self.split_status_table.model().index(row, base_column + 5)
+            self.split_status_table.viewport().update(
+                self.split_status_table.visualRect(model_index)
+            )
+
     def _update_split_status_job_column_texts(self, profile: dict[str, int]) -> None:
         if not hasattr(self, "split_status_table"):
             return
@@ -1475,6 +1539,22 @@ class MainWindow(QMainWindow):
         self.split_submit_btn.setText("提交剩余包")
         self.split_submit_btn.setEnabled(has_split_group and needs_submit and not running)
 
+    def _refresh_writeback_for_manifest_path(self, manifest_path: str) -> None:
+        spec = work_mode_spec(self._current_work_mode())
+        if not spec.supports_translation_writeback:
+            self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
+            return
+        try:
+            manifest = self.state.load_manifest_file(manifest_path, lite=True)
+        except ValueError:
+            self._set_writeback_summary(idle_writeback_summary())
+            return
+        summary = summarize_manifest_writeback(manifest)
+        if summary is None:
+            self._set_writeback_summary(idle_writeback_summary())
+            return
+        self._set_writeback_summary(summary)
+
     def _select_split_manifest(self, manifest_path: str) -> None:
         try:
             self.state.remember_latest_manifest_path(manifest_path)
@@ -1483,13 +1563,30 @@ class MainWindow(QMainWindow):
             return
         self._workflow = None
         self._workflow_step_output_lines = []
-        self._refresh_manifest_derived_ui(refresh_writeback=True)
+        self._split_status_selected_manifest_path = manifest_path
+        if self._split_status_entries:
+            self._update_split_status_selection_ui(manifest_path)
+        else:
+            self._refresh_split_status_ui(manifest_path=manifest_path)
+        self._refresh_writeback_for_manifest_path(manifest_path)
+        QTimer.singleShot(
+            0,
+            lambda path=manifest_path: self._deferred_select_split_manifest_refresh(path),
+        )
         writeback_summary = self._current_writeback_summary()
         if writeback_summary.status not in {"idle", "running", "stale"}:
             self._focus_workbench_status_tab(2)
         else:
             self._focus_workbench_status_tab(1)
         self.statusBar().showMessage("已选择拆分包；可继续下载、检查或写回。", 5000)
+
+    def _deferred_select_split_manifest_refresh(self, manifest_path: str) -> None:
+        if not self._same_manifest_path(
+            manifest_path,
+            self._split_status_selected_manifest_path,
+        ):
+            return
+        self._refresh_workflow_from_latest_manifest()
 
     def _writeback_issues_ready(self, summary: WritebackSummary) -> bool:
         if self._uses_revision_writeback():
@@ -2327,10 +2424,15 @@ class MainWindow(QMainWindow):
             workflow,
             step_key=timeline_step_key,
         )
-        self._render_split_status_entries(
-            split_entries,
-            selected_manifest_path=retry_parent_text or str(latest_manifest),
-        )
+        selected_manifest_path = retry_parent_text or str(latest_manifest)
+        if self._split_entries_unchanged(split_entries):
+            self._split_status_selected_manifest_path = selected_manifest_path
+            self._update_split_status_selection_ui(selected_manifest_path)
+        else:
+            self._render_split_status_entries(
+                split_entries,
+                selected_manifest_path=selected_manifest_path,
+            )
 
     def _clear_bootstrap_progress_ui(self) -> None:
         self._bootstrap_progress = None

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1333,8 +1333,9 @@ class MainWindow(QMainWindow):
             self._split_job_text(entry, profile["job_chars"]),
             tooltip=entry.job_name or entry.manifest_path,
         )
+        show_action_button = entry.selectable and not is_current
         action_payload = split_action_item_payload(
-            selectable=entry.selectable,
+            selectable=show_action_button,
             manifest_path=entry.manifest_path,
             part_label=entry.part_label,
         )

--- a/gui_qt/manifest_lite.py
+++ b/gui_qt/manifest_lite.py
@@ -95,8 +95,17 @@ def read_manifest_lite(path: str | Path) -> dict[str, Any]:
             if marker_offset is not None:
                 head_limit = marker_offset
                 head = handle.read(head_limit).decode("utf-8-sig", errors="replace")
-                handle.seek(marker_offset)
-                tail = handle.read().decode("utf-8-sig", errors="replace")
+                # Tail metadata lives after the huge ``chunks`` array near EOF.
+                # Never read from the marker through EOF; that would decode the
+                # entire chunks payload and stall the GUI for multi-MB manifests.
+                if size > _TAIL_READ_BYTES:
+                    handle.seek(size - _TAIL_READ_BYTES)
+                    tail = handle.read().decode("utf-8-sig", errors="replace")
+                elif head_limit < size:
+                    handle.seek(head_limit)
+                    tail = handle.read().decode("utf-8-sig", errors="replace")
+                else:
+                    tail = head
             else:
                 head_limit = min(_HEAD_READ_BYTES, size)
                 head = handle.read(head_limit).decode("utf-8-sig", errors="replace")

--- a/gui_qt/manifest_lite.py
+++ b/gui_qt/manifest_lite.py
@@ -72,6 +72,15 @@ def read_manifest_index_fields(path: str | Path) -> dict[str, Any]:
     return result
 
 
+def _read_tail_window(handle: Any, head: str, head_limit: int, size: int) -> str:
+    if size > _TAIL_READ_BYTES:
+        handle.seek(size - _TAIL_READ_BYTES)
+        return handle.read().decode("utf-8-sig", errors="replace")
+    if head_limit < size:
+        return handle.read().decode("utf-8-sig", errors="replace")
+    return head
+
+
 def read_manifest_lite(path: str | Path) -> dict[str, Any]:
     """Load manifest metadata without parsing the heavy ``chunks`` array."""
     manifest_path = Path(path)
@@ -95,27 +104,11 @@ def read_manifest_lite(path: str | Path) -> dict[str, Any]:
             if marker_offset is not None:
                 head_limit = marker_offset
                 head = handle.read(head_limit).decode("utf-8-sig", errors="replace")
-                # Tail metadata lives after the huge ``chunks`` array near EOF.
-                # Never read from the marker through EOF; that would decode the
-                # entire chunks payload and stall the GUI for multi-MB manifests.
-                if size > _TAIL_READ_BYTES:
-                    handle.seek(size - _TAIL_READ_BYTES)
-                    tail = handle.read().decode("utf-8-sig", errors="replace")
-                elif head_limit < size:
-                    handle.seek(head_limit)
-                    tail = handle.read().decode("utf-8-sig", errors="replace")
-                else:
-                    tail = head
+                tail = _read_tail_window(handle, head, head_limit, size)
             else:
                 head_limit = min(_HEAD_READ_BYTES, size)
                 head = handle.read(head_limit).decode("utf-8-sig", errors="replace")
-                if size > _TAIL_READ_BYTES:
-                    handle.seek(size - _TAIL_READ_BYTES)
-                    tail = handle.read().decode("utf-8-sig", errors="replace")
-                elif head_limit < size:
-                    tail = handle.read().decode("utf-8-sig", errors="replace")
-                else:
-                    tail = head
+                tail = _read_tail_window(handle, head, head_limit, size)
     except (OSError, UnicodeDecodeError):
         return {}
 

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -79,7 +79,6 @@ class ProjectState:
         try:
             latest_file.parent.mkdir(parents=True, exist_ok=True)
             latest_file.write_text(str(manifest_path), encoding="utf-8")
-            self.invalidate_manifest_history_cache()
         except OSError as exc:
             raise ValueError(f"Failed to update latest manifest pointer: {latest_file}") from exc
 

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -458,10 +458,10 @@ QPushButton#secondary_btn:disabled {
 /* Compact table action buttons */
 QPushButton#split_select_btn {
     background-color: #ffffff;
-    border: 1px solid #cbd5e1;
+    border: 1px solid #94a3b8;
     border-radius: 6px;
-    color: #475569;
-    font-weight: 500;
+    color: #334155;
+    font-weight: 600;
     min-width: 72px;
     min-height: 28px;
     padding: 0px 10px;
@@ -470,12 +470,13 @@ QPushButton#split_select_btn {
 
 QPushButton#split_select_btn:hover {
     background-color: #f8fafc;
-    border-color: #94a3b8;
+    border-color: #64748b;
     color: #0f172a;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #f1f5f9;
+    background-color: #e2e8f0;
+    border-color: #64748b;
 }
 
 QPushButton#split_select_btn:disabled {

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -457,11 +457,11 @@ QPushButton#secondary_btn:disabled {
 
 /* Compact table action buttons */
 QPushButton#split_select_btn {
-    background-color: #1e293b;
-    border: 1px solid #475569;
+    background-color: #0f172a;
+    border: 1px solid #94a3b8;
     border-radius: 6px;
-    color: #cbd5e1;
-    font-weight: 500;
+    color: #e2e8f0;
+    font-weight: 600;
     min-width: 72px;
     min-height: 28px;
     padding: 0px 10px;
@@ -469,13 +469,14 @@ QPushButton#split_select_btn {
 }
 
 QPushButton#split_select_btn:hover {
-    background-color: #334155;
-    border-color: #64748b;
+    background-color: #1e293b;
+    border-color: #cbd5e1;
     color: #f8fafc;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #0f172a;
+    background-color: #020617;
+    border-color: #64748b;
 }
 
 QPushButton#split_select_btn:disabled {

--- a/gui_qt/split_batch.py
+++ b/gui_qt/split_batch.py
@@ -176,7 +176,9 @@ def _is_selectable(
     has_result: bool,
 ) -> bool:
     if applied:
-        return False
+        # Completed packages stay selectable so the workbench can switch
+        # which manifest drives diagnostics/writeback summaries.
+        return True
     if safety_level:
         return True
     if job_state == "JOB_STATE_SUCCEEDED":

--- a/gui_qt/split_status_delegate.py
+++ b/gui_qt/split_status_delegate.py
@@ -1,0 +1,181 @@
+"""Painted action buttons for the split-status table via QStyledItemDelegate."""
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import QEvent, QModelIndex, QRect, QRectF, Qt, Signal
+from PySide6.QtGui import QColor, QFont, QHelpEvent, QPainter
+from PySide6.QtWidgets import QStyle, QStyledItemDelegate, QStyleOptionViewItem, QToolTip, QWidget
+
+from .split_status_table_helpers import (
+    SPLIT_ACTION_BUTTON_LABEL,
+    ButtonVisualState,
+    split_action_button_colors,
+    split_action_button_rect,
+)
+
+SPLIT_ACTION_DATA_ROLE = Qt.ItemDataRole.UserRole + 42
+
+
+def read_split_action_payload(index: QModelIndex) -> dict[str, str] | None:
+    data = index.data(SPLIT_ACTION_DATA_ROLE)
+    if not isinstance(data, dict):
+        return None
+    manifest_path = data.get("manifest_path")
+    if not isinstance(manifest_path, str) or not manifest_path.strip():
+        return None
+    part_label = data.get("part_label")
+    if not isinstance(part_label, str):
+        part_label = ""
+    return {"manifest_path": manifest_path, "part_label": part_label}
+
+
+class SplitStatusActionDelegate(QStyledItemDelegate):
+    select_requested = Signal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._hover_index: QModelIndex | None = None
+        self._pressed_index: QModelIndex | None = None
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index: QModelIndex,
+    ) -> None:
+        payload = read_split_action_payload(index)
+        if payload is None:
+            self._paint_empty_cell(painter, option)
+            return
+
+        state = self._visual_state(index)
+        dark = option.palette.window().color().lightness() < 128
+        bg_color, border_color, text_color = split_action_button_colors(dark=dark, state=state)
+        rect = option.rect
+        painter.save()
+        painter.fillRect(rect, option.backgroundBrush.color())
+
+        left, top, width, height = split_action_button_rect(float(rect.width()), float(rect.height()))
+        button_rect = QRectF(rect.left() + left, rect.top() + top, width, height)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(QColor(border_color))
+        painter.setBrush(QColor(bg_color))
+        painter.drawRoundedRect(button_rect, 6.0, 6.0)
+
+        font = QFont(option.font)
+        font.setWeight(QFont.Weight.Medium)
+        painter.setFont(font)
+        painter.setPen(QColor(text_color))
+        painter.drawText(button_rect, int(Qt.AlignmentFlag.AlignCenter), SPLIT_ACTION_BUTTON_LABEL)
+        painter.restore()
+
+    def editorEvent(
+        self,
+        event: QEvent,
+        model: Any,
+        option: QStyleOptionViewItem,
+        index: QModelIndex,
+    ) -> bool:
+        payload = read_split_action_payload(index)
+        if payload is None:
+            return False
+
+        event_type = event.type()
+        if event_type == QEvent.Type.MouseMove:
+            self._set_hover_index(index)
+            return False
+        if event_type == QEvent.Type.MouseButtonPress:
+            if hasattr(event, "button") and event.button() != Qt.MouseButton.LeftButton:
+                return False
+            if self._event_hits_button(event, option):
+                self._pressed_index = index
+                if self.parent() is not None and hasattr(self.parent(), "viewport"):
+                    self.parent().viewport().update(option.rect)
+                return True
+            return False
+        if event_type == QEvent.Type.MouseButtonRelease:
+            if hasattr(event, "button") and event.button() != Qt.MouseButton.LeftButton:
+                return False
+            pressed = self._pressed_index
+            self._pressed_index = None
+            if pressed == index and self._event_hits_button(event, option):
+                self.select_requested.emit(payload["manifest_path"])
+                if self.parent() is not None and hasattr(self.parent(), "viewport"):
+                    self.parent().viewport().update(option.rect)
+                return True
+            if self.parent() is not None and hasattr(self.parent(), "viewport"):
+                self.parent().viewport().update(option.rect)
+            return False
+        if event_type == QEvent.Type.Leave:
+            self.clear_hover_state()
+            return False
+        return False
+
+    def helpEvent(
+        self,
+        event: QEvent,
+        view: Any,
+        option: QStyleOptionViewItem,
+        index: QModelIndex,
+    ) -> bool:
+        if not isinstance(event, QHelpEvent):
+            return False
+        payload = read_split_action_payload(index)
+        if payload is None:
+            return False
+        part_label = payload.get("part_label") or payload["manifest_path"]
+        QToolTip.showText(event.globalPos(), f"\u5207\u6362\u5230 {part_label}", view)
+        return True
+
+    def _visual_state(self, index: QModelIndex) -> ButtonVisualState:
+        if self._pressed_index == index:
+            return "pressed"
+        if self._hover_index == index:
+            return "hover"
+        return "normal"
+
+    def _event_hits_button(self, event: QEvent, option: QStyleOptionViewItem) -> bool:
+        if not hasattr(event, "position"):
+            return False
+        left, top, width, height = split_action_button_rect(
+            float(option.rect.width()),
+            float(option.rect.height()),
+        )
+        button_rect = QRectF(
+            option.rect.left() + left,
+            option.rect.top() + top,
+            width,
+            height,
+        )
+        return button_rect.contains(event.position())
+
+    def _set_hover_index(self, index: QModelIndex) -> None:
+        if self._hover_index == index:
+            return
+        previous = self._hover_index
+        self._hover_index = index
+        view = self.parent()
+        if view is None or not hasattr(view, "viewport"):
+            return
+        viewport = view.viewport()
+        if previous is not None and previous.isValid():
+            viewport.update(view.visualRect(previous))
+        if index.isValid():
+            viewport.update(view.visualRect(index))
+
+    def clear_hover_state(self) -> None:
+        previous = self._hover_index
+        self._hover_index = None
+        if previous is None or not previous.isValid():
+            return
+        view = self.parent()
+        if view is None or not hasattr(view, "viewport"):
+            return
+        view.viewport().update(view.visualRect(previous))
+
+    def _paint_empty_cell(self, painter: QPainter, option: QStyleOptionViewItem) -> None:
+        if option.state & QStyle.StateFlag.State_Selected:
+            painter.fillRect(option.rect, option.palette.highlight())
+        else:
+            painter.fillRect(option.rect, option.backgroundBrush)

--- a/gui_qt/split_status_delegate.py
+++ b/gui_qt/split_status_delegate.py
@@ -187,6 +187,16 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
         if index.isValid():
             viewport.update(view.visualRect(index))
 
+    def clear_pressed_state(self) -> None:
+        previous = self._pressed_index
+        self._pressed_index = None
+        if previous is None or not previous.isValid():
+            return
+        view = self.parent()
+        if view is None or not hasattr(view, "viewport"):
+            return
+        view.viewport().update(view.visualRect(previous))
+
     def clear_hover_state(self) -> None:
         previous = self._hover_index
         self._hover_index = None

--- a/gui_qt/split_status_delegate.py
+++ b/gui_qt/split_status_delegate.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 from typing import Any
 
 from PySide6.QtCore import QEvent, QModelIndex, QRect, QRectF, Qt, Signal
-from PySide6.QtGui import QColor, QFont, QHelpEvent, QPainter
-from PySide6.QtWidgets import QStyle, QStyledItemDelegate, QStyleOptionViewItem, QToolTip, QWidget
+from PySide6.QtGui import QHelpEvent, QPainter
+from PySide6.QtWidgets import (
+    QPushButton,
+    QStyle,
+    QStyleOptionButton,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QToolTip,
+    QWidget,
+)
 
 from .split_status_table_helpers import (
+    SPLIT_ACTION_BUTTON_HEIGHT,
     SPLIT_ACTION_BUTTON_LABEL,
-    ButtonVisualState,
-    split_action_button_colors,
+    SPLIT_ACTION_BUTTON_MIN_WIDTH,
     split_action_button_rect,
 )
 
@@ -37,6 +45,7 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
         super().__init__(parent)
         self._hover_index: QModelIndex | None = None
         self._pressed_index: QModelIndex | None = None
+        self._style_button: QPushButton | None = None
 
     def paint(
         self,
@@ -49,25 +58,36 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
             self._paint_empty_cell(painter, option)
             return
 
-        state = self._visual_state(index)
-        dark = option.palette.window().color().lightness() < 128
-        bg_color, border_color, text_color = split_action_button_colors(dark=dark, state=state)
         rect = option.rect
         painter.save()
-        painter.fillRect(rect, option.backgroundBrush.color())
+        painter.fillRect(rect, option.backgroundBrush)
 
         left, top, width, height = split_action_button_rect(float(rect.width()), float(rect.height()))
-        button_rect = QRectF(rect.left() + left, rect.top() + top, width, height)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        painter.setPen(QColor(border_color))
-        painter.setBrush(QColor(bg_color))
-        painter.drawRoundedRect(button_rect, 6.0, 6.0)
+        button_rect = QRect(
+            int(rect.left() + left),
+            int(rect.top() + top),
+            int(width),
+            int(height),
+        )
+        style_button = self._ensure_style_button(option)
+        btn_option = QStyleOptionButton()
+        btn_option.initFrom(style_button)
+        btn_option.rect = button_rect
+        btn_option.text = SPLIT_ACTION_BUTTON_LABEL
+        btn_option.state = QStyle.StateFlag.State_Enabled
+        if self._pressed_index == index:
+            btn_option.state |= QStyle.StateFlag.State_Sunken
+        elif self._hover_index == index:
+            btn_option.state |= QStyle.StateFlag.State_MouseOver
 
-        font = QFont(option.font)
-        font.setWeight(QFont.Weight.Medium)
-        painter.setFont(font)
-        painter.setPen(QColor(text_color))
-        painter.drawText(button_rect, int(Qt.AlignmentFlag.AlignCenter), SPLIT_ACTION_BUTTON_LABEL)
+        widget = option.widget
+        if widget is not None:
+            widget.style().drawControl(
+                QStyle.ControlElement.CE_PushButton,
+                btn_option,
+                painter,
+                style_button,
+            )
         painter.restore()
 
     def editorEvent(
@@ -90,8 +110,7 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
                 return False
             if self._event_hits_button(event, option):
                 self._pressed_index = index
-                if self.parent() is not None and hasattr(self.parent(), "viewport"):
-                    self.parent().viewport().update(option.rect)
+                self._repaint_index(option, index)
                 return True
             return False
         if event_type == QEvent.Type.MouseButtonRelease:
@@ -101,11 +120,9 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
             self._pressed_index = None
             if pressed == index and self._event_hits_button(event, option):
                 self.select_requested.emit(payload["manifest_path"])
-                if self.parent() is not None and hasattr(self.parent(), "viewport"):
-                    self.parent().viewport().update(option.rect)
+                self._repaint_index(option, index)
                 return True
-            if self.parent() is not None and hasattr(self.parent(), "viewport"):
-                self.parent().viewport().update(option.rect)
+            self._repaint_index(option, index)
             return False
         if event_type == QEvent.Type.Leave:
             self.clear_hover_state()
@@ -128,12 +145,18 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
         QToolTip.showText(event.globalPos(), f"\u5207\u6362\u5230 {part_label}", view)
         return True
 
-    def _visual_state(self, index: QModelIndex) -> ButtonVisualState:
-        if self._pressed_index == index:
-            return "pressed"
-        if self._hover_index == index:
-            return "hover"
-        return "normal"
+    def _ensure_style_button(self, option: QStyleOptionViewItem) -> QPushButton:
+        if self._style_button is None:
+            parent = option.widget if option.widget is not None else self.parent()
+            self._style_button = QPushButton(SPLIT_ACTION_BUTTON_LABEL, parent)
+            self._style_button.setObjectName("split_select_btn")
+            self._style_button.setFixedSize(
+                SPLIT_ACTION_BUTTON_MIN_WIDTH,
+                SPLIT_ACTION_BUTTON_HEIGHT,
+            )
+            self._style_button.hide()
+            self._style_button.ensurePolished()
+        return self._style_button
 
     def _event_hits_button(self, event: QEvent, option: QStyleOptionViewItem) -> bool:
         if not hasattr(event, "position"):
@@ -173,6 +196,12 @@ class SplitStatusActionDelegate(QStyledItemDelegate):
         if view is None or not hasattr(view, "viewport"):
             return
         view.viewport().update(view.visualRect(previous))
+
+    def _repaint_index(self, option: QStyleOptionViewItem, index: QModelIndex) -> None:
+        widget = option.widget
+        if widget is None or not hasattr(widget, "viewport"):
+            return
+        widget.viewport().update(widget.visualRect(index))
 
     def _paint_empty_cell(self, painter: QPainter, option: QStyleOptionViewItem) -> None:
         if option.state & QStyle.StateFlag.State_Selected:

--- a/gui_qt/split_status_table_helpers.py
+++ b/gui_qt/split_status_table_helpers.py
@@ -1,0 +1,61 @@
+"""Pure helpers for split-status table layout (no Qt dependency)."""
+from __future__ import annotations
+
+from typing import Literal
+
+SPLIT_TABLE_GROUP_WIDTH = 6
+SPLIT_ACTION_COLUMN_OFFSET = 5
+SPLIT_ACTION_BUTTON_LABEL = "\u9009\u62e9"
+SPLIT_ACTION_BUTTON_MIN_WIDTH = 72
+SPLIT_ACTION_BUTTON_HEIGHT = 28
+SPLIT_ACTION_CELL_MARGIN_H = 8
+SPLIT_ACTION_CELL_MARGIN_V = 6
+
+ButtonVisualState = Literal["normal", "hover", "pressed"]
+
+
+def is_split_action_column(column: int) -> bool:
+    return column % SPLIT_TABLE_GROUP_WIDTH == SPLIT_ACTION_COLUMN_OFFSET
+
+
+def split_action_button_rect(
+    cell_width: float,
+    cell_height: float,
+) -> tuple[float, float, float, float]:
+    available_width = max(0.0, cell_width - (2 * SPLIT_ACTION_CELL_MARGIN_H))
+    available_height = max(0.0, cell_height - (2 * SPLIT_ACTION_CELL_MARGIN_V))
+    button_width = min(float(SPLIT_ACTION_BUTTON_MIN_WIDTH), available_width)
+    button_height = min(float(SPLIT_ACTION_BUTTON_HEIGHT), available_height)
+    left = SPLIT_ACTION_CELL_MARGIN_H + max(0.0, (available_width - button_width) / 2.0)
+    top = SPLIT_ACTION_CELL_MARGIN_V + max(0.0, (available_height - button_height) / 2.0)
+    return left, top, button_width, button_height
+
+
+def split_action_item_payload(
+    *,
+    selectable: bool,
+    manifest_path: str,
+    part_label: str,
+) -> dict[str, str] | None:
+    if not selectable:
+        return None
+    return {
+        "manifest_path": manifest_path,
+        "part_label": part_label,
+    }
+
+
+def split_action_button_colors(*, dark: bool, state: ButtonVisualState) -> tuple[str, str, str]:
+    if dark:
+        palette = {
+            "normal": ("#1e293b", "#475569", "#cbd5e1"),
+            "hover": ("#334155", "#64748b", "#f8fafc"),
+            "pressed": ("#0f172a", "#64748b", "#f8fafc"),
+        }
+    else:
+        palette = {
+            "normal": ("#ffffff", "#cbd5e1", "#475569"),
+            "hover": ("#f8fafc", "#94a3b8", "#0f172a"),
+            "pressed": ("#f1f5f9", "#94a3b8", "#0f172a"),
+        }
+    return palette[state]

--- a/gui_qt/split_status_table_helpers.py
+++ b/gui_qt/split_status_table_helpers.py
@@ -1,8 +1,6 @@
 """Pure helpers for split-status table layout (no Qt dependency)."""
 from __future__ import annotations
 
-from typing import Literal
-
 SPLIT_TABLE_GROUP_WIDTH = 6
 SPLIT_ACTION_COLUMN_OFFSET = 5
 SPLIT_ACTION_BUTTON_LABEL = "\u9009\u62e9"
@@ -10,9 +8,6 @@ SPLIT_ACTION_BUTTON_MIN_WIDTH = 72
 SPLIT_ACTION_BUTTON_HEIGHT = 28
 SPLIT_ACTION_CELL_MARGIN_H = 8
 SPLIT_ACTION_CELL_MARGIN_V = 6
-
-ButtonVisualState = Literal["normal", "hover", "pressed"]
-
 
 def is_split_action_column(column: int) -> bool:
     return column % SPLIT_TABLE_GROUP_WIDTH == SPLIT_ACTION_COLUMN_OFFSET
@@ -45,17 +40,3 @@ def split_action_item_payload(
     }
 
 
-def split_action_button_colors(*, dark: bool, state: ButtonVisualState) -> tuple[str, str, str]:
-    if dark:
-        palette = {
-            "normal": ("#1e293b", "#475569", "#cbd5e1"),
-            "hover": ("#334155", "#64748b", "#f8fafc"),
-            "pressed": ("#0f172a", "#64748b", "#f8fafc"),
-        }
-    else:
-        palette = {
-            "normal": ("#ffffff", "#cbd5e1", "#475569"),
-            "hover": ("#f8fafc", "#94a3b8", "#0f172a"),
-            "pressed": ("#f1f5f9", "#94a3b8", "#0f172a"),
-        }
-    return palette[state]

--- a/tests/test_gui_manifest_lite.py
+++ b/tests/test_gui_manifest_lite.py
@@ -64,6 +64,37 @@ class GuiManifestLiteTests(unittest.TestCase):
             self.assertEqual(lite.get("applied_at"), "2026-06-30T13:00:00")
             self.assertNotIn("chunks", lite)
 
+    def test_read_manifest_lite_reads_eof_tail_when_chunks_start_early(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            head = {
+                "mode": "translation",
+                "base_dir": "C:/game/work",
+                "job_name": "batches/early-chunks",
+                "job_state": "JOB_STATE_SUCCEEDED",
+                "summary": {"item_count": 4, "chunk_count": 1, "file_count": 1},
+            }
+            tail = {
+                "last_check_summary": {"safety_level": "safe"},
+                "applied_at": "2026-06-30T14:00:00",
+            }
+            # chunks starts immediately after a tiny header; the array body is huge.
+            chunks_body = ", ".join(f'{{"key": "chunk-{index}"}}' for index in range(120_000))
+            text = (
+                json.dumps(head, ensure_ascii=False)[:-1]
+                + f', "chunks": [{chunks_body}], '
+                + json.dumps(tail, ensure_ascii=False)[1:]
+            )
+            path.write_text(text, encoding="utf-8")
+
+            lite = read_manifest_lite(path)
+
+            self.assertEqual(lite.get("job_name"), "batches/early-chunks")
+            self.assertEqual(lite.get("summary", {}).get("item_count"), 4)
+            self.assertEqual(lite.get("last_check_summary", {}).get("safety_level"), "safe")
+            self.assertEqual(lite.get("applied_at"), "2026-06-30T14:00:00")
+            self.assertNotIn("chunks", lite)
+
     def test_read_manifest_index_fields_reads_only_header(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "manifest.json"

--- a/tests/test_gui_split_batch.py
+++ b/tests/test_gui_split_batch.py
@@ -75,7 +75,7 @@ class GuiSplitBatchTests(unittest.TestCase):
         self.assertTrue(safe_entry.selectable)
         self.assertEqual(applied_entry.status_label, "已写回")
         self.assertEqual(applied_entry.status_kind, "applied")
-        self.assertFalse(applied_entry.selectable)
+        self.assertTrue(applied_entry.selectable)
 
     def test_submit_remaining_queue_only_uses_unsubmitted_entries(self):
         part1 = r"C:\pkg\part01_of_02\manifest.json"

--- a/tests/test_gui_split_status_delegate.py
+++ b/tests/test_gui_split_status_delegate.py
@@ -1,0 +1,91 @@
+import unittest
+
+try:
+    from PySide6.QtCore import QEvent, QPointF, Qt
+    from PySide6.QtGui import QMouseEvent, QStandardItem, QStandardItemModel
+    from PySide6.QtWidgets import QApplication, QStyleOptionViewItem, QTableWidget, QTableWidgetItem
+
+    from gui_qt.split_status_delegate import (
+        SPLIT_ACTION_DATA_ROLE,
+        SplitStatusActionDelegate,
+        read_split_action_payload,
+    )
+    from gui_qt.split_status_table_helpers import split_action_item_payload
+except ImportError as exc:
+    SplitStatusActionDelegate = None  # type: ignore[assignment]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+@unittest.skipIf(SplitStatusActionDelegate is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiSplitStatusDelegateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._app = QApplication.instance() or QApplication([])
+
+    def test_read_split_action_payload_from_model_index(self):
+        model = QStandardItemModel(1, 1)
+        item = QStandardItem("")
+        item.setData(
+            split_action_item_payload(
+                selectable=True,
+                manifest_path=r"C:\pkg\part02\manifest.json",
+                part_label="part02/03",
+            ),
+            SPLIT_ACTION_DATA_ROLE,
+        )
+        model.setItem(0, 0, item)
+        payload = read_split_action_payload(model.index(0, 0))
+        self.assertEqual(payload["manifest_path"], r"C:\pkg\part02\manifest.json")
+        self.assertEqual(payload["part_label"], "part02/03")
+
+    def test_delegate_emits_select_requested_for_action_cells(self):
+        table = QTableWidget(1, 6)
+        delegate = SplitStatusActionDelegate(table)
+        selected: list[str] = []
+        delegate.select_requested.connect(selected.append)
+        table.setItemDelegateForColumn(5, delegate)
+
+        item = QTableWidgetItem("")
+        item.setData(
+            SPLIT_ACTION_DATA_ROLE,
+            split_action_item_payload(
+                selectable=True,
+                manifest_path=r"C:\pkg\part02\manifest.json",
+                part_label="part02/03",
+            ),
+        )
+        table.setItem(0, 5, item)
+        table.resizeColumnsToContents()
+        table.resizeRowsToContents()
+
+        index = table.model().index(0, 5)
+        option = QStyleOptionViewItem()
+        option.rect = table.visualRect(index)
+        option.palette = table.palette()
+        option.font = table.font()
+        center = option.rect.center()
+
+        release_event = QMouseEvent(
+            QEvent.Type.MouseButtonRelease,
+            QPointF(center),
+            QPointF(center),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        delegate._pressed_index = index
+        handled = delegate.editorEvent(
+            release_event,
+            table.model(),
+            option,
+            index,
+        )
+
+        self.assertTrue(handled)
+        self.assertEqual(selected, [r"C:\pkg\part02\manifest.json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_split_status_table_helpers.py
+++ b/tests/test_gui_split_status_table_helpers.py
@@ -1,0 +1,57 @@
+import unittest
+
+from gui_qt.split_status_table_helpers import (
+    split_action_item_payload,
+    SPLIT_ACTION_BUTTON_HEIGHT,
+    SPLIT_ACTION_BUTTON_MIN_WIDTH,
+    is_split_action_column,
+    split_action_button_colors,
+    split_action_button_rect,
+)
+
+
+class GuiSplitStatusTableHelperTests(unittest.TestCase):
+    def test_is_split_action_column(self):
+        self.assertTrue(is_split_action_column(5))
+        self.assertTrue(is_split_action_column(11))
+        self.assertFalse(is_split_action_column(4))
+        self.assertFalse(is_split_action_column(6))
+
+    def test_split_action_button_rect_centers_button(self):
+        left, top, width, height = split_action_button_rect(132.0, 44.0)
+        self.assertEqual(width, float(SPLIT_ACTION_BUTTON_MIN_WIDTH))
+        self.assertEqual(height, float(SPLIT_ACTION_BUTTON_HEIGHT))
+        self.assertGreater(left, 0.0)
+        self.assertGreater(top, 0.0)
+
+    def test_split_action_button_rect_clamps_to_small_cells(self):
+        left, top, width, height = split_action_button_rect(40.0, 20.0)
+        self.assertLessEqual(width, 24.0)
+        self.assertLessEqual(height, 8.0)
+        self.assertGreaterEqual(left, 0.0)
+        self.assertGreaterEqual(top, 0.0)
+
+    def test_split_action_button_colors_support_light_and_dark(self):
+        light_normal = split_action_button_colors(dark=False, state="normal")
+        dark_hover = split_action_button_colors(dark=True, state="hover")
+        self.assertNotEqual(light_normal, dark_hover)
+
+    def test_split_action_item_payload_only_for_selectable_entries(self):
+        self.assertIsNone(
+            split_action_item_payload(
+                selectable=False,
+                manifest_path=r"C:\pkg\manifest.json",
+                part_label="part01/03",
+            )
+        )
+        payload = split_action_item_payload(
+            selectable=True,
+            manifest_path=r"C:\pkg\manifest.json",
+            part_label="part01/03",
+        )
+        self.assertEqual(payload["manifest_path"], r"C:\pkg\manifest.json")
+        self.assertEqual(payload["part_label"], "part01/03")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_split_status_table_helpers.py
+++ b/tests/test_gui_split_status_table_helpers.py
@@ -1,12 +1,11 @@
 import unittest
 
 from gui_qt.split_status_table_helpers import (
-    split_action_item_payload,
     SPLIT_ACTION_BUTTON_HEIGHT,
     SPLIT_ACTION_BUTTON_MIN_WIDTH,
     is_split_action_column,
-    split_action_button_colors,
     split_action_button_rect,
+    split_action_item_payload,
 )
 
 
@@ -30,11 +29,6 @@ class GuiSplitStatusTableHelperTests(unittest.TestCase):
         self.assertLessEqual(height, 8.0)
         self.assertGreaterEqual(left, 0.0)
         self.assertGreaterEqual(top, 0.0)
-
-    def test_split_action_button_colors_support_light_and_dark(self):
-        light_normal = split_action_button_colors(dark=False, state="normal")
-        dark_hover = split_action_button_colors(dark=True, state="hover")
-        self.assertNotEqual(light_normal, dark_hover)
 
     def test_split_action_item_payload_only_for_selectable_entries(self):
         self.assertIsNone(


### PR DESCRIPTION
## Summary

Improves split-status table performance and UX by replacing per-cell `QPushButton` widgets with a painted `QStyledItemDelegate`, and fixes a critical `read_manifest_lite` bug that was decoding the entire multi-MB `chunks` body as tail data.

## Changes

- **Delegate buttons**: add `split_status_delegate.py` + `split_status_table_helpers.py`; wire into `app.py` so action cells store payload data instead of nested widgets
- **Button styling**: use Qt `CE_PushButton` with `split_select_btn` QSS; tweak light/dark QSS for better contrast on colored rows
- **Selection UX**: allow switching among applied split packages; hide the action button on the current row
- **Fast selection path**: update only selection markers + writeback summary on click; avoid full table/manifest reload
- **Startup**: defer diagnostics refresh to the next event-loop tick
- **Critical perf fix**: when `"chunks"` starts early in a heavy manifest, read EOF tail window only (not marker→EOF); 10-pack load drops from ~3s to ~0.06s on AfterClass data
- **Cache hygiene**: stop invalidating manifest history cache on every `remember_latest_manifest_path` write

## Testing

- Added tests for delegate helpers, delegate click signal, and early-chunks EOF tail regression
- Local full suite green; AfterClass benchmark: `load_split_manifest_entries` 3.08s → 0.065s

## Notes

This branch follows the merged GUI performance work on `main` and targets the backlog item for delegate-based split table action buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 拆分状态表支持统一的操作列交互，选择按钮体验更一致，并保留悬停与按下反馈。
  * 选择拆分包后，相关摘要与当前所选内容会自动同步更新。

* **Bug 修复**
  * 优化拆分表刷新逻辑，减少重复重绘，并尽量保留当前选中状态。
  * 改进尾部元数据读取，避免在超大清单中误读整段内容。
  * 调整“已写回”条目的可选状态，允许继续切换查看。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->