### PR TITLE
feat(gui): diagnostics probe smoke test (#111)

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -118,7 +118,9 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。
 
-工具栏提供「刷新上下文」与「清空日志」。切换到诊断 Tab 时会重新读取最近任务记录；流程进行中会优先展示当前活动的记录。
+工具栏提供「刷新上下文」「试跑样本请求」与「清空日志」。切换到诊断 Tab 时会重新读取最近任务记录；流程进行中会优先展示当前活动的记录。
+
+**试跑样本请求（probe）**：批量翻译模式下，若当前有可用的 translation manifest（version 1），可点击「试跑样本请求」对 package 内少量请求做同步 `generate_content` 冒烟测试（默认 `--limit 3`）。高级选项可调整 `--limit`、`--offset` 与 `--api-key-index`。该操作不会提交批量任务，也不会修改项目文件；摘要显示在任务上下文区，原始输出写入下方日志。适合在 `submit` 前排障 API、模型与请求格式。
 
 ## 配置兼容性
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -91,6 +91,13 @@ from .diagnostics_context import (
     existing_retry_manifest_path,
     sync_diagnostics_context,
 )
+from .probe_report import (
+    build_probe_cli_args,
+    probe_summary_to_diagnostics_context,
+    running_probe_summary,
+    summarize_probe_output,
+    translation_probe_ready,
+)
 from .keyword_report import summarize_keyword_result_from_manifest
 from .revision_report import summarize_revision_apply_output
 from .revision_writeback_report import (
@@ -265,6 +272,7 @@ class MainWindow(QMainWindow):
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
         self._recheck_output_lines: list[str] = []
+        self._probe_output_lines: list[str] = []
         self._apply_revision_output_lines: list[str] = []
         self._bootstrap_output_lines: list[str] = []
         self._bootstrap_progress: BootstrapProgressState | None = None
@@ -1243,6 +1251,15 @@ class MainWindow(QMainWindow):
         self.refresh_diagnostics_btn.setObjectName("secondary_btn")
         self.refresh_diagnostics_btn.clicked.connect(self._refresh_diagnostics_context)
         toolbar.addWidget(self.refresh_diagnostics_btn)
+
+        self.probe_btn = QPushButton("试跑样本请求")
+        self.probe_btn.setObjectName("secondary_btn")
+        self.probe_btn.setToolTip(
+            "对当前翻译包执行少量同步请求，提交批量任务前验证 API 与请求格式。"
+        )
+        self.probe_btn.clicked.connect(self._on_run_probe)
+        self.probe_btn.setEnabled(False)
+        toolbar.addWidget(self.probe_btn)
 
         self.clear_log_btn = QPushButton("清空日志")
         self.clear_log_btn.setObjectName("secondary_btn")
@@ -2400,6 +2417,36 @@ class MainWindow(QMainWindow):
         except ValueError:
             return None
 
+    def _current_diagnostics_manifest(self) -> tuple[str, dict[str, object] | None]:
+        spec = work_mode_spec(self._current_work_mode())
+        if spec.manifest_mode is None:
+            return "", None
+
+        game_root = self.state.get_game_root()
+        latest_manifest = None
+        if game_root is not None:
+            latest_manifest = self.state.get_latest_manifest_path_for_mode(
+                game_root,
+                spec.mode,
+            )
+        if self._workflow is not None and self._workflow.manifest_path:
+            manifest_path = self._workflow.manifest_path
+        elif self._writeback_manifest_path:
+            manifest_path = self._writeback_manifest_path
+        else:
+            manifest_path = str(latest_manifest) if latest_manifest is not None else ""
+        manifest = self._load_diagnostics_manifest(manifest_path or None)
+        return manifest_path, manifest
+
+    def _update_probe_btn_enabled(self, *, running: bool | None = None) -> None:
+        if not hasattr(self, "probe_btn"):
+            return
+        if running is None:
+            running = self.kill_btn.isEnabled()
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, _message = translation_probe_ready(manifest_path, manifest)
+        self.probe_btn.setEnabled(not running and ready)
+
     def _refresh_manifest_derived_ui(
         self,
         *,
@@ -2450,6 +2497,7 @@ class MainWindow(QMainWindow):
                 python_exe=sys.executable,
             )
             self._set_diagnostics_context(context)
+            self._update_probe_btn_enabled()
             return
 
         uses_batch_manifest = spec.manifest_mode is not None
@@ -2479,6 +2527,7 @@ class MainWindow(QMainWindow):
             python_exe=sys.executable,
         )
         self._set_diagnostics_context(context)
+        self._update_probe_btn_enabled()
 
     def _set_diagnostics_context(self, context: DiagnosticsContext) -> None:
         fingerprint = (
@@ -4066,6 +4115,96 @@ class MainWindow(QMainWindow):
     def _on_kill(self):
         self.runner.kill()
 
+    def _prompt_probe_options(self) -> dict[str, int | None] | None:
+        dialog = QDialog(self)
+        dialog.setWindowTitle("试跑样本请求")
+        layout = QVBoxLayout(dialog)
+
+        hint = QLabel(
+            "将对当前翻译包执行少量同步请求，不会提交批量任务，也不会修改项目文件。"
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        form = QFormLayout()
+        limit_spin = QSpinBox()
+        limit_spin.setRange(1, 50)
+        limit_spin.setValue(3)
+        form.addRow("样本条数 (--limit)", limit_spin)
+
+        offset_spin = QSpinBox()
+        offset_spin.setRange(0, 1_000_000)
+        offset_spin.setValue(0)
+        form.addRow("起始偏移 (--offset)", offset_spin)
+
+        api_key_spin = QSpinBox()
+        api_key_spin.setRange(-1, 99)
+        api_key_spin.setValue(-1)
+        api_key_spin.setSpecialValueText("默认")
+        form.addRow("API Key 索引 (--api-key-index)", api_key_spin)
+        layout.addLayout(form)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        cancel_btn = QPushButton("取消")
+        cancel_btn.clicked.connect(dialog.reject)
+        buttons.addWidget(cancel_btn)
+        run_btn = QPushButton("开始试跑")
+        run_btn.setObjectName("primary_btn")
+        run_btn.clicked.connect(dialog.accept)
+        buttons.addWidget(run_btn)
+        layout.addLayout(buttons)
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return None
+
+        api_key_index = None if api_key_spin.value() < 0 else api_key_spin.value()
+        return {
+            "limit": limit_spin.value(),
+            "offset": offset_spin.value(),
+            "api_key_index": api_key_index,
+        }
+
+    def _on_run_probe(self) -> None:
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, message = translation_probe_ready(manifest_path, manifest)
+        if not ready:
+            QMessageBox.information(self, "无法试跑样本请求", message)
+            return
+
+        options = self._prompt_probe_options()
+        if options is None:
+            return
+
+        self._clear_log_view()
+        self._focus_log_tab()
+        self._active_command = "probe"
+        self._probe_output_lines = []
+        base_context = build_diagnostics_context(
+            latest_manifest_path=manifest_path,
+            manifest=manifest,
+            batch_script_path=str(self.state.get_batch_script_path()),
+            logs_dir=str(self.state.get_logs_dir()),
+            python_exe=sys.executable,
+        )
+        self._set_diagnostics_context(
+            probe_summary_to_diagnostics_context(
+                running_probe_summary(manifest_path=manifest_path),
+                base_context,
+            )
+        )
+        args = build_probe_cli_args(
+            manifest_path,
+            limit=int(options["limit"]),
+            offset=int(options["offset"]),
+            api_key_index=options["api_key_index"],
+        )
+        self._append_log(
+            f"=== 正在试跑样本请求：gemini_translate_batch.py {' '.join(args)} ===\n"
+        )
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), args)
+
     def _on_recheck_writeback(self) -> None:
         spec = work_mode_spec(self._current_work_mode())
         if not spec.supports_translation_writeback:
@@ -4278,6 +4417,8 @@ class MainWindow(QMainWindow):
             self._apply_output_lines.append(text)
         elif self._active_command == "recheck":
             self._recheck_output_lines.append(text)
+        elif self._active_command == "probe":
+            self._probe_output_lines.append(text)
         elif self._active_command == "apply_revision":
             self._apply_revision_output_lines.append(text)
         elif self._active_command == "build_retry":
@@ -4405,6 +4546,7 @@ class MainWindow(QMainWindow):
                 and writeback_summary.can_apply
             )
         self._update_writeback_action_buttons(writeback_summary, running=running)
+        self._update_probe_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
         self._sync_task_shortcuts()
 
@@ -4565,6 +4707,8 @@ class MainWindow(QMainWindow):
             self._apply_output_lines.append(message)
         elif self._active_command == "recheck":
             self._recheck_output_lines.append(message)
+        elif self._active_command == "probe":
+            self._probe_output_lines.append(message)
         elif self._active_command == "build_retry":
             self._build_retry_output_lines.append(message)
         elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
@@ -4624,6 +4768,35 @@ class MainWindow(QMainWindow):
                     self.statusBar().showMessage("重新检查完成，当前禁止写回。", 6000)
                 else:
                     self.statusBar().showMessage("重新检查完成。", 6000)
+            return
+
+        if self._active_command == "probe":
+            manifest_path, manifest = self._current_diagnostics_manifest()
+            probe_summary = summarize_probe_output(
+                "\n".join(self._probe_output_lines),
+                exit_code,
+                manifest_path=manifest_path,
+            )
+            base_context = build_diagnostics_context(
+                latest_manifest_path=manifest_path or None,
+                manifest=manifest,
+                batch_script_path=str(self.state.get_batch_script_path()),
+                logs_dir=str(self.state.get_logs_dir()),
+                python_exe=sys.executable,
+            )
+            self._set_diagnostics_context(
+                probe_summary_to_diagnostics_context(probe_summary, base_context)
+            )
+            self._active_command = ""
+            self._set_task_running(False)
+            if probe_summary.status == "ok":
+                self.statusBar().showMessage("样本试跑通过。", 6000)
+            elif probe_summary.status == "warn":
+                self.statusBar().showMessage("样本试跑完成，但需关注部分结果。", 6000)
+            elif probe_summary.status == "failed":
+                self.statusBar().showMessage("样本试跑失败，请查看诊断日志。", 8000)
+            else:
+                self.statusBar().showMessage("样本试跑已结束。", 6000)
             return
 
         if self._active_command == "apply_revision":

--- a/gui_qt/probe_report.py
+++ b/gui_qt/probe_report.py
@@ -1,0 +1,230 @@
+"""Probe smoke-test summaries and CLI helpers for the diagnostics tab."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
+from .user_copy import format_manifest_path_fact
+
+_MANIFEST_MODE_TRANSLATION = "translation"
+_PROBE_SUMMARY_PREFIX_RE = re.compile(
+    r"^\s*-\s*(sample_count|parse_ok|full_item_match|max_tokens|missing_text|request_errors):\s*(-?\d+)\s*$",
+    re.MULTILINE,
+)
+_PROBE_FILE_RE = re.compile(
+    r"^\s*-\s*(summary_file|results_file):\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class ProbeSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+    manifest_path: str = ""
+    sample_count: int | None = None
+    parse_ok: int | None = None
+    full_item_match: int | None = None
+    request_errors: int | None = None
+    summary_file: str = ""
+    results_file: str = ""
+
+
+def translation_probe_ready(
+    manifest_path: str,
+    manifest: dict[str, object] | None,
+) -> tuple[bool, str]:
+    if not manifest_path.strip():
+        return False, "没有可探测的翻译任务记录。"
+    if manifest is None:
+        return False, "无法读取任务记录，请先在诊断页刷新上下文。"
+    mode = manifest.get("mode")
+    mode_text = mode.strip() if isinstance(mode, str) else _MANIFEST_MODE_TRANSLATION
+    if mode_text != _MANIFEST_MODE_TRANSLATION:
+        return False, "试跑样本请求仅支持批量翻译任务记录。"
+    version = manifest.get("version", 1)
+    if version != 1:
+        return False, "当前仅支持 version 1 的翻译任务记录。"
+    input_jsonl = manifest.get("input_jsonl_path")
+    if not isinstance(input_jsonl, str) or not input_jsonl.strip():
+        return False, "任务记录缺少 requests.jsonl 路径，无法试跑样本请求。"
+    return True, ""
+
+
+def build_probe_cli_args(
+    manifest_path: str,
+    *,
+    limit: int = 3,
+    offset: int = 0,
+    api_key_index: int | None = None,
+) -> list[str]:
+    args = ["probe", manifest_path, "--limit", str(limit), "--offset", str(offset)]
+    if api_key_index is not None:
+        args.extend(["--api-key-index", str(api_key_index)])
+    return args
+
+
+def parse_probe_output(output: str) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    for match in _PROBE_SUMMARY_PREFIX_RE.finditer(output):
+        parsed[match.group(1)] = int(match.group(2))
+    for match in _PROBE_FILE_RE.finditer(output):
+        parsed[match.group(1)] = match.group(2).strip()
+    return parsed
+
+
+def summarize_probe_output(
+    output: str,
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+) -> ProbeSummary:
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(format_manifest_path_fact(manifest_path))
+
+    if exit_code != 0:
+        return ProbeSummary(
+            status="failed",
+            heading="样本试跑失败",
+            message="试跑样本请求没有正常完成，请查看诊断日志中的 API 或格式错误。",
+            facts=facts,
+            findings=[],
+            manifest_path=manifest_path,
+        )
+
+    parsed = parse_probe_output(output)
+    sample_count = parsed.get("sample_count")
+    parse_ok = parsed.get("parse_ok")
+    full_item_match = parsed.get("full_item_match")
+    max_tokens = parsed.get("max_tokens")
+    missing_text = parsed.get("missing_text")
+    request_errors = parsed.get("request_errors")
+    summary_file = parsed.get("summary_file")
+    results_file = parsed.get("results_file")
+
+    if isinstance(sample_count, int):
+        facts.append(f"探测条数：{sample_count}")
+    if isinstance(parse_ok, int):
+        facts.append(f"解析成功：{parse_ok}")
+    if isinstance(full_item_match, int):
+        facts.append(f"完整匹配：{full_item_match}")
+    if isinstance(max_tokens, int) and max_tokens > 0:
+        facts.append(f"触发 MAX_TOKENS：{max_tokens}")
+    if isinstance(missing_text, int) and missing_text > 0:
+        facts.append(f"缺少响应文本：{missing_text}")
+    if isinstance(request_errors, int) and request_errors > 0:
+        facts.append(f"请求错误：{request_errors}")
+    if isinstance(summary_file, str) and summary_file:
+        facts.append(f"摘要文件：{summary_file}")
+    if isinstance(results_file, str) and results_file:
+        facts.append(f"结果文件：{results_file}")
+
+    findings: list[str] = []
+    if isinstance(request_errors, int) and request_errors > 0:
+        findings.append("部分样本请求失败，请检查 API Key、模型配额或网络。")
+    if isinstance(parse_ok, int) and isinstance(sample_count, int) and parse_ok < sample_count:
+        findings.append("部分样本未能解析为有效 JSON，请检查请求格式或模型输出。")
+    if isinstance(full_item_match, int) and isinstance(sample_count, int) and full_item_match < sample_count:
+        findings.append("部分样本返回的条目数与预期不一致。")
+
+    if (
+        isinstance(sample_count, int)
+        and sample_count > 0
+        and isinstance(parse_ok, int)
+        and parse_ok == sample_count
+        and isinstance(request_errors, int)
+        and request_errors == 0
+    ):
+        return ProbeSummary(
+            status="ok",
+            heading="样本试跑通过",
+            message="同步样本请求已完成，API 与请求格式看起来正常，可继续提交批量任务。",
+            facts=facts,
+            findings=findings,
+            manifest_path=manifest_path,
+            sample_count=sample_count,
+            parse_ok=parse_ok,
+            full_item_match=full_item_match if isinstance(full_item_match, int) else None,
+            request_errors=request_errors,
+            summary_file=summary_file if isinstance(summary_file, str) else "",
+            results_file=results_file if isinstance(results_file, str) else "",
+        )
+
+    if isinstance(sample_count, int) and sample_count > 0:
+        return ProbeSummary(
+            status="warn",
+            heading="样本试跑需关注",
+            message="试跑已完成，但部分样本存在问题；提交批量任务前请先查看诊断日志。",
+            facts=facts,
+            findings=findings,
+            manifest_path=manifest_path,
+            sample_count=sample_count,
+            parse_ok=parse_ok if isinstance(parse_ok, int) else None,
+            full_item_match=full_item_match if isinstance(full_item_match, int) else None,
+            request_errors=request_errors if isinstance(request_errors, int) else None,
+            summary_file=summary_file if isinstance(summary_file, str) else "",
+            results_file=results_file if isinstance(results_file, str) else "",
+        )
+
+    return ProbeSummary(
+        status="unknown",
+        heading="样本试跑结果不明确",
+        message="命令已结束，但未能识别探测摘要，请查看诊断日志。",
+        facts=facts,
+        findings=findings,
+        manifest_path=manifest_path,
+    )
+
+
+def running_probe_summary(*, manifest_path: str = "") -> ProbeSummary:
+    facts = [format_manifest_path_fact(manifest_path)] if manifest_path else []
+    return ProbeSummary(
+        status="running",
+        heading="正在试跑样本请求",
+        message="正在对少量请求做同步冒烟测试；完成后这里会显示摘要。",
+        facts=facts,
+        findings=[],
+        manifest_path=manifest_path,
+    )
+
+
+def probe_summary_to_diagnostics_context(
+    summary: ProbeSummary,
+    base: DiagnosticsContext,
+) -> DiagnosticsContext:
+    paths = list(base.paths)
+    if summary.summary_file:
+        paths.append(DiagnosticsPathEntry(label="Probe 摘要", path=summary.summary_file))
+    if summary.results_file:
+        paths.append(DiagnosticsPathEntry(label="Probe 结果", path=summary.results_file))
+
+    facts = [*summary.facts, *base.facts]
+    if summary.findings:
+        facts.extend(summary.findings)
+
+    status = summary.status
+    if status == "ok":
+        status = "ready"
+    elif status in {"warn", "unknown"}:
+        status = "warning"
+    elif status == "running":
+        status = "running"
+
+    message = summary.message
+    if base.message and summary.status not in {"running", "failed"}:
+        message = f"{summary.message}\n\n{base.message}"
+
+    return DiagnosticsContext(
+        status=status,
+        heading=summary.heading,
+        message=message,
+        facts=facts,
+        paths=paths,
+        commands=base.commands,
+        manifest_json_preview=base.manifest_json_preview,
+    )

--- a/tests/test_gui_probe_report.py
+++ b/tests/test_gui_probe_report.py
@@ -1,0 +1,111 @@
+import unittest
+
+from gui_qt.probe_report import (
+    build_probe_cli_args,
+    parse_probe_output,
+    summarize_probe_output,
+    translation_probe_ready,
+)
+
+
+PROBE_OUTPUT_OK = """
+[1/3] chunk-001
+  finish_reason: STOP
+  parsed_items: 4/4
+  parse_ok: True
+Probe summary:
+- sample_count: 3
+- parse_ok: 3
+- full_item_match: 3
+- max_tokens: 0
+- missing_text: 0
+- request_errors: 0
+- summary_file: C:\\pkg\\probe_summary.json
+- results_file: C:\\pkg\\probe_results.jsonl
+"""
+
+PROBE_OUTPUT_PARTIAL = """
+Probe summary:
+- sample_count: 3
+- parse_ok: 2
+- full_item_match: 1
+- max_tokens: 1
+- missing_text: 0
+- request_errors: 1
+- summary_file: C:\\pkg\\probe_summary.json
+- results_file: C:\\pkg\\probe_results.jsonl
+"""
+
+
+class GuiProbeReportTests(unittest.TestCase):
+    def test_build_probe_cli_args_uses_defaults(self):
+        args = build_probe_cli_args(r"C:\pkg\manifest.json")
+        self.assertEqual(
+            args,
+            ["probe", r"C:\pkg\manifest.json", "--limit", "3", "--offset", "0"],
+        )
+
+    def test_build_probe_cli_args_includes_api_key_index(self):
+        args = build_probe_cli_args(
+            r"C:\pkg\manifest.json",
+            limit=5,
+            offset=2,
+            api_key_index=1,
+        )
+        self.assertEqual(args[-2:], ["--api-key-index", "1"])
+        self.assertIn("--limit", args)
+        self.assertIn("5", args)
+
+    def test_parse_probe_output_extracts_counts_and_files(self):
+        parsed = parse_probe_output(PROBE_OUTPUT_OK)
+        self.assertEqual(parsed["sample_count"], 3)
+        self.assertEqual(parsed["parse_ok"], 3)
+        self.assertEqual(parsed["request_errors"], 0)
+        self.assertEqual(parsed["summary_file"], r"C:\pkg\probe_summary.json")
+
+    def test_summarize_probe_output_marks_full_success_as_ok(self):
+        summary = summarize_probe_output(
+            PROBE_OUTPUT_OK,
+            0,
+            manifest_path=r"C:\pkg\manifest.json",
+        )
+        self.assertEqual(summary.status, "ok")
+        self.assertEqual(summary.sample_count, 3)
+        self.assertEqual(summary.parse_ok, 3)
+
+    def test_summarize_probe_output_marks_partial_success_as_warn(self):
+        summary = summarize_probe_output(
+            PROBE_OUTPUT_PARTIAL,
+            0,
+            manifest_path=r"C:\pkg\manifest.json",
+        )
+        self.assertEqual(summary.status, "warn")
+        self.assertTrue(any("请求失败" in finding for finding in summary.findings))
+
+    def test_summarize_probe_output_nonzero_exit_is_failed(self):
+        summary = summarize_probe_output(PROBE_OUTPUT_OK, 1)
+        self.assertEqual(summary.status, "failed")
+
+    def test_translation_probe_ready_rejects_non_translation_manifest(self):
+        ready, message = translation_probe_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "revision", "version": 1, "input_jsonl_path": r"C:\pkg\requests.jsonl"},
+        )
+        self.assertFalse(ready)
+        self.assertIn("批量翻译", message)
+
+    def test_translation_probe_ready_accepts_translation_manifest(self):
+        ready, message = translation_probe_ready(
+            r"C:\pkg\manifest.json",
+            {
+                "mode": "translation",
+                "version": 1,
+                "input_jsonl_path": r"C:\pkg\requests.jsonl",
+            },
+        )
+        self.assertTrue(ready)
+        self.assertEqual(message, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a diagnostics toolbar entry to run `gemini_translate_batch.py probe` against the current translation manifest before submit.

- New `gui_qt/probe_report.py` for CLI arg building, output parsing, and user-facing summaries
- Diagnostics button **试跑样本请求** with optional advanced options (`--limit`, `--offset`, `--api-key-index`)
- Probe results overlay the diagnostics task context; raw output stays in the log panel
- Unit tests in `tests/test_gui_probe_report.py`
- Docs update in `docs/gui_workbench.md`

## Test plan

- [x] `python -m unittest tests.test_gui_probe_report -v`
- [ ] GUI manual: open diagnostics tab with a translation manifest and run probe

Refs #42
Refs #108
Refs #111
Closes #111