### PR TITLE
feat(gui): schema-driven settings page with advanced translator_config editing

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -8,7 +8,7 @@
 
 图形工作台是现有 CLI 和 JSON 配置之上的**可选外壳**：
 
-- 普通用户走「选项目 → 配置 → 检查 → 翻译 → 写回」；高级信息集中在诊断页。
+- 普通用户走「选项目 → 设置 → 检查 → 翻译 → 写回」；运行细节集中在诊断页，完整 `translator_config.json` 配置集中在设置页。
 - 底层仍调用现有 CLI 脚本，不重写翻译核心：**批量翻译**走 `gemini_translate_batch.py`；**同步翻译**走 `gemini_translate.py`。
 - 配置仍用 `api_keys.json`、`translator_config.json`；批量写回以 CLI 的 `check -> apply` 安全合约为准，同步模式按脚本规则直接写回。
 - GUI 依赖在 `requirements-gui.txt`，不进入主 `requirements.txt`。**不装图形界面时，命令行工具可照常使用。**
@@ -57,7 +57,7 @@ git lfs pull
 GUI 的普通主流程是：
 
 ```text
-选择项目 -> 配置 API / 模型 -> 检查项目 -> 开始翻译 -> 检查结果 -> 写回翻译
+选择项目 -> 设置 API / 模型 -> 检查项目 -> 开始翻译 -> 检查结果 -> 写回翻译
 ```
 
 对应的底层 CLI 仍是：
@@ -66,7 +66,7 @@ GUI 的普通主流程是：
 doctor -> build -> submit -> status -> download -> check -> apply
 ```
 
-主界面分为三个顶层 Tab：**工作台**、**配置**、**诊断日志**。
+主界面分为三个顶层 Tab：**工作台**、**设置**、**诊断日志**。
 
 界面上的**灰色说明、状态段落和检查摘要**字号略大于普通正文，便于阅读；按钮、页眉和底部原始日志仍保持紧凑字号。
 
@@ -89,15 +89,16 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 普通用户不需要在这一页理解任务记录（manifest）的内部结构；批量写回风险仍以 CLI 的 `check -> apply` 合约为准。
 
-### 配置
+### 设置
 
-配置页采用可滚动布局，自上而下为：
+设置页采用左侧分区导航，右侧显示当前分区内容；底部固定提供 **重新加载**、**恢复推荐值**、**保存设置**。
 
-- **API Key**：读取 / 保存 `api_keys.json`；环境变量 Key 只读提示。
-- **批量上下文**：记忆库、原文索引、build 时自动补建等开关。启用后需先保存配置，再到工作台「分析与准备」运行预建子任务。
+- **账户**：读取 / 保存 `api_keys.json`；环境变量 Key 只读提示。
+- **项目**：`game_root`、术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。通常仍建议先在工作台选择项目，再在这里微调路径。
 - **模型**：同步 / 批量翻译模型、embedding model、批量 thinking level。
-- **外观**：浅色 / 深色 / 跟随系统。
-- **保存参数配置**：写回 `translator_config.json` 并保留未知字段。
+- **上下文**：批量 RAG 记忆库、原文索引、build 时自动补建、上下文库保存位置等开关。启用后需先保存设置，再到工作台「分析与准备」运行预建子任务。
+- **外观**：浅色 / 深色 / 跟随系统。切换主题会立即预览，保存设置后才写入 `translator_config.json`。
+- **高级**：翻译吞吐、retry、Batch safety settings、术语/风格、关键词提取、订正、RAG / 原文索引 / 剧情记忆的检索参数和 store 路径。数值字段会按 CLI 语义校验，路径类字段可留空表示使用默认路径；列表字段支持逐行填写，命令和 safety settings 支持 JSON。
 
 预建库不会修改游戏源文件；若记忆库未启用就点预建记忆库，界面会提示先打开开关并保存。
 
@@ -123,8 +124,8 @@ doctor -> build -> submit -> status -> download -> check -> apply
 GUI 不引入新的主配置系统。
 
 - API Key 仍保存到 `api_keys.json` 的 `api_keys` 列表。
-- 模型、embedding model、批量 thinking level、GUI 主题等写入 `translator_config.json`。
-- 保存配置时应保留未知字段，避免破坏高级配置。
+- 项目路径、准备流程、过滤器、模型、embedding model、批量 thinking level、GUI 主题、任务专用参数和上下文参数等写入 `translator_config.json`。
+- 保存设置时应保留未知字段，避免破坏手写配置。
 - 如果 API Key 来自 `GEMINI_API_KEY` 等环境变量，GUI 只提示只读状态，不强行写回文件。
 
 ## 翻译流程
@@ -196,9 +197,9 @@ build-keywords -> submit -> status -> download -> export-keywords
 
 ## 批量上下文预建
 
-若项目已有一部分译文，或希望在 build 时检索相关剧情原文，可在配置页启用批量上下文并预建本地库。
+若项目已有一部分译文，或希望在 build 时检索相关剧情原文，可在设置页启用批量上下文并预建本地库。
 
-配置页的「上下文库保存到游戏目录」会把默认 RAG / 原文索引 / 剧情图谱路径切到当前 `work` 同级的 `translation_context/`；关闭时仍使用工具项目内的 `logs/`。Batch manifest、检查失败报告、补译包等运行记录仍保存在工具日志目录。
+设置页「上下文」里的「上下文库保存到游戏目录」会把默认 RAG / 原文索引 / 剧情图谱路径切到当前 `work` 同级的 `translation_context/`；关闭时仍使用工具项目内的 `logs/`。高级分区可显式覆盖 store 路径；Batch manifest、检查失败报告、补译包等运行记录仍保存在工具日志目录。
 
 预建流程：
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -153,6 +153,7 @@ from .theme_helpers import (
     write_gui_theme_to_config,
 )
 from .settings_schema import (
+    ADVANCED_SETTING_FIELD_BY_KEY,
     ADVANCED_SETTING_FIELDS,
     BASIC_RECOMMENDED_VALUES,
     SettingField,
@@ -3190,7 +3191,13 @@ class MainWindow(QMainWindow):
         self._show_advanced_setting_errors({})
 
     def _focus_advanced_setting(self, key: str) -> None:
-        row = getattr(self, "_settings_nav_rows", {}).get("advanced")
+        field = ADVANCED_SETTING_FIELD_BY_KEY.get(key)
+        page_key = (
+            "project"
+            if field is not None and field.category in {"项目与资源", "准备流程"}
+            else "advanced"
+        )
+        row = getattr(self, "_settings_nav_rows", {}).get(page_key)
         nav = getattr(self, "settings_nav", None)
         if nav is not None and row is not None:
             nav.setCurrentRow(row)
@@ -4845,7 +4852,8 @@ class MainWindow(QMainWindow):
                 apply_advanced_settings(config, complete_advanced_values)
 
             self.state.save_translator_config(config)
-            self._sync_state_game_root_from_settings(config.get("game_root"))
+            if not self._sync_state_game_root_from_settings(config.get("game_root")):
+                self._show_settings_status("设置已保存，但同步项目目录到工作台失败。", 6000)
             if work_mode_spec(self._current_work_mode()).is_bootstrap:
                 self._apply_work_mode_ui(refresh_manifest_writeback=False)
             self._append_log("设置已成功保存至 translator_config.json。")
@@ -4862,16 +4870,27 @@ class MainWindow(QMainWindow):
             return False
 
 
-    def _sync_state_game_root_from_settings(self, value: object) -> None:
+    def _sync_state_game_root_from_settings(self, value: object) -> bool:
         if not isinstance(value, str) or not value.strip():
-            return
+            return True
         try:
-            normalized, _adjusted = self.state.normalize_game_root(value)
-            self.state._game_root = normalized
-            self.state._game_root_redirect_from = None
-            self._refresh_project_label()
-        except Exception as exc:
-            self._append_log(f"同步设置页 game_root 到当前窗口状态失败：{exc}")
+            new_root, _adjusted = self.state.normalize_game_root(value)
+        except (TypeError, ValueError) as exc:
+            QMessageBox.warning(self, "同步项目目录失败", str(exc))
+            self._append_log(f"同步设置页 game_root 到当前窗口状态失败: {exc}")
+            return False
+
+        current_root = self.state.get_game_root()
+        if current_root is not None:
+            try:
+                current_normalized, _ = self.state.normalize_game_root(current_root)
+                if canonical_abs_path(str(current_normalized)).lower() == canonical_abs_path(str(new_root)).lower():
+                    self._refresh_project_label()
+                    return True
+            except (TypeError, ValueError):
+                pass
+
+        return self._switch_game_root(value.strip())
 
 
 def run_app(argv: list[str] | None = None) -> int:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 import re
+import json
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,10 @@ from PySide6.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QSizePolicy,
+    QListWidget,
+    QStackedWidget,
+    QSpinBox,
+    QDoubleSpinBox,
 )
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
@@ -146,6 +151,16 @@ from .theme_helpers import (
     read_gui_theme_from_config,
     resolve_effective_theme,
     write_gui_theme_to_config,
+)
+from .settings_schema import (
+    ADVANCED_SETTING_FIELDS,
+    BASIC_RECOMMENDED_VALUES,
+    SettingField,
+    apply_advanced_settings,
+    grouped_advanced_fields,
+    read_advanced_settings,
+    recommended_advanced_settings,
+    validate_advanced_settings,
 )
 from .translation_workflow import WorkflowUpdate
 from .user_copy import (
@@ -260,6 +275,9 @@ class MainWindow(QMainWindow):
         self._retry_followup_confirmed: set[str] = set()
         self._writeback_manifest_path = ""
         self._config_ui_saved_snapshot: dict[str, object] = {}
+        self._advanced_setting_widgets: dict[str, QWidget] = {}
+        self._advanced_setting_error_labels: dict[str, QLabel] = {}
+        self._settings_nav_rows: dict[str, int] = {}
         self._last_main_tab_index = 0
         self._handling_config_tab_leave = False
 
@@ -340,7 +358,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "clear_log_btn"):
             self.clear_log_btn.setToolTip("清空日志 (Ctrl+L)")
         if hasattr(self, "save_config_btn"):
-            self.save_config_btn.setToolTip("保存配置 (Ctrl+S)")
+            self.save_config_btn.setToolTip("保存设置 (Ctrl+S)")
 
     def _shortcut_save_config(self) -> None:
         """Handle Ctrl+S: only save when the config tab is active."""
@@ -790,29 +808,99 @@ class MainWindow(QMainWindow):
         tab.setObjectName("config_tab")
         self._style_themed_surface(tab)
         self._config_tab = tab
-        outer_layout = QVBoxLayout(tab)
-        outer_layout.setContentsMargins(0, 0, 0, 0)
+        self._advanced_setting_widgets = {}
+        self._advanced_setting_error_labels = {}
+        self._settings_nav_rows = {}
 
+        outer_layout = QHBoxLayout(tab)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.setSpacing(0)
+
+        self.settings_nav = QListWidget()
+        self.settings_nav.setObjectName("settings_nav")
+        self.settings_nav.setFixedWidth(150)
+        self.settings_nav.setSpacing(2)
+        self.settings_nav.setFrameShape(QFrame.Shape.NoFrame)
+        outer_layout.addWidget(self.settings_nav)
+
+        right_panel = QWidget()
+        right_panel.setObjectName("settings_right_panel")
+        self._style_themed_surface(right_panel)
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(0)
+        outer_layout.addWidget(right_panel, 1)
+
+        self.settings_stack = QStackedWidget()
+        self.settings_stack.setObjectName("settings_stack")
+        right_layout.addWidget(self.settings_stack, 1)
+
+        pages = [
+            ("account", "账户", self._build_settings_account_page()),
+            ("project", "项目", self._build_settings_project_page()),
+            ("models", "模型", self._build_settings_models_page()),
+            ("context", "上下文", self._build_settings_context_page()),
+            ("appearance", "外观", self._build_settings_appearance_page()),
+            ("advanced", "高级", self._build_settings_advanced_page()),
+        ]
+        for index, (key, label, page) in enumerate(pages):
+            self._settings_nav_rows[key] = index
+            self.settings_nav.addItem(label)
+            self.settings_stack.addWidget(page)
+        self.settings_nav.currentRowChanged.connect(self.settings_stack.setCurrentIndex)
+        self.settings_nav.setCurrentRow(0)
+
+        action_bar = QFrame()
+        action_bar.setObjectName("settings_action_bar")
+        action_layout = QHBoxLayout(action_bar)
+        action_layout.setContentsMargins(12, 10, 12, 10)
+        action_layout.setSpacing(8)
+        action_layout.addStretch()
+        self.reload_config_btn = QPushButton("重新加载")
+        self.reload_config_btn.setObjectName("secondary_btn")
+        self.reload_config_btn.clicked.connect(self._on_reload_config)
+        action_layout.addWidget(self.reload_config_btn)
+        self.restore_defaults_btn = QPushButton("恢复推荐值")
+        self.restore_defaults_btn.setObjectName("secondary_btn")
+        self.restore_defaults_btn.clicked.connect(self._on_restore_recommended_config)
+        action_layout.addWidget(self.restore_defaults_btn)
+        self.save_config_btn = QPushButton("保存设置")
+        self.save_config_btn.setObjectName("save_config_btn")
+        self.save_config_btn.clicked.connect(self._on_save_config)
+        action_layout.addWidget(self.save_config_btn)
+        right_layout.addWidget(action_bar)
+
+        self.tab_widget.addTab(tab, "设置")
+
+    def _settings_page(self, object_name: str) -> tuple[QScrollArea, QVBoxLayout]:
         scroll = QScrollArea()
-        scroll.setObjectName("config_scroll")
+        scroll.setObjectName(f"{object_name}_scroll")
         self._style_themed_surface(scroll)
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         viewport = scroll.viewport()
-        viewport.setObjectName("config_scroll_viewport")
+        viewport.setObjectName(f"{object_name}_viewport")
         self._style_themed_surface(viewport)
 
         content = QWidget()
-        content.setObjectName("config_scroll_content")
+        content.setObjectName(f"{object_name}_content")
         self._style_themed_surface(content)
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(12, 16, 12, 12)
+        layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(14)
+        scroll.setWidget(content)
+        return scroll, layout
 
-        api_box = QGroupBox("API Key")
-        api_layout = QVBoxLayout(api_box)
-        api_layout.setSpacing(10)
-        api_layout.setContentsMargins(12, 16, 12, 12)
+    def _settings_group(self, title: str) -> tuple[QGroupBox, QVBoxLayout]:
+        group = QGroupBox(title)
+        layout = QVBoxLayout(group)
+        layout.setSpacing(10)
+        layout.setContentsMargins(12, 16, 12, 12)
+        return group, layout
+
+    def _build_settings_account_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_account")
+        api_box, api_layout = self._settings_group("API Key")
 
         api_hint = QLabel(
             "翻译任务需要 Gemini API 密钥。密钥保存在本地配置文件中，"
@@ -836,14 +924,40 @@ class MainWindow(QMainWindow):
         api_layout.addLayout(api_actions)
 
         layout.addWidget(api_box)
+        layout.addStretch(1)
+        return page
 
-        context_box = QGroupBox("批量上下文")
-        context_layout = QVBoxLayout(context_box)
-        context_layout.setSpacing(8)
-        context_layout.setContentsMargins(12, 16, 12, 12)
+    def _build_settings_project_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_project")
+        hint = QLabel(
+            "项目路径、术语表、翻译目录和准备流程都写入 translator_config.json。"
+            "通常建议通过工作台选择项目，再在这里微调其余路径。"
+        )
+        hint.setWordWrap(True)
+        hint.setObjectName("config_hint_label")
+        layout.addWidget(hint)
+
+        for group_title in ("项目与资源", "准备流程"):
+            group = QGroupBox(group_title)
+            form = QFormLayout(group)
+            form.setSpacing(8)
+            form.setContentsMargins(12, 16, 12, 12)
+            form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+            for field in [item for item in ADVANCED_SETTING_FIELDS if item.category == group_title]:
+                widget = self._create_advanced_setting_widget(field)
+                self._advanced_setting_widgets[field.key] = widget
+                row = self._advanced_setting_row(field, widget)
+                form.addRow(f"{field.label}：", row)
+            layout.addWidget(group)
+        layout.addStretch(1)
+        return page
+
+    def _build_settings_context_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_context")
+        context_box, context_layout = self._settings_group("批量上下文")
 
         context_hint = QLabel(
-            "启用后先保存配置，再到工作台「分析与准备」下运行预建子任务。"
+            "启用后先保存设置，再到工作台「分析与准备」下运行预建子任务。"
             "记忆库使用已有译文；原文索引只使用翻译模板里的原文；均不修改游戏脚本。"
         )
         context_hint.setWordWrap(True)
@@ -866,7 +980,11 @@ class MainWindow(QMainWindow):
         context_layout.addWidget(self.context_storage_game_cb)
 
         layout.addWidget(context_box)
+        layout.addStretch(1)
+        return page
 
+    def _build_settings_models_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_models")
         config_row = QHBoxLayout()
         config_row.setSpacing(16)
 
@@ -929,8 +1047,12 @@ class MainWindow(QMainWindow):
         batch_layout.addRow("思考程度：", self.batch_thinking_combo)
 
         config_row.addWidget(batch_box, 1)
-        layout.addLayout(config_row, 1)
+        layout.addLayout(config_row)
+        layout.addStretch(1)
+        return page
 
+    def _build_settings_appearance_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_appearance")
         appearance_box = QGroupBox("外观")
         appearance_layout = QFormLayout(appearance_box)
         appearance_layout.setSpacing(8)
@@ -941,19 +1063,98 @@ class MainWindow(QMainWindow):
         self.theme_combo.addItem("深色", "dark")
         self.theme_combo.currentIndexChanged.connect(self._on_theme_changed)
         appearance_layout.addRow("主题：", self.theme_combo)
+        hint = QLabel("切换主题会立即预览；点击保存设置后才会写入 translator_config.json。")
+        hint.setWordWrap(True)
+        hint.setObjectName("config_hint_label")
+        appearance_layout.addRow("", hint)
         layout.addWidget(appearance_box)
+        layout.addStretch(1)
+        return page
 
-        save_layout = QHBoxLayout()
-        save_layout.addStretch()
-        self.save_config_btn = QPushButton("保存参数配置")
-        self.save_config_btn.setObjectName("save_config_btn")
-        self.save_config_btn.clicked.connect(self._on_save_config)
-        save_layout.addWidget(self.save_config_btn)
-        layout.addLayout(save_layout)
+    def _build_settings_advanced_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_advanced")
+        hint = QLabel(
+            "高级设置会直接影响请求大小、上下文注入和本地上下文路径。"
+            "无效字段会在本页标出，并阻止保存。"
+        )
+        hint.setWordWrap(True)
+        hint.setObjectName("config_hint_label")
+        layout.addWidget(hint)
 
-        scroll.setWidget(content)
-        outer_layout.addWidget(scroll)
-        self.tab_widget.addTab(tab, "配置")
+        skipped_categories = {"项目与资源", "准备流程"}
+        for group_title, fields in grouped_advanced_fields():
+            if group_title in skipped_categories:
+                continue
+            group = QGroupBox(group_title)
+            form = QFormLayout(group)
+            form.setSpacing(8)
+            form.setContentsMargins(12, 16, 12, 12)
+            form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+            for field in fields:
+                widget = self._create_advanced_setting_widget(field)
+                self._advanced_setting_widgets[field.key] = widget
+                row = self._advanced_setting_row(field, widget)
+                form.addRow(f"{field.label}：", row)
+            layout.addWidget(group)
+        layout.addStretch(1)
+        return page
+
+    def _advanced_setting_row(self, field: SettingField, widget: QWidget) -> QWidget:
+        row = QWidget()
+        row_layout = QVBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(4)
+        row_layout.addWidget(widget)
+
+        desc = QLabel(field.description)
+        desc.setWordWrap(True)
+        desc.setObjectName("settings_description_label")
+        row_layout.addWidget(desc)
+
+        error = QLabel()
+        error.setWordWrap(True)
+        error.setObjectName("settings_error_label")
+        self._advanced_setting_error_labels[field.key] = error
+        row_layout.addWidget(error)
+        return row
+
+    def _create_advanced_setting_widget(self, field: SettingField) -> QWidget:
+        if field.kind == "bool":
+            widget = QCheckBox()
+        elif field.kind == "int":
+            widget = QSpinBox()
+            widget.setAccelerated(True)
+            minimum = int(field.minimum if field.minimum is not None else 0)
+            maximum = int(field.maximum if field.maximum is not None else 9999999)
+            widget.setRange(minimum, maximum)
+        elif field.kind == "float":
+            widget = QDoubleSpinBox()
+            widget.setDecimals(3)
+            widget.setSingleStep(0.01 if field.maximum == 1.0 else 0.1)
+            minimum = float(field.minimum if field.minimum is not None else -999999.0)
+            maximum = float(field.maximum if field.maximum is not None else 999999.0)
+            widget.setRange(minimum, maximum)
+        elif field.kind in {"text", "list", "json"}:
+            widget = QTextEdit()
+            widget.setAcceptRichText(False)
+            widget.setMinimumHeight(72 if field.kind != "text" else 96)
+            widget.setPlaceholderText(self._advanced_setting_placeholder(field))
+        else:
+            widget = QLineEdit()
+            widget.setClearButtonEnabled(True)
+            if field.allow_empty:
+                widget.setPlaceholderText("留空使用默认路径" if "路径" in field.label else "可留空")
+        widget.setToolTip(field.description)
+        return widget
+
+    def _advanced_setting_placeholder(self, field: SettingField) -> str:
+        if field.kind == "list":
+            return "每行一个值，或填写 JSON 数组"
+        if field.kind == "json":
+            return "留空使用默认；可填写字符串预设或 JSON"
+        if field.kind == "text":
+            return "可留空"
+        return ""
 
     def _build_log_tab(self) -> None:
         tab = QWidget()
@@ -2912,10 +3113,101 @@ class MainWindow(QMainWindow):
 
         self.api_status_label.setText(message)
 
+    def _current_theme_preference_from_ui(self) -> str:
+        combo = getattr(self, "theme_combo", None)
+        if combo is not None:
+            try:
+                preference = combo.currentData()
+            except Exception:
+                preference = None
+            if isinstance(preference, str):
+                return normalize_theme_preference(preference)
+        return normalize_theme_preference(getattr(self, "_theme_preference", DEFAULT_THEME_PREFERENCE))
+
+    def _advanced_settings_values_from_ui(self) -> dict[str, object]:
+        widgets = getattr(self, "_advanced_setting_widgets", {})
+        if not widgets:
+            return {}
+        values: dict[str, object] = {}
+        for field in ADVANCED_SETTING_FIELDS:
+            widget = widgets.get(field.key)
+            if widget is None:
+                continue
+            if field.kind == "bool":
+                values[field.key] = widget.isChecked()
+            elif field.kind in {"int", "float"}:
+                values[field.key] = widget.value()
+            elif hasattr(widget, "toPlainText"):
+                values[field.key] = widget.toPlainText().strip()
+            else:
+                values[field.key] = widget.text().strip()
+        return values
+
+    def _load_advanced_settings_to_ui(self, values: dict[str, object]) -> None:
+        widgets = getattr(self, "_advanced_setting_widgets", {})
+        if not widgets:
+            return
+        for field in ADVANCED_SETTING_FIELDS:
+            widget = widgets.get(field.key)
+            if widget is None:
+                continue
+            value = values.get(field.key, field.default)
+            if field.kind == "bool":
+                widget.setChecked(bool(value))
+            elif field.kind == "int":
+                widget.setValue(int(value))
+            elif field.kind == "float":
+                widget.setValue(float(value))
+            elif hasattr(widget, "setPlainText"):
+                widget.setPlainText(self._format_advanced_setting_text(field, value))
+            else:
+                widget.setText(str(value))
+
+    def _format_advanced_setting_text(self, field: SettingField, value: object) -> str:
+        if field.kind == "list":
+            if isinstance(value, (list, tuple, set)):
+                return "\n".join(str(item) for item in value)
+            return str(value or "")
+        if field.kind == "json":
+            if value in (None, ""):
+                return ""
+            if isinstance(value, str):
+                return value
+            try:
+                return json.dumps(value, ensure_ascii=False, indent=2)
+            except TypeError:
+                return str(value)
+        return str(value or "")
+
+    def _show_advanced_setting_errors(self, errors: dict[str, str]) -> None:
+        labels = getattr(self, "_advanced_setting_error_labels", {})
+        for key, label in labels.items():
+            label.setText(errors.get(key, ""))
+        if errors:
+            self._focus_advanced_setting(next(iter(errors)))
+
+    def _clear_advanced_setting_errors(self) -> None:
+        self._show_advanced_setting_errors({})
+
+    def _focus_advanced_setting(self, key: str) -> None:
+        row = getattr(self, "_settings_nav_rows", {}).get("advanced")
+        nav = getattr(self, "settings_nav", None)
+        if nav is not None and row is not None:
+            nav.setCurrentRow(row)
+        widget = getattr(self, "_advanced_setting_widgets", {}).get(key)
+        if widget is not None:
+            widget.setFocus()
+
+    def _show_settings_status(self, message: str, timeout: int = 4000) -> None:
+        try:
+            self.statusBar().showMessage(message, timeout)
+        except Exception:
+            return
+
     def _current_config_ui_snapshot(self) -> dict[str, object]:
         thinking_val = self.batch_thinking_combo.currentData()
         thinking_level = thinking_val if isinstance(thinking_val, str) else ""
-        return {
+        snapshot: dict[str, object] = {
             "rag_enabled": self.rag_enabled_cb.isChecked(),
             "source_index_enabled": self.source_index_enabled_cb.isChecked(),
             "bootstrap_on_build": self.bootstrap_on_build_cb.isChecked(),
@@ -2925,7 +3217,10 @@ class MainWindow(QMainWindow):
             "sync_embedding_model": self.sync_embedding_combo.currentText().strip(),
             "batch_embedding_model": self.batch_embedding_combo.currentText().strip(),
             "batch_thinking_level": thinking_level,
+            "theme": self._current_theme_preference_from_ui(),
         }
+        snapshot.update(self._advanced_settings_values_from_ui())
+        return snapshot
 
     def _config_tab_has_unsaved_changes(self) -> bool:
         if self._loading_config_to_ui:
@@ -2937,12 +3232,12 @@ class MainWindow(QMainWindow):
     def _confirm_leave_config_tab(self, previous_index: int) -> bool:
         message = QMessageBox(self)
         message.setIcon(QMessageBox.Icon.Warning)
-        message.setWindowTitle("配置尚未保存")
-        message.setText("配置页有未保存的更改。")
-        message.setInformativeText("离开前可以保存配置，或留在配置页继续检查。")
+        message.setWindowTitle("设置尚未保存")
+        message.setText("设置页有未保存的更改。")
+        message.setInformativeText("离开前可以保存设置，或留在设置页继续检查。")
         save_btn = message.addButton("保存并离开", QMessageBox.ButtonRole.AcceptRole)
         discard_btn = message.addButton("不保存离开", QMessageBox.ButtonRole.DestructiveRole)
-        stay_btn = message.addButton("留在配置页", QMessageBox.ButtonRole.RejectRole)
+        stay_btn = message.addButton("留在设置页", QMessageBox.ButtonRole.RejectRole)
         message.setDefaultButton(save_btn)
         message.exec()
         clicked = message.clickedButton()
@@ -2983,6 +3278,36 @@ class MainWindow(QMainWindow):
         if current_widget is getattr(self, "_diagnostics_tab", None):
             self._refresh_diagnostics_context()
         self._last_main_tab_index = index
+
+
+    def _on_reload_config(self) -> None:
+        self._load_config_to_ui()
+        self._refresh_api_status()
+        self._show_settings_status("已重新加载已保存设置。")
+
+    def _on_restore_recommended_config(self) -> None:
+        values = BASIC_RECOMMENDED_VALUES
+        self.rag_enabled_cb.setChecked(bool(values["rag_enabled"]))
+        self.source_index_enabled_cb.setChecked(bool(values["source_index_enabled"]))
+        self.bootstrap_on_build_cb.setChecked(bool(values["bootstrap_on_build"]))
+        self.context_storage_game_cb.setChecked(values["context_storage_location"] == "game")
+        self._set_combo_value(self.sync_model_combo, values["sync_model"])
+        self._set_combo_value(self.batch_model_combo, values["batch_model"])
+        self._set_combo_value(self.sync_embedding_combo, values["sync_embedding_model"])
+        self._set_combo_value(self.batch_embedding_combo, values["batch_embedding_model"])
+        self._set_batch_thinking_value(str(values["batch_thinking_level"]))
+        self._set_theme_combo_value(str(values["theme"]))
+        self._set_theme_preference(str(values["theme"]), persist=False)
+        advanced_defaults = recommended_advanced_settings()
+        state = getattr(self, "state", None)
+        get_game_root = getattr(state, "get_game_root", None)
+        current_game_root = get_game_root() if callable(get_game_root) else None
+        if current_game_root:
+            advanced_defaults["game_root"] = str(current_game_root)
+        self._load_advanced_settings_to_ui(advanced_defaults)
+        self._clear_advanced_setting_errors()
+        self._batch_thinking_user_changed = True
+        self._show_settings_status("已恢复推荐值，保存后生效。")
 
 
     def _on_manage_api_keys(self):
@@ -3290,7 +3615,7 @@ class MainWindow(QMainWindow):
                 QMessageBox.information(
                     self,
                     "请先配置 API Key",
-                    "同步模式需要 Gemini API 密钥；请在配置页管理 API Key 或设置环境变量。",
+                    "同步模式需要 Gemini API 密钥；请在设置页管理 API Key 或设置环境变量。",
                 )
                 return
 
@@ -3718,6 +4043,10 @@ class MainWindow(QMainWindow):
         self.resume_btn.setEnabled(spec.implemented and spec.supports_resume and not running)
         self._update_split_submit_btn(running=running)
         self.save_config_btn.setEnabled(not running)
+        if hasattr(self, "reload_config_btn"):
+            self.reload_config_btn.setEnabled(not running)
+        if hasattr(self, "restore_defaults_btn"):
+            self.restore_defaults_btn.setEnabled(not running)
         writeback_summary = self._current_writeback_summary()
         self.apply_btn.setEnabled(
             not running
@@ -4281,6 +4610,15 @@ class MainWindow(QMainWindow):
             combo.addItem(value)
             combo.setCurrentIndex(combo.count() - 1)
 
+    def _set_theme_combo_value(self, value: str) -> None:
+        combo = getattr(self, "theme_combo", None)
+        if combo is None:
+            return
+        theme = normalize_theme_preference(value)
+        idx = combo.findData(theme)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+
     def _set_batch_thinking_value(self, value: str):
         idx = self.batch_thinking_combo.findData(value)
         self._updating_batch_thinking_combo = True
@@ -4300,17 +4638,18 @@ class MainWindow(QMainWindow):
         self._theme_preference = theme
         self._loading_theme_to_ui = True
         try:
-            idx = self.theme_combo.findData(theme)
-            if idx >= 0:
-                self.theme_combo.setCurrentIndex(idx)
+            self._set_theme_combo_value(theme)
         finally:
             self._loading_theme_to_ui = False
+        self._apply_theme()
 
     def _apply_theme(self) -> None:
-        if self._qt_app is None:
+        qt_app = getattr(self, "_qt_app", None)
+        if qt_app is None:
             return
         try:
-            apply_theme(self._qt_app, self._resources_dir, self._theme_preference)
+            resources_dir = getattr(self, "_resources_dir", Path(__file__).resolve().parent / "resources")
+            apply_theme(qt_app, resources_dir, self._theme_preference)
             if hasattr(self, "_log_highlighter"):
                 self._log_highlighter.update_theme(self._effective_theme_is_dark())
             QTimer.singleShot(0, self._refresh_split_status_table_after_theme_change)
@@ -4338,7 +4677,7 @@ class MainWindow(QMainWindow):
         preference = self.theme_combo.currentData()
         if not isinstance(preference, str):
             return
-        self._set_theme_preference(preference, persist=True)
+        self._set_theme_preference(preference, persist=False)
 
     def _on_system_color_scheme_changed(self, _scheme: object) -> None:
         if self._theme_preference != THEME_SYSTEM:
@@ -4365,7 +4704,6 @@ class MainWindow(QMainWindow):
             self.context_storage_game_cb.setChecked(storage_location == "game")
             self._batch_thinking_config_has_key = "thinking_level" in batch_config
 
-            # Populate sync model
             sync_models = sync_config.get("models")
             sync_val = ""
             if isinstance(sync_models, list):
@@ -4376,26 +4714,36 @@ class MainWindow(QMainWindow):
             elif isinstance(sync_models, str):
                 sync_val = self._config_string(sync_models)
             if not sync_val:
-                sync_val = sync_config.get("model", "")
+                sync_val = self._config_string(sync_config.get("model", ""))
+            if not sync_val:
+                sync_val = str(BASIC_RECOMMENDED_VALUES["sync_model"])
             self._set_combo_value(self.sync_model_combo, sync_val)
 
-            # Populate batch model
-            batch_val = batch_config.get("model", "")
+            batch_val = self._config_string(batch_config.get("model", "")) or str(
+                BASIC_RECOMMENDED_VALUES["batch_model"]
+            )
             self._set_combo_value(self.batch_model_combo, batch_val)
 
-            # Populate sync embedding
-            sync_emb_val = sync_rag_config.get("embedding_model", "")
+            sync_emb_val = self._config_string(sync_rag_config.get("embedding_model", "")) or str(
+                BASIC_RECOMMENDED_VALUES["sync_embedding_model"]
+            )
             self._set_combo_value(self.sync_embedding_combo, sync_emb_val)
 
-            # Populate batch embedding
-            batch_emb_val = batch_rag_config.get("embedding_model", "")
+            batch_emb_val = self._config_string(batch_rag_config.get("embedding_model", "")) or str(
+                BASIC_RECOMMENDED_VALUES["batch_embedding_model"]
+            )
             self._set_combo_value(self.batch_embedding_combo, batch_emb_val)
 
             self._on_batch_model_changed(batch_val)
-            # Populate thinking level. Missing config keeps the CLI's supported-model
-            # default visible; choosing "not enabled" then saves an explicit empty value.
             thinking_val = self._batch_thinking_value_for_load(batch_config, batch_val)
             self._set_batch_thinking_value(thinking_val)
+            advanced_values = read_advanced_settings(config)
+            get_game_root = getattr(self.state, "get_game_root", None)
+            current_game_root = get_game_root() if callable(get_game_root) else None
+            if current_game_root and not self._config_string(advanced_values.get("game_root")):
+                advanced_values["game_root"] = str(current_game_root)
+            self._load_advanced_settings_to_ui(advanced_values)
+            self._clear_advanced_setting_errors()
         finally:
             self._batch_thinking_user_changed = False
             self._loading_config_to_ui = False
@@ -4474,21 +4822,56 @@ class MainWindow(QMainWindow):
             ):
                 batch_config["thinking_level"] = thinking_level
 
+            write_gui_theme_to_config(config, self._current_theme_preference_from_ui())
+
+            advanced_values = self._advanced_settings_values_from_ui()
+            if advanced_values:
+                complete_advanced_values = read_advanced_settings(config)
+                complete_advanced_values.update(advanced_values)
+                if not self._config_string(complete_advanced_values.get("game_root")):
+                    get_game_root = getattr(self.state, "get_game_root", None)
+                    current_game_root = get_game_root() if callable(get_game_root) else None
+                    if current_game_root:
+                        complete_advanced_values["game_root"] = str(current_game_root)
+                        game_root_widget = getattr(self, "_advanced_setting_widgets", {}).get("game_root")
+                        if game_root_widget is not None and hasattr(game_root_widget, "setText"):
+                            game_root_widget.setText(str(current_game_root))
+                errors = validate_advanced_settings(complete_advanced_values)
+                if errors:
+                    self._show_advanced_setting_errors(errors)
+                    self._show_settings_status("高级设置有无效字段，未保存。", 6000)
+                    return False
+                self._clear_advanced_setting_errors()
+                apply_advanced_settings(config, complete_advanced_values)
+
             self.state.save_translator_config(config)
+            self._sync_state_game_root_from_settings(config.get("game_root"))
             if work_mode_spec(self._current_work_mode()).is_bootstrap:
                 self._apply_work_mode_ui(refresh_manifest_writeback=False)
-            self._append_log("配置已成功保存至 translator_config.json。")
+            self._append_log("设置已成功保存至 translator_config.json。")
             try:
-                ToastNotification.show_toast(self, "✓ 配置已成功保存")
+                ToastNotification.show_toast(self, "✓ 设置已成功保存")
             except Exception as exc:
                 self._append_log(f"提示通知显示失败：{exc}")
-                self.statusBar().showMessage("配置已成功保存", 3000)
+                self.statusBar().showMessage("设置已成功保存", 3000)
             self._config_ui_saved_snapshot = self._current_config_ui_snapshot()
             return True
         except Exception as exc:
-            QMessageBox.warning(self, "保存配置失败", str(exc))
-            self._append_log(f"保存配置失败：{exc}")
+            QMessageBox.warning(self, "保存设置失败", str(exc))
+            self._append_log(f"保存设置失败：{exc}")
             return False
+
+
+    def _sync_state_game_root_from_settings(self, value: object) -> None:
+        if not isinstance(value, str) or not value.strip():
+            return
+        try:
+            normalized, _adjusted = self.state.normalize_game_root(value)
+            self.state._game_root = normalized
+            self.state._game_root_redirect_from = None
+            self._refresh_project_label()
+        except Exception as exc:
+            self._append_log(f"同步设置页 game_root 到当前窗口状态失败：{exc}")
 
 
 def run_app(argv: list[str] | None = None) -> int:

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -118,9 +118,48 @@ QTabWidget#main_tabs::pane {
 QWidget#config_tab,
 QScrollArea#config_scroll,
 QWidget#config_scroll_viewport,
-QWidget#config_scroll_content {
+QWidget#config_scroll_content,
+QWidget#settings_right_panel,
+QStackedWidget#settings_stack,
+QFrame#settings_action_bar {
     background-color: ${bg_surface};
     border: none;
+}
+
+QListWidget#settings_nav {
+    background-color: ${bg_surface_alt};
+    border: none;
+    border-right: 1px solid ${border_default};
+    padding: 10px 8px;
+    outline: none;
+}
+
+QListWidget#settings_nav::item {
+    color: ${fg_body};
+    padding: 9px 10px;
+    margin: 2px 0;
+    border-radius: 6px;
+}
+
+QListWidget#settings_nav::item:selected {
+    background-color: ${bg_secondary};
+    color: ${fg_secondary_btn};
+    font-weight: 700;
+}
+
+QListWidget#settings_nav::item:hover:!selected {
+    background-color: ${bg_secondary_hover};
+}
+
+QLabel#settings_description_label {
+    color: ${fg_muted};
+    font-size: 12px;
+}
+
+QLabel#settings_error_label {
+    color: ${badge_danger_fg};
+    font-size: 12px;
+    font-weight: 600;
 }
 
 QWidget#diagnostics_tab,

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -121,7 +121,25 @@ QWidget#config_scroll_viewport,
 QWidget#config_scroll_content,
 QWidget#settings_right_panel,
 QStackedWidget#settings_stack,
-QFrame#settings_action_bar {
+QFrame#settings_action_bar,
+QScrollArea#settings_account_scroll,
+QWidget#settings_account_viewport,
+QWidget#settings_account_content,
+QScrollArea#settings_project_scroll,
+QWidget#settings_project_viewport,
+QWidget#settings_project_content,
+QScrollArea#settings_models_scroll,
+QWidget#settings_models_viewport,
+QWidget#settings_models_content,
+QScrollArea#settings_context_scroll,
+QWidget#settings_context_viewport,
+QWidget#settings_context_content,
+QScrollArea#settings_appearance_scroll,
+QWidget#settings_appearance_viewport,
+QWidget#settings_appearance_content,
+QScrollArea#settings_advanced_scroll,
+QWidget#settings_advanced_viewport,
+QWidget#settings_advanced_content {
     background-color: ${bg_surface};
     border: none;
 }

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -1,0 +1,949 @@
+"""Pure helpers for GUI-managed translator settings.
+
+This module intentionally has no Qt dependency.  The GUI owns widgets and user
+interaction; this module owns field metadata, coercion, validation, and
+translator_config.json writes for managed advanced settings.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Iterable, Literal
+
+
+SettingKind = Literal["bool", "int", "float", "str", "text", "list", "json"]
+SettingValue = Any
+
+
+@dataclass(frozen=True)
+class SettingField:
+    key: str
+    path: tuple[str, ...]
+    label: str
+    description: str
+    kind: SettingKind
+    default: SettingValue
+    category: str
+    recommended: SettingValue | None = None
+    minimum: float | None = None
+    maximum: float | None = None
+    allow_empty: bool = False
+
+    @property
+    def recommended_value(self) -> SettingValue:
+        return self.default if self.recommended is None else self.recommended
+
+
+BASIC_RECOMMENDED_VALUES: dict[str, SettingValue] = {
+    "theme": "system",
+    "context_storage_location": "tool",
+    "rag_enabled": True,
+    "source_index_enabled": False,
+    "bootstrap_on_build": True,
+    "sync_model": "gemini-3.1-flash-lite",
+    "batch_model": "gemini-3.1-flash-lite",
+    "sync_embedding_model": "gemini-embedding-001",
+    "batch_embedding_model": "gemini-embedding-001",
+    "batch_thinking_level": "minimal",
+}
+
+
+ADVANCED_SETTING_FIELDS: tuple[SettingField, ...] = (
+    SettingField(
+        "sync_chunk_size",
+        ("sync", "chunk_size"),
+        "同步 chunk 条数",
+        "同步翻译单次请求最多包含的条目数。",
+        "int",
+        40,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_max_source_chars",
+        ("sync", "max_source_chars"),
+        "同步原文字符上限",
+        "同步翻译单次请求允许的原文字符预算。",
+        "int",
+        12000,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_max_output_tokens",
+        ("sync", "max_output_tokens"),
+        "同步输出 token 上限",
+        "同步请求传给模型的 max_output_tokens。",
+        "int",
+        24576,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_chunk_size",
+        ("batch", "chunk_size"),
+        "批量 chunk 条数",
+        "Batch 构建时每个请求最多包含的条目数。",
+        "int",
+        60,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_max_source_chars",
+        ("batch", "max_source_chars"),
+        "批量原文字符上限",
+        "Batch 构建时每个请求允许的原文字符预算。",
+        "int",
+        18000,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_context_before",
+        ("batch", "context_before"),
+        "前文条目数",
+        "Batch 请求附带的前文条目数量。",
+        "int",
+        30,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_context_after",
+        ("batch", "context_after"),
+        "后文条目数",
+        "Batch 请求附带的后文条目数量。",
+        "int",
+        10,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_max_output_tokens",
+        ("batch", "max_output_tokens"),
+        "批量输出 token 上限",
+        "Batch 请求传给模型的 max_output_tokens。",
+        "int",
+        32768,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_temperature",
+        ("batch", "temperature"),
+        "批量 temperature",
+        "Batch 请求的温度；越低越稳定。",
+        "float",
+        0.2,
+        "翻译吞吐",
+        minimum=0.0,
+        maximum=2.0,
+    ),
+    SettingField(
+        "batch_display_name_prefix",
+        ("batch", "display_name_prefix"),
+        "批量任务名称前缀",
+        "提交 Batch 任务时使用的 display name 前缀。",
+        "str",
+        "renpy-translate",
+        "翻译吞吐",
+        allow_empty=True,
+    ),
+    SettingField(
+        "context_storage_game_dir_name",
+        ("context_storage", "game_dir_name"),
+        "游戏目录上下文文件夹",
+        "context storage 使用游戏目录模式时的文件夹名。",
+        "str",
+        "translation_context",
+        "上下文路径",
+    ),
+    SettingField(
+        "sync_rag_enabled",
+        ("sync", "rag", "enabled"),
+        "启用同步 RAG",
+        "同步翻译时检索本地记忆库。",
+        "bool",
+        False,
+        "同步 RAG",
+    ),
+    SettingField(
+        "sync_rag_output_dimensionality",
+        ("sync", "rag", "output_dimensionality"),
+        "同步 RAG 向量维度",
+        "同步 RAG 存储和查询使用的 embedding 维度。",
+        "int",
+        768,
+        "同步 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_rag_top_k_history",
+        ("sync", "rag", "top_k_history"),
+        "同步历史命中数",
+        "同步翻译检索历史译文的最大命中数。",
+        "int",
+        4,
+        "同步 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_rag_top_k_terms",
+        ("sync", "rag", "top_k_terms"),
+        "同步术语命中数",
+        "同步翻译检索术语/短语的最大命中数。",
+        "int",
+        8,
+        "同步 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_rag_min_similarity",
+        ("sync", "rag", "min_similarity"),
+        "同步相似度阈值",
+        "同步 RAG 命中的最低相似度。",
+        "float",
+        0.72,
+        "同步 RAG",
+        minimum=0.0,
+        maximum=1.0,
+    ),
+    SettingField(
+        "sync_rag_segment_lines",
+        ("sync", "rag", "segment_lines"),
+        "同步索引分段行数",
+        "写入同步记忆库时每段合并的行数。",
+        "int",
+        4,
+        "同步 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_rag_history_char_limit",
+        ("sync", "rag", "history_char_limit"),
+        "同步历史字符上限",
+        "同步 RAG 单条历史命中注入 prompt 前的截断上限。",
+        "int",
+        220,
+        "同步 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_rag_store_dir",
+        ("sync", "rag", "store_dir"),
+        "同步 RAG 存储路径",
+        "留空时使用当前 context storage 默认路径。",
+        "str",
+        "",
+        "同步 RAG",
+        allow_empty=True,
+    ),
+    SettingField(
+        "sync_rag_update_on_success",
+        ("sync", "rag", "update_on_success"),
+        "同步成功后更新记忆库",
+        "同步翻译成功后把结果写入本地 RAG 记忆库。",
+        "bool",
+        True,
+        "同步 RAG",
+    ),
+    SettingField(
+        "batch_rag_output_dimensionality",
+        ("batch", "rag", "output_dimensionality"),
+        "批量 RAG 向量维度",
+        "Batch RAG 存储和查询使用的 embedding 维度。",
+        "int",
+        768,
+        "批量 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_rag_top_k_history",
+        ("batch", "rag", "top_k_history"),
+        "批量历史命中数",
+        "Batch 请求检索历史译文的最大命中数。",
+        "int",
+        4,
+        "批量 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_rag_top_k_terms",
+        ("batch", "rag", "top_k_terms"),
+        "批量术语命中数",
+        "Batch 请求检索术语/短语的最大命中数。",
+        "int",
+        8,
+        "批量 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_rag_min_similarity",
+        ("batch", "rag", "min_similarity"),
+        "批量相似度阈值",
+        "Batch RAG 命中的最低相似度。",
+        "float",
+        0.72,
+        "批量 RAG",
+        minimum=0.0,
+        maximum=1.0,
+    ),
+    SettingField(
+        "batch_rag_segment_lines",
+        ("batch", "rag", "segment_lines"),
+        "批量索引分段行数",
+        "预建批量记忆库时每段合并的行数。",
+        "int",
+        4,
+        "批量 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_rag_history_char_limit",
+        ("batch", "rag", "history_char_limit"),
+        "批量历史字符上限",
+        "Batch RAG 单条历史命中注入 prompt 前的截断上限。",
+        "int",
+        220,
+        "批量 RAG",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_rag_store_dir",
+        ("batch", "rag", "store_dir"),
+        "批量 RAG 存储路径",
+        "留空时使用当前 context storage 默认路径。",
+        "str",
+        "",
+        "批量 RAG",
+        allow_empty=True,
+    ),
+    SettingField(
+        "batch_source_index_top_k",
+        ("batch", "source_index", "top_k"),
+        "原文索引命中数",
+        "Batch 请求检索原文索引的最大命中数。",
+        "int",
+        4,
+        "原文索引",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_source_index_min_similarity",
+        ("batch", "source_index", "min_similarity"),
+        "原文索引相似度阈值",
+        "原文索引命中的最低相似度。",
+        "float",
+        0.72,
+        "原文索引",
+        minimum=0.0,
+        maximum=1.0,
+    ),
+    SettingField(
+        "batch_source_index_char_limit",
+        ("batch", "source_index", "char_limit"),
+        "原文索引字符上限",
+        "单条原文索引命中注入 prompt 前的截断上限。",
+        "int",
+        220,
+        "原文索引",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_source_index_store_dir",
+        ("batch", "source_index", "store_dir"),
+        "原文索引存储路径",
+        "留空时使用当前 context storage 默认路径。",
+        "str",
+        "",
+        "原文索引",
+        allow_empty=True,
+    ),
+    SettingField(
+        "sync_story_memory_enabled",
+        ("sync", "story_memory", "enabled"),
+        "启用同步剧情记忆",
+        "同步翻译时注入本地 story_graph 上下文。",
+        "bool",
+        False,
+        "同步剧情记忆",
+    ),
+    SettingField(
+        "sync_story_memory_graph_file",
+        ("sync", "story_memory", "graph_file"),
+        "同步剧情图谱路径",
+        "留空时使用当前 context storage 默认 story_graph 路径。",
+        "str",
+        "",
+        "同步剧情记忆",
+        allow_empty=True,
+    ),
+    SettingField(
+        "sync_story_memory_max_context_chars",
+        ("sync", "story_memory", "max_context_chars"),
+        "同步剧情字符预算",
+        "同步翻译注入剧情记忆的最大字符预算。",
+        "int",
+        800,
+        "同步剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_story_memory_top_k_relations",
+        ("sync", "story_memory", "top_k_relations"),
+        "同步关系命中数",
+        "同步剧情记忆检索关系的最大命中数。",
+        "int",
+        4,
+        "同步剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_story_memory_top_k_terms",
+        ("sync", "story_memory", "top_k_terms"),
+        "同步剧情术语命中数",
+        "同步剧情记忆检索术语的最大命中数。",
+        "int",
+        8,
+        "同步剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "sync_story_memory_include_scene_summary",
+        ("sync", "story_memory", "include_scene_summary"),
+        "同步包含场景摘要",
+        "同步剧情记忆命中时把场景摘要也注入 prompt。",
+        "bool",
+        True,
+        "同步剧情记忆",
+    ),
+    SettingField(
+        "batch_story_memory_enabled",
+        ("batch", "story_memory", "enabled"),
+        "启用批量剧情记忆",
+        "Batch 构建时注入本地 story_graph 上下文。",
+        "bool",
+        False,
+        "批量剧情记忆",
+    ),
+    SettingField(
+        "batch_story_memory_graph_file",
+        ("batch", "story_memory", "graph_file"),
+        "批量剧情图谱路径",
+        "留空时使用当前 context storage 默认 story_graph 路径。",
+        "str",
+        "",
+        "批量剧情记忆",
+        allow_empty=True,
+    ),
+    SettingField(
+        "batch_story_memory_max_context_chars",
+        ("batch", "story_memory", "max_context_chars"),
+        "批量剧情字符预算",
+        "Batch 请求注入剧情记忆的最大字符预算。",
+        "int",
+        1200,
+        "批量剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_story_memory_top_k_relations",
+        ("batch", "story_memory", "top_k_relations"),
+        "批量关系命中数",
+        "Batch 剧情记忆检索关系的最大命中数。",
+        "int",
+        6,
+        "批量剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_story_memory_top_k_terms",
+        ("batch", "story_memory", "top_k_terms"),
+        "批量剧情术语命中数",
+        "Batch 剧情记忆检索术语的最大命中数。",
+        "int",
+        12,
+        "批量剧情记忆",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_story_memory_include_scene_summary",
+        ("batch", "story_memory", "include_scene_summary"),
+        "批量包含场景摘要",
+        "Batch 剧情记忆命中时把场景摘要也注入 prompt。",
+        "bool",
+        True,
+        "批量剧情记忆",
+    ),
+)
+
+
+FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
+    SettingField(
+        "game_root",
+        ("game_root",),
+        "游戏 work 目录",
+        "当前项目的 work 目录；通常建议在工作台选择项目。",
+        "str",
+        "",
+        "项目与资源",
+    ),
+    SettingField(
+        "glossary_file",
+        ("glossary_file",),
+        "术语表路径",
+        "glossary.json 路径；留空时使用默认术语表路径。",
+        "str",
+        "glossary.json",
+        "项目与资源",
+        allow_empty=True,
+    ),
+    SettingField(
+        "tl_subdir",
+        ("tl_subdir",),
+        "翻译目录",
+        "相对 work 目录的 Ren'Py 翻译目录。",
+        "str",
+        "game/tl/schinese",
+        "项目与资源",
+        allow_empty=True,
+    ),
+    SettingField(
+        "include_files",
+        ("include_files",),
+        "仅包含文件",
+        "可选过滤列表；每行一个相对路径。留空表示不过滤。",
+        "list",
+        [],
+        "项目与资源",
+        allow_empty=True,
+    ),
+    SettingField(
+        "include_prefixes",
+        ("include_prefixes",),
+        "仅包含路径前缀",
+        "可选过滤列表；每行一个相对路径前缀。留空表示不过滤。",
+        "list",
+        [],
+        "项目与资源",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_enabled",
+        ("prepare", "enabled"),
+        "启用准备流程",
+        "允许 build 前准备 work 目录、解包和生成翻译模板。",
+        "bool",
+        True,
+        "准备流程",
+    ),
+    SettingField(
+        "prepare_source_game_dir",
+        ("prepare", "source_game_dir"),
+        "源 game 目录",
+        "准备流程复制/生成模板时使用的原始 game 目录。",
+        "str",
+        "../original/game",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_unpack_rpa",
+        ("prepare", "unpack_rpa"),
+        "解包 RPA",
+        "准备流程中是否尝试解包 .rpa 资源。",
+        "bool",
+        True,
+        "准备流程",
+    ),
+    SettingField(
+        "prepare_generate_template",
+        ("prepare", "generate_template"),
+        "生成翻译模板",
+        "准备流程中是否调用 Ren'Py 生成翻译模板。",
+        "bool",
+        True,
+        "准备流程",
+    ),
+    SettingField(
+        "prepare_refresh_existing_template",
+        ("prepare", "refresh_existing_template"),
+        "刷新已有模板",
+        "已存在翻译模板时是否允许准备流程刷新。",
+        "bool",
+        True,
+        "准备流程",
+    ),
+    SettingField(
+        "prepare_language",
+        ("prepare", "language"),
+        "模板语言代码",
+        "Ren'Py generate_translations 使用的语言目录名。",
+        "str",
+        "schinese",
+        "准备流程",
+    ),
+    SettingField(
+        "prepare_renpy_sdk_dir",
+        ("prepare", "renpy_sdk_dir"),
+        "Ren'Py SDK 目录",
+        "留空时自动发现或使用 RENPY_SDK_DIR 环境变量。",
+        "str",
+        "",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_python_exe",
+        ("prepare", "python_exe"),
+        "准备流程 Python",
+        "自定义 Python 可执行文件路径；留空时使用默认。",
+        "str",
+        "",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_launcher_py",
+        ("prepare", "launcher_py"),
+        "Ren'Py launcher.py",
+        "自定义 Ren'Py launcher.py 路径；留空时使用 SDK 默认路径。",
+        "str",
+        "",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_unpack_command",
+        ("prepare", "unpack_command"),
+        "自定义解包命令",
+        "可填命令字符串，或 JSON 数组。留空使用内置解包流程。",
+        "json",
+        "",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "prepare_template_command",
+        ("prepare", "template_command"),
+        "自定义模板命令",
+        "可填命令字符串，或 JSON 数组。留空使用内置模板流程。",
+        "json",
+        "",
+        "准备流程",
+        allow_empty=True,
+    ),
+    SettingField(
+        "batch_retry_chunk_size",
+        ("batch", "retry_chunk_size"),
+        "补译 chunk 条数",
+        "build-retry 生成补译请求时每个 chunk 的最大条目数。",
+        "int",
+        8,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_retry_max_source_chars",
+        ("batch", "retry_max_source_chars"),
+        "补译原文字符上限",
+        "build-retry 生成补译请求时每个 chunk 的原文字符预算。",
+        "int",
+        4000,
+        "翻译吞吐",
+        minimum=1,
+    ),
+    SettingField(
+        "batch_safety_settings",
+        ("batch", "safety_settings"),
+        "Batch safety settings",
+        "可填 relaxed_adult 等预设，或 Google safety settings JSON 数组。留空表示默认。",
+        "json",
+        [],
+        "翻译吞吐",
+        allow_empty=True,
+    ),
+    SettingField(
+        "batch_macro_setting_file",
+        ("batch", "macro_setting_file"),
+        "风格设定文件",
+        "macro_setting.md 路径；通常位于当前 work 目录。",
+        "str",
+        "macro_setting.md",
+        "术语与风格",
+        allow_empty=True,
+    ),
+    SettingField(
+        "batch_macro_setting",
+        ("batch", "macro_setting"),
+        "内联风格设定",
+        "直接写入 prompt 的风格设定文本；留空时读取风格设定文件。",
+        "text",
+        "",
+        "术语与风格",
+        allow_empty=True,
+    ),
+    SettingField(
+        "keyword_chunk_size",
+        ("batch", "keyword_extraction", "chunk_size"),
+        "关键词 chunk 条数",
+        "批量关键词提取每个请求的最大条目数。",
+        "int",
+        40,
+        "关键词提取",
+        minimum=1,
+    ),
+    SettingField(
+        "keyword_max_candidates_per_chunk",
+        ("batch", "keyword_extraction", "max_candidates_per_chunk"),
+        "每 chunk 候选上限",
+        "关键词提取每个 chunk 允许返回的候选数量。",
+        "int",
+        12,
+        "关键词提取",
+        minimum=1,
+    ),
+    SettingField(
+        "keyword_display_name_prefix",
+        ("batch", "keyword_extraction", "display_name_prefix"),
+        "关键词任务名称前缀",
+        "提交关键词 Batch 任务时使用的 display name 前缀。",
+        "str",
+        "renpy-keywords",
+        "关键词提取",
+        allow_empty=True,
+    ),
+    SettingField(
+        "revision_chunk_size",
+        ("batch", "revision", "chunk_size"),
+        "订正 chunk 条数",
+        "批量订正每个请求的最大条目数。",
+        "int",
+        6,
+        "订正",
+        minimum=1,
+    ),
+    SettingField(
+        "revision_display_name_prefix",
+        ("batch", "revision", "display_name_prefix"),
+        "订正任务名称前缀",
+        "提交订正 Batch 任务时使用的 display name 前缀。",
+        "str",
+        "renpy-revise",
+        "订正",
+        allow_empty=True,
+    ),
+    SettingField(
+        "sync_rag_query_task_type",
+        ("sync", "rag", "query_task_type"),
+        "同步查询 task type",
+        "同步 RAG 查询 embedding 的 task type。",
+        "str",
+        "RETRIEVAL_QUERY",
+        "同步 RAG",
+    ),
+    SettingField(
+        "sync_rag_document_task_type",
+        ("sync", "rag", "document_task_type"),
+        "同步文档 task type",
+        "同步 RAG 写入文档 embedding 的 task type。",
+        "str",
+        "RETRIEVAL_DOCUMENT",
+        "同步 RAG",
+    ),
+    SettingField(
+        "batch_rag_query_task_type",
+        ("batch", "rag", "query_task_type"),
+        "批量查询 task type",
+        "Batch RAG 查询 embedding 的 task type。",
+        "str",
+        "RETRIEVAL_QUERY",
+        "批量 RAG",
+    ),
+    SettingField(
+        "batch_rag_document_task_type",
+        ("batch", "rag", "document_task_type"),
+        "批量文档 task type",
+        "Batch RAG / 原文索引写入文档 embedding 的 task type。",
+        "str",
+        "RETRIEVAL_DOCUMENT",
+        "批量 RAG",
+    ),
+)
+
+ADVANCED_SETTING_FIELDS = FULL_COVERAGE_SETTING_FIELDS + ADVANCED_SETTING_FIELDS
+
+
+ADVANCED_SETTING_FIELD_BY_KEY = {field.key: field for field in ADVANCED_SETTING_FIELDS}
+
+
+def grouped_advanced_fields() -> list[tuple[str, list[SettingField]]]:
+    groups: list[tuple[str, list[SettingField]]] = []
+    by_category: dict[str, list[SettingField]] = {}
+    for field in ADVANCED_SETTING_FIELDS:
+        if field.category not in by_category:
+            by_category[field.category] = []
+            groups.append((field.category, by_category[field.category]))
+        by_category[field.category].append(field)
+    return groups
+
+
+def read_advanced_settings(config: dict[str, Any]) -> dict[str, SettingValue]:
+    return {field.key: read_setting(config, field) for field in ADVANCED_SETTING_FIELDS}
+
+
+def recommended_advanced_settings() -> dict[str, SettingValue]:
+    return {field.key: field.recommended_value for field in ADVANCED_SETTING_FIELDS}
+
+
+def validate_advanced_settings(values: dict[str, Any]) -> dict[str, str]:
+    errors: dict[str, str] = {}
+    for field in ADVANCED_SETTING_FIELDS:
+        error = validate_value(field, values.get(field.key))
+        if error:
+            errors[field.key] = error
+    return errors
+
+
+def apply_advanced_settings(
+    config: dict[str, Any],
+    values: dict[str, Any],
+) -> dict[str, Any]:
+    errors = validate_advanced_settings(values)
+    if errors:
+        first = next(iter(errors.values()))
+        raise ValueError(first)
+
+    for field in ADVANCED_SETTING_FIELDS:
+        set_nested_value(config, field.path, normalize_for_write(field, values[field.key]))
+    return config
+
+
+def read_setting(config: dict[str, Any], field: SettingField) -> SettingValue:
+    raw = get_nested_value(config, field.path)
+    if raw is None:
+        return field.default
+    try:
+        return normalize_for_write(field, raw)
+    except ValueError:
+        return field.default
+
+
+def validate_value(field: SettingField, value: Any) -> str:
+    try:
+        normalized = normalize_for_write(field, value)
+    except ValueError as exc:
+        return str(exc)
+
+    if field.kind in {"str", "text"}:
+        if not field.allow_empty and not str(normalized).strip():
+            return f"{field.label}不能为空。"
+        return ""
+
+    if field.kind in {"bool", "list", "json"}:
+        return ""
+
+    number = float(normalized)
+    if field.minimum is not None and number < field.minimum:
+        if field.kind == "int" and field.minimum == 1:
+            return f"{field.label}必须是大于 0 的整数。"
+        return f"{field.label}不能小于 {field.minimum:g}。"
+    if field.maximum is not None and number > field.maximum:
+        return f"{field.label}不能大于 {field.maximum:g}。"
+    return ""
+
+
+def normalize_for_write(field: SettingField, value: Any) -> SettingValue:
+    if field.kind == "bool":
+        if isinstance(value, bool):
+            return value
+        raise ValueError(f"{field.label}必须是布尔值。")
+
+    if field.kind == "int":
+        if isinstance(value, bool):
+            raise ValueError(f"{field.label}必须是整数。")
+        try:
+            if isinstance(value, str) and not value.strip():
+                raise ValueError
+            return int(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{field.label}必须是整数。") from None
+
+    if field.kind == "float":
+        if isinstance(value, bool):
+            raise ValueError(f"{field.label}必须是数字。")
+        try:
+            if isinstance(value, str) and not value.strip():
+                raise ValueError
+            return float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{field.label}必须是数字。") from None
+
+    if field.kind in {"str", "text"}:
+        return value.strip() if isinstance(value, str) else str(value).strip()
+
+    if field.kind == "list":
+        return normalize_list_value(field, value)
+
+    if field.kind == "json":
+        return normalize_json_value(field, value)
+
+    raise ValueError(f"Unsupported setting type: {field.kind}")
+
+
+def normalize_list_value(field: SettingField, value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{field.label}必须是 JSON 数组或逐行列表。") from exc
+            value = parsed
+        else:
+            value = [part.strip() for line in text.splitlines() for part in line.split(",")]
+    if not isinstance(value, (list, tuple, set)):
+        raise ValueError(f"{field.label}必须是列表。")
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def normalize_json_value(field: SettingField, value: Any) -> Any:
+    if value is None:
+        return field.default if field.allow_empty else None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return field.default if field.allow_empty else ""
+        if text.startswith("[") or text.startswith("{"):
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{field.label}必须是有效 JSON。") from exc
+        return text
+    return value
+
+
+def get_nested_value(config: dict[str, Any], path: Iterable[str]) -> Any:
+    current: Any = config
+    for part in path:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def set_nested_value(config: dict[str, Any], path: tuple[str, ...], value: SettingValue) -> None:
+    current: dict[str, Any] = config
+    for part in path[:-1]:
+        existing = current.get(part)
+        if not isinstance(existing, dict):
+            existing = {}
+            current[part] = existing
+        current = existing
+    current[path[-1]] = value
+

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -462,6 +462,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+            def normalize_game_root(self, path):
+                return Path("C:/Game/work"), False
             def load_translator_config(self):
                 return config
             def save_translator_config(self, saved_config):
@@ -499,6 +501,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._batch_thinking_user_changed = False
         self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
         self.window._append_log = lambda _text: None
+        self.window._refresh_project_label = lambda: None
         self.window.statusBar = lambda: FakeStatusBar()
 
         saved = self.window._on_save_config()
@@ -523,6 +526,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+            def normalize_game_root(self, path):
+                return Path("C:/Game/work"), False
             def load_translator_config(self):
                 return config
             def save_translator_config(self, saved_config):
@@ -560,6 +565,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._batch_thinking_user_changed = False
         self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
         self.window._append_log = lambda _text: None
+        self.window._refresh_project_label = lambda: None
         self.window.statusBar = lambda: FakeStatusBar()
 
         saved = self.window._on_save_config()
@@ -584,6 +590,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+            def normalize_game_root(self, path):
+                return Path("C:/Game/work"), False
             def load_translator_config(self):
                 return config
             def save_translator_config(self, saved_config):
@@ -636,6 +644,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window.batch_embedding_combo = FakeCombo("gemini-embedding-001")
         self.window.batch_thinking_combo = FakeCombo(data="minimal")
         self.window.theme_combo = FakeCombo(data="dark")
+        self.window._refresh_project_label = lambda: None
         self.window._advanced_setting_widgets = {
             "game_root": FakeText("C:/Game/work"),
             "batch_chunk_size": FakeValue(12),
@@ -767,6 +776,75 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(nav.row, 4)
         self.assertTrue(invalid_widget.focused)
         self.assertEqual(status_bar.messages[-1][0], "高级设置有无效字段，未保存。")
+
+    def test_focus_advanced_setting_navigates_to_project_page_for_project_fields(self):
+        class FakeNav:
+            def __init__(self):
+                self.row = None
+
+            def setCurrentRow(self, row):
+                self.row = row
+
+        class FakeText:
+            def __init__(self):
+                self.focused = False
+
+            def setFocus(self):
+                self.focused = True
+
+        nav = FakeNav()
+        widget = FakeText()
+        self.window.settings_nav = nav
+        self.window._settings_nav_rows = {"project": 1, "advanced": 5}
+        self.window._advanced_setting_widgets = {"game_root": widget}
+
+        self.window._focus_advanced_setting("game_root")
+
+        self.assertEqual(nav.row, 1)
+        self.assertTrue(widget.focused)
+
+    def test_sync_state_game_root_from_settings_switches_root_when_changed(self):
+        class FakeState:
+            def __init__(self):
+                self._game_root = Path("C:/Game/old_work")
+
+            def get_game_root(self):
+                return self._game_root
+
+            def normalize_game_root(self, path):
+                return Path(str(path).replace("\\", "/")), False
+
+        switched = []
+        self.window.state = FakeState()
+        self.window._switch_game_root = lambda directory: switched.append(directory) or True
+
+        result = self.window._sync_state_game_root_from_settings("C:/Game/new_work")
+
+        self.assertTrue(result)
+        self.assertEqual(switched, ["C:/Game/new_work"])
+
+    def test_sync_state_game_root_from_settings_skips_switch_when_unchanged(self):
+        class FakeState:
+            def __init__(self):
+                self._game_root = Path("C:/Game/work")
+
+            def get_game_root(self):
+                return self._game_root
+
+            def normalize_game_root(self, path):
+                return Path("C:/Game/work"), False
+
+        switched = []
+        refreshed = []
+        self.window.state = FakeState()
+        self.window._switch_game_root = lambda directory: switched.append(directory) or True
+        self.window._refresh_project_label = lambda: refreshed.append(True)
+
+        result = self.window._sync_state_game_root_from_settings("C:/Game/work")
+
+        self.assertTrue(result)
+        self.assertEqual(switched, [])
+        self.assertEqual(refreshed, [True])
 
     def test_restore_recommended_config_updates_basic_and_advanced_widgets(self):
         class FakeCheckBox:

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -567,6 +567,332 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertTrue(saved)
         self.assertEqual(saved_configs[0]["context_storage"]["game_dir_name"], "my_context")
 
+    def test_save_config_persists_advanced_settings_and_theme(self):
+        from gui_qt.work_modes import WorkMode
+
+        saved_configs = []
+        config = {
+            "sync": {"rag": {}, "custom": 1},
+            "batch": {
+                "rag": {},
+                "source_index": {},
+                "model": "gemini-3.1-flash-lite",
+                "custom": "keep",
+            },
+        }
+
+        class FakeState:
+            def get_game_root(self):
+                return Path("C:/Game/work")
+            def load_translator_config(self):
+                return config
+            def save_translator_config(self, saved_config):
+                saved_configs.append(saved_config)
+
+        class FakeCheckBox:
+            def __init__(self, checked):
+                self._checked = checked
+            def isChecked(self):
+                return self._checked
+
+        class FakeCombo:
+            def __init__(self, text="", data=""):
+                self._text = text
+                self._data = data
+            def currentText(self):
+                return self._text
+            def currentData(self):
+                return self._data
+
+        class FakeText:
+            def __init__(self, text):
+                self._text = text
+                self.focused = False
+            def text(self):
+                return self._text
+            def setFocus(self):
+                self.focused = True
+
+        class FakeValue:
+            def __init__(self, value):
+                self._value = value
+            def value(self):
+                return self._value
+            def setFocus(self):
+                pass
+
+        class FakeStatusBar:
+            def showMessage(self, text, timeout):
+                pass
+
+        self.window.state = FakeState()
+        self.window.rag_enabled_cb = FakeCheckBox(True)
+        self.window.source_index_enabled_cb = FakeCheckBox(True)
+        self.window.bootstrap_on_build_cb = FakeCheckBox(False)
+        self.window.context_storage_game_cb = FakeCheckBox(True)
+        self.window.sync_model_combo = FakeCombo("gemini-sync")
+        self.window.batch_model_combo = FakeCombo("gemini-3.1-flash-lite")
+        self.window.sync_embedding_combo = FakeCombo("gemini-embedding-001")
+        self.window.batch_embedding_combo = FakeCombo("gemini-embedding-001")
+        self.window.batch_thinking_combo = FakeCombo(data="minimal")
+        self.window.theme_combo = FakeCombo(data="dark")
+        self.window._advanced_setting_widgets = {
+            "game_root": FakeText("C:/Game/work"),
+            "batch_chunk_size": FakeValue(12),
+            "batch_temperature": FakeValue(0.4),
+            "context_storage_game_dir_name": FakeText("custom_context"),
+            "include_files": FakeText("chapter01.rpy\nchapter02.rpy"),
+            "prepare_unpack_command": FakeText("[\"python\", \"unpack.py\"]"),
+            "batch_safety_settings": FakeText("relaxed_adult"),
+            "batch_macro_setting": FakeText("Use a concise voice.\nKeep honorifics."),
+            "batch_source_index_store_dir": FakeText("C:/ctx/source"),
+        }
+        self.window._advanced_setting_error_labels = {}
+        self.window._settings_nav_rows = {}
+        self.window._batch_thinking_user_changed = False
+        self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
+        self.window._append_log = lambda _text: None
+        self.window.statusBar = lambda: FakeStatusBar()
+
+        saved = self.window._on_save_config()
+
+        self.assertTrue(saved)
+        self.assertEqual(len(saved_configs), 1)
+        saved_config = saved_configs[0]
+        self.assertEqual(saved_config["gui"]["theme"], "dark")
+        self.assertEqual(saved_config["sync"]["custom"], 1)
+        self.assertEqual(saved_config["batch"]["custom"], "keep")
+        self.assertEqual(saved_config["game_root"], "C:/Game/work")
+        self.assertEqual(saved_config["batch"]["chunk_size"], 12)
+        self.assertEqual(saved_config["batch"]["temperature"], 0.4)
+        self.assertEqual(saved_config["context_storage"]["game_dir_name"], "custom_context")
+        self.assertEqual(saved_config["include_files"], ["chapter01.rpy", "chapter02.rpy"])
+        self.assertEqual(saved_config["prepare"]["unpack_command"], ["python", "unpack.py"])
+        self.assertEqual(saved_config["batch"]["safety_settings"], "relaxed_adult")
+        self.assertEqual(saved_config["batch"]["macro_setting"], "Use a concise voice.\nKeep honorifics.")
+        self.assertEqual(saved_config["batch"]["source_index"]["store_dir"], "C:/ctx/source")
+
+    def test_save_config_validation_error_blocks_write(self):
+        from gui_qt.work_modes import WorkMode
+
+        saved_configs = []
+        config = {
+            "sync": {"rag": {}},
+            "batch": {"rag": {}, "source_index": {}, "model": "gemini-3.1-flash-lite"},
+        }
+
+        class FakeState:
+            def get_game_root(self):
+                return Path("C:/Game/work")
+            def load_translator_config(self):
+                return config
+            def save_translator_config(self, saved_config):
+                saved_configs.append(saved_config)
+
+        class FakeCheckBox:
+            def __init__(self, checked):
+                self._checked = checked
+            def isChecked(self):
+                return self._checked
+
+        class FakeCombo:
+            def __init__(self, text="", data=""):
+                self._text = text
+                self._data = data
+            def currentText(self):
+                return self._text
+            def currentData(self):
+                return self._data
+
+        class FakeText:
+            def __init__(self, text):
+                self._text = text
+                self.focused = False
+            def text(self):
+                return self._text
+            def setFocus(self):
+                self.focused = True
+
+        class FakeLabel:
+            def __init__(self):
+                self.text = ""
+            def setText(self, value):
+                self.text = value
+
+        class FakeNav:
+            def __init__(self):
+                self.row = None
+            def setCurrentRow(self, row):
+                self.row = row
+
+        class FakeStatusBar:
+            def __init__(self):
+                self.messages = []
+            def showMessage(self, text, timeout):
+                self.messages.append((text, timeout))
+
+        invalid_widget = FakeText("")
+        error_label = FakeLabel()
+        nav = FakeNav()
+        status_bar = FakeStatusBar()
+        self.window.state = FakeState()
+        self.window.rag_enabled_cb = FakeCheckBox(True)
+        self.window.source_index_enabled_cb = FakeCheckBox(False)
+        self.window.bootstrap_on_build_cb = FakeCheckBox(True)
+        self.window.context_storage_game_cb = FakeCheckBox(True)
+        self.window.sync_model_combo = FakeCombo("gemini-sync")
+        self.window.batch_model_combo = FakeCombo("gemini-3.1-flash-lite")
+        self.window.sync_embedding_combo = FakeCombo("gemini-embedding-001")
+        self.window.batch_embedding_combo = FakeCombo("gemini-embedding-001")
+        self.window.batch_thinking_combo = FakeCombo(data="minimal")
+        self.window.theme_combo = FakeCombo(data="system")
+        self.window._advanced_setting_widgets = {
+            "context_storage_game_dir_name": invalid_widget,
+        }
+        self.window._advanced_setting_error_labels = {
+            "context_storage_game_dir_name": error_label,
+        }
+        self.window._settings_nav_rows = {"advanced": 4}
+        self.window.settings_nav = nav
+        self.window._batch_thinking_user_changed = False
+        self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
+        self.window._append_log = lambda _text: None
+        self.window.statusBar = lambda: status_bar
+
+        saved = self.window._on_save_config()
+
+        self.assertFalse(saved)
+        self.assertEqual(saved_configs, [])
+        self.assertIn("不能为空", error_label.text)
+        self.assertEqual(nav.row, 4)
+        self.assertTrue(invalid_widget.focused)
+        self.assertEqual(status_bar.messages[-1][0], "高级设置有无效字段，未保存。")
+
+    def test_restore_recommended_config_updates_basic_and_advanced_widgets(self):
+        class FakeCheckBox:
+            def __init__(self):
+                self.checked = None
+            def setChecked(self, value):
+                self.checked = value
+            def isChecked(self):
+                return bool(self.checked)
+
+        class FakeCombo:
+            def __init__(self):
+                self.items = []
+                self.current_index = -1
+                self.current_data = ""
+            def findText(self, text):
+                try:
+                    return self.items.index((text, text))
+                except ValueError:
+                    return -1
+            def addItem(self, text, data=None):
+                self.items.append((text, text if data is None else data))
+            def count(self):
+                return len(self.items)
+            def setCurrentIndex(self, index):
+                self.current_index = index
+                if 0 <= index < len(self.items):
+                    self.current_data = self.items[index][1]
+            def findData(self, data):
+                for index, (_text, item_data) in enumerate(self.items):
+                    if item_data == data:
+                        return index
+                return -1
+            def currentText(self):
+                if 0 <= self.current_index < len(self.items):
+                    return self.items[self.current_index][0]
+                return ""
+            def currentData(self):
+                return self.current_data
+
+        class FakeValue:
+            def __init__(self):
+                self.saved = None
+            def setValue(self, value):
+                self.saved = value
+            def value(self):
+                return self.saved
+
+        class FakeText:
+            def __init__(self):
+                self.saved = None
+            def setText(self, value):
+                self.saved = value
+            def text(self):
+                return self.saved or ""
+
+        class FakeLabel:
+            def __init__(self):
+                self.text = "stale"
+            def setText(self, value):
+                self.text = value
+
+        class FakeStatusBar:
+            def __init__(self):
+                self.messages = []
+            def showMessage(self, text, timeout):
+                self.messages.append((text, timeout))
+
+        self.window.rag_enabled_cb = FakeCheckBox()
+        self.window.source_index_enabled_cb = FakeCheckBox()
+        self.window.bootstrap_on_build_cb = FakeCheckBox()
+        self.window.context_storage_game_cb = FakeCheckBox()
+        self.window.sync_model_combo = FakeCombo()
+        self.window.batch_model_combo = FakeCombo()
+        self.window.sync_embedding_combo = FakeCombo()
+        self.window.batch_embedding_combo = FakeCombo()
+        self.window.batch_thinking_combo = FakeCombo()
+        for text, data in (("（不启用）", ""), ("最小", "minimal")):
+            self.window.batch_thinking_combo.addItem(text, data)
+        self.window.theme_combo = FakeCombo()
+        for text, data in (("跟随系统", "system"), ("浅色", "light"), ("深色", "dark")):
+            self.window.theme_combo.addItem(text, data)
+        batch_chunk = FakeValue()
+        context_dir = FakeText()
+        error_label = FakeLabel()
+        self.window._advanced_setting_widgets = {
+            "batch_chunk_size": batch_chunk,
+            "context_storage_game_dir_name": context_dir,
+        }
+        self.window._advanced_setting_error_labels = {
+            "batch_chunk_size": error_label,
+        }
+        self.window._qt_app = None
+        status_bar = FakeStatusBar()
+        self.window.statusBar = lambda: status_bar
+
+        self.window._on_restore_recommended_config()
+
+        self.assertTrue(self.window.rag_enabled_cb.checked)
+        self.assertFalse(self.window.source_index_enabled_cb.checked)
+        self.assertEqual(self.window.sync_model_combo.currentText(), "gemini-3.1-flash-lite")
+        self.assertEqual(self.window.batch_embedding_combo.currentText(), "gemini-embedding-001")
+        self.assertEqual(self.window.batch_thinking_combo.currentData(), "minimal")
+        self.assertEqual(self.window.theme_combo.currentData(), "system")
+        self.assertEqual(batch_chunk.saved, 60)
+        self.assertEqual(context_dir.saved, "translation_context")
+        self.assertEqual(error_label.text, "")
+        self.assertEqual(status_bar.messages[-1][0], "已恢复推荐值，保存后生效。")
+
+    def test_theme_change_previews_without_persisting(self):
+        class FakeCombo:
+            def currentData(self):
+                return "dark"
+
+        calls = []
+        self.window._loading_config_to_ui = False
+        self.window._loading_theme_to_ui = False
+        self.window.theme_combo = FakeCombo()
+        self.window._set_theme_preference = lambda preference, persist: calls.append(
+            (preference, persist)
+        )
+
+        self.window._on_theme_changed(0)
+
+        self.assertEqual(calls, [("dark", False)])
+
     def test_load_config_reads_legacy_context_storage_location(self):
         config = {
             "context_storage_location": "game",
@@ -1174,7 +1500,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def setInformativeText(self, text):
                 pass
             def addButton(self, text, role):
-                button = self._stay_btn if text == "留在配置页" else object()
+                button = self._stay_btn if text == "留在设置页" else object()
                 self._buttons.append((text, button))
                 return button
             def setDefaultButton(self, button):

--- a/tests/test_gui_settings_schema.py
+++ b/tests/test_gui_settings_schema.py
@@ -1,0 +1,153 @@
+import unittest
+
+from gui_qt.settings_schema import (
+    ADVANCED_SETTING_FIELD_BY_KEY,
+    apply_advanced_settings,
+    read_advanced_settings,
+    recommended_advanced_settings,
+    validate_advanced_settings,
+)
+
+
+class GuiSettingsSchemaTests(unittest.TestCase):
+    def test_read_advanced_settings_uses_defaults_for_missing_config(self):
+        values = read_advanced_settings({})
+
+        self.assertEqual(values["sync_chunk_size"], 40)
+        self.assertEqual(values["batch_chunk_size"], 60)
+        self.assertEqual(values["batch_temperature"], 0.2)
+        self.assertEqual(values["batch_source_index_min_similarity"], 0.72)
+        self.assertEqual(values["context_storage_game_dir_name"], "translation_context")
+        self.assertEqual(values["batch_rag_store_dir"], "")
+
+    def test_read_advanced_settings_coerces_valid_existing_values(self):
+        values = read_advanced_settings(
+            {
+                "sync": {
+                    "chunk_size": "7",
+                    "rag": {
+                        "enabled": True,
+                        "min_similarity": "0.5",
+                        "store_dir": " logs/sync_rag ",
+                    },
+                },
+                "batch": {
+                    "temperature": "0.6",
+                    "source_index": {"top_k": "3"},
+                    "story_memory": {"include_scene_summary": False},
+                },
+            }
+        )
+
+        self.assertEqual(values["sync_chunk_size"], 7)
+        self.assertTrue(values["sync_rag_enabled"])
+        self.assertEqual(values["sync_rag_min_similarity"], 0.5)
+        self.assertEqual(values["sync_rag_store_dir"], "logs/sync_rag")
+        self.assertEqual(values["batch_temperature"], 0.6)
+        self.assertEqual(values["batch_source_index_top_k"], 3)
+        self.assertFalse(values["batch_story_memory_include_scene_summary"])
+
+    def test_validate_advanced_settings_rejects_out_of_range_values(self):
+        values = recommended_advanced_settings()
+        values["batch_chunk_size"] = 0
+        values["batch_temperature"] = 2.5
+        values["sync_rag_min_similarity"] = -0.1
+        values["context_storage_game_dir_name"] = ""
+
+        errors = validate_advanced_settings(values)
+
+        self.assertIn("batch_chunk_size", errors)
+        self.assertIn("batch_temperature", errors)
+        self.assertIn("sync_rag_min_similarity", errors)
+        self.assertIn("context_storage_game_dir_name", errors)
+
+    def test_list_and_json_fields_round_trip_from_text(self):
+        config = {"game_root": "C:/Game/work", "batch": {}}
+        values = recommended_advanced_settings()
+        values["game_root"] = "C:/Game/work"
+        values["include_files"] = "chapter01.rpy\nchapter02.rpy"
+        values["include_prefixes"] = "routes/common, routes/extra"
+        values["batch_safety_settings"] = '[{"category":"sexually_explicit","threshold":"BLOCK_NONE"}]'
+        values["prepare_unpack_command"] = '["python", "unpack.py"]'
+        values["batch_macro_setting"] = "Use a concise voice.\nKeep honorifics."
+
+        saved = apply_advanced_settings(config, values)
+
+        self.assertEqual(saved["include_files"], ["chapter01.rpy", "chapter02.rpy"])
+        self.assertEqual(saved["include_prefixes"], ["routes/common", "routes/extra"])
+        self.assertEqual(
+            saved["batch"]["safety_settings"],
+            [{"category": "sexually_explicit", "threshold": "BLOCK_NONE"}],
+        )
+        self.assertEqual(saved["prepare"]["unpack_command"], ["python", "unpack.py"])
+        self.assertEqual(saved["batch"]["macro_setting"], "Use a concise voice.\nKeep honorifics.")
+
+    def test_invalid_json_field_reports_error(self):
+        values = recommended_advanced_settings()
+        values["game_root"] = "C:/Game/work"
+        values["batch_safety_settings"] = '[{"bad"'
+
+        errors = validate_advanced_settings(values)
+
+        self.assertIn("batch_safety_settings", errors)
+        self.assertIn("有效 JSON", errors["batch_safety_settings"])
+
+    def test_validate_advanced_settings_allows_empty_paths(self):
+        values = recommended_advanced_settings()
+        values["batch_rag_store_dir"] = ""
+        values["batch_source_index_store_dir"] = ""
+        values["batch_story_memory_graph_file"] = ""
+
+        errors = validate_advanced_settings(values)
+
+        self.assertNotIn("batch_rag_store_dir", errors)
+        self.assertNotIn("batch_source_index_store_dir", errors)
+        self.assertNotIn("batch_story_memory_graph_file", errors)
+
+    def test_apply_advanced_settings_preserves_unknown_fields(self):
+        config = {
+            "game_root": "C:/Game/work",
+            "sync": {"model": "gemini-sync", "custom": 1},
+            "batch": {
+                "model": "gemini-batch",
+                "rag": {"enabled": True, "unknown_rag": "keep"},
+                "source_index": {"enabled": True},
+            },
+            "unknown_top": {"keep": True},
+        }
+        values = recommended_advanced_settings()
+        values["game_root"] = "C:/Game/work"
+        values["sync_chunk_size"] = 12
+        values["batch_temperature"] = 0.4
+        values["batch_rag_top_k_history"] = 9
+        values["batch_source_index_store_dir"] = "C:/ctx/source"
+
+        saved = apply_advanced_settings(config, values)
+
+        self.assertIs(saved, config)
+        self.assertEqual(saved["game_root"], "C:/Game/work")
+        self.assertEqual(saved["sync"]["model"], "gemini-sync")
+        self.assertEqual(saved["sync"]["custom"], 1)
+        self.assertEqual(saved["batch"]["model"], "gemini-batch")
+        self.assertTrue(saved["batch"]["rag"]["enabled"])
+        self.assertEqual(saved["batch"]["rag"]["unknown_rag"], "keep")
+        self.assertTrue(saved["batch"]["source_index"]["enabled"])
+        self.assertEqual(saved["unknown_top"], {"keep": True})
+        self.assertEqual(saved["sync"]["chunk_size"], 12)
+        self.assertEqual(saved["batch"]["temperature"], 0.4)
+        self.assertEqual(saved["batch"]["rag"]["top_k_history"], 9)
+        self.assertEqual(saved["batch"]["source_index"]["store_dir"], "C:/ctx/source")
+
+    def test_field_registry_exposes_expected_paths(self):
+        self.assertEqual(
+            ADVANCED_SETTING_FIELD_BY_KEY["batch_source_index_char_limit"].path,
+            ("batch", "source_index", "char_limit"),
+        )
+        self.assertEqual(
+            ADVANCED_SETTING_FIELD_BY_KEY["sync_story_memory_graph_file"].path,
+            ("sync", "story_memory", "graph_file"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refactors the GUI **配置** tab into a **设置** page with left-nav sections and schema-driven advanced field editing for `translator_config.json`.

## Changes

- **New `gui_qt/settings_schema.py`** — Qt-free module defining ~60+ managed fields (metadata, coercion, validation, nested read/write). Preserves unknown config keys on save.
- **Settings page layout** — Left navigation: 账户 / 项目 / 模型 / 上下文 / 外观 / 高级. Bottom action bar: 重新加载 / 恢复推荐值 / 保存设置.
- **Advanced settings in GUI** — Translation throughput, RAG/source-index/story-memory params, prepare flow, filters, safety settings, macro style, keyword/revision options, etc.
- **Theme behavior** — Theme switches preview immediately; persisted only on save.
- **Validation** — Invalid advanced fields are highlighted and block save.
- **Docs & styles** — Updated `docs/gui_workbench.md` and `app_template.qss` for the new layout.

## Test plan

- [x] `pytest tests/test_gui_settings_schema.py tests/test_gui_app_config.py -v` — **57 passed**
- [ ] Manual: open Settings tab, edit advanced fields, verify validation errors and save/reload round-trip
- [ ] Manual: restore recommended values, confirm theme preview vs persisted save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 设置页升级为左侧导航 + 右侧分区堆叠布局，并新增“重新加载”“恢复推荐值”“保存设置”操作。
  * 高级设置支持分组查看、输入类型支持、保存前校验与一键恢复推荐值。
  * 主题切换支持即时预览，保存后生效。
* **Bug 修复**
  * 保存设置时保留未知/未识别字段；无效输入会阻止保存并自动定位错误字段。
* **文档**
  * 更新 GUI 工作台文档中的“设置”术语、页面结构与参数/默认保存位置说明。
* **样式**
  * 统一设置区域外观与导航选中/错误提示样式。
* **测试**
  * 新增/扩充设置读取、校验、应用与持久化相关测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->