### PR TITLE
feat(gui): responsive action panel and workbench polish

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4822,6 +4822,29 @@ def translated_text_variants(translated):
     return variants
 
 
+def filter_non_translatable_noop_relocation_missing(missing_items, result_items):
+    """Drop relocation misses that only preserve non-translatable source text."""
+    if not missing_items:
+        return []
+    result_by_id = {
+        str(item.get('id') or ''): item.get('translation', '')
+        for item in result_items or []
+        if isinstance(item, dict)
+    }
+    remaining = []
+    for item in missing_items:
+        source = item.get('text') or item.get('source') or ''
+        item_id = str(item.get('id') or '')
+        translated = result_by_id.get(item_id, '')
+        if (
+            legacy.is_non_translatable(source)
+            and (translated or '').strip() == (source or '').strip()
+        ):
+            continue
+        remaining.append(item)
+    return remaining
+
+
 def filter_already_applied_relocation_missing(manifest, chunk, missing_items, result_items, summary):
     if not missing_items:
         return []
@@ -5439,6 +5462,10 @@ def collect_result_actions(manifest, validate_sources=False):
                 relocation_missing,
                 result_items,
                 summary,
+            )
+            relocation_missing = filter_non_translatable_noop_relocation_missing(
+                relocation_missing,
+                result_items,
             )
             relocation_missing_ids = record_v2_relocation_failures(
                 manifest,
@@ -7734,6 +7761,85 @@ def assess_doctor_layout_status(report, context=None):
     return 'failed'
 
 
+def _doctor_pending_task_count(report):
+    try:
+        return int(report.get('pending_task_count') or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _doctor_pending_baseline(report):
+    counts = report.get('counts') or {}
+    baseline = int(counts.get('commented_original_lines') or 0)
+    if baseline <= 0:
+        baseline = int(counts.get('translate_blocks') or 0)
+    return baseline
+
+
+def _doctor_pending_is_minor(report):
+    """True when remaining pending lines are negligible for a mostly-finished project."""
+    pending = _doctor_pending_task_count(report)
+    if pending <= 0:
+        return True
+    baseline = _doctor_pending_baseline(report)
+    if baseline <= 0:
+        return pending < 50
+    return pending < 50 or (pending / baseline) < 0.01
+
+
+def _doctor_should_recommend_enabling_rag(report):
+    pending = _doctor_pending_task_count(report)
+    if pending <= 0 or not _doctor_has_existing_translations(report):
+        return False
+    if _doctor_pending_is_minor(report):
+        return False
+    baseline = _doctor_pending_baseline(report)
+    if pending >= 150:
+        return True
+    if baseline > 0 and (pending / baseline) >= 0.01:
+        return True
+    return pending >= 50
+
+
+def _doctor_source_index_needs_bootstrap(source_index):
+    if not source_index.get('enabled'):
+        return ''
+    segments = int(source_index.get('source_segments') or 0)
+    expected = int(source_index.get('expected_segments') or 0)
+    if not source_index.get('store_exists') or segments <= 0:
+        return 'missing'
+    if expected > 0 and segments < expected:
+        return 'incomplete'
+    return ''
+
+
+def _doctor_rag_needs_bootstrap(rag):
+    if not rag.get('enabled'):
+        return False
+    if not rag.get('store_exists'):
+        return True
+    return int(rag.get('history_records') or 0) <= 0
+
+
+def _doctor_has_existing_translations(report):
+    counts = report.get('counts') or {}
+    if int(counts.get('old_lines') or 0) > 0:
+        return True
+
+    translate_blocks = int(counts.get('translate_blocks') or 0)
+    pending = _doctor_pending_task_count(report)
+    if translate_blocks > 0 and pending > 0 and pending < translate_blocks:
+        return True
+    return False
+
+
+def _doctor_is_incremental_translation(report):
+    pending = _doctor_pending_task_count(report)
+    if pending <= 0:
+        return False
+    return _doctor_has_existing_translations(report)
+
+
 def collect_doctor_recommendations(report):
     recommendations = []
 
@@ -7755,6 +7861,9 @@ def collect_doctor_recommendations(report):
 
     mode = report.get('mode', '')
     has_tl = report.get('counts', {}).get('rpy_files', 0) > 0
+    pending = _doctor_pending_task_count(report)
+    has_existing_translations = _doctor_has_existing_translations(report)
+
     if report.get('work_bootstrap_allowed') and report.get('original_game_dir'):
         recommendations.append(
             'work directory is missing or empty and original/game exists; '
@@ -7775,25 +7884,81 @@ def collect_doctor_recommendations(report):
         recommendations.append(
             'prepare is disabled; enable prepare.enabled in translator_config.json, then run build.'
         )
+        return recommendations
+
     context_status = report.get('context_status') or {}
     source_index = context_status.get('source_index') or {}
-    if source_index.get('enabled'):
-        segments = int(source_index.get('source_segments') or 0)
-        expected = int(source_index.get('expected_segments') or 0)
-        if not source_index.get('store_exists') or segments <= 0:
-            recommendations.append(
-                'Source index is enabled but not built; run bootstrap-source-index.'
-            )
-            return recommendations
-        if expected > 0 and segments < expected:
-            recommendations.append(
-                'Source index bootstrap is incomplete; run bootstrap-source-index.'
-            )
-            return recommendations
+    rag = context_status.get('rag') or {}
 
-    if has_tl and report.get('pending_task_count', 0) > 0:
+    source_index_status = _doctor_source_index_needs_bootstrap(source_index)
+    if source_index_status == 'missing':
         recommendations.append(
-            'Pending translation lines are ready; start batch translation when API keys are configured.'
+            'Source index is enabled but not built; run bootstrap-source-index.'
+        )
+        return recommendations
+    if source_index_status == 'incomplete':
+        recommendations.append(
+            'Source index bootstrap is incomplete; run bootstrap-source-index.'
+        )
+        return recommendations
+
+    if _doctor_rag_needs_bootstrap(rag):
+        if rag.get('bootstrap_on_build'):
+            recommendations.append(
+                'RAG store is empty; run bootstrap-rag before batch translation, '
+                'or start batch translation to warm the store automatically on build.'
+            )
+        else:
+            recommendations.append(
+                'RAG store is enabled but empty; run bootstrap-rag before batch translation.'
+            )
+        return recommendations
+
+    if (
+        not rag.get('enabled')
+        and has_existing_translations
+        and pending > 0
+        and _doctor_should_recommend_enabling_rag(report)
+    ):
+        recommendations.append(
+            'Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag '
+            'for better terminology consistency, then start batch translation.'
+        )
+        return recommendations
+
+    if has_tl and pending > 0 and has_existing_translations and _doctor_pending_is_minor(report):
+        recommendations.append(
+            'Project is substantially complete; remaining pending lines are minor. '
+            'Batch translation and RAG bootstrap are optional.'
+        )
+        return recommendations
+
+    if (
+        not source_index.get('enabled')
+        and pending > 0
+        and has_tl
+        and not has_existing_translations
+    ):
+        recommendations.append(
+            'Source index is disabled; enable it and run bootstrap-source-index '
+            'for better story context on a new translation project.'
+        )
+        return recommendations
+
+    if has_tl and pending > 0:
+        if _doctor_is_incremental_translation(report):
+            recommendations.append(
+                'Incremental translation is ready; start batch translation when API keys are configured.'
+            )
+        else:
+            recommendations.append(
+                'Pending translation lines are ready; start batch translation when API keys are configured.'
+            )
+        return recommendations
+
+    if has_tl and pending == 0:
+        recommendations.append(
+            'No pending translation lines detected; review TL files or refresh templates before starting a new batch.'
         )
 
     return recommendations
@@ -7901,6 +8066,93 @@ def collect_doctor_context_status():
         'source_index': source_index_status,
     }
 
+def _read_translator_config_object():
+    if not os.path.exists(legacy.TRANSLATOR_CONFIG):
+        return {}
+    try:
+        with open(legacy.TRANSLATOR_CONFIG, 'r', encoding='utf-8-sig') as handle:
+            data = json.load(handle) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def collect_doctor_project_assets_status(base_dir):
+    from project_asset_paths import expected_project_asset_paths, paths_match_project
+
+    config = _read_translator_config_object()
+    expected = expected_project_asset_paths(base_dir)
+
+    glossary_configured = config.get('glossary_file') or config.get('glossary_path') or ''
+    batch = config.get('batch') if isinstance(config.get('batch'), dict) else {}
+    macro_configured = batch.get('macro_setting_file') or ''
+
+    glossary_resolved = (
+        legacy._resolve_preferred_path(legacy.TOOL_DIR, base_dir, glossary_configured)
+        if glossary_configured
+        else expected['glossary_file']
+    )
+    macro_resolved = (
+        legacy._resolve_preferred_path(base_dir, base_dir, macro_configured)
+        if macro_configured
+        else expected['macro_setting_file']
+    )
+
+    return {
+        'glossary_file': glossary_resolved or expected['glossary_file'],
+        'glossary_exists': os.path.isfile(glossary_resolved or expected['glossary_file']),
+        'glossary_matches_project': paths_match_project(
+            glossary_resolved or glossary_configured,
+            expected['glossary_file'],
+        ),
+        'macro_setting_file': macro_resolved or expected['macro_setting_file'],
+        'macro_exists': os.path.isfile(macro_resolved or expected['macro_setting_file']),
+        'macro_matches_project': paths_match_project(
+            macro_resolved or macro_configured,
+            expected['macro_setting_file'],
+        ),
+        'expected_glossary_file': expected['glossary_file'],
+        'expected_macro_setting_file': expected['macro_setting_file'],
+    }
+
+
+def collect_doctor_project_assets_warnings(project_assets):
+    warnings = []
+    if not project_assets:
+        return warnings
+
+    glossary_file = project_assets.get('glossary_file') or ''
+    macro_file = project_assets.get('macro_setting_file') or ''
+
+    if not project_assets.get('glossary_matches_project'):
+        expected = project_assets.get('expected_glossary_file') or ''
+        warnings.append(
+            f'glossary_file does not match current project; expected {expected}, '
+            f'configured {glossary_file or "(not set)"}.'
+        )
+    elif not project_assets.get('glossary_exists'):
+        expected = project_assets.get('expected_glossary_file') or glossary_file
+        warnings.append(
+            f'glossary.json not found for current project ({expected}); '
+            'batch translation will fall back to default preserve terms.'
+        )
+
+    if not project_assets.get('macro_matches_project'):
+        expected = project_assets.get('expected_macro_setting_file') or ''
+        warnings.append(
+            f'macro_setting_file does not match current project; expected {expected}, '
+            f'configured {macro_file or "(not set)"}.'
+        )
+    elif not project_assets.get('macro_exists'):
+        expected = project_assets.get('expected_macro_setting_file') or macro_file
+        warnings.append(
+            f'macro_setting.md not found for current project ({expected}); '
+            'batch translation will run without project style guidance.'
+        )
+
+    return warnings
+
+
 def collect_doctor_report():
     source_game_dir = legacy._guess_source_game_dir()
     template_info = legacy.get_prepare_template_command_info(source_game_dir)
@@ -7992,6 +8244,8 @@ def collect_doctor_report():
             print(f'Warning: Could not compute pending translation counts: {exc}')
 
     context_status = collect_doctor_context_status()
+    project_assets = collect_doctor_project_assets_status(legacy.BASE_DIR)
+    warnings.extend(collect_doctor_project_assets_warnings(project_assets))
 
     report = {
         'base_dir': legacy.BASE_DIR,
@@ -8018,6 +8272,7 @@ def collect_doctor_report():
         'pending_task_count': pending_task_count,
         'pending_file_count': pending_file_count,
         'context_status': context_status,
+        'project_assets': project_assets,
         'warnings': warnings,
     }
     layout_context = collect_doctor_layout_context(report)
@@ -8074,6 +8329,12 @@ def print_doctor_report(report):
             f"task_count={report['pending_task_count']}, "
             f"file_count={report['pending_file_count']}"
         )
+        if report['pending_task_count'] > 0:
+            print(
+                '  Note: counts English strings without Han characters; may include '
+                'preserved names, patron lists, or punctuation-only updates. '
+                'This does not indicate missed batch writeback.'
+            )
     print(
         '- RAG context: '
         f"enabled={rag_context.get('enabled', False)}, "
@@ -8094,6 +8355,16 @@ def print_doctor_report(report):
         f"schema_version={source_index_context.get('schema_version') or ''}, "
         f"updated_at={source_index_context.get('updated_at') or ''}, "
         f"error={source_index_context.get('error') or ''}"
+    )
+    project_assets = report.get('project_assets') or {}
+    print(
+        '- Project assets: '
+        f"glossary_exists={project_assets.get('glossary_exists', False)}, "
+        f"glossary_matches_project={project_assets.get('glossary_matches_project', False)}, "
+        f"glossary_file={project_assets.get('glossary_file') or ''}, "
+        f"macro_exists={project_assets.get('macro_exists', False)}, "
+        f"macro_matches_project={project_assets.get('macro_matches_project', False)}, "
+        f"macro_setting_file={project_assets.get('macro_setting_file') or ''}"
     )
     if report['warnings']:
         print('Warnings:')

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2134,6 +2134,7 @@ class MainWindow(QMainWindow):
         self._workflow = None
         self._workflow_step_output_lines = []
         self._writeback_manifest_path = ""
+        self._clear_completed_manifest_snapshot()
         self._apply_work_mode_ui(refresh_manifest_writeback=refresh_manifest_writeback)
 
     def _update_resume_btn_text(self) -> None:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -42,6 +42,7 @@ from PySide6.QtWidgets import (
 )
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
+from .responsive_layout import ResponsiveActionPanel
 from .api_key_dialog import ApiKeyDialog
 from .api_key_helpers import mask_api_key
 from .bootstrap_report import (
@@ -112,6 +113,11 @@ from .doctor_report import (
     stale_summary,
     summarize_doctor_output,
 )
+from .manifest_resume_summary import (
+    ManifestWorkflowDisplay,
+    build_manifest_workflow_display,
+    completed_manifest_entry_fact,
+)
 from .work_bootstrap_report import (
     running_work_bootstrap_summary,
     summarize_work_bootstrap_output,
@@ -127,13 +133,11 @@ from .theme_helpers import (
     read_gui_theme_from_config,
     write_gui_theme_to_config,
 )
-from .translation_workflow import TERMINAL_FAILURE_STATES, WorkflowUpdate
+from .translation_workflow import WorkflowUpdate
 from .user_copy import (
     format_job_fact,
     format_job_state_fact,
     format_manifest_path_fact,
-    job_state_label,
-    safety_level_label,
 )
 from .work_modes import (
     TASK_CATEGORY_ORDER,
@@ -212,6 +216,8 @@ class MainWindow(QMainWindow):
         self._workflow = None
         self._split_status_entries: list[SplitManifestEntry] = []
         self._split_status_selected_manifest_path = ""
+        self._completed_manifest_snapshot: dict[str, object] | None = None
+        self._viewing_completed_manifest = False
         self._work_mode = WorkMode.BATCH_TRANSLATION
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
@@ -467,62 +473,31 @@ class MainWindow(QMainWindow):
         action_outer.setContentsMargins(12, 10, 12, 10)
         action_outer.setSpacing(8)
 
-        prep_group = QHBoxLayout()
-        prep_group.setSpacing(12)
-        prep_label = QLabel("项目准备")
-        prep_label.setObjectName("action_group_label")
-        prep_label.setMinimumWidth(84)
-        prep_group.addWidget(prep_label)
-        self.doctor_btn = QPushButton("环境检查")
+        self.action_panel = ResponsiveActionPanel()
+        self.translate_group_label = self.action_panel.translate_label
+        self.doctor_btn = self.action_panel.add_prep_button(QPushButton("环境检查"))
         self.doctor_btn.setObjectName("secondary_btn")
-        self.doctor_btn.setMinimumWidth(160)
         self.doctor_btn.clicked.connect(self._on_run_doctor)
-        prep_group.addWidget(self.doctor_btn)
-        self.bootstrap_work_btn = QPushButton("准备工作目录")
+        self.bootstrap_work_btn = self.action_panel.add_prep_button(QPushButton("准备工作目录"))
         self.bootstrap_work_btn.setObjectName("secondary_btn")
-        self.bootstrap_work_btn.setMinimumWidth(160)
         self.bootstrap_work_btn.clicked.connect(self._on_bootstrap_work)
-        prep_group.addWidget(self.bootstrap_work_btn)
-        prep_group.addStretch()
-        action_outer.addLayout(prep_group)
-
-        action_separator = QFrame()
-        action_separator.setFrameShape(QFrame.Shape.HLine)
-        action_separator.setObjectName("action_separator")
-        action_outer.addWidget(action_separator)
-
-        translate_group = QHBoxLayout()
-        translate_group.setSpacing(12)
-        self.translate_group_label = QLabel("翻译任务")
-        self.translate_group_label.setObjectName("action_group_label")
-        self.translate_group_label.setMinimumWidth(84)
-        translate_group.addWidget(self.translate_group_label)
-        self.translate_btn = QPushButton("开始翻译")
+        self.translate_btn = self.action_panel.add_translate_button(QPushButton("开始翻译"))
         self.translate_btn.setObjectName("translate_btn")
-        self.translate_btn.setMinimumWidth(160)
         self.translate_btn.clicked.connect(self._on_start_translation)
-        translate_group.addWidget(self.translate_btn)
-        self.resume_btn = QPushButton("继续翻译")
+        self.resume_btn = self.action_panel.add_translate_button(QPushButton("继续翻译"))
         self.resume_btn.setObjectName("secondary_btn")
-        self.resume_btn.setMinimumWidth(160)
         self.resume_btn.clicked.connect(self._on_resume_translation)
-        translate_group.addWidget(self.resume_btn)
-        self.split_submit_btn = QPushButton("提交剩余包")
+        self.split_submit_btn = self.action_panel.add_translate_button(QPushButton("提交剩余包"))
         self.split_submit_btn.setObjectName("secondary_btn")
-        self.split_submit_btn.setMinimumWidth(180)
         self.split_submit_btn.setToolTip("提交当前拆分组中尚未提交的包")
         self.split_submit_btn.clicked.connect(self._on_submit_remaining_split_packages)
         self.split_submit_btn.setVisible(False)
-        translate_group.addWidget(self.split_submit_btn)
-        translate_group.addStretch()
-
-        self.kill_btn = QPushButton("停止")
+        self.kill_btn = self.action_panel.add_translate_trailing(QPushButton("停止"))
         self.kill_btn.setObjectName("kill_btn")
-        self.kill_btn.setMinimumWidth(90)
         self.kill_btn.clicked.connect(self._on_kill)
         self.kill_btn.setEnabled(False)
-        translate_group.addWidget(self.kill_btn)
-        action_outer.addLayout(translate_group)
+        self.action_panel.finish_setup()
+        action_outer.addWidget(self.action_panel)
         layout.addWidget(action_frame)
 
         self.timeline = WizardTimeline()
@@ -611,6 +586,20 @@ class MainWindow(QMainWindow):
         self.workflow_facts_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         self.workflow_facts_label.setObjectName("workflow_facts_label")
         workflow_layout.addWidget(self.workflow_facts_label)
+        completed_actions = QHBoxLayout()
+        completed_actions.setSpacing(8)
+        self.view_last_completed_btn = QPushButton("查看上次已完成任务")
+        self.view_last_completed_btn.setObjectName("secondary_btn")
+        self.view_last_completed_btn.setVisible(False)
+        self.view_last_completed_btn.clicked.connect(self._on_view_last_completed_task)
+        completed_actions.addWidget(self.view_last_completed_btn)
+        self.hide_completed_view_btn = QPushButton("返回概览")
+        self.hide_completed_view_btn.setObjectName("secondary_btn")
+        self.hide_completed_view_btn.setVisible(False)
+        self.hide_completed_view_btn.clicked.connect(self._on_hide_completed_manifest_view)
+        completed_actions.addWidget(self.hide_completed_view_btn)
+        completed_actions.addStretch()
+        workflow_layout.addLayout(completed_actions)
         self.split_status_title = QLabel("拆分包状态")
         self.split_status_title.setObjectName("diagnostics_section_label")
         self.split_status_title.setVisible(False)
@@ -1545,6 +1534,7 @@ class MainWindow(QMainWindow):
         self.split_submit_btn.setText("提交剩余包")
         self.split_submit_btn.setEnabled(has_split_group and needs_submit and not running)
 
+
     def _refresh_writeback_for_manifest_path(self, manifest_path: str) -> None:
         spec = work_mode_spec(self._current_work_mode())
         if not spec.supports_translation_writeback:
@@ -1584,6 +1574,7 @@ class MainWindow(QMainWindow):
                 latest_manifest=manifest_path,
                 manifest=selected_manifest,
                 split_entries=self._split_status_entries or None,
+                force_expand=True,
             )
         writeback_summary = self._current_writeback_summary()
         if writeback_summary.status not in {"idle", "running", "stale"}:
@@ -2269,6 +2260,69 @@ class MainWindow(QMainWindow):
             self.timeline.set_current_step(step_key, status)
         self.timeline.setVisible(True)
 
+    def _clear_completed_manifest_snapshot(self) -> None:
+        self._completed_manifest_snapshot = None
+        self._viewing_completed_manifest = False
+        self._update_completed_manifest_entry_ui()
+
+    def _update_completed_manifest_entry_ui(self) -> None:
+        if not hasattr(self, "view_last_completed_btn"):
+            return
+        running = self.kill_btn.isEnabled()
+        if self._viewing_completed_manifest:
+            self.view_last_completed_btn.setVisible(False)
+            self.hide_completed_view_btn.setVisible(not running)
+            return
+        has_snapshot = self._completed_manifest_snapshot is not None
+        self.view_last_completed_btn.setVisible(has_snapshot and not running)
+        self.hide_completed_view_btn.setVisible(False)
+
+    def _apply_manifest_workflow_display(
+        self,
+        display: ManifestWorkflowDisplay,
+        split_entries: list[SplitManifestEntry],
+    ) -> None:
+        self._set_workflow_summary(
+            display.status,
+            display.heading,
+            display.message,
+            list(display.facts),
+        )
+        self._sync_timeline_from_workflow_status(
+            display.status,
+            display.workflow,
+            step_key=display.timeline_step_key,
+        )
+        if self._split_entries_unchanged(split_entries):
+            self._split_status_selected_manifest_path = display.selected_manifest_path
+            self._update_split_status_selection_ui(display.selected_manifest_path)
+        else:
+            self._render_split_status_entries(
+                split_entries,
+                selected_manifest_path=display.selected_manifest_path,
+            )
+
+    def _show_completed_manifest_snapshot(self) -> None:
+        snapshot = self._completed_manifest_snapshot
+        if not isinstance(snapshot, dict):
+            return
+        display = snapshot.get("display")
+        split_entries = snapshot.get("split_entries")
+        if not isinstance(display, ManifestWorkflowDisplay):
+            return
+        entries = split_entries if isinstance(split_entries, list) else []
+        self._viewing_completed_manifest = True
+        self._apply_manifest_workflow_display(display, entries)
+        self._update_completed_manifest_entry_ui()
+
+    def _on_view_last_completed_task(self) -> None:
+        self._show_completed_manifest_snapshot()
+        self._focus_workbench_status_tab(1)
+
+    def _on_hide_completed_manifest_view(self) -> None:
+        self._viewing_completed_manifest = False
+        self._refresh_workflow_idle_summary()
+
     def _refresh_workflow_idle_summary(self) -> None:
         if self.kill_btn.isEnabled():
             return
@@ -2277,11 +2331,18 @@ class MainWindow(QMainWindow):
             self.timeline.setVisible(False)
         self._render_split_status_entries([])
         spec = work_mode_spec(self._current_work_mode())
+        facts: list[str] = []
+        if self._completed_manifest_snapshot and not self._viewing_completed_manifest:
+            manifest_path = self._completed_manifest_snapshot.get("manifest_path")
+            if isinstance(manifest_path, str) and manifest_path.strip():
+                facts.append(completed_manifest_entry_fact(spec, manifest_path))
         self._set_workflow_summary(
             "idle",
             spec.idle_workflow_heading,
             spec.idle_workflow_message,
+            facts,
         )
+        self._update_completed_manifest_entry_ui()
 
     def _refresh_workflow_from_latest_manifest(
         self,
@@ -2289,6 +2350,7 @@ class MainWindow(QMainWindow):
         latest_manifest: Path | str | None = None,
         manifest: dict[str, object] | None = None,
         split_entries: list[SplitManifestEntry] | None = None,
+        force_expand: bool = False,
     ) -> None:
         if self.kill_btn.isEnabled():
             return
@@ -2321,124 +2383,36 @@ class MainWindow(QMainWindow):
                 self._refresh_workflow_idle_summary()
                 return
 
-        job_state = manifest.get("job_state")
-        job_state_text = job_state if isinstance(job_state, str) else ""
-        job_name = manifest.get("job_name")
-        job_error = manifest.get("job_error")
-        retry_parent = manifest.get("retry_of_manifest")
-        retry_parent_text = retry_parent.strip() if isinstance(retry_parent, str) else ""
-        latest_safety = ""
-        check_summary = manifest.get("last_check_summary")
-        if isinstance(check_summary, dict):
-            safety_value = check_summary.get("safety_level")
-            latest_safety = safety_value.strip().lower() if isinstance(safety_value, str) else ""
-
-        facts = []
-        facts.append(format_manifest_path_fact(str(latest_manifest)))
-        if job_name:
-            facts.append(format_job_fact(job_name))
-        if job_state_text:
-            facts.append(format_job_state_fact(job_state_text))
-
-        summary_info = manifest.get("summary", {})
-        if isinstance(summary_info, dict):
-            file_count = summary_info.get("file_count")
-            chunk_count = summary_info.get("chunk_count")
-            item_count = summary_info.get("item_count")
-            if file_count is not None:
-                facts.append(f"扫描文件：{file_count} 个")
-            if chunk_count is not None:
-                facts.append(f"分块数量：{chunk_count} 个")
-            if item_count is not None:
-                if spec.mode == WorkMode.KEYWORD_EXTRACTION:
-                    facts.append(f"待处理行：{item_count} 行")
-                elif spec.mode == WorkMode.REVISION:
-                    facts.append(f"待修订项：{item_count} 项")
-                else:
-                    facts.append(f"待翻译项：{item_count} 项")
-
-        if retry_parent_text:
-            facts.append(f"父任务：{retry_parent_text}")
+        if self._viewing_completed_manifest and not force_expand:
+            snapshot = self._completed_manifest_snapshot
+            if isinstance(snapshot, dict) and snapshot.get("manifest_path") == str(latest_manifest):
+                self._show_completed_manifest_snapshot()
+                return
 
         if split_entries is None:
             split_entries = self._split_entries_for_manifest(str(latest_manifest), manifest)
-        facts.extend(summarize_split_entries(split_entries))
-
-        is_waiting = job_state_text in ("JOB_STATE_PENDING", "JOB_STATE_RUNNING")
-        timeline_step_key = None
-        workflow = None
-
-        if is_waiting:
-            status = "waiting"
-            timeline_step_key = "status"
-            heading = f"最新{spec.label}任务进行中"
-            message = "云端批量任务处理中。可以点击下方「查询云端状态」按钮进行刷新。"
-        elif job_state_text in TERMINAL_FAILURE_STATES:
-            status = "failed"
-            timeline_step_key = "status"
-            if job_state_text == "JOB_STATE_FAILED":
-                heading = f"最新{spec.label}任务已失败"
-                message = f"云端任务执行失败：{job_error or '未知错误'}。可以重新开始或继续任务以重试。"
-            else:
-                heading = f"最新{spec.label}任务无法继续"
-                detail = f"：{job_error}" if job_error else ""
-                message = f"云端任务状态为「{job_state_label(job_state_text)}」{detail}，无法继续该任务；可以重新开始。"
-        else:
-            workflow = resume_workflow(spec.mode, str(latest_manifest), manifest)
-            if retry_parent_text:
-                if workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
-                    status = "stale" if latest_safety == "warn" else "failed"
-                    timeline_step_key = "check"
-                    heading = "补译结果仍需处理"
-                    message = (
-                        f"补译包检查结果为「{safety_level_label(latest_safety)}」，暂不能合并回父任务。"
-                        "请先查看问题清单，必要时继续补译或人工处理。"
-                    )
-                elif workflow and workflow.current_step() is None:
-                    status = "done"
-                    heading = "补译任务已完成"
-                    message = "补译包流程已完成。"
-                else:
-                    status = "ready"
-                    heading = "可继续补译后续处理"
-                    message = "检测到补译任务还有后续步骤，点击「继续翻译」继续执行。"
-            elif workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
-                status = "stale" if latest_safety == "warn" else "failed"
-                timeline_step_key = "check"
-                heading = "需要先处理问题"
-                message = (
-                    f"最近一次检查结果为「{safety_level_label(latest_safety)}」，暂不能写回。"
-                    "可先查看问题清单，必要时生成「补译包」并预览；处理完重新检查后，显示「可写回」才能写入项目。"
-                )
-            elif workflow and workflow.current_step() is None:
-                status = "done"
-                heading = f"最新{spec.label}任务已完成"
-                message = "该任务流程的所有步骤已全部执行完毕。"
-            else:
-                status = "ready"
-                heading = f"可继续最新{spec.label}任务"
-                message = f"检测到未完成的最新任务，点击「{spec.resume_button_label or '继续任务'}」继续执行。"
-
-        self._set_workflow_summary(
-            status=status,
-            heading=heading,
-            message=message,
-            facts=facts,
+        split_fact_lines = summarize_split_entries(split_entries)
+        display = build_manifest_workflow_display(
+            spec,
+            str(latest_manifest),
+            manifest,
+            extra_facts=split_fact_lines,
         )
-        self._sync_timeline_from_workflow_status(
-            status,
-            workflow,
-            step_key=timeline_step_key,
-        )
-        selected_manifest_path = retry_parent_text or str(latest_manifest)
-        if self._split_entries_unchanged(split_entries):
-            self._split_status_selected_manifest_path = selected_manifest_path
-            self._update_split_status_selection_ui(selected_manifest_path)
-        else:
-            self._render_split_status_entries(
-                split_entries,
-                selected_manifest_path=selected_manifest_path,
-            )
+
+        if display.archive_when_idle and not force_expand:
+            self._completed_manifest_snapshot = {
+                "manifest_path": str(latest_manifest),
+                "display": display,
+                "split_entries": list(split_entries),
+            }
+            self._viewing_completed_manifest = False
+            self._refresh_workflow_idle_summary()
+            return
+
+        self._completed_manifest_snapshot = None
+        self._viewing_completed_manifest = False
+        self._apply_manifest_workflow_display(display, split_entries)
+        self._update_completed_manifest_entry_ui()
 
     def _clear_bootstrap_progress_ui(self) -> None:
         self._bootstrap_progress = None
@@ -2685,6 +2659,7 @@ class MainWindow(QMainWindow):
             self._doctor_output_lines = []
             self._workflow = None
             self._workflow_step_output_lines = []
+            self._clear_completed_manifest_snapshot()
             self._set_doctor_summary(stale_summary())
             spec = work_mode_spec(self._current_work_mode())
             if spec.is_bootstrap:
@@ -3007,6 +2982,7 @@ class MainWindow(QMainWindow):
 
         self._clear_log_view()
         self._focus_log_tab()
+        self._clear_completed_manifest_snapshot()
         self._writeback_manifest_path = ""
         if spec.supports_translation_writeback:
             self._set_writeback_summary(stale_writeback_summary())
@@ -3077,22 +3053,12 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "无法继续任务", spec.not_implemented_message)
             return
         if workflow.current_step() is None:
-            facts = [format_manifest_path_fact(str(latest_manifest))]
-            job_name = manifest.get("job_name")
-            job_state = manifest.get("job_state")
-            if job_name:
-                facts.append(format_job_fact(job_name))
-            if job_state:
-                facts.append(format_job_state_fact(job_state))
-            self._set_workflow_summary(
-                "done",
-                f"最新{spec.label}任务已完成",
-                "该任务流程的所有步骤已全部执行完毕。",
-                facts,
-            )
-            self._sync_timeline_from_workflow_status("done", workflow)
             self._refresh_diagnostics_context()
             self._refresh_writeback_from_latest_manifest()
+            self._refresh_workflow_from_latest_manifest(
+                latest_manifest=latest_manifest,
+                manifest=manifest,
+            )
             writeback_summary = self._current_writeback_summary()
             if writeback_summary.status not in {"idle", "running", "stale"}:
                 self._focus_workbench_status_tab(2)
@@ -3828,7 +3794,9 @@ class MainWindow(QMainWindow):
                 exit_code,
                 manifest_path,
             )
-        self._set_workflow_update(update)
+        archive_completed = not update.should_continue and update.status == "done"
+        if not archive_completed:
+            self._set_workflow_update(update)
         self._clear_workflow_progress_ui()
         self._workflow_step_output_lines = []
         self._refresh_diagnostics_context()
@@ -3858,7 +3826,9 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("翻译任务失败，请查看诊断日志。", 8000)
         elif update.status == "waiting":
             self.statusBar().showMessage("批量任务仍在处理，可稍后继续最新任务。", 8000)
-        elif update.status == "done":
+        elif archive_completed:
+            self._viewing_completed_manifest = False
+            self._refresh_workflow_from_latest_manifest()
             self.statusBar().showMessage(update.heading, 6000)
         else:
             self.statusBar().showMessage("翻译任务流程完成。", 6000)

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -198,13 +198,19 @@ def format_project_assets_facts(project_assets: dict[str, object] | None) -> lis
     facts: list[str] = []
     glossary_exists = project_assets.get("glossary_exists") is True
     macro_exists = project_assets.get("macro_exists") is True
+    glossary_matches = project_assets.get("glossary_matches_project")
+    macro_matches = project_assets.get("macro_matches_project")
 
-    if glossary_exists:
+    if glossary_matches is False:
+        facts.append("术语表：路径与当前项目不匹配")
+    elif glossary_exists:
         facts.append("术语表：已找到 glossary.json")
     else:
         facts.append("术语表：当前项目缺少 glossary.json（将使用默认保留词）")
 
-    if macro_exists:
+    if macro_matches is False:
+        facts.append("风格设定：路径与当前项目不匹配")
+    elif macro_exists:
         facts.append("风格设定：已找到 macro_setting.md")
     else:
         facts.append("风格设定：当前项目缺少 macro_setting.md（批量翻译无项目口吻指引）")

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -8,8 +8,11 @@ from dataclasses import dataclass
 from .summary_helpers import append_unique_fact
 from .user_copy import (
     doctor_mode_label,
+    findings_require_attention,
     format_doctor_recommendation_fact,
     format_doctor_warning_fact,
+    primary_recommendation_message,
+    recommendation_requires_attention,
     translate_doctor_warning,
 )
 
@@ -101,6 +104,10 @@ def format_tl_scan_facts(
             facts.append(
                 f"待翻译条目：约 {task_count} 条（分布在 {file_count} 个文件中，与 build 统计一致）"
             )
+            facts.append(
+                "说明：此项统计仍含英文且无汉字的字符串，可能包含故意保留的专名、"
+                "赞助名单或仅改标点的行，不代表批量翻译漏翻；批次是否完成请以任务记录的写回状态为准。"
+            )
         else:
             facts.append("待翻译条目：0 条（当前没有需要批量翻译的待译行）")
 
@@ -180,6 +187,35 @@ def format_context_status_facts(
                 facts.append(f"原文索引读取异常：{source_index_context['error']}")
         elif source_index_context.get("enabled") is False:
             facts.append("原文索引：未启用")
+
+    return facts
+
+
+def format_project_assets_facts(project_assets: dict[str, object] | None) -> list[str]:
+    if not project_assets:
+        return []
+
+    facts: list[str] = []
+    glossary_exists = project_assets.get("glossary_exists") is True
+    macro_exists = project_assets.get("macro_exists") is True
+
+    if glossary_exists:
+        facts.append("术语表：已找到 glossary.json")
+    else:
+        facts.append("术语表：当前项目缺少 glossary.json（将使用默认保留词）")
+
+    if macro_exists:
+        facts.append("风格设定：已找到 macro_setting.md")
+    else:
+        facts.append("风格设定：当前项目缺少 macro_setting.md（批量翻译无项目口吻指引）")
+
+    glossary_file = project_assets.get("glossary_file")
+    if isinstance(glossary_file, str) and glossary_file.strip():
+        facts.append(f"术语表路径：{glossary_file}")
+
+    macro_file = project_assets.get("macro_setting_file")
+    if isinstance(macro_file, str) and macro_file.strip():
+        facts.append(f"风格设定路径：{macro_file}")
 
     return facts
 
@@ -285,6 +321,10 @@ def parse_doctor_output(output: str) -> dict[str, object]:
             parsed["source_index_context"] = _parse_context_fields(line.split(":", 1)[1])
             continue
 
+        if line.startswith("- Project assets:"):
+            parsed["project_assets"] = _parse_context_fields(line.split(":", 1)[1])
+            continue
+
     return parsed
 
 
@@ -365,6 +405,12 @@ def summarize_doctor_output(
         else None,
     ):
         append_unique_fact(facts, fact)
+    for fact in format_project_assets_facts(
+        parsed.get("project_assets")
+        if isinstance(parsed.get("project_assets"), dict)
+        else None,
+    ):
+        append_unique_fact(facts, fact)
 
     findings = list(warnings)
     if api_key_count is not None:
@@ -383,6 +429,8 @@ def summarize_doctor_output(
         append_unique_fact(facts, fact)
     for warning in warnings:
         append_unique_fact(facts, format_doctor_warning_fact(warning))
+
+    recommendation_message = primary_recommendation_message(recommendation_facts)
 
     if exit_code != 0:
         return DoctorSummary(
@@ -407,7 +455,7 @@ def summarize_doctor_output(
         if layout_status == "ready" and api_key_count == 0:
             status = "warning"
             heading = LAYOUT_STATUS_HEADINGS["attention"][1]
-        elif layout_status == "ready" and findings:
+        elif layout_status == "ready" and findings_require_attention(findings):
             status = "warning"
             heading = LAYOUT_STATUS_HEADINGS["attention"][1]
     elif mode == "blocked_missing_template":
@@ -415,8 +463,10 @@ def summarize_doctor_output(
         heading = "项目检查失败"
         message = MODE_MESSAGES.get(mode, "项目检查失败。")
     else:
-        needs_attention = bool(findings) or bool(recommendation_facts) or (
-            api_key_count is not None and api_key_count == 0
+        needs_attention = (
+            findings_require_attention(findings)
+            or recommendation_requires_attention(recommendation_facts)
+            or (api_key_count is not None and api_key_count == 0)
         )
         if needs_attention:
             status = "warning"
@@ -425,6 +475,13 @@ def summarize_doctor_output(
             status = "ready"
             heading = "项目检查通过"
         message = MODE_MESSAGES.get(mode, "项目检查已完成。")
+
+    if recommendation_message:
+        message = recommendation_message
+        if recommendation_requires_attention(recommendation_facts) and status == "ready":
+            status = "warning"
+            heading = LAYOUT_STATUS_HEADINGS["attention"][1]
+
     return DoctorSummary(
         status=status,
         heading=heading,

--- a/gui_qt/manifest_resume_summary.py
+++ b/gui_qt/manifest_resume_summary.py
@@ -29,6 +29,61 @@ class ManifestWorkflowDisplay:
     archive_when_idle: bool
 
 
+@dataclass(frozen=True)
+class _ResumeDisplayCopy:
+    safety_heading: str
+    safety_message: str
+    done_heading: str
+    done_message: str
+    ready_heading: str
+    ready_message: str
+
+
+def _display_for_resumed_workflow(
+    workflow: Any | None,
+    *,
+    latest_safety: str,
+    copy: _ResumeDisplayCopy,
+) -> tuple[str, str, str, str | None]:
+    if workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
+        status = "stale" if latest_safety == "warn" else "failed"
+        message = copy.safety_message.format(safety=safety_level_label(latest_safety))
+        return status, copy.safety_heading, message, "check"
+    if workflow and workflow.current_step() is None:
+        return "done", copy.done_heading, copy.done_message, None
+    return "ready", copy.ready_heading, copy.ready_message, None
+
+
+def _resume_display_copy(spec: WorkModeSpec, *, is_retry: bool) -> _ResumeDisplayCopy:
+    if is_retry:
+        return _ResumeDisplayCopy(
+            safety_heading="补译结果仍需处理",
+            safety_message=(
+                "补译包检查结果为「{safety}」，暂不能合并回父任务。"
+                "请先查看问题清单，必要时继续补译或人工处理。"
+            ),
+            done_heading="补译任务已完成",
+            done_message="补译包流程已完成。",
+            ready_heading="可继续补译后续处理",
+            ready_message="检测到补译任务还有后续步骤，点击「继续翻译」继续执行。",
+        )
+    return _ResumeDisplayCopy(
+        safety_heading="需要先处理问题",
+        safety_message=(
+            "最近一次检查结果为「{safety}」，暂不能写回。"
+            "可先查看问题清单，必要时生成「补译包」并预览；"
+            "处理完重新检查后，显示「可写回」才能写入项目。"
+        ),
+        done_heading=f"最新{spec.label}任务已完成",
+        done_message="该任务流程的所有步骤已全部执行完毕。",
+        ready_heading=f"可继续最新{spec.label}任务",
+        ready_message=(
+            f"检测到未完成的最新任务，"
+            f"点击「{spec.resume_button_label or '继续任务'}」继续执行。"
+        ),
+    )
+
+
 def _manifest_item_count_label(spec: WorkModeSpec, item_count: object) -> str | None:
     if item_count is None:
         return None
@@ -110,43 +165,12 @@ def build_manifest_workflow_display(
             )
     else:
         workflow = resume_workflow(spec.mode, manifest_path, manifest)
-        if retry_parent_text:
-            if workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
-                status = "stale" if latest_safety == "warn" else "failed"
-                timeline_step_key = "check"
-                heading = "补译结果仍需处理"
-                message = (
-                    f"补译包检查结果为「{safety_level_label(latest_safety)}」，暂不能合并回父任务。"
-                    "请先查看问题清单，必要时继续补译或人工处理。"
-                )
-            elif workflow and workflow.current_step() is None:
-                status = "done"
-                heading = "补译任务已完成"
-                message = "补译包流程已完成。"
-            else:
-                status = "ready"
-                heading = "可继续补译后续处理"
-                message = "检测到补译任务还有后续步骤，点击「继续翻译」继续执行。"
-        elif workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
-            status = "stale" if latest_safety == "warn" else "failed"
-            timeline_step_key = "check"
-            heading = "需要先处理问题"
-            message = (
-                f"最近一次检查结果为「{safety_level_label(latest_safety)}」，暂不能写回。"
-                "可先查看问题清单，必要时生成「补译包」并预览；"
-                "处理完重新检查后，显示「可写回」才能写入项目。"
-            )
-        elif workflow and workflow.current_step() is None:
-            status = "done"
-            heading = f"最新{spec.label}任务已完成"
-            message = "该任务流程的所有步骤已全部执行完毕。"
-        else:
-            status = "ready"
-            heading = f"可继续最新{spec.label}任务"
-            message = (
-                f"检测到未完成的最新任务，"
-                f"点击「{spec.resume_button_label or '继续任务'}」继续执行。"
-            )
+        copy = _resume_display_copy(spec, is_retry=bool(retry_parent_text))
+        status, heading, message, timeline_step_key = _display_for_resumed_workflow(
+            workflow,
+            latest_safety=latest_safety,
+            copy=copy,
+        )
 
     selected_manifest_path = retry_parent_text or manifest_path
     return ManifestWorkflowDisplay(

--- a/gui_qt/manifest_resume_summary.py
+++ b/gui_qt/manifest_resume_summary.py
@@ -1,0 +1,166 @@
+"""Summarize resumable batch manifest state for the GUI workbench."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .translation_workflow import TERMINAL_FAILURE_STATES
+from .user_copy import (
+    format_job_fact,
+    format_job_state_fact,
+    format_manifest_path_fact,
+    job_state_label,
+    safety_level_label,
+)
+from .workflow_factory import resume_workflow
+from .work_modes import WorkMode, WorkModeSpec
+
+
+@dataclass(frozen=True)
+class ManifestWorkflowDisplay:
+    status: str
+    heading: str
+    message: str
+    facts: tuple[str, ...]
+    timeline_step_key: str | None
+    workflow: Any | None
+    selected_manifest_path: str
+    archive_when_idle: bool
+
+
+def _manifest_item_count_label(spec: WorkModeSpec, item_count: object) -> str | None:
+    if item_count is None:
+        return None
+    if spec.mode == WorkMode.KEYWORD_EXTRACTION:
+        return f"待处理行：{item_count} 行"
+    if spec.mode == WorkMode.REVISION:
+        return f"待修订项：{item_count} 项"
+    return f"待翻译项：{item_count} 项"
+
+
+def build_manifest_workflow_display(
+    spec: WorkModeSpec,
+    manifest_path: str,
+    manifest: dict[str, object],
+    *,
+    extra_facts: list[str] | None = None,
+) -> ManifestWorkflowDisplay:
+    job_state = manifest.get("job_state")
+    job_state_text = job_state if isinstance(job_state, str) else ""
+    job_name = manifest.get("job_name")
+    job_error = manifest.get("job_error")
+    retry_parent = manifest.get("retry_of_manifest")
+    retry_parent_text = retry_parent.strip() if isinstance(retry_parent, str) else ""
+
+    latest_safety = ""
+    check_summary = manifest.get("last_check_summary")
+    if isinstance(check_summary, dict):
+        safety_value = check_summary.get("safety_level")
+        latest_safety = safety_value.strip().lower() if isinstance(safety_value, str) else ""
+
+    facts: list[str] = [format_manifest_path_fact(manifest_path)]
+    if job_name:
+        facts.append(format_job_fact(str(job_name)))
+    if job_state_text:
+        facts.append(format_job_state_fact(job_state_text))
+
+    summary_info = manifest.get("summary", {})
+    if isinstance(summary_info, dict):
+        file_count = summary_info.get("file_count")
+        chunk_count = summary_info.get("chunk_count")
+        item_count = summary_info.get("item_count")
+        if file_count is not None:
+            facts.append(f"扫描文件：{file_count} 个")
+        if chunk_count is not None:
+            facts.append(f"分块数量：{chunk_count} 个")
+        item_label = _manifest_item_count_label(spec, item_count)
+        if item_label:
+            facts.append(item_label)
+
+    if retry_parent_text:
+        facts.append(f"父任务：{retry_parent_text}")
+    if extra_facts:
+        facts.extend(extra_facts)
+
+    is_waiting = job_state_text in ("JOB_STATE_PENDING", "JOB_STATE_RUNNING")
+    timeline_step_key: str | None = None
+    workflow = None
+
+    if is_waiting:
+        status = "waiting"
+        timeline_step_key = "status"
+        heading = f"最新{spec.label}任务进行中"
+        message = "云端批量任务处理中。可以点击下方「查询云端状态」按钮进行刷新。"
+    elif job_state_text in TERMINAL_FAILURE_STATES:
+        status = "failed"
+        timeline_step_key = "status"
+        if job_state_text == "JOB_STATE_FAILED":
+            heading = f"最新{spec.label}任务已失败"
+            message = (
+                f"云端任务执行失败：{job_error or '未知错误'}。"
+                "可以重新开始或继续任务以重试。"
+            )
+        else:
+            heading = f"最新{spec.label}任务无法继续"
+            detail = f"：{job_error}" if job_error else ""
+            message = (
+                f"云端任务状态为「{job_state_label(job_state_text)}」{detail}，"
+                "无法继续该任务；可以重新开始。"
+            )
+    else:
+        workflow = resume_workflow(spec.mode, manifest_path, manifest)
+        if retry_parent_text:
+            if workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
+                status = "stale" if latest_safety == "warn" else "failed"
+                timeline_step_key = "check"
+                heading = "补译结果仍需处理"
+                message = (
+                    f"补译包检查结果为「{safety_level_label(latest_safety)}」，暂不能合并回父任务。"
+                    "请先查看问题清单，必要时继续补译或人工处理。"
+                )
+            elif workflow and workflow.current_step() is None:
+                status = "done"
+                heading = "补译任务已完成"
+                message = "补译包流程已完成。"
+            else:
+                status = "ready"
+                heading = "可继续补译后续处理"
+                message = "检测到补译任务还有后续步骤，点击「继续翻译」继续执行。"
+        elif workflow and workflow.current_step() is None and latest_safety in {"warn", "block"}:
+            status = "stale" if latest_safety == "warn" else "failed"
+            timeline_step_key = "check"
+            heading = "需要先处理问题"
+            message = (
+                f"最近一次检查结果为「{safety_level_label(latest_safety)}」，暂不能写回。"
+                "可先查看问题清单，必要时生成「补译包」并预览；"
+                "处理完重新检查后，显示「可写回」才能写入项目。"
+            )
+        elif workflow and workflow.current_step() is None:
+            status = "done"
+            heading = f"最新{spec.label}任务已完成"
+            message = "该任务流程的所有步骤已全部执行完毕。"
+        else:
+            status = "ready"
+            heading = f"可继续最新{spec.label}任务"
+            message = (
+                f"检测到未完成的最新任务，"
+                f"点击「{spec.resume_button_label or '继续任务'}」继续执行。"
+            )
+
+    selected_manifest_path = retry_parent_text or manifest_path
+    return ManifestWorkflowDisplay(
+        status=status,
+        heading=heading,
+        message=message,
+        facts=tuple(facts),
+        timeline_step_key=timeline_step_key,
+        workflow=workflow,
+        selected_manifest_path=selected_manifest_path,
+        archive_when_idle=status == "done",
+    )
+
+
+def completed_manifest_entry_fact(spec: WorkModeSpec, manifest_path: str) -> str:
+    label = Path(manifest_path).parent.name or manifest_path
+    return f"上次{spec.label}任务：{label}（已完成，可查看详情）"

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -21,6 +21,8 @@ from .manifest_lite import (
     read_manifest_index_fields,
     read_manifest_lite,
 )
+from project_asset_paths import sync_project_asset_paths_in_config
+
 from .path_utils import canonical_abs_path, resolve_effective_game_root
 
 
@@ -402,9 +404,11 @@ class ProjectState:
             pass
 
     def _save_game_root_to_config(self, game_root: Path) -> None:
-        """Update only the game_root key, preserve everything else."""
+        """Update game_root and sync per-project asset paths, preserve everything else."""
         data = self._read_json_object(self.config_path, "translator_config.json")
-        data["game_root"] = canonical_abs_path(str(game_root))
+        normalized_root = canonical_abs_path(str(game_root))
+        data["game_root"] = normalized_root
+        sync_project_asset_paths_in_config(data, normalized_root)
         self._write_json_object(self.config_path, data)
 
     # --- Config helpers (api_keys + translator_config) ---

--- a/gui_qt/responsive_layout.py
+++ b/gui_qt/responsive_layout.py
@@ -1,0 +1,146 @@
+"""Responsive layouts for workbench action button groups."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def _configure_action_button(widget: QWidget, *, min_width: int = 100) -> QWidget:
+    widget.setMinimumWidth(min_width)
+    widget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    return widget
+
+
+class ResponsiveActionPanel(QFrame):
+    """Merge prep + translate rows on wide screens; stack them when narrow."""
+
+    def __init__(
+        self,
+        *,
+        prep_label: str = "项目准备",
+        translate_label: str = "翻译任务",
+        compact_width: int = 720,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._compact_width = compact_width
+        self._is_wide: bool | None = None
+        self._prep_buttons: list[QWidget] = []
+        self._translate_buttons: list[QWidget] = []
+        self._translate_trailing: list[QWidget] = []
+
+        self.prep_label = QLabel(prep_label)
+        self.prep_label.setObjectName("action_group_label")
+        self.prep_label.setMinimumWidth(72)
+
+        self.translate_label = QLabel(translate_label)
+        self.translate_label.setObjectName("action_group_label")
+        self.translate_label.setMinimumWidth(72)
+
+        self._root = QVBoxLayout(self)
+        self._root.setContentsMargins(0, 0, 0, 0)
+        self._root.setSpacing(8)
+
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+
+    def add_prep_button(self, widget: QWidget, *, min_width: int = 100) -> QWidget:
+        self._prep_buttons.append(_configure_action_button(widget, min_width=min_width))
+        return widget
+
+    def add_translate_button(self, widget: QWidget, *, min_width: int = 100) -> QWidget:
+        self._translate_buttons.append(_configure_action_button(widget, min_width=min_width))
+        return widget
+
+    def add_translate_trailing(self, widget: QWidget, *, min_width: int = 80) -> QWidget:
+        self._translate_trailing.append(_configure_action_button(widget, min_width=min_width))
+        return widget
+
+    def finish_setup(self) -> None:
+        self._is_wide = None
+        self._apply_layout_mode(self._effective_width() >= self._compact_width, force=True)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        super().resizeEvent(event)
+        wide = self._effective_width() >= self._compact_width
+        self._apply_layout_mode(wide)
+
+    def _effective_width(self) -> int:
+        width = self.width()
+        if width > 0:
+            return width
+        parent = self.parentWidget()
+        while parent is not None:
+            if parent.width() > 0:
+                return parent.width()
+            parent = parent.parentWidget()
+        return self._compact_width
+
+    def _apply_layout_mode(self, wide: bool, *, force: bool = False) -> None:
+        if not force and wide == self._is_wide:
+            return
+        self._is_wide = wide
+        self._rebuild_layout()
+
+    def _detach_layout(self, layout) -> None:
+        while layout.count():
+            item = layout.takeAt(0)
+            child_layout = item.layout()
+            if child_layout is not None:
+                self._detach_layout(child_layout)
+                child_layout.deleteLater()
+
+    def _rebuild_layout(self) -> None:
+        self._detach_layout(self._root)
+
+        prep = self._prep_buttons
+        translate = self._translate_buttons
+        trailing = self._translate_trailing
+
+        if self._is_wide:
+            row = QHBoxLayout()
+            row.setSpacing(12)
+            row.addWidget(self.prep_label)
+            for widget in prep:
+                row.addWidget(widget)
+            separator = QFrame()
+            separator.setFrameShape(QFrame.Shape.VLine)
+            separator.setObjectName("action_separator")
+            row.addWidget(separator)
+            row.addWidget(self.translate_label)
+            for widget in translate:
+                row.addWidget(widget)
+            row.addStretch()
+            for widget in trailing:
+                row.addWidget(widget)
+            self._root.addLayout(row)
+            return
+
+        prep_row = QHBoxLayout()
+        prep_row.setSpacing(12)
+        prep_row.addWidget(self.prep_label)
+        for widget in prep:
+            prep_row.addWidget(widget)
+        prep_row.addStretch()
+
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setObjectName("action_separator")
+
+        translate_row = QHBoxLayout()
+        translate_row.setSpacing(12)
+        translate_row.addWidget(self.translate_label)
+        for widget in translate:
+            translate_row.addWidget(widget)
+        translate_row.addStretch()
+        for widget in trailing:
+            translate_row.addWidget(widget)
+
+        self._root.addLayout(prep_row)
+        self._root.addWidget(separator)
+        self._root.addLayout(translate_row)

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -73,6 +73,38 @@ DOCTOR_RECOMMENDATION_PREFIX_TRANSLATIONS: tuple[tuple[str, str], ...] = (
         "建议：继续运行「预建原文索引」补全索引库",
     ),
     (
+        "RAG store is enabled but empty; run bootstrap-rag before batch translation.",
+        "建议：先在「分析与准备」运行「预建记忆库」，再开始批量翻译",
+    ),
+    (
+        "RAG store is empty; run bootstrap-rag before batch translation, "
+        "or start batch translation to warm the store automatically on build.",
+        "建议：记忆库为空；可先「预建记忆库」，若已勾选「开始翻译时自动暖 RAG 库」也可直接「开始翻译」",
+    ),
+    (
+        "Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag "
+        "for better terminology consistency, then start batch translation.",
+        "建议：补译量较大且记忆库未启用；若要进行批量补译，建议先在配置页启用并「预建记忆库」",
+    ),
+    (
+        "Project is substantially complete; remaining pending lines are minor. "
+        "Batch translation and RAG bootstrap are optional.",
+        "建议：项目已基本译完；剩余待译行很少（可能含专名/标点），可忽略或按需补译，不必预建记忆库",
+    ),
+    (
+        "Source index is disabled; enable it and run bootstrap-source-index "
+        "for better story context on a new translation project.",
+        "建议：全新初译项目建议在配置页启用原文索引并「预建原文索引」，再开始翻译",
+    ),
+    (
+        "Incremental translation is ready; start batch translation when API keys are configured.",
+        "建议：补译环境已就绪；切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交",
+    ),
+    (
+        "No pending translation lines detected; review TL files or refresh templates before starting a new batch.",
+        "建议：当前没有待译条目；请检查翻译文件，或重新生成/刷新模板后再开始",
+    ),
+    (
         "Pending translation lines are ready; start batch translation when API keys are configured.",
         "建议：切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交云端任务",
     ),
@@ -159,6 +191,66 @@ def format_doctor_warning_fact(warning: str) -> str:
     return format_notice_fact(translate_doctor_warning(warning))
 
 
+INFORMATIONAL_DOCTOR_FINDING_MARKERS: tuple[str, ...] = (
+    "记忆库含有旧版键格式",
+    "检测到旧版任务记录",
+)
+
+
+def findings_require_attention(findings: list[str]) -> bool:
+    """Return True only when warnings should elevate the doctor status to warning."""
+    for finding in findings:
+        text = finding.strip()
+        if not text:
+            continue
+        if any(marker in text for marker in INFORMATIONAL_DOCTOR_FINDING_MARKERS):
+            continue
+        return True
+    return False
+
+
+def recommendation_requires_attention(recommendation_facts: list[str]) -> bool:
+    """Return True when the primary recommendation is a prep step, not ready-to-translate."""
+    ready_messages = {
+        "补译环境已就绪，可以开始批量翻译。",
+        "翻译环境已就绪，可以开始批量翻译。",
+        "项目已基本译完；剩余待译行很少，可忽略或按需补译。",
+    }
+    message = primary_recommendation_message(recommendation_facts)
+    if message in ready_messages:
+        return False
+    return bool(recommendation_facts)
+
+
+def primary_recommendation_message(recommendation_facts: list[str]) -> str:
+    """Map the first rendered recommendation fact to a short summary message."""
+    if not recommendation_facts:
+        return ""
+    first = recommendation_facts[0].strip()
+    if not first.startswith("建议："):
+        return ""
+
+    if "已基本译完" in first:
+        return "项目已基本译完；剩余待译行很少，可忽略或按需补译。"
+    if "补译量较大且记忆库未启用" in first:
+        return "补译量较大；若要进行批量补译，建议先启用并预建记忆库。"
+    if "预建记忆库" in first and "不必预建记忆库" not in first:
+        return "记忆库尚未建立，建议先预建记忆库再开始翻译。"
+    if "预建原文索引" in first:
+        return "原文索引尚未就绪，建议先完成预建再开始翻译。"
+    if "准备工作目录" in first:
+        return "请先准备工作目录，再开始翻译流程。"
+    if "全新初译项目" in first:
+        return "全新项目建议先预建原文索引，再开始批量翻译。"
+    if "补译环境已就绪" in first:
+        return "补译环境已就绪，可以开始批量翻译。"
+    if "没有待译条目" in first:
+        return "当前没有待译条目，请先检查或刷新翻译模板。"
+    if "开始翻译" in first:
+        return "翻译环境已就绪，可以开始批量翻译。"
+    return ""
+
+
 def format_doctor_recommendation_fact(recommendation: str) -> str:
     """Render doctor recommendations in the same `标签：值` style as other facts."""
     text = recommendation.strip()
@@ -183,6 +275,14 @@ def translate_doctor_warning(warning: str) -> str:
         return "自定义模板命令无法解析，请检查配置。"
     if text.startswith("RAG store contains legacy ID format keys."):
         return "记忆库含有旧版键格式，下次写回时会自动迁移。"
+    if text.startswith("glossary_file does not match current project;"):
+        return "术语表路径仍指向其他项目，切换项目后应自动同步到当前 work 目录。"
+    if text.startswith("glossary.json not found for current project"):
+        return "当前项目缺少 glossary.json，批量翻译将使用默认保留词。"
+    if text.startswith("macro_setting_file does not match current project;"):
+        return "风格设定路径仍指向其他项目，切换项目后应自动同步到当前 work 目录。"
+    if text.startswith("macro_setting.md not found for current project"):
+        return "当前项目缺少 macro_setting.md，批量翻译将缺少项目口吻与风格指引。"
     return text
 
 

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -246,7 +246,7 @@ def primary_recommendation_message(recommendation_facts: list[str]) -> str:
         return "补译环境已就绪，可以开始批量翻译。"
     if "没有待译条目" in first:
         return "当前没有待译条目，请先检查或刷新翻译模板。"
-    if "开始翻译" in first:
+    if "打包并提交" in first:
         return "翻译环境已就绪，可以开始批量翻译。"
     return ""
 

--- a/project_asset_paths.py
+++ b/project_asset_paths.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 DEFAULT_GLOSSARY_NAME = "glossary.json"
@@ -9,9 +10,14 @@ DEFAULT_MACRO_SETTING_NAME = "macro_setting.md"
 
 
 def canonical_abs_path(path: str | os.PathLike[str]) -> str:
+    """Return a stable absolute path (long path on Windows, not 8.3 short names)."""
     if not path:
         return ""
-    return os.path.abspath(str(path))
+    abs_path = os.path.abspath(str(path))
+    try:
+        return str(Path(abs_path).resolve(strict=False))
+    except OSError:
+        return abs_path
 
 
 def expected_project_asset_paths(game_root: str | os.PathLike[str]) -> dict[str, str]:

--- a/project_asset_paths.py
+++ b/project_asset_paths.py
@@ -1,0 +1,50 @@
+"""Project-scoped asset paths (glossary, macro setting) for translator_config.json."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+DEFAULT_GLOSSARY_NAME = "glossary.json"
+DEFAULT_MACRO_SETTING_NAME = "macro_setting.md"
+
+
+def canonical_abs_path(path: str | os.PathLike[str]) -> str:
+    if not path:
+        return ""
+    return os.path.abspath(str(path))
+
+
+def expected_project_asset_paths(game_root: str | os.PathLike[str]) -> dict[str, str]:
+    root = canonical_abs_path(game_root)
+    return {
+        "glossary_file": os.path.join(root, DEFAULT_GLOSSARY_NAME),
+        "macro_setting_file": os.path.join(root, DEFAULT_MACRO_SETTING_NAME),
+    }
+
+
+def sync_project_asset_paths_in_config(
+    config: dict[str, Any],
+    game_root: str | os.PathLike[str],
+) -> dict[str, Any]:
+    """Point glossary/macro_setting paths at the current work directory."""
+    if not isinstance(config, dict):
+        config = {}
+    expected = expected_project_asset_paths(game_root)
+    config["glossary_file"] = expected["glossary_file"]
+    batch = config.get("batch")
+    if not isinstance(batch, dict):
+        batch = {}
+        config["batch"] = batch
+    batch["macro_setting_file"] = expected["macro_setting_file"]
+    return config
+
+
+def paths_match_project(
+    configured_path: str,
+    expected_path: str,
+) -> bool:
+    if not configured_path or not expected_path:
+        return False
+    return os.path.normcase(canonical_abs_path(configured_path)) == os.path.normcase(
+        canonical_abs_path(expected_path)
+    )

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -199,13 +199,13 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             rpy_files=3,
             layout_status="ready",
         )
-        report["pending_task_count"] = 110407
+        report["pending_task_count"] = 8500
         report["context_status"] = {
             "source_index": {
                 "enabled": True,
                 "store_exists": True,
-                "source_segments": 10385,
-                "expected_segments": 28886,
+                "source_segments": 4200,
+                "expected_segments": 12000,
             }
         }
 
@@ -221,7 +221,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             rpy_files=20,
             layout_status="ready",
         )
-        report["pending_task_count"] = 687
+        report["pending_task_count"] = 240
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -255,7 +255,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             rpy_files=20,
             layout_status="ready",
         )
-        report["pending_task_count"] = 687
+        report["pending_task_count"] = 240
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -266,7 +266,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             "rag": {
                 "enabled": True,
                 "store_exists": True,
-                "history_records": 11346,
+                "history_records": 5200,
             },
             "source_index": {
                 "enabled": True,
@@ -284,24 +284,24 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
     def test_mostly_complete_project_without_rag_does_not_require_bootstrap(self):
         report = _layout_report(
             base_dir="C:/Games/Example/work",
-            rpy_files=159,
+            rpy_files=48,
             layout_status="ready",
         )
-        report["pending_task_count"] = 77
+        report["pending_task_count"] = 45
         report["counts"] = {
-            "rpy_files": 159,
+            "rpy_files": 48,
             "translate_blocks": 120000,
-            "old_lines": 2422,
-            "new_lines": 2422,
-            "commented_original_lines": 112858,
+            "old_lines": 800,
+            "new_lines": 800,
+            "commented_original_lines": 85000,
         }
         report["context_status"] = {
             "rag": {"enabled": False},
             "source_index": {
                 "enabled": True,
                 "store_exists": True,
-                "source_segments": 28886,
-                "expected_segments": 28886,
+                "source_segments": 12000,
+                "expected_segments": 12000,
             },
         }
 
@@ -317,7 +317,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             rpy_files=20,
             layout_status="ready",
         )
-        report["pending_task_count"] = 687
+        report["pending_task_count"] = 240
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -215,6 +215,130 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         self.assertIn("incomplete", recommendations[0])
         self.assertNotIn("Pending translation lines", recommendations[0])
 
+    def test_empty_rag_blocks_batch_translation_when_enabled(self):
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=20,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 687
+        report["counts"] = {
+            "rpy_files": 20,
+            "translate_blocks": 12000,
+            "old_lines": 120,
+            "new_lines": 120,
+        }
+        report["context_status"] = {
+            "rag": {
+                "enabled": True,
+                "store_exists": False,
+                "history_records": 0,
+                "bootstrap_on_build": False,
+            },
+            "source_index": {
+                "enabled": True,
+                "store_exists": True,
+                "source_segments": 2979,
+                "expected_segments": 2979,
+            },
+        }
+
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+
+        self.assertEqual(len(recommendations), 1)
+        self.assertIn("bootstrap-rag", recommendations[0])
+        self.assertNotIn("Pending translation lines", recommendations[0])
+
+    def test_incremental_translation_uses_incremental_recommendation(self):
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=20,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 687
+        report["counts"] = {
+            "rpy_files": 20,
+            "translate_blocks": 12000,
+            "old_lines": 120,
+            "new_lines": 120,
+        }
+        report["context_status"] = {
+            "rag": {
+                "enabled": True,
+                "store_exists": True,
+                "history_records": 11346,
+            },
+            "source_index": {
+                "enabled": True,
+                "store_exists": True,
+                "source_segments": 2979,
+                "expected_segments": 2979,
+            },
+        }
+
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+
+        self.assertEqual(len(recommendations), 1)
+        self.assertIn("Incremental translation", recommendations[0])
+
+    def test_mostly_complete_project_without_rag_does_not_require_bootstrap(self):
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=159,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 77
+        report["counts"] = {
+            "rpy_files": 159,
+            "translate_blocks": 120000,
+            "old_lines": 2422,
+            "new_lines": 2422,
+            "commented_original_lines": 112858,
+        }
+        report["context_status"] = {
+            "rag": {"enabled": False},
+            "source_index": {
+                "enabled": True,
+                "store_exists": True,
+                "source_segments": 28886,
+                "expected_segments": 28886,
+            },
+        }
+
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+
+        self.assertEqual(len(recommendations), 1)
+        self.assertIn("substantially complete", recommendations[0])
+        self.assertNotIn("RAG disabled", recommendations[0])
+
+    def test_existing_translations_without_rag_recommends_enable_rag(self):
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=20,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 687
+        report["counts"] = {
+            "rpy_files": 20,
+            "translate_blocks": 12000,
+            "old_lines": 120,
+            "new_lines": 120,
+        }
+        report["context_status"] = {
+            "rag": {"enabled": False},
+            "source_index": {
+                "enabled": True,
+                "store_exists": True,
+                "source_segments": 2979,
+                "expected_segments": 2979,
+            },
+        }
+
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+
+        self.assertEqual(len(recommendations), 1)
+        self.assertIn("RAG disabled", recommendations[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -212,6 +212,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         load_error=None,
     ):
         self.window.kill_btn = type("FakeBtn", (), {"isEnabled": lambda _self: False})()
+        self.window._completed_manifest_snapshot = None
+        self.window._viewing_completed_manifest = False
+        self.window._split_status_entries = []
+        self.window._split_status_selected_manifest_path = ""
         self.window._current_work_mode = lambda: work_mode
         self.window.state = self._make_resume_state(
             manifest,
@@ -225,6 +229,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 (status, heading, message, facts)
             )
         )
+        self.window._render_split_status_entries = lambda *_args, **_kwargs: None
+        self.window._update_completed_manifest_entry_ui = lambda: None
         return summary_calls
 
     def test_sync_models_for_save_preserves_fallback_models(self):
@@ -869,7 +875,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(self.window.timeline.status, "ready")
 
     def test_refresh_workflow_from_latest_manifest_completed_job_state(self):
-        from gui_qt.work_modes import WorkMode
+        from gui_qt.work_modes import WorkMode, work_mode_spec
         from unittest.mock import patch, MagicMock
 
         summary_calls = self._prepare_resume_refresh(
@@ -880,16 +886,17 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         mock_workflow = MagicMock()
         mock_workflow.current_step.return_value = None
 
-        with patch("gui_qt.app.resume_workflow", return_value=mock_workflow):
+        with patch("gui_qt.manifest_resume_summary.resume_workflow", return_value=mock_workflow):
             self.window._refresh_workflow_from_latest_manifest()
 
         self.assertEqual(len(summary_calls), 1)
         status, heading, message, facts = summary_calls[0]
-        self.assertEqual(status, "done")
-        self.assertIn("任务已完成", heading)
-        self.assertTrue(self.window.timeline.visible)
-        self.assertIsNone(self.window.timeline.current_step_key)
-        self.assertEqual(self.window.timeline.status, "done")
+        spec = work_mode_spec(WorkMode.KEYWORD_EXTRACTION)
+        self.assertEqual(status, "idle")
+        self.assertEqual(heading, spec.idle_workflow_heading)
+        self.assertTrue(any("已完成" in fact for fact in (facts or [])))
+        self.assertIsNotNone(self.window._completed_manifest_snapshot)
+        self.assertFalse(self.window.timeline.visible)
 
     def test_refresh_workflow_from_latest_manifest_warn_stops_at_check_step(self):
         from gui_qt.work_modes import WorkMode
@@ -908,7 +915,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         mock_workflow = MagicMock()
         mock_workflow.current_step.return_value = None
 
-        with patch("gui_qt.app.resume_workflow", return_value=mock_workflow):
+        with patch("gui_qt.workflow_factory.resume_workflow", return_value=mock_workflow):
             self.window._refresh_workflow_from_latest_manifest()
 
         self.assertEqual(len(summary_calls), 1)
@@ -921,9 +928,17 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(self.window.timeline.status, "stale")
 
     def test_resume_completed_keyword_manifest_shows_result_summary(self):
-        from gui_qt.work_modes import WorkMode
+        from gui_qt.work_modes import WorkMode, work_mode_spec
         from unittest.mock import MagicMock, patch
 
+        self.window.kill_btn = type("FakeBtn", (), {"isEnabled": lambda _self: False})()
+        self.window._completed_manifest_snapshot = None
+        self.window._viewing_completed_manifest = False
+        self.window._split_status_entries = []
+        self.window._split_status_selected_manifest_path = ""
+        self.window._split_entries_for_manifest = lambda *_args, **_kwargs: []
+        self.window._render_split_status_entries = lambda *_args, **_kwargs: None
+        self.window._update_completed_manifest_entry_ui = lambda: None
         self.window._current_work_mode = lambda: WorkMode.KEYWORD_EXTRACTION
         self.window.state = self._make_resume_state(
             {
@@ -957,17 +972,20 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         mock_workflow = MagicMock()
         mock_workflow.current_step.return_value = None
 
-        with patch("gui_qt.app.resume_workflow", return_value=mock_workflow):
+        with (
+            patch("gui_qt.app.resume_workflow", return_value=mock_workflow),
+            patch("gui_qt.manifest_resume_summary.resume_workflow", return_value=mock_workflow),
+        ):
             self.window._on_resume_translation()
 
         self.assertEqual(len(summary_calls), 1)
         status, heading, message, facts = summary_calls[0]
-        self.assertEqual(status, "done")
-        self.assertIn("任务已完成", heading)
-        self.assertTrue(self.window.timeline.visible)
-        self.assertIsNone(self.window.timeline.current_step_key)
-        self.assertEqual(self.window.timeline.status, "done")
-        self.assertTrue(any("任务记录" in fact for fact in facts))
+        spec = work_mode_spec(WorkMode.KEYWORD_EXTRACTION)
+        self.assertEqual(status, "idle")
+        self.assertEqual(heading, spec.idle_workflow_heading)
+        self.assertTrue(any("已完成" in fact for fact in (facts or [])))
+        self.assertIsNotNone(self.window._completed_manifest_snapshot)
+        self.assertFalse(self.window.timeline.visible)
         self.window._refresh_diagnostics_context.assert_called_once()
         self.window._refresh_writeback_from_latest_manifest.assert_called_once()
         self.assertEqual(focus_calls, [2])
@@ -1058,6 +1076,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._workflow = FakeWorkflow()
         self.window._workflow_step_output_lines = ["Keyword candidates: 3 deduped from 5 raw"]
         self.window._current_work_mode = lambda: WorkMode.KEYWORD_EXTRACTION
+        self.window.kill_btn = type("FakeBtn", (), {"isEnabled": lambda _self: False})()
+        self.window._refresh_workflow_from_latest_manifest = MagicMock()
         self.window._copy_keyword_reports_to_game_parent = MagicMock()
         self.window._uses_revision_writeback = lambda: False
         self.window._set_workflow_update = MagicMock()
@@ -1110,6 +1130,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._workflow = FakeWorkflow()
         self.window._workflow_step_output_lines = output.splitlines()
         self.window._current_work_mode = lambda: WorkMode.SYNC_KEYWORD_EXTRACTION
+        self.window.kill_btn = type("FakeBtn", (), {"isEnabled": lambda _self: False})()
+        self.window._refresh_workflow_from_latest_manifest = MagicMock()
         self.window._copy_sync_keyword_reports_to_game_parent = MagicMock()
         self.window._copy_keyword_reports_to_game_parent = MagicMock()
         self.window._uses_revision_writeback = lambda: False

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -1517,5 +1517,19 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertTrue(tabs.widget.layout().invalidated)
         self.assertTrue(tabs.updated)
 
+    def test_set_work_mode_clears_completed_manifest_snapshot(self):
+        from gui_qt.work_modes import WorkMode
+
+        self.window._work_mode = WorkMode.BATCH_TRANSLATION
+        self.window._completed_manifest_snapshot = {"manifest_path": "C:/dummy/manifest.json"}
+        self.window._viewing_completed_manifest = True
+        cleared = []
+        self.window._clear_completed_manifest_snapshot = lambda: cleared.append(True)
+        self.window._apply_work_mode_ui = lambda **_kwargs: None
+
+        self.window._set_work_mode(WorkMode.KEYWORD_EXTRACTION, refresh_manifest_writeback=False)
+
+        self.assertEqual(cleared, [True])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -345,10 +345,10 @@ class GuiDoctorReportTests(unittest.TestCase):
     def test_substantially_complete_stays_green_despite_optional_rag_wording(self):
         output = DOCTOR_OUTPUT.replace(
             "- Pending translation: task_count=5, file_count=2",
-            "- Pending translation: task_count=77, file_count=29",
+            "- Pending translation: task_count=45, file_count=12",
         ).replace(
             "commented_original_lines=2",
-            "commented_original_lines=112858",
+            "commented_original_lines=85000",
         ) + (
             "\nRecommendations:\n"
             "- Project is substantially complete; remaining pending lines are minor. "
@@ -388,21 +388,21 @@ Doctor report:
 - Mode: existing_tl_only
 - Layout status: ready
 - TL scan: rpy_files=3, translate_blocks=10, string_sections=0, old_lines=0, new_lines=0, commented_original_lines=100
-- Pending translation: task_count=110407, file_count=12
-- Source index context: enabled=True, store_dir=C:/logs/source_index_store/demo, store_exists=True, source_segments=10385, expected_segments=28886, schema_version=1, updated_at=, error=
+- Pending translation: task_count=8500, file_count=12
+- Source index context: enabled=True, store_dir=C:/logs/source_index_store/demo, store_exists=True, source_segments=4200, expected_segments=12000, schema_version=1, updated_at=, error=
 Recommendations:
 - Source index bootstrap is incomplete; run bootstrap-source-index.
 """
         summary = summarize_doctor_output(output, exit_code=0, api_key_count=3)
 
         self.assertTrue(
-            any("原文索引：已启用，片段数 10385/28886" in fact for fact in summary.facts)
+            any("原文索引：已启用，片段数 4200/12000" in fact for fact in summary.facts)
         )
         self.assertTrue(
             any("继续运行「预建原文索引」补全索引库" in fact for fact in summary.facts)
         )
         self.assertFalse(
-            any("提交约 110407" in fact for fact in summary.facts)
+            any("提交约 8500" in fact for fact in summary.facts)
         )
 
     def test_stale_summary_marks_previous_result_invalid(self):

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -126,6 +126,28 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertTrue(any("术语表：当前项目缺少 glossary.json" in fact for fact in facts))
         self.assertTrue(any("风格设定：当前项目缺少 macro_setting.md" in fact for fact in facts))
 
+    def test_format_project_assets_facts_reports_mismatched_paths(self):
+        facts = format_project_assets_facts(
+            {
+                "glossary_exists": True,
+                "glossary_matches_project": False,
+                "macro_exists": True,
+                "macro_matches_project": False,
+                "glossary_file": "C:/Games/Other/work/glossary.json",
+                "macro_setting_file": "C:/Games/Other/work/macro_setting.md",
+            }
+        )
+
+        self.assertTrue(any("术语表：路径与当前项目不匹配" in fact for fact in facts))
+        self.assertTrue(any("风格设定：路径与当前项目不匹配" in fact for fact in facts))
+
+    def test_primary_recommendation_message_ignores_template_prep_suggestions(self):
+        message = primary_recommendation_message(
+            ["建议：点击「开始翻译」生成翻译模板"],
+        )
+
+        self.assertEqual(message, "")
+
     def test_parse_doctor_output_extracts_context_status(self):
         parsed = parse_doctor_output(CONTEXT_OUTPUT)
 

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -1,12 +1,13 @@
 import unittest
 
 from gui_qt.doctor_report import (
+    format_project_assets_facts,
     format_tl_scan_facts,
     parse_doctor_output,
     stale_summary,
     summarize_doctor_output,
 )
-from gui_qt.user_copy import format_doctor_recommendation_fact
+from gui_qt.user_copy import format_doctor_recommendation_fact, primary_recommendation_message
 
 
 DOCTOR_OUTPUT = """
@@ -112,6 +113,19 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(parsed["pending"]["task_count"], 5)
         self.assertEqual(parsed["pending"]["file_count"], 2)
 
+    def test_format_project_assets_facts_reports_missing_files(self):
+        facts = format_project_assets_facts(
+            {
+                "glossary_exists": False,
+                "macro_exists": False,
+                "glossary_file": "C:/Games/Example/work/glossary.json",
+                "macro_setting_file": "C:/Games/Example/work/macro_setting.md",
+            }
+        )
+
+        self.assertTrue(any("术语表：当前项目缺少 glossary.json" in fact for fact in facts))
+        self.assertTrue(any("风格设定：当前项目缺少 macro_setting.md" in fact for fact in facts))
+
     def test_parse_doctor_output_extracts_context_status(self):
         parsed = parse_doctor_output(CONTEXT_OUTPUT)
 
@@ -147,6 +161,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertTrue(any("API 密钥：已配置 2 个" in fact for fact in summary.facts))
         self.assertTrue(any("翻译文件：3 个" in fact for fact in summary.facts))
         self.assertTrue(any("待翻译条目：约 5 条" in fact for fact in summary.facts))
+        self.assertTrue(any("不代表批量翻译漏翻" in fact for fact in summary.facts))
         self.assertTrue(any("剧情对话：2 条" in fact for fact in summary.facts))
         self.assertTrue(any("界面字符串：10 条" in fact for fact in summary.facts))
         self.assertFalse(any("old/new 行数" in fact for fact in summary.facts))
@@ -294,6 +309,77 @@ class GuiDoctorReportTests(unittest.TestCase):
             "建议：切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交云端任务",
         )
 
+    def test_format_doctor_recommendation_fact_for_empty_rag(self):
+        fact = format_doctor_recommendation_fact(
+            "RAG store is enabled but empty; run bootstrap-rag before batch translation."
+        )
+
+        self.assertEqual(
+            fact,
+            "建议：先在「分析与准备」运行「预建记忆库」，再开始批量翻译",
+        )
+
+    def test_primary_recommendation_message_for_incremental_translation(self):
+        message = primary_recommendation_message(
+            [
+                "建议：补译环境已就绪；切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交",
+            ]
+        )
+
+        self.assertEqual(message, "补译环境已就绪，可以开始批量翻译。")
+
+    def test_summarize_doctor_output_uses_primary_recommendation_message(self):
+        output = DOCTOR_OUTPUT + (
+            "\nRecommendations:\n"
+            "- RAG store is enabled but empty; run bootstrap-rag before batch translation.\n"
+        )
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=3)
+
+        self.assertEqual(summary.message, "记忆库尚未建立，建议先预建记忆库再开始翻译。")
+        self.assertEqual(summary.status, "warning")
+        self.assertTrue(
+            any("预建记忆库" in fact for fact in summary.facts),
+        )
+
+    def test_substantially_complete_stays_green_despite_optional_rag_wording(self):
+        output = DOCTOR_OUTPUT.replace(
+            "- Pending translation: task_count=5, file_count=2",
+            "- Pending translation: task_count=77, file_count=29",
+        ).replace(
+            "commented_original_lines=2",
+            "commented_original_lines=112858",
+        ) + (
+            "\nRecommendations:\n"
+            "- Project is substantially complete; remaining pending lines are minor. "
+            "Batch translation and RAG bootstrap are optional.\n"
+        )
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=3)
+
+        self.assertEqual(summary.status, "ready")
+        self.assertEqual(summary.heading, "项目检查通过")
+        self.assertEqual(
+            summary.message,
+            "项目已基本译完；剩余待译行很少，可忽略或按需补译。",
+        )
+
+    def test_incremental_ready_stays_green_with_informational_rag_warning(self):
+        output = DOCTOR_OUTPUT + (
+            "\nWarnings:\n"
+            "- RAG store contains legacy ID format keys. They will be seamlessly "
+            "migrated on the next successful writeback.\n"
+            "\nRecommendations:\n"
+            "- Incremental translation is ready; start batch translation when API keys are configured.\n"
+        )
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=3)
+
+        self.assertEqual(summary.status, "ready")
+        self.assertEqual(summary.heading, "项目检查通过")
+        self.assertEqual(summary.message, "补译环境已就绪，可以开始批量翻译。")
+        self.assertTrue(any("记忆库含有旧版键格式" in fact for fact in summary.facts))
+
     def test_partial_source_index_shows_progress_in_facts(self):
         output = """
 Doctor report:
@@ -339,6 +425,7 @@ Recommendations:
 
         self.assertIn("翻译文件：49 个", facts)
         self.assertTrue(any("待翻译条目：约 48394 条" in fact for fact in facts))
+        self.assertTrue(any("不代表批量翻译漏翻" in fact for fact in facts))
         self.assertTrue(any("剧情对话：49863 条" in fact for fact in facts))
         self.assertTrue(any("界面字符串：637 条" in fact for fact in facts))
 

--- a/tests/test_gui_manifest_resume_summary.py
+++ b/tests/test_gui_manifest_resume_summary.py
@@ -1,0 +1,56 @@
+"""Tests for archived completed manifest display behavior."""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from gui_qt.manifest_resume_summary import build_manifest_workflow_display
+from gui_qt.work_modes import WORK_MODE_SPECS, WorkMode
+
+
+class ManifestResumeSummaryTests(unittest.TestCase):
+    def test_completed_translation_archives_when_idle(self):
+        spec = WORK_MODE_SPECS[WorkMode.BATCH_TRANSLATION]
+        manifest = {
+            "job_state": "RESULTS_MERGED",
+            "job_name": "batches/example",
+            "summary": {"file_count": 17, "chunk_count": 285, "item_count": 11015},
+        }
+        with mock.patch("gui_qt.manifest_resume_summary.resume_workflow") as resume_mock:
+            workflow = mock.Mock()
+            workflow.current_step.return_value = None
+            resume_mock.return_value = workflow
+            display = build_manifest_workflow_display(
+                spec,
+                "C:/logs/batch_jobs/20260615_Game_GloryHounds/manifest.json",
+                manifest,
+            )
+
+        self.assertTrue(display.archive_when_idle)
+        self.assertEqual(display.status, "done")
+
+    def test_incomplete_translation_stays_active(self):
+        spec = WORK_MODE_SPECS[WorkMode.BATCH_TRANSLATION]
+        manifest = {
+            "job_state": "JOB_STATE_SUCCEEDED",
+            "job_name": "batches/example",
+            "summary": {"file_count": 3, "chunk_count": 2, "item_count": 120},
+        }
+        with mock.patch("gui_qt.manifest_resume_summary.resume_workflow") as resume_mock:
+            workflow = mock.Mock()
+            step = mock.Mock()
+            step.key = "check"
+            workflow.current_step.return_value = step
+            resume_mock.return_value = workflow
+            display = build_manifest_workflow_display(
+                spec,
+                "C:/logs/batch_jobs/current/manifest.json",
+                manifest,
+            )
+
+        self.assertFalse(display.archive_when_idle)
+        self.assertEqual(display.status, "ready")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_manifest_resume_summary.py
+++ b/tests/test_gui_manifest_resume_summary.py
@@ -14,7 +14,7 @@ class ManifestResumeSummaryTests(unittest.TestCase):
         manifest = {
             "job_state": "RESULTS_MERGED",
             "job_name": "batches/example",
-            "summary": {"file_count": 17, "chunk_count": 285, "item_count": 11015},
+            "summary": {"file_count": 5, "chunk_count": 42, "item_count": 800},
         }
         with mock.patch("gui_qt.manifest_resume_summary.resume_workflow") as resume_mock:
             workflow = mock.Mock()
@@ -22,7 +22,7 @@ class ManifestResumeSummaryTests(unittest.TestCase):
             resume_mock.return_value = workflow
             display = build_manifest_workflow_display(
                 spec,
-                "C:/logs/batch_jobs/20260615_Game_GloryHounds/manifest.json",
+                "C:/logs/batch_jobs/20260615_Game_Example/manifest.json",
                 manifest,
             )
 

--- a/tests/test_gui_manifest_resume_summary.py
+++ b/tests/test_gui_manifest_resume_summary.py
@@ -51,6 +51,50 @@ class ManifestResumeSummaryTests(unittest.TestCase):
         self.assertFalse(display.archive_when_idle)
         self.assertEqual(display.status, "ready")
 
+    def test_retry_manifest_with_safety_warn_stays_active(self):
+        spec = WORK_MODE_SPECS[WorkMode.BATCH_TRANSLATION]
+        manifest = {
+            "job_state": "JOB_STATE_SUCCEEDED",
+            "job_name": "batches/retry",
+            "retry_of_manifest": "C:/logs/batch_jobs/parent/manifest.json",
+            "last_check_summary": {"safety_level": "warn"},
+        }
+        with mock.patch("gui_qt.manifest_resume_summary.resume_workflow") as resume_mock:
+            workflow = mock.Mock()
+            workflow.current_step.return_value = None
+            resume_mock.return_value = workflow
+            display = build_manifest_workflow_display(
+                spec,
+                "C:/logs/batch_jobs/retry/manifest.json",
+                manifest,
+            )
+
+        self.assertFalse(display.archive_when_idle)
+        self.assertEqual(display.status, "stale")
+        self.assertEqual(display.timeline_step_key, "check")
+        self.assertEqual(display.heading, "补译结果仍需处理")
+
+    def test_retry_manifest_completed_archives_when_idle(self):
+        spec = WORK_MODE_SPECS[WorkMode.BATCH_TRANSLATION]
+        manifest = {
+            "job_state": "RESULTS_MERGED",
+            "job_name": "batches/retry",
+            "retry_of_manifest": "C:/logs/batch_jobs/parent/manifest.json",
+        }
+        with mock.patch("gui_qt.manifest_resume_summary.resume_workflow") as resume_mock:
+            workflow = mock.Mock()
+            workflow.current_step.return_value = None
+            resume_mock.return_value = workflow
+            display = build_manifest_workflow_display(
+                spec,
+                "C:/logs/batch_jobs/retry/manifest.json",
+                manifest,
+            )
+
+        self.assertTrue(display.archive_when_idle)
+        self.assertEqual(display.status, "done")
+        self.assertEqual(display.heading, "补译任务已完成")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -397,7 +397,12 @@ class GuiProjectStateTests(unittest.TestCase):
 
             saved = json.loads(state.config_path.read_text(encoding="utf-8"))
             self.assert_same_path(saved["game_root"], game_root)
-            self.assertEqual(saved["batch"], {"model": "gemini-test"})
+            self.assertEqual(saved["batch"]["model"], "gemini-test")
+            self.assert_same_path(
+                saved["batch"]["macro_setting_file"],
+                game_root / "macro_setting.md",
+            )
+            self.assert_same_path(saved["glossary_file"], game_root / "glossary.json")
             self.assertEqual(saved["include_files"], ["script.rpy"])
             self.assert_same_path(state.get_game_root(), game_root)
 

--- a/tests/test_gui_responsive_layout.py
+++ b/tests/test_gui_responsive_layout.py
@@ -1,10 +1,20 @@
 import unittest
 
-from PySide6.QtWidgets import QApplication, QPushButton
+try:
+    from PySide6.QtWidgets import QApplication, QPushButton
 
-from gui_qt.responsive_layout import ResponsiveActionPanel
+    from gui_qt.responsive_layout import ResponsiveActionPanel
+except ImportError as exc:
+    ResponsiveActionPanel = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
 
 
+@unittest.skipIf(
+    ResponsiveActionPanel is None,
+    f"GUI dependencies are unavailable: {IMPORT_ERROR}",
+)
 class ResponsiveActionPanelTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_gui_responsive_layout.py
+++ b/tests/test_gui_responsive_layout.py
@@ -1,0 +1,51 @@
+import unittest
+
+from PySide6.QtWidgets import QApplication, QPushButton
+
+from gui_qt.responsive_layout import ResponsiveActionPanel
+
+
+class ResponsiveActionPanelTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication.instance() or QApplication([])
+
+    def _build_panel(self) -> ResponsiveActionPanel:
+        panel = ResponsiveActionPanel(compact_width=700)
+        panel.add_prep_button(QPushButton("环境检查"))
+        panel.add_prep_button(QPushButton("准备工作目录"))
+        panel.add_translate_button(QPushButton("开始翻译"))
+        panel.add_translate_button(QPushButton("继续翻译"))
+        panel.add_translate_trailing(QPushButton("停止"))
+        panel.finish_setup()
+        return panel
+
+    def test_merges_rows_when_wide(self):
+        panel = self._build_panel()
+        panel.resize(1000, 80)
+        panel.show()
+        self._app.processEvents()
+        self.assertTrue(panel._is_wide)
+        self.assertEqual(panel._root.count(), 1)
+
+    def test_stacks_rows_when_narrow(self):
+        panel = self._build_panel()
+        panel.resize(520, 120)
+        panel.show()
+        self._app.processEvents()
+        self.assertFalse(panel._is_wide)
+        self.assertEqual(panel._root.count(), 3)
+
+    def test_resize_does_not_hang(self):
+        panel = self._build_panel()
+        panel.resize(900, 80)
+        panel.show()
+        for width in (900, 500, 1000, 480, 960):
+            panel.resize(width, 80)
+            for _ in range(5):
+                self._app.processEvents()
+        self.assertIn(panel._is_wide, (True, False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -7,12 +7,28 @@ from unittest import mock
 
 import gemini_translate_batch as batch_mod
 from project_asset_paths import (
+    canonical_abs_path,
     expected_project_asset_paths,
+    paths_match_project,
     sync_project_asset_paths_in_config,
 )
 
 
 class ProjectAssetPathsTests(unittest.TestCase):
+    def test_canonical_abs_path_resolves_relative_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            nested = Path(tmp) / "Game" / "work"
+            nested.mkdir(parents=True)
+            asset = nested / "glossary.json"
+            asset.write_text("{}", encoding="utf-8")
+
+            resolved = canonical_abs_path(asset)
+            expected = expected_project_asset_paths(nested)["glossary_file"]
+
+            self.assertTrue(
+                paths_match_project(resolved, expected),
+            )
+
     def test_sync_project_asset_paths_in_config(self):
         work_dir = "C:/Games/Example/work"
         config = {

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -1,0 +1,100 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+from project_asset_paths import (
+    expected_project_asset_paths,
+    sync_project_asset_paths_in_config,
+)
+
+
+class ProjectAssetPathsTests(unittest.TestCase):
+    def test_sync_project_asset_paths_in_config(self):
+        work_dir = "C:/Games/Example/work"
+        config = {
+            "game_root": "C:/Games/Other/work",
+            "glossary_file": "C:/Games/Other/work/glossary.json",
+            "batch": {
+                "model": "gemini-test",
+                "macro_setting_file": "C:/Games/Other/work/macro_setting.md",
+            },
+        }
+
+        synced = sync_project_asset_paths_in_config(config, work_dir)
+
+        self.assertEqual(
+            synced["glossary_file"],
+            expected_project_asset_paths(work_dir)["glossary_file"],
+        )
+        self.assertEqual(
+            synced["batch"]["macro_setting_file"],
+            expected_project_asset_paths(work_dir)["macro_setting_file"],
+        )
+        self.assertEqual(synced["batch"]["model"], "gemini-test")
+
+    def test_collect_doctor_project_assets_warnings_for_missing_files(self):
+        work_dir = "C:/Games/Example/work"
+        assets = {
+            "glossary_file": f"{work_dir}/glossary.json",
+            "glossary_exists": False,
+            "glossary_matches_project": True,
+            "macro_setting_file": f"{work_dir}/macro_setting.md",
+            "macro_exists": False,
+            "macro_matches_project": True,
+            "expected_glossary_file": f"{work_dir}/glossary.json",
+            "expected_macro_setting_file": f"{work_dir}/macro_setting.md",
+        }
+
+        warnings = batch_mod.collect_doctor_project_assets_warnings(assets)
+
+        self.assertEqual(len(warnings), 2)
+        self.assertTrue(any("glossary.json not found" in warning for warning in warnings))
+        self.assertTrue(any("macro_setting.md not found" in warning for warning in warnings))
+
+    def test_collect_doctor_report_warns_when_project_assets_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "Game" / "work"
+            work_dir.mkdir(parents=True)
+            config_path = Path(tmp) / "translator_config.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "game_root": str(work_dir),
+                        "glossary_file": str(work_dir / "glossary.json"),
+                        "batch": {
+                            "macro_setting_file": str(work_dir / "macro_setting.md"),
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, "BASE_DIR", str(work_dir)),
+                mock.patch.object(batch_mod.legacy, "TL_DIR", str(work_dir / "game" / "tl" / "schinese")),
+                mock.patch.object(batch_mod.legacy, "TRANSLATOR_CONFIG", str(config_path)),
+                mock.patch.object(batch_mod, "collect_tl_doctor_counts", return_value={"rpy_files": 1, "translate_blocks": 1, "string_sections": 0, "old_lines": 0, "new_lines": 0, "commented_original_lines": 0}),
+                mock.patch.object(batch_mod, "collect_pending_file_jobs", return_value=[]),
+                mock.patch.object(batch_mod.legacy, "_guess_source_game_dir", return_value=""),
+                mock.patch.object(batch_mod.legacy, "get_prepare_template_command_info", return_value={"available": False, "kind": "", "reason": ""}),
+                mock.patch.object(batch_mod.legacy, "resolve_original_game_dir", return_value=""),
+                mock.patch.object(batch_mod.legacy, "work_dir_bootstrap_allowed", return_value=(False, str(work_dir), "")),
+                mock.patch.object(batch_mod, "collect_doctor_context_status", return_value={"rag": {"enabled": False}, "source_index": {"enabled": False}}),
+                mock.patch.object(batch_mod.legacy, "is_work_dir_empty", return_value=False),
+                mock.patch("os.path.isdir", return_value=True),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+            self.assertFalse(report["project_assets"]["glossary_exists"])
+            self.assertFalse(report["project_assets"]["macro_exists"])
+            self.assertTrue(
+                any("glossary.json not found" in warning for warning in report["warnings"])
+            )
+            self.assertTrue(
+                any("macro_setting.md not found" in warning for warning in report["warnings"])
+            )

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1143,6 +1143,8 @@ def _apply_game_root(work_dir):
 
 
 def persist_game_root(work_dir):
+    from project_asset_paths import sync_project_asset_paths_in_config
+
     normalized = _canonical_abs_path(work_dir)
     config = {}
     if os.path.exists(TRANSLATOR_CONFIG):
@@ -1153,6 +1155,7 @@ def persist_game_root(work_dir):
             config = {}
 
     config["game_root"] = normalized
+    sync_project_asset_paths_in_config(config, normalized)
     with open(TRANSLATOR_CONFIG, "w", encoding="utf-8") as handle:
         json.dump(config, handle, indent=2, ensure_ascii=False)
         handle.write("\n")


### PR DESCRIPTION
## Summary

- Add `ResponsiveActionPanel` so **项目准备** and **翻译任务** merge into one row on wide screens (≥720px) and stack on narrow screens
- Keep action buttons at normal fixed widths; avoid resize-time relayout loops that previously froze the GUI
- Archive completed manifest workflow summaries into idle view with a "view last completed task" entry point
- Improve doctor memory-bank guidance for large projects and fix yellow status misclassification for negated suggestions
- Sync glossary/macro asset paths when switching projects via `project_asset_paths.py`
- Add noop relocation filtering for batch validation failures

## Test plan

- [x] `pytest tests/test_gui_responsive_layout.py` (skipped on headless CI without PySide6)
- [x] `pytest tests/test_gui_manifest_resume_summary.py`
- [x] `pytest tests/test_project_asset_paths.py`
- [x] `pytest tests/test_gui_app_config.py`
- [x] Full suite: 640 tests passed locally
- [x] Manual: resize GUI window — wide merges rows, narrow stacks; no freeze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加了“doctor”报告中的项目资源状态提示，可显示术语表/风格设定是否存在及是否匹配当前项目。
  * 翻译工作台新增“查看上次已完成任务”和“返回概览”，支持回看已归档的完成状态。
  * 主界面按钮区改为响应式布局，宽窄窗口下会自动调整排列方式。
* **改进**
  * 优化了翻译检查与推荐提示，减少误报，并在接近完成时给出更合适的建议。
  * 保存项目根目录时会同步更新相关资源路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->