### PR TITLE
feat(gui): separate template generation from batch translation start

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7872,8 +7872,8 @@ def collect_doctor_recommendations(report):
         )
     elif not has_tl and report.get('prepare_enabled') and report.get('can_generate_template'):
         recommendations.append(
-            'Missing translation files; run: python gemini_translate_batch.py build '
-            '(build runs prepare automatically: unpack RPA if needed, generate tl template).'
+            'Missing translation files; run: python gemini_translate_batch.py generate-template '
+            '(runs prepare only: unpack RPA if needed, generate tl template).'
         )
     elif not has_tl and report.get('prepare_enabled') and mode == 'blocked_missing_template':
         recommendations.append(
@@ -8226,10 +8226,10 @@ def collect_doctor_report():
         else:
             warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
 
-    if can_generate_template:
-        mode = 'can_generate_template'
-    elif has_tl_files:
+    if has_tl_files:
         mode = 'existing_tl_only'
+    elif can_generate_template:
+        mode = 'can_generate_template'
     else:
         mode = 'blocked_missing_template'
 
@@ -8398,6 +8398,66 @@ def run_bootstrap_work(*, save_game_root=True, refresh_runtime_paths=True):
     return result
 
 
+def print_template_generation_summary(result):
+    print('Template generation summary:')
+    print(f"- status: {result.get('status', '')}")
+    print(f"- tl_dir: {result.get('tl_dir', '')}")
+    print(f"- tl_exists: {result.get('tl_exists', False)}")
+    print(f"- rpy_files: {result.get('rpy_files', 0)}")
+    print(f"- language: {result.get('language', '')}")
+    print(f"- message: {result.get('message', '')}")
+
+
+def run_generate_template():
+    if not legacy.PREP_ENABLED:
+        result = {
+            'status': 'failed',
+            'tl_dir': legacy.TL_DIR,
+            'tl_exists': os.path.isdir(legacy.TL_DIR),
+            'rpy_files': 0,
+            'language': legacy.PREP_LANGUAGE,
+            'message': 'prepare is disabled in translator_config.json',
+        }
+        print_template_generation_summary(result)
+        raise SystemExit(f"[GenerateTemplate] {result['message']}")
+
+    if not legacy.PREP_GENERATE_TEMPLATE:
+        result = {
+            'status': 'failed',
+            'tl_dir': legacy.TL_DIR,
+            'tl_exists': os.path.isdir(legacy.TL_DIR),
+            'rpy_files': 0,
+            'language': legacy.PREP_LANGUAGE,
+            'message': 'prepare.generate_template is disabled in translator_config.json',
+        }
+        print_template_generation_summary(result)
+        raise SystemExit(f"[GenerateTemplate] {result['message']}")
+
+    legacy.run_prepare_steps()
+    counts = collect_tl_doctor_counts()
+    tl_exists = os.path.isdir(legacy.TL_DIR)
+    rpy_files = counts['rpy_files']
+    if rpy_files > 0:
+        status = 'ready'
+        message = f'Translation template ready with {rpy_files} TL file(s).'
+    else:
+        status = 'failed'
+        message = 'Template generation finished but no TL files were found.'
+
+    result = {
+        'status': status,
+        'tl_dir': legacy.TL_DIR,
+        'tl_exists': tl_exists,
+        'rpy_files': rpy_files,
+        'language': legacy.PREP_LANGUAGE,
+        'message': message,
+    }
+    print_template_generation_summary(result)
+    if status != 'ready':
+        raise SystemExit(f"[GenerateTemplate] {message}")
+    return result
+
+
 def print_banner():
     print('=' * 60)
     print('Gemini Batch Translator (Ren\'Py)')
@@ -8438,6 +8498,11 @@ def build_arg_parser():
         '--no-update-game-root',
         action='store_true',
         help='Do not update translator_config.json game_root to work/ after bootstrap.',
+    )
+
+    subparsers.add_parser(
+        'generate-template',
+        help='Run prepare steps only to generate or refresh tl/<language> templates.',
     )
 
     build_parser = subparsers.add_parser('build', help='Build local batch package and JSONL only.')
@@ -8792,6 +8857,14 @@ def main(argv=None):
             save_game_root=update_game_root,
             refresh_runtime_paths=update_game_root,
         )
+        return
+
+    if command == 'generate-template':
+        legacy.load_translator_settings()
+        legacy.load_glossary()
+        load_batch_settings()
+        print_banner()
+        run_generate_template()
         return
 
     initialize_batch_logging()

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -8408,8 +8408,9 @@ def print_template_generation_summary(result):
     print(f"- message: {result.get('message', '')}")
 
 
-def _build_template_generation_result(status, message):
-    counts = collect_tl_doctor_counts()
+def _build_template_generation_result(status, message, counts=None):
+    if counts is None:
+        counts = collect_tl_doctor_counts()
     return {
         'status': status,
         'tl_dir': legacy.TL_DIR,
@@ -8459,7 +8460,7 @@ def run_generate_template():
         status = 'failed'
         message = 'Template generation finished but no TL files were found.'
 
-    result = _build_template_generation_result(status, message)
+    result = _build_template_generation_result(status, message, counts=counts)
     print_template_generation_summary(result)
     if status != 'ready':
         raise SystemExit(f"[GenerateTemplate] {message}")

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7878,7 +7878,7 @@ def collect_doctor_recommendations(report):
     elif not has_tl and report.get('prepare_enabled') and mode == 'blocked_missing_template':
         recommendations.append(
             'Install Ren\'Py SDK or set prepare.renpy_sdk_dir, then run: '
-            'python gemini_translate_batch.py build.'
+            'python gemini_translate_batch.py generate-template.'
         )
     elif not has_tl and not report.get('prepare_enabled'):
         recommendations.append(
@@ -8408,34 +8408,49 @@ def print_template_generation_summary(result):
     print(f"- message: {result.get('message', '')}")
 
 
+def _build_template_generation_result(status, message):
+    counts = collect_tl_doctor_counts()
+    return {
+        'status': status,
+        'tl_dir': legacy.TL_DIR,
+        'tl_exists': os.path.isdir(legacy.TL_DIR),
+        'rpy_files': counts['rpy_files'],
+        'language': legacy.PREP_LANGUAGE,
+        'message': message,
+    }
+
+
+def _raise_generate_template_failure(result):
+    print_template_generation_summary(result)
+    raise SystemExit(f"[GenerateTemplate] {result['message']}")
+
+
 def run_generate_template():
     if not legacy.PREP_ENABLED:
-        result = {
-            'status': 'failed',
-            'tl_dir': legacy.TL_DIR,
-            'tl_exists': os.path.isdir(legacy.TL_DIR),
-            'rpy_files': 0,
-            'language': legacy.PREP_LANGUAGE,
-            'message': 'prepare is disabled in translator_config.json',
-        }
-        print_template_generation_summary(result)
-        raise SystemExit(f"[GenerateTemplate] {result['message']}")
+        _raise_generate_template_failure(
+            _build_template_generation_result(
+                'failed',
+                'prepare is disabled in translator_config.json',
+            )
+        )
 
     if not legacy.PREP_GENERATE_TEMPLATE:
-        result = {
-            'status': 'failed',
-            'tl_dir': legacy.TL_DIR,
-            'tl_exists': os.path.isdir(legacy.TL_DIR),
-            'rpy_files': 0,
-            'language': legacy.PREP_LANGUAGE,
-            'message': 'prepare.generate_template is disabled in translator_config.json',
-        }
-        print_template_generation_summary(result)
-        raise SystemExit(f"[GenerateTemplate] {result['message']}")
+        _raise_generate_template_failure(
+            _build_template_generation_result(
+                'failed',
+                'prepare.generate_template is disabled in translator_config.json',
+            )
+        )
 
-    legacy.run_prepare_steps()
+    try:
+        legacy.run_prepare_steps()
+    except SystemExit as exc:
+        message = str(exc.args[0]) if exc.args else 'Template generation failed during prepare.'
+        _raise_generate_template_failure(
+            _build_template_generation_result('failed', message)
+        )
+
     counts = collect_tl_doctor_counts()
-    tl_exists = os.path.isdir(legacy.TL_DIR)
     rpy_files = counts['rpy_files']
     if rpy_files > 0:
         status = 'ready'
@@ -8444,14 +8459,7 @@ def run_generate_template():
         status = 'failed'
         message = 'Template generation finished but no TL files were found.'
 
-    result = {
-        'status': status,
-        'tl_dir': legacy.TL_DIR,
-        'tl_exists': tl_exists,
-        'rpy_files': rpy_files,
-        'language': legacy.PREP_LANGUAGE,
-        'message': message,
-    }
+    result = _build_template_generation_result(status, message)
     print_template_generation_summary(result)
     if status != 'ready':
         raise SystemExit(f"[GenerateTemplate] {message}")

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from PySide6.QtCore import QEvent, Qt, QTimer
-from PySide6.QtGui import QBrush, QColor, QGuiApplication
+from PySide6.QtGui import QBrush, QColor, QGuiApplication, QPalette
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
@@ -130,12 +130,14 @@ from .work_bootstrap_report import (
     work_bootstrap_to_doctor_summary,
 )
 from .project_state import ProjectState
-from .theme import apply_theme
+from .theme import apply_theme, system_prefers_dark
 from .theme_helpers import (
     DEFAULT_THEME_PREFERENCE,
+    THEME_DARK,
     THEME_SYSTEM,
     normalize_theme_preference,
     read_gui_theme_from_config,
+    resolve_effective_theme,
     write_gui_theme_to_config,
 )
 from .translation_workflow import WorkflowUpdate
@@ -623,6 +625,7 @@ class MainWindow(QMainWindow):
         self.split_status_table.setMinimumHeight(260)
         self.split_status_table.setMaximumHeight(360)
         self.split_status_table.verticalHeader().setVisible(False)
+        self._configure_split_status_table_hover_palette()
         self.split_status_table.viewport().installEventFilter(self)
         self._split_status_action_delegate = SplitStatusActionDelegate(self.split_status_table)
         self._split_status_action_delegate.select_requested.connect(self._select_split_manifest)
@@ -1188,6 +1191,38 @@ class MainWindow(QMainWindow):
         self.split_status_table.setVisible(True)
         self._update_split_submit_btn(entries)
 
+    def _effective_theme_is_dark(self) -> bool:
+        system_is_dark = system_prefers_dark(self._qt_app) if self._qt_app is not None else None
+        return (
+            resolve_effective_theme(self._theme_preference, system_is_dark=system_is_dark)
+            == THEME_DARK
+        )
+
+    def _refresh_split_status_table_after_theme_change(self) -> None:
+        self._configure_split_status_table_hover_palette()
+        if not self._split_status_entries:
+            return
+        self._update_split_status_selection_ui(self._split_status_selected_manifest_path)
+
+    def _configure_split_status_table_hover_palette(self) -> None:
+        if not hasattr(self, "split_status_table"):
+            return
+        dark = self._effective_theme_is_dark()
+        table_palette = self.split_status_table.palette()
+        if dark:
+            table_palette.setColor(
+                QPalette.ColorGroup.All,
+                QPalette.ColorRole.Highlight,
+                QColor(148, 163, 184, 31),
+            )
+        else:
+            table_palette.setColor(
+                QPalette.ColorGroup.All,
+                QPalette.ColorRole.Highlight,
+                QColor(148, 163, 184, 26),
+            )
+        self.split_status_table.setPalette(table_palette)
+
     def _split_status_table_profile(self) -> dict[str, int]:
         table = getattr(self, "split_status_table", None)
         width = 0
@@ -1257,9 +1292,7 @@ class MainWindow(QMainWindow):
         delegate = getattr(self, "_split_status_action_delegate", None)
         if delegate is None:
             return
-        for column in range(self.split_status_table.columnCount()):
-            if is_split_action_column(column):
-                self.split_status_table.setItemDelegateForColumn(column, delegate)
+        pass
 
     def _sync_split_status_table_columns(self) -> None:
         if not hasattr(self, "split_status_table"):
@@ -1347,13 +1380,17 @@ class MainWindow(QMainWindow):
             if action_payload is not None:
                 action_item.setData(SPLIT_ACTION_DATA_ROLE, action_payload)
                 action_item.setToolTip(f"\u5207\u6362\u5230 {entry.part_label}")
+            if show_action_button:
+                btn = QPushButton("选择")
+                btn.setObjectName("split_select_btn")
+                btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+                btn.setToolTip(f"切换到 {entry.part_label}")
+                btn.clicked.connect(lambda checked=False, path=entry.manifest_path: self._select_split_manifest(path))
+                self.split_status_table.setCellWidget(row, base_column + 5, btn)
             else:
-                action_item.setData(SPLIT_ACTION_DATA_ROLE, None)
-                action_item.setToolTip("")
-            model_index = self.split_status_table.model().index(row, base_column + 5)
-            self.split_status_table.viewport().update(
-                self.split_status_table.visualRect(model_index)
-            )
+                self.split_status_table.removeCellWidget(row, base_column + 5)
+            
+            self._apply_split_table_row_style(row, entry, base_column=base_column, is_current=is_current)
 
     def _update_split_status_job_column_texts(self, profile: dict[str, int]) -> None:
         if not hasattr(self, "split_status_table"):
@@ -1400,20 +1437,24 @@ class MainWindow(QMainWindow):
             self._split_job_text(entry, profile["job_chars"]),
             tooltip=entry.job_name or entry.manifest_path,
         )
+        
         show_action_button = entry.selectable and not is_current
-        action_payload = split_action_item_payload(
-            selectable=show_action_button,
-            manifest_path=entry.manifest_path,
-            part_label=entry.part_label,
-        )
+        
+        # Always set an empty QTableWidgetItem to allow background styling on the cell
         action_item = QTableWidgetItem("")
         action_item.setFlags(action_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
-        action_item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter)
-        if action_payload is not None:
-            action_item.setData(SPLIT_ACTION_DATA_ROLE, action_payload)
-            action_item.setToolTip(f"\u5207\u6362\u5230 {entry.part_label}")
         self.split_status_table.setItem(row, base_column + 5, action_item)
         self._apply_split_table_row_style(row, entry, base_column=base_column, is_current=is_current)
+        
+        if show_action_button:
+            btn = QPushButton("选择")
+            btn.setObjectName("split_select_btn")
+            btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+            btn.setToolTip(f"切换到 {entry.part_label}")
+            btn.clicked.connect(lambda checked=False, path=entry.manifest_path: self._select_split_manifest(path))
+            self.split_status_table.setCellWidget(row, base_column + 5, btn)
+        else:
+            self.split_status_table.removeCellWidget(row, base_column + 5)
 
     def _split_job_text(self, entry: SplitManifestEntry, max_chars: int) -> str:
         text = entry.job_name if entry.job_name else entry.display_name
@@ -1452,14 +1493,14 @@ class MainWindow(QMainWindow):
         base_column: int = 0,
         is_current: bool,
     ) -> None:
-        dark = self.palette().window().color().lightness() < 128
+        dark = self._effective_theme_is_dark()
         bg_color, text_color, status_color = self._split_status_row_colors(entry.status_kind)
         
-        # Highlight the currently active/selected split manifest row
+        # Highlight the currently active/selected split manifest row with neutral colors.
         if is_current:
-            bg_color = "#1e293b" if dark else "#e0e7ff"
-            text_color = "#60a5fa" if dark else "#1d4ed8"
-            
+            bg_color = "#27272a" if dark else "#e4e4e7"
+            text_color = "#ffffff" if dark else "#0f172a"
+
         background = QBrush(QColor(bg_color)) if bg_color != "transparent" else None
         foreground = QBrush(QColor(text_color))
         status_foreground = QBrush(QColor(status_color))
@@ -1478,7 +1519,7 @@ class MainWindow(QMainWindow):
             item.setFont(font)
 
     def _split_status_row_colors(self, status_kind: str) -> tuple[str, str, str]:
-        dark = self.palette().window().color().lightness() < 128
+        dark = self._effective_theme_is_dark()
         if dark:
             colors = {
                 "applied": ("transparent", "#cbd5e1", "#34d399"),
@@ -4098,6 +4139,7 @@ class MainWindow(QMainWindow):
             return
         try:
             apply_theme(self._qt_app, self._resources_dir, self._theme_preference)
+            QTimer.singleShot(0, self._refresh_split_status_table_after_theme_change)
         except OSError as exc:
             self.statusBar().showMessage("主题样式加载失败，已保留当前样式。", 6000)
             self._append_log(f"加载主题样式失败：{exc}")

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -118,6 +118,11 @@ from .manifest_resume_summary import (
     build_manifest_workflow_display,
     completed_manifest_entry_fact,
 )
+from .template_generation_report import (
+    running_template_generation_summary,
+    summarize_template_generation_output,
+    template_generation_to_doctor_summary,
+)
 from .work_bootstrap_report import (
     running_work_bootstrap_summary,
     summarize_work_bootstrap_output,
@@ -233,6 +238,9 @@ class MainWindow(QMainWindow):
             self._on_bootstrap_progress_eta_tick
         )
         self._work_bootstrap_output_lines: list[str] = []
+        self._template_generation_output_lines: list[str] = []
+        self._doctor_summary_mode = ""
+        self._doctor_check_completed = False
         self._build_retry_output_lines: list[str] = []
         self._retry_followup_confirmed: set[str] = set()
         self._writeback_manifest_path = ""
@@ -1444,15 +1452,26 @@ class MainWindow(QMainWindow):
         base_column: int = 0,
         is_current: bool,
     ) -> None:
+        dark = self.palette().window().color().lightness() < 128
         bg_color, text_color, status_color = self._split_status_row_colors(entry.status_kind)
-        background = QBrush(QColor(bg_color))
+        
+        # Highlight the currently active/selected split manifest row
+        if is_current:
+            bg_color = "#1e293b" if dark else "#e0e7ff"
+            text_color = "#60a5fa" if dark else "#1d4ed8"
+            
+        background = QBrush(QColor(bg_color)) if bg_color != "transparent" else None
         foreground = QBrush(QColor(text_color))
         status_foreground = QBrush(QColor(status_color))
+        
         for column in range(base_column, min(base_column + 6, self.split_status_table.columnCount())):
             item = self.split_status_table.item(row, column)
             if item is None:
                 continue
-            item.setBackground(background)
+            if background is not None:
+                item.setBackground(background)
+            else:
+                item.setData(Qt.ItemDataRole.BackgroundRole, None)
             item.setForeground(status_foreground if column == base_column + 1 else foreground)
             font = item.font()
             font.setBold(column == base_column + 1 or (is_current and column == base_column))
@@ -1462,31 +1481,31 @@ class MainWindow(QMainWindow):
         dark = self.palette().window().color().lightness() < 128
         if dark:
             colors = {
-                "applied": ("#052e2b", "#d1fae5", "#34d399"),
-                "checked_safe": ("#12351f", "#dcfce7", "#4ade80"),
-                "checked_warn": ("#422006", "#fef3c7", "#fbbf24"),
-                "checked_block": ("#450a0a", "#fee2e2", "#f87171"),
-                "failed": ("#450a0a", "#fee2e2", "#f87171"),
-                "downloaded": ("#172554", "#dbeafe", "#60a5fa"),
-                "running": ("#3b2505", "#fef3c7", "#f59e0b"),
-                "submitted": ("#1e293b", "#cbd5e1", "#93c5fd"),
-                "succeeded": ("#14345b", "#dbeafe", "#60a5fa"),
-                "unsubmitted": ("#111827", "#94a3b8", "#94a3b8"),
+                "applied": ("transparent", "#cbd5e1", "#34d399"),
+                "checked_safe": ("transparent", "#cbd5e1", "#4ade80"),
+                "checked_warn": ("transparent", "#cbd5e1", "#fbbf24"),
+                "checked_block": ("transparent", "#cbd5e1", "#f87171"),
+                "failed": ("transparent", "#cbd5e1", "#f87171"),
+                "downloaded": ("transparent", "#cbd5e1", "#60a5fa"),
+                "running": ("transparent", "#cbd5e1", "#fbbf24"),
+                "submitted": ("transparent", "#cbd5e1", "#93c5fd"),
+                "succeeded": ("transparent", "#cbd5e1", "#60a5fa"),
+                "unsubmitted": ("transparent", "#94a3b8", "#94a3b8"),
             }
-            return colors.get(status_kind, ("#0f172a", "#cbd5e1", "#cbd5e1"))
+            return colors.get(status_kind, ("transparent", "#cbd5e1", "#cbd5e1"))
         colors = {
-            "applied": ("#d1fae5", "#064e3b", "#047857"),
-            "checked_safe": ("#dcfce7", "#14532d", "#15803d"),
-            "checked_warn": ("#fef3c7", "#78350f", "#b45309"),
-            "checked_block": ("#fee2e2", "#7f1d1d", "#dc2626"),
-            "failed": ("#fee2e2", "#7f1d1d", "#dc2626"),
-            "downloaded": ("#dbeafe", "#1e3a8a", "#2563eb"),
-            "running": ("#fef3c7", "#78350f", "#d97706"),
-            "submitted": ("#e2e8f0", "#334155", "#2563eb"),
-            "succeeded": ("#e0f2fe", "#075985", "#0284c7"),
-            "unsubmitted": ("#f8fafc", "#64748b", "#64748b"),
+            "applied": ("transparent", "#334155", "#059669"),
+            "checked_safe": ("transparent", "#334155", "#15803d"),
+            "checked_warn": ("transparent", "#334155", "#b45309"),
+            "checked_block": ("transparent", "#334155", "#dc2626"),
+            "failed": ("transparent", "#334155", "#dc2626"),
+            "downloaded": ("transparent", "#334155", "#2563eb"),
+            "running": ("transparent", "#334155", "#d97706"),
+            "submitted": ("transparent", "#334155", "#2563eb"),
+            "succeeded": ("transparent", "#334155", "#0284c7"),
+            "unsubmitted": ("transparent", "#64748b", "#64748b"),
         }
-        return colors.get(status_kind, ("#f8fafc", "#334155", "#334155"))
+        return colors.get(status_kind, ("transparent", "#334155", "#334155"))
 
     def _short_job_name(self, job_name: str) -> str:
         if not job_name:
@@ -2155,6 +2174,37 @@ class MainWindow(QMainWindow):
     def _resume_button_is_query_mode(self) -> bool:
         return hasattr(self, "resume_btn") and self.resume_btn.text() == "查询云端状态"
 
+    def _should_generate_template_only(self) -> bool:
+        spec = work_mode_spec(self._current_work_mode())
+        if spec.mode not in {WorkMode.BATCH_TRANSLATION, WorkMode.SYNC_TRANSLATION}:
+            return False
+        return self._doctor_summary_mode == "can_generate_template"
+
+    def _translate_button_label(self) -> str:
+        spec = work_mode_spec(self._current_work_mode())
+        if self._should_generate_template_only():
+            return "生成翻译模板"
+        return spec.start_button_label
+
+    def _translation_requires_doctor_check(self, mode: WorkMode) -> bool:
+        return mode in {WorkMode.BATCH_TRANSLATION, WorkMode.SYNC_TRANSLATION}
+
+    def _translate_button_enabled(
+        self,
+        *,
+        spec,
+        bootstrap_ready: bool,
+        running: bool,
+    ) -> bool:
+        if running or not spec.implemented or not bootstrap_ready:
+            return False
+        if self._translation_requires_doctor_check(spec.mode):
+            return self._doctor_check_completed
+        return True
+
+    def _update_translate_button_label(self) -> None:
+        self.translate_btn.setText(self._translate_button_label())
+
     def _apply_work_mode_ui(
         self,
         *,
@@ -2166,7 +2216,7 @@ class MainWindow(QMainWindow):
         self.timeline.setVisible(False)
         self._sync_task_selectors_from_work_mode()
         self.translate_group_label.setText(spec.task_group_label)
-        self.translate_btn.setText(spec.start_button_label)
+        self._update_translate_button_label()
         if spec.resume_button_label:
             self.resume_btn.setText(spec.resume_button_label)
         self._update_resume_btn_text()
@@ -2190,7 +2240,13 @@ class MainWindow(QMainWindow):
             self._refresh_workflow_from_latest_manifest()
         running = self.kill_btn.isEnabled()
         bootstrap_ready = self._bootstrap_task_ready(spec)
-        self.translate_btn.setEnabled(spec.implemented and bootstrap_ready and not running)
+        self.translate_btn.setEnabled(
+            self._translate_button_enabled(
+                spec=spec,
+                bootstrap_ready=bootstrap_ready,
+                running=running,
+            )
+        )
         self.resume_btn.setEnabled(spec.implemented and spec.supports_resume and not running)
         self._update_split_submit_btn(running=running)
 
@@ -2661,6 +2717,7 @@ class MainWindow(QMainWindow):
             self._workflow = None
             self._workflow_step_output_lines = []
             self._clear_completed_manifest_snapshot()
+            self._doctor_check_completed = False
             self._set_doctor_summary(stale_summary())
             spec = work_mode_spec(self._current_work_mode())
             if spec.is_bootstrap:
@@ -2878,6 +2935,32 @@ class MainWindow(QMainWindow):
         self._set_task_running(True)
         self.runner.run(self.state.get_batch_script_path(), ["bootstrap-work"])
 
+    def _on_generate_template(self):
+        if not self.state.get_game_root():
+            QMessageBox.information(
+                self,
+                "请先选择项目",
+                "请先选择游戏的 work 目录。",
+            )
+            return
+
+        self._clear_log_view()
+        self._active_command = "generate_template"
+        self._template_generation_output_lines = []
+        self._focus_workbench_status_tab(1)
+        running_summary = running_template_generation_summary()
+        doctor_summary = template_generation_to_doctor_summary(running_summary)
+        self._set_doctor_summary(doctor_summary)
+        self._set_workflow_summary(
+            "running",
+            running_summary.heading,
+            running_summary.message,
+            running_summary.facts,
+        )
+        self._append_log("=== 正在运行：gemini_translate_batch.py generate-template ===\n")
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), ["generate-template"])
+
     def _saved_batch_context_flags(self) -> dict[str, bool]:
         return read_batch_context_flags(self.state.load_translator_config())
 
@@ -2958,11 +3041,21 @@ class MainWindow(QMainWindow):
         if spec.is_bootstrap:
             self._start_bootstrap_task(spec.bootstrap_kind)
             return
+        if self._should_generate_template_only():
+            self._on_generate_template()
+            return
         if not self.state.get_game_root():
             QMessageBox.information(
                 self,
                 "请先选择项目",
                 "请先选择游戏的 work 目录。",
+            )
+            return
+        if self._translation_requires_doctor_check(spec.mode) and not self._doctor_check_completed:
+            QMessageBox.information(
+                self,
+                "请先运行环境检查",
+                "批量翻译与同步翻译需要先完成环境检查，确认项目状态后再开始。",
             )
             return
 
@@ -3319,6 +3412,8 @@ class MainWindow(QMainWindow):
                 self._workflow_progress,
             )
             self._schedule_progress_ui_flush()
+        elif self._active_command == "generate_template":
+            self._template_generation_output_lines.append(text)
         self._append_log(text)
 
     def _schedule_progress_ui_flush(self) -> None:
@@ -3387,7 +3482,13 @@ class MainWindow(QMainWindow):
         self.bootstrap_work_btn.setEnabled(not running)
         self.api_btn.setEnabled(not running)
         bootstrap_ready = self._bootstrap_task_ready(spec)
-        self.translate_btn.setEnabled(spec.implemented and bootstrap_ready and not running)
+        self.translate_btn.setEnabled(
+            self._translate_button_enabled(
+                spec=spec,
+                bootstrap_ready=bootstrap_ready,
+                running=running,
+            )
+        )
         self.resume_btn.setEnabled(spec.implemented and spec.supports_resume and not running)
         self._update_split_submit_btn(running=running)
         self.save_config_btn.setEnabled(not running)
@@ -3529,6 +3630,7 @@ class MainWindow(QMainWindow):
             self._focus_workbench_status_tab(2)
 
     def _set_doctor_summary(self, summary: DoctorSummary):
+        self._doctor_summary_mode = summary.mode
         self.doctor_status_label.setText(summary.heading)
         self.doctor_status_label.setProperty("status", summary.status)
         self.doctor_status_label.style().unpolish(self.doctor_status_label)
@@ -3536,6 +3638,17 @@ class MainWindow(QMainWindow):
         self.doctor_message_label.setText(summary.message)
         self.doctor_facts_label.setText("\n".join(summary.facts))
         self._set_details_label(self.doctor_details_label, [])
+        self._update_translate_button_label()
+        spec = work_mode_spec(self._current_work_mode())
+        running = self.kill_btn.isEnabled()
+        bootstrap_ready = self._bootstrap_task_ready(spec)
+        self.translate_btn.setEnabled(
+            self._translate_button_enabled(
+                spec=spec,
+                bootstrap_ready=bootstrap_ready,
+                running=running,
+            )
+        )
         self._sync_layout_sizes()
 
     def _on_runner_error(self, message: str):
@@ -3552,6 +3665,8 @@ class MainWindow(QMainWindow):
             self._bootstrap_output_lines.append(message)
         elif self._active_command == "bootstrap_work":
             self._work_bootstrap_output_lines.append(message)
+        elif self._active_command == "generate_template":
+            self._template_generation_output_lines.append(message)
         self._focus_log_tab()
         self.statusBar().showMessage("任务运行失败，请查看诊断日志。", 6000)
 
@@ -3565,6 +3680,7 @@ class MainWindow(QMainWindow):
                 api_key_count=api_key_count,
                 api_key_source=api_key_source,
             )
+            self._doctor_check_completed = exit_code == 0
             self._set_doctor_summary(summary)
             self._active_command = ""
             self._set_task_running(False)
@@ -3707,6 +3823,31 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("准备工作目录已结束，请查看摘要。", 6000)
             else:
                 self.statusBar().showMessage("准备工作目录失败，请查看诊断日志。", 8000)
+            return
+
+        if self._active_command == "generate_template":
+            summary = summarize_template_generation_output(
+                "\n".join(self._template_generation_output_lines),
+                exit_code,
+            )
+            self._set_doctor_summary(template_generation_to_doctor_summary(summary))
+            self._set_workflow_summary(
+                summary.status,
+                summary.heading,
+                summary.message,
+                summary.facts,
+            )
+            self._active_command = ""
+            self._set_task_running(False)
+            if exit_code == 0 and summary.status == "ready":
+                self.statusBar().showMessage(
+                    "翻译模板已生成，可以开始翻译。",
+                    6000,
+                )
+            elif exit_code == 0:
+                self.statusBar().showMessage("翻译模板生成已结束，请查看摘要。", 6000)
+            else:
+                self.statusBar().showMessage("翻译模板生成失败，请查看诊断日志。", 8000)
             return
 
         self._set_task_running(False)

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -24,11 +24,12 @@ class DoctorSummary:
     message: str
     facts: list[str]
     findings: list[str]
+    mode: str = ""
 
 
 MODE_MESSAGES = {
     "can_generate_template": "Ren'Py 模板生成环境可用；翻译模板尚未生成。",
-    "existing_tl_only": "已有翻译文件可处理；模板生成环境不可用，后续依赖现有翻译文件。",
+    "existing_tl_only": "翻译模板已就绪，可以开始翻译流程。",
     "blocked_missing_template": "缺少可处理的翻译文件，也无法自动生成模板。",
 }
 
@@ -494,6 +495,7 @@ def summarize_doctor_output(
         message=message,
         facts=facts,
         findings=findings,
+        mode=mode,
     )
 
 
@@ -504,6 +506,7 @@ def running_summary() -> DoctorSummary:
         message="正在运行环境检查；完成后这里会显示摘要。",
         facts=[],
         findings=[],
+        mode="",
     )
 
 
@@ -514,6 +517,7 @@ def idle_summary() -> DoctorSummary:
         message="选择 work 目录（或项目根目录）后点击「环境检查」。",
         facts=[],
         findings=[],
+        mode="",
     )
 
 
@@ -524,4 +528,5 @@ def stale_summary() -> DoctorSummary:
         message="当前摘要已清空；请针对新的 work 目录重新运行环境检查。",
         facts=[],
         findings=[],
+        mode="",
     )

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -26,14 +26,12 @@ QWidget {
     color: #4b5563;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
     color: #374151;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.5;
 }
 
 /* Dialogs are top-level windows */
@@ -184,7 +182,7 @@ QLabel#bootstrap_status_label {
     font-weight: 700;
     padding: 4px 12px;
     border-radius: 12px;
-    qproperty-alignment: 'AlignCenter';
+    qproperty-alignment: AlignCenter;
 }
 
 /* Success Badges */
@@ -709,7 +707,6 @@ QTextEdit#log_view QScrollBar:vertical {
     width: 8px;
 }
 
-QModelIndex QScrollBar::handle:vertical,
 QScrollBar::handle:vertical,
 QScrollBar::handle:horizontal {
     background-color: rgba(100, 116, 139, 0.2);

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -13,30 +13,30 @@ QWidget {
 
 /* Header style */
 #header_label {
-    font-size: 18px;
-    font-weight: 700;
-    color: #1e3a8a;
-    padding-bottom: 2px;
+    font-size: 20px;
+    font-weight: 800;
+    color: #1e3a8a; /* Deep blue */
+    background: transparent;
+    padding-bottom: 4px;
 }
 
 #subtitle_label,
 #config_hint_label,
 #work_mode_hint_label {
-    color: #64748b;
-    font-size: 15px;
+    color: #4b5563;
+    font-size: 14px;
     font-weight: 400;
-    line-height: 1.45;
+    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
-    color: #475569;
+    color: #374151;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.45;
+    line-height: 1.5;
 }
 
-/* Dialogs are top-level windows; set an explicit light surface so Windows
-   dark mode does not leak through when only QMainWindow is themed. */
+/* Dialogs are top-level windows */
 QDialog,
 QDialog#api_key_dialog {
     background-color: #ffffff;
@@ -45,7 +45,7 @@ QDialog#api_key_dialog {
 
 QDialog QLabel {
     background-color: transparent;
-    color: #475569;
+    color: #374151;
 }
 
 QDialog#api_key_dialog QDialogButtonBox QPushButton {
@@ -55,55 +55,57 @@ QDialog#api_key_dialog QDialogButtonBox QPushButton {
 #api_status_label {
     background-color: #f8fafc;
     border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    color: #334155;
+    border-radius: 8px;
+    color: #374151;
     font-size: 14px;
-    padding: 10px 12px;
+    padding: 12px 14px;
 }
 
 QLineEdit#api_key_input {
     background-color: #ffffff;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 8px;
     color: #0f172a;
-    padding: 6px 10px;
-    min-height: 20px;
+    padding: 8px 12px;
+    min-height: 24px;
 }
 
 QLineEdit#api_key_input:focus {
-    border-color: #2563eb;
+    border-color: #3b82f6;
+    background-color: #fdfdfd;
 }
 
 QListWidget#api_key_list {
     background-color: #ffffff;
     border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    color: #334155;
+    border-radius: 8px;
+    color: #374151;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
-    padding: 4px;
+    padding: 6px;
 }
 
 QListWidget#api_key_list QAbstractItemView {
     background-color: #ffffff;
-    color: #334155;
+    color: #374151;
     selection-background-color: #dbeafe;
-    selection-color: #1e3a8a;
+    selection-color: #1e40af;
 }
 
 QListWidget#api_key_list::item {
     padding: 6px 8px;
+    border-radius: 4px;
 }
 
 QListWidget#api_key_list::item:selected {
     background-color: #dbeafe;
-    color: #1e3a8a;
+    color: #1e40af;
 }
 
 /* Tab widget */
 QTabWidget#main_tabs::pane {
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
     background-color: #ffffff;
     top: -1px;
 }
@@ -125,10 +127,10 @@ QWidget#diagnostics_log_panel {
 }
 
 QSplitter#diagnostics_splitter::handle {
-    background-color: #e2e8f0;
-    height: 4px;
+    background-color: #cbd5e1;
+    height: 6px;
     margin: 4px 0;
-    border-radius: 2px;
+    border-radius: 3px;
 }
 
 QSplitter#diagnostics_splitter::handle:hover {
@@ -136,8 +138,8 @@ QSplitter#diagnostics_splitter::handle:hover {
 }
 
 QTabWidget#diagnostics_inner_tabs::pane {
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
     background-color: #ffffff;
     top: -1px;
 }
@@ -146,50 +148,103 @@ QTabWidget#diagnostics_inner_tabs QWidget {
     background-color: #ffffff;
 }
 
-QTabWidget#diagnostics_inner_tabs > QTabBar::tab {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 7px 16px;
-    margin-right: 3px;
+QTabWidget#diagnostics_inner_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 18px;
+    margin: 2px 6px;
     color: #64748b;
-    font-weight: 500;
+    font-weight: 600;
 }
 
-QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
-    background-color: #ffffff;
-    color: #2563eb;
+QTabWidget#diagnostics_inner_tabs QTabBar::tab:selected {
+    color: #3b82f6;
+    border-bottom: 2px solid #3b82f6;
+}
+
+QTabWidget#diagnostics_inner_tabs QTabBar::tab:hover:!selected {
+    color: #0f172a;
+    border-bottom: 2px solid #cbd5e1;
 }
 
 QLabel#diagnostics_section_label {
-    color: #475569;
+    color: #64748b;
     font-size: 14px;
     font-weight: 600;
 }
 
-QLabel#diagnostics_status_label {
-    font-size: 15px;
+/* Status Labels generalized to pill badges */
+QLabel#diagnostics_status_label,
+QLabel#doctor_status_label,
+QLabel#workflow_status_label,
+QLabel#writeback_status_label,
+QLabel#bootstrap_status_label {
+    font-size: 12px;
     font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 12px;
+    qproperty-alignment: 'AlignCenter';
 }
 
+/* Success Badges */
+QLabel#diagnostics_status_label[status="ready"],
+QLabel#doctor_status_label[status="ready"],
+QLabel#workflow_status_label[status="done"],
+QLabel#writeback_status_label[status="safe"],
+QLabel#writeback_status_label[status="applied"],
+QLabel#bootstrap_status_label[status="ready"] {
+    color: #065f46;
+    background-color: rgba(16, 185, 129, 0.08);
+    border: 1px solid rgba(16, 185, 129, 0.4);
+}
+
+/* Info / Running / Idle Badges */
 QLabel#diagnostics_status_label[status="idle"],
-QLabel#diagnostics_status_label[status="running"] {
-    color: #2563eb;
+QLabel#diagnostics_status_label[status="running"],
+QLabel#doctor_status_label[status="idle"],
+QLabel#doctor_status_label[status="running"],
+QLabel#workflow_status_label[status="idle"],
+QLabel#workflow_status_label[status="running"],
+QLabel#writeback_status_label[status="idle"],
+QLabel#writeback_status_label[status="running"],
+QLabel#bootstrap_status_label[status="idle"],
+QLabel#bootstrap_status_label[status="running"] {
+    color: #1e40af;
+    background-color: rgba(59, 130, 246, 0.08);
+    border: 1px solid rgba(59, 130, 246, 0.4);
 }
 
-QLabel#diagnostics_status_label[status="ready"] {
-    color: #15803d;
+/* Warning Badges */
+QLabel#diagnostics_status_label[status="warning"],
+QLabel#doctor_status_label[status="warning"],
+QLabel#doctor_status_label[status="stale"],
+QLabel#workflow_status_label[status="waiting"],
+QLabel#workflow_status_label[status="stale"],
+QLabel#writeback_status_label[status="warn"],
+QLabel#writeback_status_label[status="stale"],
+QLabel#bootstrap_status_label[status="warning"],
+QLabel#bootstrap_status_label[status="stale"] {
+    color: #92400e;
+    background-color: rgba(245, 158, 11, 0.08);
+    border: 1px solid rgba(245, 158, 11, 0.4);
 }
 
-QLabel#diagnostics_status_label[status="warning"] {
-    color: #b45309;
+/* Danger / Blocked Badges */
+QLabel#doctor_status_label[status="blocked"],
+QLabel#workflow_status_label[status="failed"],
+QLabel#writeback_status_label[status="block"],
+QLabel#writeback_status_label[status="failed"],
+QLabel#writeback_status_label[status="unknown"],
+QLabel#bootstrap_status_label[status="failed"] {
+    color: #991b1b;
+    background-color: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.4);
 }
 
 QFrame#diagnostics_facts_frame {
     background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
+    border: 1px solid #cbd5e1;
     border-radius: 8px;
 }
 
@@ -220,33 +275,34 @@ QTextEdit#diagnostics_manifest_preview {
     padding: 10px;
 }
 
-QTabWidget#main_tabs > QTabBar::tab {
-    background-color: #f1f5f9;
-    border: 1px solid #e2e8f0;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 9px 22px;
-    margin-right: 4px;
+/* Modern Underline style tabs for Main Tabs */
+QTabWidget#main_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 24px;
+    margin: 2px 8px;
     color: #64748b;
-    font-weight: 500;
-    min-width: 72px;
-}
-
-QTabWidget#main_tabs > QTabBar::tab:selected {
-    background-color: #ffffff;
-    color: #2563eb;
     font-weight: 600;
+    min-width: 80px;
 }
 
-QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
-    background-color: #e2e8f0;
-    color: #334155;
+QTabWidget#main_tabs QTabBar::tab:selected {
+    background-color: transparent;
+    color: #2563eb;
+    border-bottom: 2px solid #2563eb;
 }
 
+QTabWidget#main_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
+    color: #0f172a;
+    border-bottom: 2px solid #cbd5e1;
+}
+
+/* Workbench status inner tabs style */
 QTabWidget#workbench_status_tabs::pane {
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
     background-color: #ffffff;
     top: -1px;
 }
@@ -262,38 +318,44 @@ QWidget#workflow_summary_content {
     border: none;
 }
 
-QTabWidget#workbench_status_tabs > QTabBar::tab {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 7px 16px;
-    margin-right: 3px;
+QTabWidget#workbench_status_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 6px 18px;
+    margin: 2px 6px;
     color: #64748b;
-    font-weight: 500;
+    font-weight: 600;
 }
 
-QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
-    background-color: #ffffff;
+QTabWidget#workbench_status_tabs QTabBar::tab:selected {
+    background-color: transparent;
     color: #2563eb;
+    border-bottom: 2px solid #2563eb;
 }
 
-/* Project Path, Mode selector, and Action Frame styling (Glassmorphism) */
+QTabWidget#workbench_status_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
+    color: #0f172a;
+    border-bottom: 2px solid #cbd5e1;
+}
+
+/* Project Path, Mode selector, and Action Frame styling (Glassmorphism Cards) */
 #project_frame,
 #mode_frame,
 #action_frame {
     background-color: rgba(255, 255, 255, 0.85);
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    border-radius: 8px;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    border-top: 1px solid rgba(255, 255, 255, 0.9); /* Subtle highlight rim */
+    border-radius: 10px;
 }
 
 #project_path_edit {
-    background-color: #f1f5f9;
+    background-color: #f8fafc;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 8px;
     color: #334155;
-    padding: 6px 10px;
+    padding: 8px 12px;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
 }
@@ -302,21 +364,21 @@ QLabel#action_group_label {
     color: #64748b;
     font-size: 12px;
     font-weight: 600;
-    padding-right: 2px;
+    padding-right: 4px;
 }
 
 QFrame#action_separator {
     color: #e2e8f0;
-    margin-top: 2px;
-    margin-bottom: 2px;
+    margin-top: 4px;
+    margin-bottom: 4px;
 }
 
-/* GroupBox styling */
+/* GroupBox Card styling */
 QGroupBox {
     background-color: #ffffff;
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    margin-top: 16px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    margin-top: 20px;
     font-weight: 600;
     color: #0f172a;
     padding-top: 24px;
@@ -325,15 +387,15 @@ QGroupBox {
 QGroupBox::title {
     subcontrol-origin: margin;
     subcontrol-position: top left;
-    left: 12px;
-    top: 6px;
+    left: 14px;
+    top: 5px;
     background-color: #ffffff;
-    padding: 0 6px;
+    padding: 0 8px;
     color: #2563eb;
     font-size: 13px;
 }
 
-/* Form layout labels */
+/* Label styling */
 QLabel {
     color: #475569;
     font-weight: 500;
@@ -343,10 +405,10 @@ QLabel {
 QComboBox {
     background-color: #ffffff;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 8px;
     color: #0f172a;
-    padding: 5px 10px;
-    min-height: 20px;
+    padding: 6px 12px;
+    min-height: 22px;
 }
 
 QComboBox:hover {
@@ -355,6 +417,7 @@ QComboBox:hover {
 
 QComboBox:focus {
     border-color: #2563eb;
+    background-color: #fdfdfd;
 }
 
 QComboBox:disabled {
@@ -372,11 +435,11 @@ QComboBox::drop-down {
 QPushButton {
     background-color: #ffffff;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 8px;
     color: #334155;
-    font-weight: 500;
-    padding: 8px 16px;
-    min-height: 18px;
+    font-weight: 600;
+    padding: 8px 18px;
+    min-height: 20px;
 }
 
 QPushButton:hover {
@@ -395,38 +458,35 @@ QPushButton:disabled {
     color: #cbd5e1;
 }
 
-/* Primary Action Buttons */
+/* Primary Action Buttons - Aurora Gradient */
 QPushButton#save_config_btn,
 QPushButton#api_btn,
 QPushButton#translate_btn {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #2563eb, stop:1 #3b82f6);
-    border: 1px solid #1d4ed8;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #3b82f6, stop:1 #1d4ed8);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
     min-width: 108px;
 }
 
 QPushButton#save_config_btn:hover,
 QPushButton#api_btn:hover,
 QPushButton#translate_btn:hover {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #1d4ed8, stop:1 #2563eb);
-    border-color: #1e40af;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #60a5fa, stop:1 #2563eb);
 }
 
 QPushButton#save_config_btn:pressed,
 QPushButton#api_btn:pressed,
 QPushButton#translate_btn:pressed {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #1e3a8a, stop:1 #1d4ed8);
-    border-color: #1d4ed8;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #1e3a8a, stop:1 #1d4ed8);
 }
 
 QPushButton#save_config_btn:disabled,
 QPushButton#api_btn:disabled,
 QPushButton#translate_btn:disabled {
     background-color: #f1f5f9;
-    border-color: #e2e8f0;
+    border: 1px solid #e2e8f0;
     color: #cbd5e1;
-    font-weight: 600;
 }
 
 /* Secondary Action Buttons */
@@ -434,7 +494,7 @@ QPushButton#secondary_btn {
     background-color: #ffffff;
     border: 1px solid #cbd5e1;
     color: #475569;
-    font-weight: 500;
+    font-weight: 600;
     min-width: 108px;
 }
 
@@ -454,96 +514,67 @@ QPushButton#secondary_btn:disabled {
     color: #cbd5e1;
 }
 
-
 /* Compact table action buttons */
 QPushButton#split_select_btn {
-    background-color: #ffffff;
-    border: 1px solid #94a3b8;
+    background-color: #f1f5f9;
+    border: 1px solid #cbd5e1;
     border-radius: 6px;
-    color: #334155;
-    font-weight: 600;
-    min-width: 72px;
-    min-height: 28px;
-    padding: 0px 10px;
+    color: #475569;
+    font-size: 11px;
+    font-weight: bold;
+    min-width: 64px;
+    min-height: 22px;
+    padding: 2px 10px;
     text-align: center;
 }
 
 QPushButton#split_select_btn:hover {
-    background-color: #f8fafc;
-    border-color: #64748b;
+    background-color: #e2e8f0;
+    border-color: #3b82f6;
     color: #0f172a;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #e2e8f0;
-    border-color: #64748b;
+    background-color: #cbd5e1;
 }
 
 QPushButton#split_select_btn:disabled {
-    background-color: #f1f5f9;
+    background-color: #f8fafc;
     border-color: #e2e8f0;
-    color: #cbd5e1;
+    color: #94a3b8;
 }
 
 /* Danger Action Button */
 QPushButton#kill_btn {
-    background-color: #ef4444;
-    border: 1px solid #ef4444;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #dc2626, stop:1 #ef4444);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
 }
 
 QPushButton#kill_btn:hover {
-    background-color: #dc2626;
-    border-color: #dc2626;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #ef4444, stop:1 #f87171);
 }
 
 QPushButton#kill_btn:pressed {
-    background-color: #b91c1c;
-    border-color: #b91c1c;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b91c1c, stop:1 #dc2626);
 }
 
 QPushButton#kill_btn:disabled {
     background-color: #f1f5f9;
-    border-color: #e2e8f0;
+    border: 1px solid #e2e8f0;
     color: #cbd5e1;
 }
 
-/* Log View (QTextEdit) terminal styling */
+/* Log View terminal styling */
 QTextEdit#log_view {
     background-color: #0f172a;
-    border: 1px solid #1e293b;
-    border-radius: 8px;
-    color: #e2e8f0;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    color: #f1f5f9;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
-    padding: 12px;
-}
-
-QLabel#doctor_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#doctor_status_label[status="idle"],
-QLabel#doctor_status_label[status="running"] {
-    color: #2563eb;
-}
-
-QLabel#doctor_status_label[status="ready"] {
-    color: #15803d;
-}
-
-QLabel#doctor_status_label[status="warning"] {
-    color: #b45309;
-}
-
-QLabel#doctor_status_label[status="stale"] {
-    color: #b45309;
-}
-
-QLabel#doctor_status_label[status="blocked"] {
-    color: #b91c1c;
+    padding: 14px;
 }
 
 QLabel#doctor_facts_label {
@@ -551,113 +582,65 @@ QLabel#doctor_facts_label {
     font-size: 14px;
 }
 
-QLabel#workflow_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#workflow_status_label[status="idle"],
-QLabel#workflow_status_label[status="running"] {
-    color: #2563eb;
-}
-
-QLabel#workflow_status_label[status="done"] {
-    color: #15803d;
-}
-
-QLabel#workflow_status_label[status="waiting"],
-QLabel#workflow_status_label[status="stale"] {
-    color: #b45309;
-}
-
-QLabel#workflow_status_label[status="failed"] {
-    color: #b91c1c;
-}
-
 QLabel#workflow_facts_label {
     color: #334155;
     font-size: 14px;
 }
 
+/* Progress bar styling */
 QProgressBar#workflow_progress_bar {
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 8px;
     background: #f8fafc;
-    color: #334155;
-    font-size: 12px;
+    color: #0f172a;
+    font-size: 11px;
+    font-weight: bold;
     min-height: 18px;
     max-height: 22px;
     text-align: center;
 }
 
 QProgressBar#workflow_progress_bar::chunk {
-    background-color: #2563eb;
-    border-radius: 5px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #2563eb, stop:1 #60a5fa);
+    border-radius: 6px;
 }
 
+/* Table Widget styling */
 QTableWidget#split_status_table {
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
-    background: #f8fafc;
-    alternate-background-color: #f1f5f9;
+    border-radius: 8px;
+    background: #ffffff;
+    alternate-background-color: #f8fafc;
     color: #334155;
     gridline-color: #e2e8f0;
 }
 
 QTableWidget#split_status_table::item {
-    padding: 4px 6px;
+    padding: 6px 8px;
 }
 
 QTableWidget#split_status_table QHeaderView::section {
-    background-color: #e2e8f0;
-    color: #334155;
+    background-color: #f1f5f9;
+    color: #64748b;
     border: none;
     border-right: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
-    padding: 5px 6px;
-    font-weight: 600;
+    padding: 6px 8px;
+    font-size: 11px;
+    font-weight: 700;
 }
 
 QFrame#workflow_separator {
     color: #e2e8f0;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 QLabel#workflow_section_label {
     color: #2563eb;
     font-size: 14px;
     font-weight: 600;
-    margin-top: 2px;
-}
-
-QLabel#writeback_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#writeback_status_label[status="idle"],
-QLabel#writeback_status_label[status="running"] {
-    color: #2563eb;
-}
-
-QLabel#writeback_status_label[status="safe"] {
-    color: #15803d;
-}
-
-QLabel#writeback_status_label[status="applied"] {
-    color: #15803d;
-}
-
-QLabel#writeback_status_label[status="warn"],
-QLabel#writeback_status_label[status="stale"] {
-    color: #b45309;
-}
-
-QLabel#writeback_status_label[status="block"],
-QLabel#writeback_status_label[status="failed"],
-QLabel#writeback_status_label[status="unknown"] {
-    color: #b91c1c;
+    margin-top: 4px;
 }
 
 QLabel#writeback_facts_label {
@@ -665,124 +648,92 @@ QLabel#writeback_facts_label {
     font-size: 14px;
 }
 
-QLabel#bootstrap_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#bootstrap_status_label[status="idle"],
-QLabel#bootstrap_status_label[status="running"] {
-    color: #2563eb;
-}
-
-QLabel#bootstrap_status_label[status="ready"] {
-    color: #15803d;
-}
-
-QLabel#bootstrap_status_label[status="warning"],
-QLabel#bootstrap_status_label[status="stale"] {
-    color: #b45309;
-}
-
-QLabel#bootstrap_status_label[status="failed"] {
-    color: #b91c1c;
-}
-
 QLabel#bootstrap_facts_label {
     color: #334155;
     font-size: 14px;
 }
 
-QTextEdit#bootstrap_findings_view {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 6px;
+QTextEdit#bootstrap_findings_view,
+QTextEdit#writeback_findings_view,
+QTextEdit#doctor_findings_view {
+    background-color: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
     color: #334155;
     font-size: 14px;
-    padding: 8px;
+    padding: 10px;
 }
 
-QTextEdit#writeback_findings_view {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    color: #334155;
-    font-size: 14px;
-    padding: 8px;
-}
-
-QPushButton#apply_btn {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #15803d, stop:1 #22c55e);
-    border: 1px solid #166534;
+/* Emerald Green Gradient for writeback apply button */
+QPushButton#apply_btn,
+QPushButton#apply_revision_btn {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #10b981, stop:1 #047857);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
     min-width: 108px;
 }
 
-QPushButton#apply_btn:hover {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #166534, stop:1 #15803d);
-    border-color: #14532d;
+QPushButton#apply_btn:hover,
+QPushButton#apply_revision_btn:hover {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #34d399, stop:1 #059669);
 }
 
-QPushButton#apply_btn:pressed {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #14532d, stop:1 #166534);
-    border-color: #166534;
+QPushButton#apply_btn:pressed,
+QPushButton#apply_revision_btn:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #064e3b, stop:1 #065f46);
 }
 
-QPushButton#apply_btn:disabled {
+QPushButton#apply_btn:disabled,
+QPushButton#apply_revision_btn:disabled {
     background-color: #f1f5f9;
-    border-color: #e2e8f0;
+    border: 1px solid #cbd5e1;
     color: #cbd5e1;
-    font-weight: 600;
 }
 
-QTextEdit#doctor_findings_view {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    color: #334155;
-    font-size: 14px;
-    padding: 8px;
-}
-
-/* ScrollBar Styling */
+/* Sleek minimalist scrollbar styling */
 QScrollBar:vertical {
-    background-color: #f1f5f9;
-    width: 10px;
+    background-color: transparent;
+    width: 8px;
+    margin: 0px;
+}
+
+QScrollBar:horizontal {
+    background-color: transparent;
+    height: 8px;
     margin: 0px;
 }
 
 QTextEdit#log_view QScrollBar:vertical {
-    background-color: #0f172a;
-    width: 12px;
+    background-color: transparent;
+    width: 8px;
 }
 
-QScrollBar::handle:vertical {
-    background-color: #cbd5e1;
-    min-height: 20px;
-    border-radius: 5px;
-    border: 2px solid #f1f5f9;
+QModelIndex QScrollBar::handle:vertical,
+QScrollBar::handle:vertical,
+QScrollBar::handle:horizontal {
+    background-color: rgba(100, 116, 139, 0.2);
+    border-radius: 4px;
+    min-height: 24px;
+    min-width: 24px;
 }
 
-QScrollBar::handle:vertical:hover {
-    background-color: #94a3b8;
-}
-
-QTextEdit#log_view QScrollBar::handle:vertical {
-    background-color: #334155;
-    border: 2px solid #0f172a;
-}
-
-QTextEdit#log_view QScrollBar::handle:vertical:hover {
-    background-color: #475569;
+QScrollBar::handle:vertical:hover,
+QScrollBar::handle:horizontal:hover {
+    background-color: rgba(100, 116, 139, 0.4);
 }
 
 QScrollBar::add-line:vertical,
-QScrollBar::sub-line:vertical {
+QScrollBar::sub-line:vertical,
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal {
+    width: 0px;
     height: 0px;
 }
 
 QScrollBar::add-page:vertical,
-QScrollBar::sub-page:vertical {
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal {
     background: none;
 }

--- a/gui_qt/resources/app.qss
+++ b/gui_qt/resources/app.qss
@@ -26,12 +26,14 @@ QWidget {
     color: #4b5563;
     font-size: 14px;
     font-weight: 400;
+    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
     color: #374151;
     font-size: 14px;
     font-weight: 400;
+    line-height: 1.5;
 }
 
 /* Dialogs are top-level windows */
@@ -157,11 +159,13 @@ QTabWidget#diagnostics_inner_tabs QTabBar::tab {
 }
 
 QTabWidget#diagnostics_inner_tabs QTabBar::tab:selected {
+    background-color: transparent;
     color: #3b82f6;
     border-bottom: 2px solid #3b82f6;
 }
 
 QTabWidget#diagnostics_inner_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
     color: #0f172a;
     border-bottom: 2px solid #cbd5e1;
 }
@@ -182,7 +186,7 @@ QLabel#bootstrap_status_label {
     font-weight: 700;
     padding: 4px 12px;
     border-radius: 12px;
-    qproperty-alignment: AlignCenter;
+    qproperty-alignment: 'AlignCenter';
 }
 
 /* Success Badges */
@@ -512,34 +516,39 @@ QPushButton#secondary_btn:disabled {
     color: #cbd5e1;
 }
 
-/* Compact table action buttons */
+/* Compact table action buttons (seamless with transparent backgrounds) */
 QPushButton#split_select_btn {
-    background-color: #f1f5f9;
-    border: 1px solid #cbd5e1;
-    border-radius: 6px;
-    color: #475569;
-    font-size: 11px;
-    font-weight: bold;
-    min-width: 64px;
-    min-height: 22px;
-    padding: 2px 10px;
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #475569; /* Soft neutral slate gray */
+    font-size: 12px;
+    font-weight: 700;
+    min-width: 60px;
+    min-height: 20px;
+    padding: 3px 10px;
     text-align: center;
 }
 
 QPushButton#split_select_btn:hover {
-    background-color: #e2e8f0;
-    border-color: #3b82f6;
+    background-color: rgba(100, 116, 139, 0.10);
+    border-color: rgba(100, 116, 139, 0.25);
     color: #0f172a;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #cbd5e1;
+    background-color: rgba(100, 116, 139, 0.18);
+}
+
+QPushButton#split_select_btn:focus {
+    outline: none;
+    border: 1px solid transparent;
 }
 
 QPushButton#split_select_btn:disabled {
-    background-color: #f8fafc;
-    border-color: #e2e8f0;
-    color: #94a3b8;
+    background-color: transparent;
+    border-color: transparent;
+    color: #cbd5e1;
 }
 
 /* Danger Action Button */
@@ -611,10 +620,23 @@ QTableWidget#split_status_table {
     alternate-background-color: #f8fafc;
     color: #334155;
     gridline-color: #e2e8f0;
+    outline: none;
+    selection-background-color: transparent;
+    selection-color: inherit;
 }
 
 QTableWidget#split_status_table::item {
     padding: 6px 8px;
+    outline: none;
+}
+
+QTableWidget#split_status_table::item:hover {
+    background-color: rgba(148, 163, 184, 0.10);
+}
+
+QTableWidget#split_status_table::item:selected {
+    background-color: transparent;
+    color: inherit;
 }
 
 QTableWidget#split_status_table QHeaderView::section {
@@ -707,6 +729,7 @@ QTextEdit#log_view QScrollBar:vertical {
     width: 8px;
 }
 
+QModelIndex QScrollBar::handle:vertical,
 QScrollBar::handle:vertical,
 QScrollBar::handle:horizontal {
     background-color: rgba(100, 116, 139, 0.2);

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -2,50 +2,50 @@
 
 /* Global Window styling */
 QMainWindow {
-    background-color: #0f172a;
+    background-color: #0b0f19;
 }
 
 QWidget {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     font-size: 13px;
-    color: #f1f5f9;
+    color: #f3f4f6;
 }
 
 /* Header style */
 #header_label {
-    font-size: 18px;
-    font-weight: 700;
-    color: #93c5fd;
-    padding-bottom: 2px;
+    font-size: 20px;
+    font-weight: 800;
+    color: #38bdf8; /* Soft bright cyan */
+    background: transparent;
+    padding-bottom: 4px;
 }
 
 #subtitle_label,
 #config_hint_label,
 #work_mode_hint_label {
-    color: #94a3b8;
-    font-size: 15px;
+    color: #9ca3af;
+    font-size: 14px;
     font-weight: 400;
-    line-height: 1.45;
+    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.45;
+    line-height: 1.5;
 }
 
-/* Dialogs are top-level windows; set an explicit surface so native OS chrome
-   does not leak through when only QMainWindow is themed. */
+/* Dialogs are top-level windows */
 QDialog,
 QDialog#api_key_dialog {
-    background-color: #1e293b;
-    color: #f1f5f9;
+    background-color: #111827;
+    color: #f3f4f6;
 }
 
 QDialog QLabel {
     background-color: transparent;
-    color: #cbd5e1;
+    color: #d1d5db;
 }
 
 QDialog#api_key_dialog QDialogButtonBox QPushButton {
@@ -53,58 +53,60 @@ QDialog#api_key_dialog QDialogButtonBox QPushButton {
 }
 
 #api_status_label {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    color: #cbd5e1;
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
+    border-radius: 8px;
+    color: #d1d5db;
     font-size: 14px;
-    padding: 10px 12px;
+    padding: 12px 14px;
 }
 
 QLineEdit#api_key_input {
-    background-color: #0f172a;
-    border: 1px solid #475569;
-    border-radius: 6px;
-    color: #f1f5f9;
-    padding: 6px 10px;
-    min-height: 20px;
+    background-color: #0b0f19;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    color: #f3f4f6;
+    padding: 8px 12px;
+    min-height: 24px;
 }
 
 QLineEdit#api_key_input:focus {
-    border-color: #3b82f6;
+    border-color: #6366f1;
+    background-color: #090d16;
 }
 
 QListWidget#api_key_list {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-radius: 6px;
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
+    border-radius: 8px;
     color: #cbd5e1;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
-    padding: 4px;
+    padding: 6px;
 }
 
 QListWidget#api_key_list QAbstractItemView {
-    background-color: #0f172a;
+    background-color: #0b0f19;
     color: #cbd5e1;
-    selection-background-color: #1e40af;
-    selection-color: #dbeafe;
+    selection-background-color: #312e81;
+    selection-color: #e0e7ff;
 }
 
 QListWidget#api_key_list::item {
     padding: 6px 8px;
+    border-radius: 4px;
 }
 
 QListWidget#api_key_list::item:selected {
-    background-color: #1e40af;
-    color: #dbeafe;
+    background-color: #312e81;
+    color: #e0e7ff;
 }
 
 /* Tab widget */
 QTabWidget#main_tabs::pane {
-    border: 1px solid #334155;
-    border-radius: 8px;
-    background-color: #1e293b;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    background-color: #111827;
     top: -1px;
 }
 
@@ -112,7 +114,7 @@ QWidget#config_tab,
 QScrollArea#config_scroll,
 QWidget#config_scroll_viewport,
 QWidget#config_scroll_content {
-    background-color: #1e293b;
+    background-color: #111827;
     border: none;
 }
 
@@ -120,233 +122,295 @@ QWidget#diagnostics_tab,
 QScrollArea#diagnostics_context_scroll,
 QScrollArea#diagnostics_commands_scroll,
 QWidget#diagnostics_log_panel {
-    background-color: #1e293b;
+    background-color: #111827;
     border: none;
 }
 
 QSplitter#diagnostics_splitter::handle {
-    background-color: #334155;
-    height: 4px;
+    background-color: #1f2937;
+    height: 6px;
     margin: 4px 0;
-    border-radius: 2px;
+    border-radius: 3px;
 }
 
 QSplitter#diagnostics_splitter::handle:hover {
-    background-color: #64748b;
+    background-color: #4b5563;
 }
 
 QTabWidget#diagnostics_inner_tabs::pane {
-    border: 1px solid #334155;
-    border-radius: 8px;
-    background-color: #1e293b;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    background-color: #111827;
     top: -1px;
 }
 
 QTabWidget#diagnostics_inner_tabs QWidget {
-    background-color: #1e293b;
+    background-color: #111827;
 }
 
-QTabWidget#diagnostics_inner_tabs > QTabBar::tab {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 7px 16px;
-    margin-right: 3px;
-    color: #94a3b8;
-    font-weight: 500;
+QTabWidget#diagnostics_inner_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 18px;
+    margin: 2px 6px;
+    color: #9ca3af;
+    font-weight: 600;
 }
 
-QTabWidget#diagnostics_inner_tabs > QTabBar::tab:selected {
-    background-color: #1e293b;
-    color: #60a5fa;
+QTabWidget#diagnostics_inner_tabs QTabBar::tab:selected {
+    background-color: transparent;
+    color: #818cf8;
+    border-bottom: 2px solid #818cf8;
+}
+
+QTabWidget#diagnostics_inner_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
+    color: #f3f4f6;
+    border-bottom: 2px solid #4b5563;
 }
 
 QLabel#diagnostics_section_label {
-    color: #94a3b8;
+    color: #9ca3af;
     font-size: 14px;
     font-weight: 600;
 }
 
-QLabel#diagnostics_status_label {
-    font-size: 15px;
+/* Status Labels generalized to pill badges */
+QLabel#diagnostics_status_label,
+QLabel#doctor_status_label,
+QLabel#workflow_status_label,
+QLabel#writeback_status_label,
+QLabel#bootstrap_status_label {
+    font-size: 12px;
     font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 12px;
+    qproperty-alignment: 'AlignCenter';
 }
 
+/* Success Badges */
+QLabel#diagnostics_status_label[status="ready"],
+QLabel#doctor_status_label[status="ready"],
+QLabel#workflow_status_label[status="done"],
+QLabel#writeback_status_label[status="safe"],
+QLabel#writeback_status_label[status="applied"],
+QLabel#bootstrap_status_label[status="ready"] {
+    color: #34d399;
+    background-color: rgba(16, 185, 129, 0.12);
+    border: 1px solid rgba(16, 185, 129, 0.35);
+}
+
+/* Info / Running / Idle Badges */
 QLabel#diagnostics_status_label[status="idle"],
-QLabel#diagnostics_status_label[status="running"] {
+QLabel#diagnostics_status_label[status="running"],
+QLabel#doctor_status_label[status="idle"],
+QLabel#doctor_status_label[status="running"],
+QLabel#workflow_status_label[status="idle"],
+QLabel#workflow_status_label[status="running"],
+QLabel#writeback_status_label[status="idle"],
+QLabel#writeback_status_label[status="running"],
+QLabel#bootstrap_status_label[status="idle"],
+QLabel#bootstrap_status_label[status="running"] {
     color: #60a5fa;
+    background-color: rgba(59, 130, 246, 0.12);
+    border: 1px solid rgba(59, 130, 246, 0.35);
 }
 
-QLabel#diagnostics_status_label[status="ready"] {
-    color: #4ade80;
-}
-
-QLabel#diagnostics_status_label[status="warning"] {
+/* Warning Badges */
+QLabel#diagnostics_status_label[status="warning"],
+QLabel#doctor_status_label[status="warning"],
+QLabel#doctor_status_label[status="stale"],
+QLabel#workflow_status_label[status="waiting"],
+QLabel#workflow_status_label[status="stale"],
+QLabel#writeback_status_label[status="warn"],
+QLabel#writeback_status_label[status="stale"],
+QLabel#bootstrap_status_label[status="warning"],
+QLabel#bootstrap_status_label[status="stale"] {
     color: #fbbf24;
+    background-color: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+/* Danger / Blocked Badges */
+QLabel#doctor_status_label[status="blocked"],
+QLabel#workflow_status_label[status="failed"],
+QLabel#writeback_status_label[status="block"],
+QLabel#writeback_status_label[status="failed"],
+QLabel#writeback_status_label[status="unknown"],
+QLabel#bootstrap_status_label[status="failed"] {
+    color: #f87171;
+    background-color: rgba(239, 68, 68, 0.12);
+    border: 1px solid rgba(239, 68, 68, 0.35);
 }
 
 QFrame#diagnostics_facts_frame {
-    background-color: #0f172a;
-    border: 1px solid #334155;
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
     border-radius: 8px;
 }
 
 QLabel#diagnostics_facts_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 13px;
 }
 
 QLineEdit#diagnostics_command_edit,
 QLineEdit#diagnostics_path_edit {
-    background-color: #0f172a;
-    border: 1px solid #334155;
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
     border-radius: 6px;
-    color: #e2e8f0;
+    color: #e5e7eb;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
     padding: 6px 10px;
 }
 
 QTextEdit#diagnostics_manifest_preview {
-    background-color: #0f172a;
-    border: 1px solid #334155;
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
     border-radius: 8px;
-    color: #e2e8f0;
+    color: #e5e7eb;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
     padding: 10px;
 }
 
-QTabWidget#main_tabs > QTabBar::tab {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 9px 22px;
-    margin-right: 4px;
-    color: #94a3b8;
-    font-weight: 500;
-    min-width: 72px;
-}
-
-QTabWidget#main_tabs > QTabBar::tab:selected {
-    background-color: #1e293b;
-    color: #60a5fa;
+/* Modern Underline style tabs for Main Tabs */
+QTabWidget#main_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 24px;
+    margin: 2px 8px;
+    color: #9ca3af;
     font-weight: 600;
+    min-width: 80px;
 }
 
-QTabWidget#main_tabs > QTabBar::tab:hover:!selected {
-    background-color: #334155;
-    color: #e2e8f0;
+QTabWidget#main_tabs QTabBar::tab:selected {
+    background-color: transparent;
+    color: #60a5fa;
+    border-bottom: 2px solid #3b82f6;
 }
 
+QTabWidget#main_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
+    color: #f3f4f6;
+    border-bottom: 2px solid #4b5563;
+}
+
+/* Workbench status inner tabs style */
 QTabWidget#workbench_status_tabs::pane {
-    border: 1px solid #334155;
-    border-radius: 8px;
-    background-color: #1e293b;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    background-color: #111827;
     top: -1px;
 }
 
 QTabWidget#workbench_status_tabs QWidget {
-    background-color: #1e293b;
+    background-color: #111827;
 }
 
 QScrollArea#workflow_summary_scroll,
 QWidget#workflow_summary_viewport,
 QWidget#workflow_summary_content {
-    background-color: #1e293b;
+    background-color: #111827;
     border: none;
 }
 
-QTabWidget#workbench_status_tabs > QTabBar::tab {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-bottom: none;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    padding: 7px 16px;
-    margin-right: 3px;
-    color: #94a3b8;
-    font-weight: 500;
+QTabWidget#workbench_status_tabs QTabBar::tab {
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 6px 18px;
+    margin: 2px 6px;
+    color: #9ca3af;
+    font-weight: 600;
 }
 
-QTabWidget#workbench_status_tabs > QTabBar::tab:selected {
-    background-color: #1e293b;
+QTabWidget#workbench_status_tabs QTabBar::tab:selected {
+    background-color: transparent;
     color: #60a5fa;
+    border-bottom: 2px solid #3b82f6;
 }
 
-/* Project Path, Mode selector, and Action Frame styling (Glassmorphism) */
+QTabWidget#workbench_status_tabs QTabBar::tab:hover:!selected {
+    background-color: transparent;
+    color: #f3f4f6;
+    border-bottom: 2px solid #4b5563;
+}
+
+/* Project Path, Mode selector, and Action Frame styling (Glassmorphism Cards) */
 #project_frame,
 #mode_frame,
 #action_frame {
-    background-color: rgba(30, 41, 59, 0.75);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 8px;
+    background-color: rgba(22, 30, 46, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: 1px solid rgba(255, 255, 255, 0.12); /* Subtle highlight rim */
+    border-radius: 10px;
 }
 
 #project_path_edit {
-    background-color: #0f172a;
-    border: 1px solid #475569;
-    border-radius: 6px;
-    color: #e2e8f0;
-    padding: 6px 10px;
+    background-color: #0b0f19;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    color: #e5e7eb;
+    padding: 8px 12px;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
 }
 
 QLabel#action_group_label {
-    color: #94a3b8;
+    color: #9ca3af;
     font-size: 12px;
     font-weight: 600;
-    padding-right: 2px;
+    padding-right: 4px;
 }
 
 QFrame#action_separator {
-    color: #334155;
-    margin-top: 2px;
-    margin-bottom: 2px;
+    color: #1f2937;
+    margin-top: 4px;
+    margin-bottom: 4px;
 }
 
-/* GroupBox styling */
+/* GroupBox Card styling */
 QGroupBox {
-    background-color: #1e293b;
-    border: 1px solid #334155;
-    border-radius: 8px;
-    margin-top: 16px;
+    background-color: #161e2e;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    margin-top: 20px;
     font-weight: 600;
-    color: #f1f5f9;
+    color: #f3f4f6;
     padding-top: 24px;
 }
 
 QGroupBox::title {
     subcontrol-origin: margin;
     subcontrol-position: top left;
-    left: 12px;
-    top: 6px;
-    background-color: #1e293b;
-    padding: 0 6px;
-    color: #60a5fa;
+    left: 14px;
+    top: 5px;
+    background-color: #161e2e;
+    padding: 0 8px;
+    color: #818cf8;
     font-size: 13px;
 }
 
-/* Form layout labels */
+/* Label styling */
 QLabel {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-weight: 500;
 }
 
 /* Input Elements (ComboBox) styling */
 QComboBox {
-    background-color: #0f172a;
-    border: 1px solid #475569;
-    border-radius: 6px;
-    color: #f1f5f9;
-    padding: 5px 10px;
-    min-height: 20px;
+    background-color: #0b0f19;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    color: #f3f4f6;
+    padding: 6px 12px;
+    min-height: 22px;
 }
 
 QComboBox:hover {
@@ -354,13 +418,14 @@ QComboBox:hover {
 }
 
 QComboBox:focus {
-    border-color: #3b82f6;
+    border-color: #6366f1;
+    background-color: #090d16;
 }
 
 QComboBox:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+    background-color: #111827;
+    border-color: #1f2937;
+    color: #6b7280;
 }
 
 QComboBox::drop-down {
@@ -370,418 +435,306 @@ QComboBox::drop-down {
 
 /* Default Buttons styling */
 QPushButton {
-    background-color: #1e293b;
-    border: 1px solid #475569;
-    border-radius: 6px;
-    color: #e2e8f0;
-    font-weight: 500;
-    padding: 8px 16px;
-    min-height: 18px;
+    background-color: #1f2937;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    color: #d1d5db;
+    font-weight: 600;
+    padding: 8px 18px;
+    min-height: 20px;
 }
 
 QPushButton:hover {
-    background-color: #334155;
-    border-color: #64748b;
-    color: #f8fafc;
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #ffffff;
 }
 
 QPushButton:pressed {
-    background-color: #0f172a;
+    background-color: #111827;
 }
 
 QPushButton:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+    background-color: #111827;
+    border-color: #1f2937;
+    color: #6b7280;
 }
 
-/* Primary Action Buttons */
+/* Primary Action Buttons - Aurora Gradient */
 QPushButton#save_config_btn,
 QPushButton#api_btn,
 QPushButton#translate_btn {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #1d40af, stop:1 #3b82f6);
-    border: 1px solid #1e3a8a;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #4f46e5, stop:1 #2563eb);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
     min-width: 108px;
 }
 
 QPushButton#save_config_btn:hover,
 QPushButton#api_btn:hover,
 QPushButton#translate_btn:hover {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #1e3a8a, stop:1 #2563eb);
-    border-color: #2563eb;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #6366f1, stop:1 #3b82f6);
 }
 
 QPushButton#save_config_btn:pressed,
 QPushButton#api_btn:pressed,
 QPushButton#translate_btn:pressed {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #172554, stop:1 #1d4ed8);
-    border-color: #1d4ed8;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #3730a3, stop:1 #1d4ed8);
 }
 
 QPushButton#save_config_btn:disabled,
 QPushButton#api_btn:disabled,
 QPushButton#translate_btn:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
-    font-weight: 600;
+    background-color: #111827;
+    border: 1px solid #1f2937;
+    color: #6b7280;
 }
 
 /* Secondary Action Buttons */
 QPushButton#secondary_btn {
-    background-color: #1e293b;
-    border: 1px solid #475569;
-    color: #cbd5e1;
-    font-weight: 500;
+    background-color: #1f2937;
+    border: 1px solid #374151;
+    color: #d1d5db;
+    font-weight: 600;
     min-width: 108px;
 }
 
 QPushButton#secondary_btn:hover {
-    background-color: #334155;
-    border-color: #64748b;
-    color: #f8fafc;
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #ffffff;
 }
 
 QPushButton#secondary_btn:pressed {
-    background-color: #0f172a;
+    background-color: #111827;
 }
 
 QPushButton#secondary_btn:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+    background-color: #111827;
+    border-color: #1f2937;
+    color: #6b7280;
 }
-
 
 /* Compact table action buttons */
 QPushButton#split_select_btn {
-    background-color: #0f172a;
-    border: 1px solid #94a3b8;
+    background-color: #1f2937;
+    border: 1px solid #374151;
     border-radius: 6px;
-    color: #e2e8f0;
-    font-weight: 600;
-    min-width: 72px;
-    min-height: 28px;
-    padding: 0px 10px;
+    color: #cbd5e1;
+    font-size: 11px;
+    font-weight: bold;
+    min-width: 64px;
+    min-height: 22px;
+    padding: 2px 10px;
     text-align: center;
 }
 
 QPushButton#split_select_btn:hover {
-    background-color: #1e293b;
-    border-color: #cbd5e1;
-    color: #f8fafc;
+    background-color: #374151;
+    border-color: #60a5fa;
+    color: #ffffff;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #020617;
-    border-color: #64748b;
+    background-color: #111827;
 }
 
 QPushButton#split_select_btn:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+    background-color: #0b0f19;
+    border-color: #1f2937;
+    color: #4b5563;
 }
 
 /* Danger Action Button */
 QPushButton#kill_btn {
-    background-color: #ef4444;
-    border: 1px solid #ef4444;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #dc2626, stop:1 #ef4444);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
 }
 
 QPushButton#kill_btn:hover {
-    background-color: #f87171;
-    border-color: #f87171;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #ef4444, stop:1 #f87171);
 }
 
 QPushButton#kill_btn:pressed {
-    background-color: #dc2626;
-    border-color: #dc2626;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b91c1c, stop:1 #dc2626);
 }
 
 QPushButton#kill_btn:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+    background-color: #111827;
+    border: 1px solid #1f2937;
+    color: #6b7280;
 }
 
-/* Log View (QTextEdit) terminal styling */
+/* Log View terminal styling */
 QTextEdit#log_view {
-    background-color: #020617;
-    border: 1px solid #1e293b;
-    border-radius: 8px;
-    color: #e2e8f0;
+    background-color: #030712;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    color: #f3f4f6;
     font-family: "Consolas", "Courier New", monospace;
     font-size: 12px;
-    padding: 12px;
-}
-
-QLabel#doctor_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#doctor_status_label[status="idle"],
-QLabel#doctor_status_label[status="running"] {
-    color: #60a5fa;
-}
-
-QLabel#doctor_status_label[status="ready"] {
-    color: #4ade80;
-}
-
-QLabel#doctor_status_label[status="warning"] {
-    color: #fbbf24;
-}
-
-QLabel#doctor_status_label[status="stale"] {
-    color: #fbbf24;
-}
-
-QLabel#doctor_status_label[status="blocked"] {
-    color: #f87171;
+    padding: 14px;
 }
 
 QLabel#doctor_facts_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-size: 14px;
-}
-
-QLabel#workflow_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#workflow_status_label[status="idle"],
-QLabel#workflow_status_label[status="running"] {
-    color: #60a5fa;
-}
-
-QLabel#workflow_status_label[status="done"] {
-    color: #4ade80;
-}
-
-QLabel#workflow_status_label[status="waiting"],
-QLabel#workflow_status_label[status="stale"] {
-    color: #fbbf24;
-}
-
-QLabel#workflow_status_label[status="failed"] {
-    color: #f87171;
 }
 
 QLabel#workflow_facts_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-size: 14px;
 }
 
+/* Progress bar styling */
 QProgressBar#workflow_progress_bar {
-    border: 1px solid #475569;
-    border-radius: 6px;
-    background: #1e293b;
-    color: #e2e8f0;
-    font-size: 12px;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    background: #0b0f19;
+    color: #ffffff;
+    font-size: 11px;
+    font-weight: bold;
     min-height: 18px;
     max-height: 22px;
     text-align: center;
 }
 
 QProgressBar#workflow_progress_bar::chunk {
-    background-color: #3b82f6;
-    border-radius: 5px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #4f46e5, stop:1 #06b6d4);
+    border-radius: 6px;
 }
 
+/* Table Widget styling */
 QTableWidget#split_status_table {
-    border: 1px solid #334155;
-    border-radius: 6px;
-    background: #0f172a;
-    alternate-background-color: #162033;
-    color: #cbd5e1;
-    gridline-color: #334155;
+    border: 1px solid #1f2937;
+    border-radius: 8px;
+    background: #0b0f19;
+    alternate-background-color: #111c30;
+    color: #d1d5db;
+    gridline-color: #1f2937;
 }
 
 QTableWidget#split_status_table::item {
-    padding: 4px 6px;
+    padding: 6px 8px;
 }
 
 QTableWidget#split_status_table QHeaderView::section {
-    background-color: #1e293b;
-    color: #cbd5e1;
+    background-color: #111827;
+    color: #9ca3af;
     border: none;
-    border-right: 1px solid #334155;
-    border-bottom: 1px solid #334155;
-    padding: 5px 6px;
-    font-weight: 600;
+    border-right: 1px solid #1f2937;
+    border-bottom: 1px solid #1f2937;
+    padding: 6px 8px;
+    font-size: 11px;
+    font-weight: 700;
 }
 
 QFrame#workflow_separator {
-    color: #334155;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    color: #1f2937;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 QLabel#workflow_section_label {
-    color: #60a5fa;
+    color: #818cf8;
     font-size: 14px;
     font-weight: 600;
-    margin-top: 2px;
-}
-
-QLabel#writeback_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#writeback_status_label[status="idle"],
-QLabel#writeback_status_label[status="running"] {
-    color: #60a5fa;
-}
-
-QLabel#writeback_status_label[status="safe"] {
-    color: #4ade80;
-}
-
-QLabel#writeback_status_label[status="applied"] {
-    color: #4ade80;
-}
-
-QLabel#writeback_status_label[status="warn"],
-QLabel#writeback_status_label[status="stale"] {
-    color: #fbbf24;
-}
-
-QLabel#writeback_status_label[status="block"],
-QLabel#writeback_status_label[status="failed"],
-QLabel#writeback_status_label[status="unknown"] {
-    color: #f87171;
+    margin-top: 4px;
 }
 
 QLabel#writeback_facts_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-size: 14px;
-}
-
-QLabel#bootstrap_status_label {
-    font-size: 15px;
-    font-weight: 700;
-}
-
-QLabel#bootstrap_status_label[status="idle"],
-QLabel#bootstrap_status_label[status="running"] {
-    color: #60a5fa;
-}
-
-QLabel#bootstrap_status_label[status="ready"] {
-    color: #4ade80;
-}
-
-QLabel#bootstrap_status_label[status="warning"],
-QLabel#bootstrap_status_label[status="stale"] {
-    color: #fbbf24;
-}
-
-QLabel#bootstrap_status_label[status="failed"] {
-    color: #f87171;
 }
 
 QLabel#bootstrap_facts_label {
-    color: #cbd5e1;
+    color: #d1d5db;
     font-size: 14px;
 }
 
-QTextEdit#bootstrap_findings_view {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    color: #cbd5e1;
+QTextEdit#bootstrap_findings_view,
+QTextEdit#writeback_findings_view,
+QTextEdit#doctor_findings_view {
+    background-color: #0b0f19;
+    border: 1px solid #1f2937;
+    border-radius: 8px;
+    color: #d1d5db;
     font-size: 14px;
-    padding: 8px;
+    padding: 10px;
 }
 
-QTextEdit#writeback_findings_view {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    color: #cbd5e1;
-    font-size: 14px;
-    padding: 8px;
-}
-
-QPushButton#apply_btn {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #065f46, stop:1 #10b981);
-    border: 1px solid #047857;
+/* Emerald Green Gradient for writeback apply button */
+QPushButton#apply_btn,
+QPushButton#apply_revision_btn {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #059669, stop:1 #10b981);
+    border: none;
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
     min-width: 108px;
 }
 
-QPushButton#apply_btn:hover {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #047857, stop:1 #059669);
-    border-color: #059669;
+QPushButton#apply_btn:hover,
+QPushButton#apply_revision_btn:hover {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #067652, stop:1 #059669);
 }
 
-QPushButton#apply_btn:pressed {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #064e3b, stop:1 #065f46);
-    border-color: #065f46;
+QPushButton#apply_btn:pressed,
+QPushButton#apply_revision_btn:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #044e37, stop:1 #065f46);
 }
 
-QPushButton#apply_btn:disabled {
-    background-color: #1e293b;
-    border-color: #334155;
-    color: #64748b;
+QPushButton#apply_btn:disabled,
+QPushButton#apply_revision_btn:disabled {
+    background-color: #111827;
+    border: 1px solid #1f2937;
+    color: #6b7280;
 }
 
-QTextEdit#doctor_findings_view {
-    background-color: #0f172a;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    color: #cbd5e1;
-    font-size: 14px;
-    padding: 8px;
-}
-
-/* ScrollBar Styling */
+/* Sleek minimalist scrollbar styling */
 QScrollBar:vertical {
-    background-color: #1e293b;
-    width: 10px;
+    background-color: transparent;
+    width: 8px;
+    margin: 0px;
+}
+
+QScrollBar:horizontal {
+    background-color: transparent;
+    height: 8px;
     margin: 0px;
 }
 
 QTextEdit#log_view QScrollBar:vertical {
-    background-color: #020617;
-    width: 12px;
+    background-color: transparent;
+    width: 8px;
 }
 
-QScrollBar::handle:vertical {
-    background-color: #475569;
-    min-height: 20px;
-    border-radius: 5px;
-    border: 2px solid #1e293b;
+QScrollBar::handle:vertical,
+QScrollBar::handle:horizontal {
+    background-color: rgba(156, 163, 175, 0.25);
+    border-radius: 4px;
+    min-height: 24px;
+    min-width: 24px;
 }
 
-QScrollBar::handle:vertical:hover {
-    background-color: #64748b;
-}
-
-QTextEdit#log_view QScrollBar::handle:vertical {
-    background-color: #334155;
-    border: 2px solid #020617;
-}
-
-QTextEdit#log_view QScrollBar::handle:vertical:hover {
-    background-color: #475569;
+QScrollBar::handle:vertical:hover,
+QScrollBar::handle:horizontal:hover {
+    background-color: rgba(156, 163, 175, 0.45);
 }
 
 QScrollBar::add-line:vertical,
-QScrollBar::sub-line:vertical {
+QScrollBar::sub-line:vertical,
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal {
+    width: 0px;
     height: 0px;
 }
 
 QScrollBar::add-page:vertical,
-QScrollBar::sub-page:vertical {
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal {
     background: none;
 }

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -26,12 +26,14 @@ QWidget {
     color: #9ca3af;
     font-size: 14px;
     font-weight: 400;
+    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
     color: #d1d5db;
     font-size: 14px;
     font-weight: 400;
+    line-height: 1.5;
 }
 
 /* Dialogs are top-level windows */
@@ -184,7 +186,7 @@ QLabel#bootstrap_status_label {
     font-weight: 700;
     padding: 4px 12px;
     border-radius: 12px;
-    qproperty-alignment: AlignCenter;
+    qproperty-alignment: 'AlignCenter';
 }
 
 /* Success Badges */
@@ -514,33 +516,38 @@ QPushButton#secondary_btn:disabled {
     color: #6b7280;
 }
 
-/* Compact table action buttons */
+/* Compact table action buttons (seamless with transparent backgrounds) */
 QPushButton#split_select_btn {
-    background-color: #1f2937;
-    border: 1px solid #374151;
-    border-radius: 6px;
-    color: #cbd5e1;
-    font-size: 11px;
-    font-weight: bold;
-    min-width: 64px;
-    min-height: 22px;
-    padding: 2px 10px;
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #38bdf8; /* Match bright cyan theme */
+    font-size: 12px;
+    font-weight: 700;
+    min-width: 60px;
+    min-height: 20px;
+    padding: 3px 10px;
     text-align: center;
 }
 
 QPushButton#split_select_btn:hover {
-    background-color: #374151;
-    border-color: #60a5fa;
-    color: #ffffff;
+    background-color: rgba(148, 163, 184, 0.14);
+    border-color: rgba(148, 163, 184, 0.30);
+    color: #e2e8f0;
 }
 
 QPushButton#split_select_btn:pressed {
-    background-color: #111827;
+    background-color: rgba(148, 163, 184, 0.22);
+}
+
+QPushButton#split_select_btn:focus {
+    outline: none;
+    border: 1px solid transparent;
 }
 
 QPushButton#split_select_btn:disabled {
-    background-color: #0b0f19;
-    border-color: #1f2937;
+    background-color: transparent;
+    border-color: transparent;
     color: #4b5563;
 }
 
@@ -613,10 +620,23 @@ QTableWidget#split_status_table {
     alternate-background-color: #111c30;
     color: #d1d5db;
     gridline-color: #1f2937;
+    outline: none;
+    selection-background-color: transparent;
+    selection-color: inherit;
 }
 
 QTableWidget#split_status_table::item {
     padding: 6px 8px;
+    outline: none;
+}
+
+QTableWidget#split_status_table::item:hover {
+    background-color: rgba(148, 163, 184, 0.12);
+}
+
+QTableWidget#split_status_table::item:selected {
+    background-color: transparent;
+    color: inherit;
 }
 
 QTableWidget#split_status_table QHeaderView::section {

--- a/gui_qt/resources/app_dark.qss
+++ b/gui_qt/resources/app_dark.qss
@@ -26,14 +26,12 @@ QWidget {
     color: #9ca3af;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.5;
 }
 
 QLabel#summary_body_label {
     color: #d1d5db;
     font-size: 14px;
     font-weight: 400;
-    line-height: 1.5;
 }
 
 /* Dialogs are top-level windows */
@@ -186,7 +184,7 @@ QLabel#bootstrap_status_label {
     font-weight: 700;
     padding: 4px 12px;
     border-radius: 12px;
-    qproperty-alignment: 'AlignCenter';
+    qproperty-alignment: AlignCenter;
 }
 
 /* Success Badges */

--- a/gui_qt/template_generation_report.py
+++ b/gui_qt/template_generation_report.py
@@ -87,6 +87,17 @@ def summarize_template_generation_output(
             rpy_files=rpy_files,
         )
 
+    if status != "ready":
+        return TemplateGenerationSummary(
+            status="blocked",
+            heading="翻译模板生成失败",
+            message=message or "翻译模板生成返回了未知状态，请查看诊断日志。",
+            facts=facts,
+            findings=[],
+            tl_dir=tl_dir,
+            rpy_files=rpy_files,
+        )
+
     ready_facts = list(facts)
     append_unique_fact(
         ready_facts,
@@ -106,9 +117,10 @@ def summarize_template_generation_output(
 def template_generation_to_doctor_summary(
     summary: TemplateGenerationSummary,
 ) -> DoctorSummary:
-    mode = ""
     if summary.status == "ready" and summary.rpy_files > 0:
         mode = "existing_tl_only"
+    else:
+        mode = "can_generate_template"
     return DoctorSummary(
         status=summary.status,
         heading=summary.heading,

--- a/gui_qt/template_generation_report.py
+++ b/gui_qt/template_generation_report.py
@@ -1,0 +1,119 @@
+"""User-facing summaries for GUI generate-template command."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .doctor_report import DoctorSummary
+from .summary_helpers import append_unique_fact
+
+
+TEMPLATE_GENERATION_HEADER = "Template generation summary:"
+
+
+@dataclass(frozen=True)
+class TemplateGenerationSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+    tl_dir: str
+    rpy_files: int
+
+
+def _parse_summary_values(output: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    in_section = False
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line == TEMPLATE_GENERATION_HEADER:
+            in_section = True
+            continue
+        if in_section and line.startswith("- "):
+            match = re.match(r"-\s*([a-z_]+):\s*(.*)$", line)
+            if match:
+                values[match.group(1)] = match.group(2).strip()
+            continue
+        if in_section and not line.startswith("- "):
+            break
+    return values
+
+
+def running_template_generation_summary() -> TemplateGenerationSummary:
+    return TemplateGenerationSummary(
+        status="running",
+        heading="正在生成翻译模板",
+        message="正在准备 work/game 并调用 Ren'Py 生成翻译模板，请稍候。",
+        facts=[],
+        findings=[],
+        tl_dir="",
+        rpy_files=0,
+    )
+
+
+def summarize_template_generation_output(
+    output: str,
+    exit_code: int,
+) -> TemplateGenerationSummary:
+    values = _parse_summary_values(output)
+    status = values.get("status", "")
+    tl_dir = values.get("tl_dir", "")
+    message = values.get("message", "")
+    language = values.get("language", "")
+    try:
+        rpy_files = int(values.get("rpy_files", "0") or "0")
+    except ValueError:
+        rpy_files = 0
+
+    facts: list[str] = []
+    if language:
+        append_unique_fact(facts, f"目标语言：{language}")
+    if tl_dir:
+        append_unique_fact(facts, f"翻译目录：{tl_dir}")
+    if rpy_files > 0:
+        append_unique_fact(facts, f"翻译文件：{rpy_files} 个")
+
+    if exit_code != 0 or status == "failed":
+        return TemplateGenerationSummary(
+            status="blocked",
+            heading="翻译模板生成失败",
+            message=message or "翻译模板生成没有正常完成，请查看诊断日志。",
+            facts=facts,
+            findings=[],
+            tl_dir=tl_dir,
+            rpy_files=rpy_files,
+        )
+
+    ready_facts = list(facts)
+    append_unique_fact(
+        ready_facts,
+        "建议：如需查看最新待译统计，可重新运行「环境检查」",
+    )
+    return TemplateGenerationSummary(
+        status="ready",
+        heading="翻译模板已生成",
+        message="翻译模板已就绪，可以开始翻译流程。",
+        facts=ready_facts,
+        findings=[],
+        tl_dir=tl_dir,
+        rpy_files=rpy_files,
+    )
+
+
+def template_generation_to_doctor_summary(
+    summary: TemplateGenerationSummary,
+) -> DoctorSummary:
+    mode = ""
+    if summary.status == "ready" and summary.rpy_files > 0:
+        mode = "existing_tl_only"
+    return DoctorSummary(
+        status=summary.status,
+        heading=summary.heading,
+        message=summary.message,
+        facts=summary.facts,
+        findings=summary.findings,
+        mode=mode,
+    )

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -9,7 +9,7 @@ SAFETY_LEVEL_LABELS = {
 
 DOCTOR_MODE_LABELS = {
     "can_generate_template": "可生成翻译模板",
-    "existing_tl_only": "仅处理已有翻译文件",
+    "existing_tl_only": "已有翻译模板",
     "blocked_missing_template": "缺少模板且无法生成",
 }
 
@@ -53,8 +53,8 @@ DOCTOR_RECOMMENDATION_PREFIX_TRANSLATIONS: tuple[tuple[str, str], ...] = (
         "建议：点击「准备工作目录」",
     ),
     (
-        "Missing translation files; run: python gemini_translate_batch.py build",
-        "建议：点击「开始翻译」生成翻译模板",
+        "Missing translation files; run: python gemini_translate_batch.py generate-template",
+        "建议：点击「生成翻译模板」",
     ),
     (
         "Install Ren'Py SDK or set prepare.renpy_sdk_dir, then run:",

--- a/tests/test_batch_rag.py
+++ b/tests/test_batch_rag.py
@@ -645,6 +645,53 @@ class BatchRagRegressionTests(unittest.TestCase):
 
         self.assertEqual(args.command, 'generate-template')
 
+    def test_run_generate_template_prints_summary_when_prepare_raises(self):
+        buffer = io.StringIO()
+        with (
+            mock.patch.object(batch_mod.legacy, 'PREP_ENABLED', True),
+            mock.patch.object(batch_mod.legacy, 'PREP_GENERATE_TEMPLATE', True),
+            mock.patch.object(batch_mod.legacy, 'TL_DIR', 'C:/Games/Example/work/game/tl/schinese'),
+            mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+            mock.patch.object(batch_mod, 'collect_tl_doctor_counts', return_value={'rpy_files': 0}),
+            mock.patch.object(batch_mod.os.path, 'isdir', return_value=False),
+            mock.patch.object(batch_mod.sys, 'stdout', buffer),
+            mock.patch.object(
+                batch_mod.legacy,
+                'run_prepare_steps',
+                side_effect=SystemExit('[Prepare] Cannot generate translation template'),
+            ),
+        ):
+            with self.assertRaises(SystemExit):
+                batch_mod.run_generate_template()
+
+        self.assertIn('Template generation summary:', buffer.getvalue())
+        self.assertIn('status: failed', buffer.getvalue())
+
+    def test_run_generate_template_disabled_prepare_reports_existing_rpy_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'work' / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text(
+                'translate schinese start_123:\n'
+                '    e "hello"\n',
+                encoding='utf-8',
+            )
+            buffer = io.StringIO()
+            with (
+                mock.patch.object(batch_mod.legacy, 'PREP_ENABLED', False),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+                mock.patch.object(batch_mod.sys, 'stdout', buffer),
+            ):
+                with self.assertRaises(SystemExit):
+                    batch_mod.run_generate_template()
+
+            output = buffer.getvalue()
+            self.assertIn('Template generation summary:', output)
+            self.assertIn('rpy_files: 1', output)
+            self.assertIn('tl_exists: True', output)
+
     def test_assess_doctor_layout_status_failed_without_work_or_original(self):
         report = {
             'base_dir': 'C:/Games/Example',

--- a/tests/test_batch_rag.py
+++ b/tests/test_batch_rag.py
@@ -640,6 +640,11 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertEqual(args.command, 'bootstrap-work')
         self.assertFalse(args.no_update_game_root)
 
+    def test_build_arg_parser_accepts_generate_template_command(self):
+        args = batch_mod.build_arg_parser().parse_args(['generate-template'])
+
+        self.assertEqual(args.command, 'generate-template')
+
     def test_assess_doctor_layout_status_failed_without_work_or_original(self):
         report = {
             'base_dir': 'C:/Games/Example',
@@ -701,6 +706,46 @@ class BatchRagRegressionTests(unittest.TestCase):
 
         joined = ' '.join(report.get('recommendations', []))
         self.assertIn('bootstrap-work', joined)
+
+    def test_doctor_report_prefers_existing_tl_when_files_and_sdk_available(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            (tl_dir / 'script.rpy').write_text(
+                'translate schinese start_123:\n'
+                '    # e "Hello"\n'
+                '    e "\u4f60\u597d"\n',
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'BASE_DIR', str(base)),
+                mock.patch.object(batch_mod.legacy, 'WORK_GAME_DIR', str(base / 'game')),
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod.legacy, 'TL_SUBDIR', 'game/tl/schinese'),
+                mock.patch.object(batch_mod.legacy, 'SOURCE_GAME_DIR', ''),
+                mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+                mock.patch.object(batch_mod.legacy, 'PREP_RENPY_SDK_DIR', 'C:/RenPy'),
+                mock.patch.object(batch_mod.legacy, 'PREP_LAUNCHER_PY', 'C:/RenPy/renpy.exe'),
+                mock.patch.object(
+                    batch_mod.legacy,
+                    'get_prepare_template_command_info',
+                    return_value={
+                        'available': True,
+                        'kind': 'renpy-sdk',
+                        'command': ['C:/RenPy/renpy.exe', 'translate', 'schinese'],
+                        'cwd': str(base / 'game'),
+                        'reason': '',
+                    },
+                ),
+            ):
+                report = batch_mod.collect_doctor_report()
+
+        self.assertEqual(report['mode'], 'existing_tl_only')
+        self.assertTrue(report['can_generate_template'])
+        self.assertEqual(report['counts']['rpy_files'], 1)
 
     def test_doctor_report_classifies_existing_tl_without_sdk(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -167,7 +167,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         self.assertIn("switch to C:/Games/Example/work", joined)
         self.assertNotIn("bootstrap-work", joined)
 
-    def test_work_root_without_tl_recommends_build_when_template_available(self):
+    def test_work_root_without_tl_recommends_generate_template_when_available(self):
         report = _layout_report(
             base_dir="C:/Games/Example/work",
             can_generate_template=True,
@@ -177,7 +177,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
         joined = " ".join(recommendations)
 
-        self.assertIn("gemini_translate_batch.py build", joined)
+        self.assertIn("gemini_translate_batch.py generate-template", joined)
         self.assertNotIn("switch to", joined)
 
     def test_resolve_source_index_expected_segments_scans_when_metadata_missing(self):

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -143,7 +143,7 @@ class GuiDoctorReportTests(unittest.TestCase):
 
     def test_primary_recommendation_message_ignores_template_prep_suggestions(self):
         message = primary_recommendation_message(
-            ["建议：点击「开始翻译」生成翻译模板"],
+            ["建议：点击「生成翻译模板」"],
         )
 
         self.assertEqual(message, "")
@@ -171,7 +171,7 @@ class GuiDoctorReportTests(unittest.TestCase):
 
         self.assertEqual(summary.status, "warning")
         self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
-        self.assertIn("已有翻译文件", summary.message)
+        self.assertIn("翻译模板已就绪", summary.message)
         self.assertTrue(any("API 密钥" in fact or fact.startswith("建议：") for fact in summary.facts))
         self.assertEqual(summary.findings, [])
 
@@ -199,6 +199,7 @@ class GuiDoctorReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "warning")
         self.assertEqual(summary.heading, "检查完成，但有需要处理的事项")
         self.assertEqual(summary.findings, [])
+        self.assertEqual(summary.mode, "can_generate_template")
         self.assertIn("翻译模板尚未生成", summary.message)
         self.assertTrue(any("翻译文件：0 个" in fact for fact in summary.facts))
 

--- a/tests/test_gui_split_status_theme.py
+++ b/tests/test_gui_split_status_theme.py
@@ -1,0 +1,85 @@
+import unittest
+
+try:
+    from gui_qt.app import MainWindow
+except ImportError as exc:
+    MainWindow = None  # type: ignore[assignment]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+@unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiSplitStatusThemeTests(unittest.TestCase):
+    def setUp(self):
+        self.window = MainWindow.__new__(MainWindow)
+        self.window._qt_app = None
+
+    def test_effective_theme_is_dark_follows_explicit_preference(self):
+        self.window._theme_preference = "dark"
+        self.assertTrue(self.window._effective_theme_is_dark())
+        self.window._theme_preference = "light"
+        self.assertFalse(self.window._effective_theme_is_dark())
+
+    def test_split_status_row_colors_switch_with_theme(self):
+        self.window._theme_preference = "light"
+        light = self.window._split_status_row_colors("applied")
+        self.window._theme_preference = "dark"
+        dark = self.window._split_status_row_colors("applied")
+        self.assertNotEqual(light, dark)
+
+    def test_refresh_split_status_table_after_theme_change_updates_rows(self):
+        from gui_qt.split_batch import SplitManifestEntry
+
+        entry = SplitManifestEntry(
+            index=1,
+            total=2,
+            manifest_path="/tmp/part01/manifest.json",
+            display_name="part01",
+            job_name="",
+            job_state="",
+            safety_level="",
+            item_count=10,
+            chunk_count=1,
+            applied=True,
+            has_result=True,
+            selectable=False,
+            needs_submit=False,
+            needs_status=False,
+            status_label="已写回",
+            status_kind="applied",
+        )
+        calls: list[str] = []
+        self.window._split_status_entries = [entry]
+        self.window._split_status_selected_manifest_path = entry.manifest_path
+        self.window._configure_split_status_table_hover_palette = (
+            lambda: calls.append("palette")
+        )
+        self.window._update_split_status_selection_ui = (
+            lambda path: calls.append(f"ui:{path}")
+        )
+
+        self.window._refresh_split_status_table_after_theme_change()
+
+        self.assertEqual(
+            calls,
+            ["palette", f"ui:{entry.manifest_path}"],
+        )
+
+    def test_refresh_split_status_table_after_theme_change_skips_empty_entries(self):
+        calls: list[str] = []
+        self.window._split_status_entries = []
+        self.window._configure_split_status_table_hover_palette = (
+            lambda: calls.append("palette")
+        )
+        self.window._update_split_status_selection_ui = (
+            lambda _path: calls.append("ui")
+        )
+
+        self.window._refresh_split_status_table_after_theme_change()
+
+        self.assertEqual(calls, ["palette"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_template_generation_report.py
+++ b/tests/test_gui_template_generation_report.py
@@ -34,6 +34,29 @@ class GuiTemplateGenerationReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "blocked")
         self.assertEqual(summary.heading, "翻译模板生成失败")
 
+    def test_summarize_unknown_status_is_blocked(self):
+        output = """
+Template generation summary:
+- status: pending
+- tl_dir: C:\\Games\\Example\\work\\game\\tl\\schinese
+- tl_exists: True
+- rpy_files: 0
+- language: schinese
+- message:
+"""
+
+        summary = summarize_template_generation_output(output, exit_code=0)
+
+        self.assertEqual(summary.status, "blocked")
+        self.assertIn("未知状态", summary.message)
+
+    def test_template_generation_to_doctor_summary_keeps_generate_mode_on_failure(self):
+        output = TEMPLATE_OUTPUT.replace("status: ready", "status: failed")
+        summary = summarize_template_generation_output(output, exit_code=1)
+        doctor_summary = template_generation_to_doctor_summary(summary)
+
+        self.assertEqual(doctor_summary.mode, "can_generate_template")
+
     def test_template_generation_to_doctor_summary_switches_to_existing_tl_mode(self):
         summary = summarize_template_generation_output(TEMPLATE_OUTPUT, exit_code=0)
         doctor_summary = template_generation_to_doctor_summary(summary)

--- a/tests/test_gui_template_generation_report.py
+++ b/tests/test_gui_template_generation_report.py
@@ -1,0 +1,48 @@
+import unittest
+
+from gui_qt.template_generation_report import (
+    summarize_template_generation_output,
+    template_generation_to_doctor_summary,
+)
+
+
+TEMPLATE_OUTPUT = """
+Template generation summary:
+- status: ready
+- tl_dir: C:\\Games\\Example\\work\\game\\tl\\schinese
+- tl_exists: True
+- rpy_files: 12
+- language: schinese
+- message: Translation template ready with 12 TL file(s).
+"""
+
+
+class GuiTemplateGenerationReportTests(unittest.TestCase):
+    def test_summarize_ready_template_generation_output(self):
+        summary = summarize_template_generation_output(TEMPLATE_OUTPUT, exit_code=0)
+
+        self.assertEqual(summary.status, "ready")
+        self.assertEqual(summary.rpy_files, 12)
+        self.assertTrue(any("翻译文件：12 个" in fact for fact in summary.facts))
+        self.assertTrue(any("目标语言：schinese" in fact for fact in summary.facts))
+
+    def test_summarize_failed_template_generation_output(self):
+        output = TEMPLATE_OUTPUT.replace("status: ready", "status: failed")
+
+        summary = summarize_template_generation_output(output, exit_code=1)
+
+        self.assertEqual(summary.status, "blocked")
+        self.assertEqual(summary.heading, "翻译模板生成失败")
+
+    def test_template_generation_to_doctor_summary_switches_to_existing_tl_mode(self):
+        summary = summarize_template_generation_output(TEMPLATE_OUTPUT, exit_code=0)
+        doctor_summary = template_generation_to_doctor_summary(summary)
+
+        self.assertEqual(doctor_summary.mode, "existing_tl_only")
+        self.assertTrue(
+            any("重新运行「环境检查」" in fact for fact in doctor_summary.facts)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_translate_button_label.py
+++ b/tests/test_gui_translate_button_label.py
@@ -5,6 +5,10 @@ try:
 
     from gui_qt.app import MainWindow
     from gui_qt.doctor_report import DoctorSummary
+    from gui_qt.template_generation_report import (
+        summarize_template_generation_output,
+        template_generation_to_doctor_summary,
+    )
     from gui_qt.work_modes import WorkMode
 except ImportError as exc:
     MainWindow = None  # type: ignore[assignment,misc]
@@ -81,6 +85,25 @@ class GuiTranslateButtonLabelTests(unittest.TestCase):
             )
         )
 
+        self.assertTrue(window.translate_btn.isEnabled())
+
+    def test_button_keeps_generate_template_after_unknown_cli_status(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        unknown_output = """
+Template generation summary:
+- status: pending
+- tl_dir: C:\\Games\\Example\\work\\game\\tl\\schinese
+- tl_exists: False
+- rpy_files: 0
+- language: schinese
+- message:
+"""
+        summary = summarize_template_generation_output(unknown_output, exit_code=0)
+        window._set_doctor_summary(template_generation_to_doctor_summary(summary))
+
+        self.assertEqual(window.translate_btn.text(), "生成翻译模板")
         self.assertTrue(window.translate_btn.isEnabled())
 
     def test_button_keeps_generate_template_after_generation_failure(self):

--- a/tests/test_gui_translate_button_label.py
+++ b/tests/test_gui_translate_button_label.py
@@ -83,6 +83,24 @@ class GuiTranslateButtonLabelTests(unittest.TestCase):
 
         self.assertTrue(window.translate_btn.isEnabled())
 
+    def test_button_keeps_generate_template_after_generation_failure(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="blocked",
+                heading="翻译模板生成失败",
+                message="翻译模板生成没有正常完成，请查看诊断日志。",
+                facts=[],
+                findings=[],
+                mode="can_generate_template",
+            )
+        )
+
+        self.assertEqual(window.translate_btn.text(), "生成翻译模板")
+        self.assertTrue(window.translate_btn.isEnabled())
+
     def test_button_switches_to_start_translation_after_template_generated(self):
         window = MainWindow()
         window._work_mode = WorkMode.BATCH_TRANSLATION

--- a/tests/test_gui_translate_button_label.py
+++ b/tests/test_gui_translate_button_label.py
@@ -1,0 +1,114 @@
+import unittest
+
+try:
+    from PySide6.QtWidgets import QApplication
+
+    from gui_qt.app import MainWindow
+    from gui_qt.doctor_report import DoctorSummary
+    from gui_qt.work_modes import WorkMode
+except ImportError as exc:
+    MainWindow = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+@unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiTranslateButtonLabelTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication.instance() or QApplication([])
+    def test_batch_mode_shows_generate_template_when_doctor_mode_requires_it(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_summary_mode = "can_generate_template"
+
+        self.assertEqual(window._translate_button_label(), "生成翻译模板")
+        self.assertTrue(window._should_generate_template_only())
+
+    def test_batch_mode_shows_start_translation_when_template_exists(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_summary_mode = "existing_tl_only"
+
+        self.assertEqual(window._translate_button_label(), "开始翻译")
+        self.assertFalse(window._should_generate_template_only())
+
+    def test_keyword_mode_keeps_extract_label_even_when_template_missing(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.KEYWORD_EXTRACTION
+        window._doctor_summary_mode = "can_generate_template"
+
+        self.assertEqual(window._translate_button_label(), "提取关键词")
+        self.assertFalse(window._should_generate_template_only())
+
+    def test_set_doctor_summary_updates_button_label(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="warning",
+                heading="检查完成，但有需要处理的事项",
+                message="Ren'Py 模板生成环境可用；翻译模板尚未生成。",
+                facts=[],
+                findings=[],
+                mode="can_generate_template",
+            )
+        )
+
+        self.assertEqual(window.translate_btn.text(), "生成翻译模板")
+
+    def test_batch_translation_button_disabled_without_doctor_check(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = False
+
+        self.assertFalse(window.translate_btn.isEnabled())
+
+    def test_batch_translation_button_enabled_after_doctor_check(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="ready",
+                heading="项目检查通过",
+                message="work 目录已就绪，可以开始翻译流程。",
+                facts=[],
+                findings=[],
+                mode="existing_tl_only",
+            )
+        )
+
+        self.assertTrue(window.translate_btn.isEnabled())
+
+    def test_button_switches_to_start_translation_after_template_generated(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="ready",
+                heading="翻译模板已生成",
+                message="翻译模板已就绪，可以开始翻译流程。",
+                facts=["翻译文件：12 个"],
+                findings=[],
+                mode="existing_tl_only",
+            )
+        )
+
+        self.assertEqual(window.translate_btn.text(), "开始翻译")
+        self.assertTrue(window.translate_btn.isEnabled())
+
+    def test_keyword_mode_does_not_require_doctor_check(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.KEYWORD_EXTRACTION
+        window._doctor_check_completed = False
+        window._apply_work_mode_ui()
+
+        self.assertTrue(window.translate_btn.isEnabled())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_user_copy.py
+++ b/tests/test_gui_user_copy.py
@@ -24,7 +24,7 @@ class GuiUserCopyTests(unittest.TestCase):
 
     def test_doctor_mode_label_maps_known_values(self):
         self.assertEqual(doctor_mode_label("can_generate_template"), "可生成翻译模板")
-        self.assertEqual(doctor_mode_label("existing_tl_only"), "仅处理已有翻译文件")
+        self.assertEqual(doctor_mode_label("existing_tl_only"), "已有翻译模板")
         self.assertEqual(doctor_mode_label("blocked_missing_template"), "缺少模板且无法生成")
 
     def test_job_state_label_maps_known_values(self):


### PR DESCRIPTION
## Summary

This PR improves the GUI translation workbench flow around template preparation and project readiness checks.

- Adds a dedicated `generate-template` CLI command and GUI action that only runs prepare steps (work bootstrap, RPA unpack, Ren'Py TL generation) without entering the batch build/submit pipeline.
- Changes the primary action button to **生成翻译模板** when doctor reports `can_generate_template`, and back to **开始翻译** once TL files exist.
- Requires a successful **环境检查** before batch/sync translation can start; the button stays disabled until doctor completes.
- Fixes doctor mode selection so existing TL files take priority over SDK availability (previously SDK presence could incorrectly keep the UI in `can_generate_template`).
- Removes the post-template auto-doctor refresh that could appear hung on large projects.
- Includes workbench QSS polish for the modernized action panel.

## Motivation

Users were clicking **开始翻译** expecting only template generation, but the GUI launched the full `build -> submit -> status -> download -> check` workflow. After template generation, an automatic doctor rerun could also look stuck while scanning thousands of TL entries.

## Test plan

- [x] `pytest tests/test_gui_template_generation_report.py`
- [x] `pytest tests/test_gui_translate_button_label.py`
- [x] `pytest tests/test_gui_doctor_report.py`
- [x] `pytest tests/test_doctor_layout_status.py`
- [x] `pytest tests/test_batch_rag.py`
- [x] `pytest tests/test_gui_user_copy.py`

## Manual verification

1. Select a project with no TL files, run **环境检查** → button shows **生成翻译模板**.
2. Click **生成翻译模板** → only `generate-template` runs; no submit/status/download.
3. Re-run **环境检查** with TL files present → button shows **开始翻译**.
4. Switch project without doctor → **开始翻译** remains disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“generate-template/生成翻译模板”命令与 GUI 独立任务流；执行后输出模板生成汇总信息。
* **改进/变更**
  * 医生报告推荐与医生模式提示文案更新：更准确区分“翻译模板已就绪/需生成模板”，并基于已有 TL/可生成模板调整模式逻辑。
  * 翻译按钮文案与启用状态随“仅生成模板/医生检查完成/生成结果”动态切换。
* **界面更新**
  * 统一重绘桌面与暗色主题样式，优化按钮、状态徽章、表格与滚动条等视觉表现。
* **测试**
  * 新增/更新回归用例覆盖模板生成链路与 GUI 按钮/模式映射。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->