### PR TITLE
fix(gui): address Codex PR #128 follow-ups

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -918,7 +918,6 @@ class MainWindow(QMainWindow):
             current_game_root=self.state.get_game_root(),
             get_doctor_report=self._current_registry_doctor_report,
             on_switch_project=self._on_registry_switch_project,
-            auto_discover_on_show=False,
         )
         layout.addWidget(self._games_registry_panel, 1)
         return page
@@ -3128,6 +3127,8 @@ class MainWindow(QMainWindow):
         return None
 
     def _on_registry_switch_project(self, target: str) -> bool:
+        if not self._confirm_unsaved_config_before_registry_switch():
+            return False
         if not self._switch_game_root(target):
             return False
         panel = getattr(self, "_games_registry_panel", None)
@@ -3327,6 +3328,30 @@ class MainWindow(QMainWindow):
         if not self._config_ui_saved_snapshot:
             return False
         return self._current_config_ui_snapshot() != self._config_ui_saved_snapshot
+
+    def _confirm_unsaved_config_before_registry_switch(self) -> bool:
+        if not self._config_tab_has_unsaved_changes():
+            return True
+
+        message = QMessageBox(self)
+        message.setIcon(QMessageBox.Icon.Warning)
+        message.setWindowTitle("设置尚未保存")
+        message.setText("设置页有未保存的更改。")
+        message.setInformativeText(
+            "切换工作区项目会重新加载设置，未保存的更改将丢失。"
+        )
+        save_btn = message.addButton("保存并切换", QMessageBox.ButtonRole.AcceptRole)
+        discard_btn = message.addButton("不保存切换", QMessageBox.ButtonRole.DestructiveRole)
+        cancel_btn = message.addButton("取消", QMessageBox.ButtonRole.RejectRole)
+        message.setDefaultButton(save_btn)
+        message.exec()
+        clicked = message.clickedButton()
+
+        if clicked is save_btn:
+            return self._on_save_config()
+        if clicked is discard_btn:
+            return True
+        return False
 
     def _confirm_leave_config_tab(self, previous_index: int) -> bool:
         message = QMessageBox(self)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -3151,16 +3151,27 @@ class MainWindow(QMainWindow):
     def _on_go_to_workspace_for_project_switch(self) -> None:
         self._focus_settings_section("workspace")
 
+    def _is_config_tab_active(self) -> bool:
+        tab_widget = getattr(self, "tab_widget", None)
+        config_tab = getattr(self, "_config_tab", None)
+        if tab_widget is None or config_tab is None:
+            return False
+        return tab_widget.currentWidget() is config_tab
+
+    def _activate_workspace_registry_section(self) -> None:
+        panel = getattr(self, "_games_registry_panel", None)
+        if panel is None:
+            return
+        panel.set_current_game_root(self.state.get_game_root())
+        panel.activate_section()
+
     def _on_settings_nav_row_changed(self, row: int) -> None:
         if row < 0:
             return
         self.settings_stack.setCurrentIndex(row)
         self._sync_settings_action_bar_enabled(task_running=self._task_running, nav_row=row)
-        if self._settings_nav_rows.get("workspace") == row:
-            panel = getattr(self, "_games_registry_panel", None)
-            if panel is not None:
-                panel.set_current_game_root(self.state.get_game_root())
-                panel.activate_section()
+        if self._settings_nav_rows.get("workspace") == row and self._is_config_tab_active():
+            self._activate_workspace_registry_section()
 
     def _sync_settings_action_bar_enabled(
         self,
@@ -3399,6 +3410,12 @@ class MainWindow(QMainWindow):
 
         if current_widget is self._config_tab:
             self._refresh_api_status()
+            nav = getattr(self, "settings_nav", None)
+            if (
+                nav is not None
+                and self._settings_nav_rows.get("workspace") == nav.currentRow()
+            ):
+                self._activate_workspace_registry_section()
         if current_widget is getattr(self, "_diagnostics_tab", None):
             self._refresh_diagnostics_context()
         self._last_main_tab_index = index

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -819,6 +819,131 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertTrue(save_btn.enabled)
         self.assertTrue(restore_btn.enabled)
 
+    def test_settings_workspace_nav_skips_registry_activate_before_config_tab_open(self):
+        activated = []
+
+        class FakeNav:
+            def currentRow(self):
+                return 0
+
+        class FakeStack:
+            def setCurrentIndex(self, _index):
+                pass
+
+        class FakePanel:
+            def set_current_game_root(self, _root):
+                pass
+
+            def activate_section(self):
+                activated.append(True)
+
+        config_tab = object()
+        other_tab = object()
+        self.window._config_tab = config_tab
+        self.window.tab_widget = type(
+            "FakeTabs",
+            (),
+            {"currentWidget": lambda self: other_tab},
+        )()
+        self.window.settings_nav = FakeNav()
+        self.window.settings_stack = FakeStack()
+        self.window._settings_nav_rows = {"workspace": 0, "project": 1}
+        self.window._games_registry_panel = FakePanel()
+        self.window._task_running = False
+        self.window._sync_settings_action_bar_enabled = lambda **_kwargs: None
+
+        self.window._on_settings_nav_row_changed(0)
+
+        self.assertEqual(activated, [])
+
+    def test_settings_workspace_nav_activates_registry_when_config_tab_open(self):
+        activated = []
+
+        class FakeNav:
+            def currentRow(self):
+                return 0
+
+        class FakeStack:
+            def setCurrentIndex(self, _index):
+                pass
+
+        class FakePanel:
+            def set_current_game_root(self, _root):
+                pass
+
+            def activate_section(self):
+                activated.append(True)
+
+        config_tab = object()
+        self.window._config_tab = config_tab
+        self.window.tab_widget = type(
+            "FakeTabs",
+            (),
+            {"currentWidget": lambda self: config_tab},
+        )()
+        self.window.settings_nav = FakeNav()
+        self.window.settings_stack = FakeStack()
+        self.window._settings_nav_rows = {"workspace": 0, "project": 1}
+        self.window._games_registry_panel = FakePanel()
+        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window._task_running = False
+        self.window._sync_settings_action_bar_enabled = lambda **_kwargs: None
+
+        self.window._on_settings_nav_row_changed(0)
+
+        self.assertEqual(activated, [True])
+
+    def test_opening_config_tab_activates_workspace_registry_section(self):
+        activated = []
+
+        class FakeNav:
+            def __init__(self):
+                self.row = 0
+
+            def currentRow(self):
+                return self.row
+
+        class FakePanel:
+            def set_current_game_root(self, _root):
+                pass
+
+            def activate_section(self):
+                activated.append(True)
+
+        config_tab = object()
+        other_tab = object()
+
+        class FakeTabs:
+            def __init__(self):
+                self.widgets = {0: other_tab, 1: config_tab}
+                self.current_index = 0
+
+            def widget(self, index):
+                return self.widgets[index]
+
+            def setCurrentIndex(self, index):
+                self.current_index = index
+
+            def currentWidget(self):
+                return self.widgets[self.current_index]
+
+        self.window._config_tab = config_tab
+        self.window._diagnostics_tab = object()
+        self.window.tab_widget = FakeTabs()
+        self.window.settings_nav = FakeNav()
+        self.window._settings_nav_rows = {"workspace": 0, "project": 1}
+        self.window._games_registry_panel = FakePanel()
+        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window._handling_config_tab_leave = False
+        self.window._last_main_tab_index = 0
+        self.window._refresh_api_status = lambda: None
+        self.window._refresh_diagnostics_context = lambda: None
+
+        self.window._on_tab_changed(1)
+
+        self.assertEqual(activated, [True])
+        self.assertEqual(self.window._last_main_tab_index, 1)
+
     def test_on_registry_switch_project_focuses_project_section(self):
         switched = []
         focused = []

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -830,6 +830,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._switch_game_root = lambda target: switched.append(target) or True
         self.window._focus_settings_section = lambda key: focused.append(key)
         self.window._show_settings_status = lambda *_args, **_kwargs: None
+        self.window._confirm_unsaved_config_before_registry_switch = lambda: True
         self.window._games_registry_panel = FakePanel()
         self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
 
@@ -838,6 +839,216 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(switched, ["C:/Game/work"])
         self.assertEqual(focused, ["project"])
+
+    def test_on_registry_switch_project_blocked_when_unsaved_changes_cancelled(self):
+        from unittest.mock import patch
+
+        switched = []
+
+        class FakeMessageBox:
+            class Icon:
+                Warning = object()
+
+            class ButtonRole:
+                AcceptRole = object()
+                DestructiveRole = object()
+                RejectRole = object()
+
+            shown = False
+
+            def __init__(self, *_args, **_kwargs):
+                self._cancel_btn = object()
+
+            def setIcon(self, _icon):
+                pass
+
+            def setWindowTitle(self, _title):
+                pass
+
+            def setText(self, _text):
+                pass
+
+            def setInformativeText(self, _text):
+                pass
+
+            def addButton(self, text, _role):
+                return self._cancel_btn if text == "取消" else object()
+
+            def setDefaultButton(self, _button):
+                pass
+
+            def exec(self):
+                FakeMessageBox.shown = True
+
+            def clickedButton(self):
+                return self._cancel_btn
+
+        self.window._loading_config_to_ui = False
+        self.window._config_ui_saved_snapshot = {"dirty": False}
+        self.window._current_config_ui_snapshot = lambda: {"dirty": True}
+        self.window._switch_game_root = lambda target: switched.append(target) or True
+
+        with patch("gui_qt.app.QMessageBox", FakeMessageBox):
+            result = self.window._on_registry_switch_project("C:/Game/work")
+
+        self.assertFalse(result)
+        self.assertEqual(switched, [])
+        self.assertTrue(FakeMessageBox.shown)
+
+    def test_on_registry_switch_project_discards_unsaved_changes_when_confirmed(self):
+        from unittest.mock import patch
+
+        switched = []
+
+        class FakeMessageBox:
+            class Icon:
+                Warning = object()
+
+            class ButtonRole:
+                AcceptRole = object()
+                DestructiveRole = object()
+                RejectRole = object()
+
+            shown = False
+
+            def __init__(self, *_args, **_kwargs):
+                self._discard_btn = object()
+
+            def setIcon(self, _icon):
+                pass
+
+            def setWindowTitle(self, _title):
+                pass
+
+            def setText(self, _text):
+                pass
+
+            def setInformativeText(self, _text):
+                pass
+
+            def addButton(self, text, _role):
+                return self._discard_btn if text == "不保存切换" else object()
+
+            def setDefaultButton(self, _button):
+                pass
+
+            def exec(self):
+                FakeMessageBox.shown = True
+
+            def clickedButton(self):
+                return self._discard_btn
+
+        self.window._loading_config_to_ui = False
+        self.window._config_ui_saved_snapshot = {"dirty": False}
+        self.window._current_config_ui_snapshot = lambda: {"dirty": True}
+        self.window._switch_game_root = lambda target: switched.append(target) or True
+        self.window._focus_settings_section = lambda _key: None
+        self.window._show_settings_status = lambda *_args, **_kwargs: None
+        self.window._games_registry_panel = type(
+            "FakePanel",
+            (),
+            {"set_current_game_root": lambda self, _root: None},
+        )()
+        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+
+        with patch("gui_qt.app.QMessageBox", FakeMessageBox):
+            result = self.window._on_registry_switch_project("C:/Game/work")
+
+        self.assertTrue(result)
+        self.assertEqual(switched, ["C:/Game/work"])
+        self.assertTrue(FakeMessageBox.shown)
+
+    def test_on_registry_switch_project_saves_before_switch_when_requested(self):
+        from unittest.mock import patch
+
+        switched = []
+        saved = []
+
+        class FakeMessageBox:
+            class Icon:
+                Warning = object()
+
+            class ButtonRole:
+                AcceptRole = object()
+                DestructiveRole = object()
+                RejectRole = object()
+
+            def __init__(self, *_args, **_kwargs):
+                self._save_btn = object()
+
+            def setIcon(self, _icon):
+                pass
+
+            def setWindowTitle(self, _title):
+                pass
+
+            def setText(self, _text):
+                pass
+
+            def setInformativeText(self, _text):
+                pass
+
+            def addButton(self, text, _role):
+                return self._save_btn if text == "保存并切换" else object()
+
+            def setDefaultButton(self, _button):
+                pass
+
+            def exec(self):
+                pass
+
+            def clickedButton(self):
+                return self._save_btn
+
+        self.window._loading_config_to_ui = False
+        self.window._config_ui_saved_snapshot = {"dirty": False}
+        self.window._current_config_ui_snapshot = lambda: {"dirty": True}
+        self.window._on_save_config = lambda: saved.append(True) or True
+        self.window._switch_game_root = lambda target: switched.append(target) or True
+        self.window._focus_settings_section = lambda _key: None
+        self.window._show_settings_status = lambda *_args, **_kwargs: None
+        self.window._games_registry_panel = type(
+            "FakePanel",
+            (),
+            {"set_current_game_root": lambda self, _root: None},
+        )()
+        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+
+        with patch("gui_qt.app.QMessageBox", FakeMessageBox):
+            result = self.window._on_registry_switch_project("C:/Game/work")
+
+        self.assertTrue(result)
+        self.assertEqual(saved, [True])
+        self.assertEqual(switched, ["C:/Game/work"])
+
+    def test_settings_workspace_panel_enables_auto_discover_on_show(self):
+        from unittest.mock import MagicMock, patch
+
+        fake_page = MagicMock()
+        fake_layout = MagicMock()
+        with patch.object(MainWindow, "_settings_page", return_value=(fake_page, fake_layout)):
+            with patch("gui_qt.app.GamesRegistryPanel") as panel_cls:
+                with patch("gui_qt.app.resolve_workspace_root", return_value=Path("C:/workspace")):
+                    with patch("gui_qt.app.QLabel", return_value=MagicMock()):
+                        self.window.state = type(
+                            "FakeState",
+                            (),
+                            {
+                                "get_tool_root": lambda self: Path("C:/tool"),
+                                "get_game_root": lambda self: Path("C:/Game/work"),
+                            },
+                        )()
+                        self.window._current_registry_doctor_report = lambda: None
+                        self.window._on_registry_switch_project = lambda _target: True
+
+                        self.window._build_settings_workspace_page()
+
+        panel_cls.assert_called_once()
+        self.assertNotIn(
+            "auto_discover_on_show",
+            panel_cls.call_args.kwargs,
+            "workspace panel should use default auto_discover_on_show=True",
+        )
 
     def test_focus_advanced_setting_navigates_to_workspace_for_game_root(self):
         class FakeNav:


### PR DESCRIPTION
## Summary

Follow-up to #128 addressing the two unresolved Codex review items from [review #4641367178](https://github.com/hu-border-collie/renpy-translation-lab/pull/128#pullrequestreview-4641367178) that arrived after merge.

## Changes

- **Unsaved settings guard** — switching projects from **设置 → 工作区** now prompts to save, discard, or cancel when other settings sections have unsaved edits
- **Auto-discover restored** — embedded `GamesRegistryPanel` uses default `auto_discover_on_show=True` so the "打开分区时自动扫描新项目" preference works again

## Test plan

- [x] `pytest tests/test_gui_games_registry_dialog.py tests/test_gui_app_config.py -v` — **69 passed**
- [ ] Manual: edit a setting on **项目**, go to **工作区**, click **切换到此项目** — confirm dialog appears
- [ ] Manual: with auto-scan enabled, open **设置 → 工作区** — undiscovered projects are scanned automatically