### PR TITLE
feat(gui): diagnostics split package entry (#112)

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -118,9 +118,11 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。
 
-工具栏提供「刷新上下文」「试跑样本请求」与「清空日志」。切换到诊断 Tab 时会重新读取最近任务记录；流程进行中会优先展示当前活动的记录。
+工具栏提供「刷新上下文」「试跑样本请求」「拆分翻译包」与「清空日志」。切换到诊断 Tab 时会重新读取最近任务记录；流程进行中会优先展示当前活动的记录。
 
 **试跑样本请求（probe）**：批量翻译模式下，若当前有可用的 translation manifest（version 1），可点击「试跑样本请求」对 package 内少量请求做同步 `generate_content` 冒烟测试（默认 `--limit 3`）。高级选项可调整 `--limit`、`--offset` 与 `--api-key-index`。该操作不会提交批量任务，也不会修改项目文件；摘要显示在任务上下文区，原始输出写入下方日志。适合在 `submit` 前排障 API、模型与请求格式。
+
+**拆分翻译包（split）**：批量翻译模式下，若当前 translation manifest（version 1）含有可拆分的块，可点击「拆分翻译包」按上限生成多个子包（默认 `--max-chunks 600`）。高级选项可调整 `--max-items` 与 `--display-name-prefix`。拆分后 RAG 记忆库为静态快照，各子包需分别 submit，不会自动提交；子包路径会列在任务上下文区，命令参考会补充各子包的 `submit` 示例。详见 `docs/context_systems.md`。
 
 ## 配置兼容性
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -109,6 +109,13 @@ from .split_batch import (
     load_split_manifest_entries,
     summarize_split_entries,
 )
+from .split_report import (
+    build_split_cli_args,
+    running_split_summary,
+    split_summary_to_diagnostics_context,
+    summarize_split_output,
+    translation_split_ready,
+)
 from .split_batch_workflow import SplitBatchQueueWorkflow
 from .split_status_delegate import SPLIT_ACTION_DATA_ROLE, SplitStatusActionDelegate
 from .split_status_table_helpers import is_split_action_column, split_action_item_payload
@@ -273,6 +280,7 @@ class MainWindow(QMainWindow):
         self._apply_output_lines: list[str] = []
         self._recheck_output_lines: list[str] = []
         self._probe_output_lines: list[str] = []
+        self._split_output_lines: list[str] = []
         self._apply_revision_output_lines: list[str] = []
         self._bootstrap_output_lines: list[str] = []
         self._bootstrap_progress: BootstrapProgressState | None = None
@@ -1260,6 +1268,15 @@ class MainWindow(QMainWindow):
         self.probe_btn.clicked.connect(self._on_run_probe)
         self.probe_btn.setEnabled(False)
         toolbar.addWidget(self.probe_btn)
+
+        self.split_btn = QPushButton("拆分翻译包")
+        self.split_btn.setObjectName("secondary_btn")
+        self.split_btn.setToolTip(
+            "将过大的翻译包拆成多个子包；拆分后需分别提交，RAG 为静态快照。"
+        )
+        self.split_btn.clicked.connect(self._on_run_split)
+        self.split_btn.setEnabled(False)
+        toolbar.addWidget(self.split_btn)
 
         self.clear_log_btn = QPushButton("清空日志")
         self.clear_log_btn.setObjectName("secondary_btn")
@@ -2447,6 +2464,15 @@ class MainWindow(QMainWindow):
         ready, _message = translation_probe_ready(manifest_path, manifest)
         self.probe_btn.setEnabled(not running and ready)
 
+    def _update_split_btn_enabled(self, *, running: bool | None = None) -> None:
+        if not hasattr(self, "split_btn"):
+            return
+        if running is None:
+            running = self.kill_btn.isEnabled()
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, _message = translation_split_ready(manifest_path, manifest)
+        self.split_btn.setEnabled(not running and ready)
+
     def _refresh_manifest_derived_ui(
         self,
         *,
@@ -2498,6 +2524,7 @@ class MainWindow(QMainWindow):
             )
             self._set_diagnostics_context(context)
             self._update_probe_btn_enabled()
+            self._update_split_btn_enabled()
             return
 
         uses_batch_manifest = spec.manifest_mode is not None
@@ -2528,6 +2555,7 @@ class MainWindow(QMainWindow):
         )
         self._set_diagnostics_context(context)
         self._update_probe_btn_enabled()
+        self._update_split_btn_enabled()
 
     def _set_diagnostics_context(self, context: DiagnosticsContext) -> None:
         fingerprint = (
@@ -4165,6 +4193,55 @@ class MainWindow(QMainWindow):
             "api_key_index": api_key_index,
         }
 
+    def _prompt_split_options(self) -> dict[str, int | str] | None:
+        dialog = QDialog(self)
+        dialog.setWindowTitle("拆分翻译包")
+        layout = QVBoxLayout(dialog)
+
+        hint = QLabel(
+            "将把当前翻译包拆成多个子包。拆分后 RAG 记忆库为静态快照，"
+            "各子包需分别 submit，不会自动提交。"
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        form = QFormLayout()
+        max_chunks_spin = QSpinBox()
+        max_chunks_spin.setRange(1, 10_000)
+        max_chunks_spin.setValue(600)
+        form.addRow("每包最大块数 (--max-chunks)", max_chunks_spin)
+
+        max_items_spin = QSpinBox()
+        max_items_spin.setRange(0, 1_000_000)
+        max_items_spin.setValue(0)
+        max_items_spin.setSpecialValueText("不限制")
+        form.addRow("每包最大条目 (--max-items)", max_items_spin)
+
+        prefix_edit = QLineEdit()
+        prefix_edit.setPlaceholderText("留空则沿用源包显示名")
+        form.addRow("显示名前缀 (--display-name-prefix)", prefix_edit)
+        layout.addLayout(form)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        cancel_btn = QPushButton("取消")
+        cancel_btn.clicked.connect(dialog.reject)
+        buttons.addWidget(cancel_btn)
+        run_btn = QPushButton("开始拆分")
+        run_btn.setObjectName("primary_btn")
+        run_btn.clicked.connect(dialog.accept)
+        buttons.addWidget(run_btn)
+        layout.addLayout(buttons)
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return None
+
+        return {
+            "max_chunks": max_chunks_spin.value(),
+            "max_items": max_items_spin.value(),
+            "display_name_prefix": prefix_edit.text().strip(),
+        }
+
     def _on_run_probe(self) -> None:
         manifest_path, manifest = self._current_diagnostics_manifest()
         ready, message = translation_probe_ready(manifest_path, manifest)
@@ -4201,6 +4278,46 @@ class MainWindow(QMainWindow):
         )
         self._append_log(
             f"=== 正在试跑样本请求：gemini_translate_batch.py {' '.join(args)} ===\n"
+        )
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), args)
+
+    def _on_run_split(self) -> None:
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, message = translation_split_ready(manifest_path, manifest)
+        if not ready:
+            QMessageBox.information(self, "无法拆分翻译包", message)
+            return
+
+        options = self._prompt_split_options()
+        if options is None:
+            return
+
+        self._clear_log_view()
+        self._focus_log_tab()
+        self._active_command = "split"
+        self._split_output_lines = []
+        base_context = build_diagnostics_context(
+            latest_manifest_path=manifest_path,
+            manifest=manifest,
+            batch_script_path=str(self.state.get_batch_script_path()),
+            logs_dir=str(self.state.get_logs_dir()),
+            python_exe=sys.executable,
+        )
+        self._set_diagnostics_context(
+            split_summary_to_diagnostics_context(
+                running_split_summary(manifest_path=manifest_path),
+                base_context,
+            )
+        )
+        args = build_split_cli_args(
+            manifest_path,
+            max_chunks=int(options["max_chunks"]),
+            max_items=int(options["max_items"]),
+            display_name_prefix=str(options["display_name_prefix"]),
+        )
+        self._append_log(
+            f"=== 正在拆分翻译包：gemini_translate_batch.py {' '.join(args)} ===\n"
         )
         self._set_task_running(True)
         self.runner.run(self.state.get_batch_script_path(), args)
@@ -4419,6 +4536,8 @@ class MainWindow(QMainWindow):
             self._recheck_output_lines.append(text)
         elif self._active_command == "probe":
             self._probe_output_lines.append(text)
+        elif self._active_command == "split":
+            self._split_output_lines.append(text)
         elif self._active_command == "apply_revision":
             self._apply_revision_output_lines.append(text)
         elif self._active_command == "build_retry":
@@ -4547,6 +4666,7 @@ class MainWindow(QMainWindow):
             )
         self._update_writeback_action_buttons(writeback_summary, running=running)
         self._update_probe_btn_enabled(running=running)
+        self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
         self._sync_task_shortcuts()
 
@@ -4709,6 +4829,8 @@ class MainWindow(QMainWindow):
             self._recheck_output_lines.append(message)
         elif self._active_command == "probe":
             self._probe_output_lines.append(message)
+        elif self._active_command == "split":
+            self._split_output_lines.append(message)
         elif self._active_command == "build_retry":
             self._build_retry_output_lines.append(message)
         elif self._active_command in {"bootstrap_rag", "bootstrap_source_index"}:
@@ -4797,6 +4919,56 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("样本试跑失败，请查看诊断日志。", 8000)
             else:
                 self.statusBar().showMessage("样本试跑已结束。", 6000)
+            return
+
+        if self._active_command == "split":
+            manifest_path, _manifest = self._current_diagnostics_manifest()
+            split_summary = summarize_split_output(
+                "\n".join(self._split_output_lines),
+                exit_code,
+                manifest_path=manifest_path,
+            )
+            latest_manifest_path = split_summary.latest_manifest_path or manifest_path
+            context_manifest_path = (
+                split_summary.source_manifest_path or manifest_path
+            )
+            context_manifest = self._load_diagnostics_manifest(
+                context_manifest_path or None
+            )
+            base_context = build_diagnostics_context(
+                latest_manifest_path=latest_manifest_path or None,
+                manifest=context_manifest,
+                batch_script_path=str(self.state.get_batch_script_path()),
+                logs_dir=str(self.state.get_logs_dir()),
+                python_exe=sys.executable,
+            )
+            self._set_diagnostics_context(
+                split_summary_to_diagnostics_context(split_summary, base_context)
+            )
+            self._active_command = ""
+            self._set_task_running(False)
+            if split_summary.status == "ok":
+                latest_manifest = self._load_diagnostics_manifest(
+                    latest_manifest_path or None
+                )
+                self._refresh_workflow_from_latest_manifest(
+                    latest_manifest=latest_manifest_path or None,
+                    manifest=latest_manifest,
+                )
+                self._refresh_split_status_ui(
+                    manifest_path=context_manifest_path or manifest_path,
+                    manifest=context_manifest,
+                )
+                self.statusBar().showMessage(
+                    f"拆分完成，已生成 {len(split_summary.child_manifest_paths or [])} 个子包。",
+                    8000,
+                )
+            elif split_summary.status == "unchanged":
+                self.statusBar().showMessage("当前翻译包无需拆分。", 6000)
+            elif split_summary.status == "failed":
+                self.statusBar().showMessage("拆分翻译包失败，请查看诊断日志。", 8000)
+            else:
+                self.statusBar().showMessage("拆分翻译包已结束。", 6000)
             return
 
         if self._active_command == "apply_revision":

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -340,6 +340,41 @@ def build_cli_commands(
             )
         )
 
+    commands.extend(
+        build_split_child_submit_commands(
+            python_exe=python_exe,
+            batch_script_path=batch_script_path,
+            manifest=manifest,
+        )
+    )
+
+    return commands
+
+
+def build_split_child_submit_commands(
+    *,
+    python_exe: str,
+    batch_script_path: str,
+    manifest: dict[str, object],
+) -> list[DiagnosticsCommand]:
+    children = manifest.get("split_children")
+    if not isinstance(children, list):
+        return []
+
+    commands: list[DiagnosticsCommand] = []
+    for index, child_path in enumerate(children, start=1):
+        if not isinstance(child_path, str) or not child_path.strip():
+            continue
+        commands.append(
+            DiagnosticsCommand(
+                label=f"提交拆分包 {index:02d}",
+                command=format_cli_command(
+                    python_exe,
+                    batch_script_path,
+                    ["submit", child_path.strip()],
+                ),
+            )
+        )
     return commands
 
 

--- a/gui_qt/split_report.py
+++ b/gui_qt/split_report.py
@@ -1,0 +1,234 @@
+"""Split package summaries and CLI helpers for the diagnostics tab."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
+from .user_copy import format_manifest_path_fact
+
+_MANIFEST_MODE_TRANSLATION = "translation"
+_CREATED_SPLIT_PACKAGE_RE = re.compile(
+    r"^\s*Created split package:\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+_SOURCE_MANIFEST_RE = re.compile(
+    r"^\s*Source manifest updated:\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+_LATEST_SPLIT_MANIFEST_RE = re.compile(
+    r"^\s*Latest manifest set to first split package:\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class SplitSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+    manifest_path: str = ""
+    source_manifest_path: str = ""
+    latest_manifest_path: str = ""
+    child_manifest_paths: list[str] | None = None
+
+
+def translation_split_ready(
+    manifest_path: str,
+    manifest: dict[str, object] | None,
+) -> tuple[bool, str]:
+    if not manifest_path.strip():
+        return False, "没有可拆分的翻译任务记录。"
+    if manifest is None:
+        return False, "无法读取任务记录，请先在诊断页刷新上下文。"
+    mode = manifest.get("mode")
+    mode_text = mode.strip() if isinstance(mode, str) else _MANIFEST_MODE_TRANSLATION
+    if mode_text != _MANIFEST_MODE_TRANSLATION:
+        return False, "拆分翻译包仅支持批量翻译任务记录。"
+    version = manifest.get("version", 1)
+    if version != 1:
+        return False, "当前仅支持 version 1 的翻译任务记录。"
+    chunks = manifest.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        return False, "任务记录中没有可拆分的块。"
+    return True, ""
+
+
+def build_split_cli_args(
+    manifest_path: str,
+    *,
+    max_chunks: int = 600,
+    max_items: int = 0,
+    display_name_prefix: str = "",
+) -> list[str]:
+    args = ["split", manifest_path, "--max-chunks", str(max_chunks)]
+    if max_items > 0:
+        args.extend(["--max-items", str(max_items)])
+    if display_name_prefix.strip():
+        args.extend(["--display-name-prefix", display_name_prefix.strip()])
+    return args
+
+
+def parse_split_output(output: str) -> dict[str, object]:
+    child_dirs = [
+        match.group(1).strip()
+        for match in _CREATED_SPLIT_PACKAGE_RE.finditer(output)
+    ]
+    child_manifest_paths = [
+        _join_manifest_path(part_dir)
+        for part_dir in child_dirs
+        if part_dir
+    ]
+    source_match = _SOURCE_MANIFEST_RE.search(output)
+    latest_match = _LATEST_SPLIT_MANIFEST_RE.search(output)
+    return {
+        "unchanged": "Split not needed; current package already fits the requested limits." in output,
+        "child_manifest_paths": child_manifest_paths,
+        "source_manifest_path": source_match.group(1).strip() if source_match else "",
+        "latest_manifest_path": latest_match.group(1).strip() if latest_match else "",
+    }
+
+
+def _join_manifest_path(package_dir: str) -> str:
+    normalized = package_dir.rstrip("/\\")
+    if normalized.lower().endswith("manifest.json"):
+        return normalized
+    separator = "\\" if "\\" in normalized and "/" not in normalized else "/"
+    return f"{normalized}{separator}manifest.json"
+
+
+def summarize_split_output(
+    output: str,
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+) -> SplitSummary:
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(format_manifest_path_fact(manifest_path))
+
+    if exit_code != 0:
+        return SplitSummary(
+            status="failed",
+            heading="拆分翻译包失败",
+            message="拆分命令没有正常完成，请查看诊断日志。",
+            facts=facts,
+            findings=[],
+            manifest_path=manifest_path,
+        )
+
+    parsed = parse_split_output(output)
+    if parsed.get("unchanged"):
+        return SplitSummary(
+            status="unchanged",
+            heading="无需拆分",
+            message="当前翻译包已符合所选上限，无需生成子包。",
+            facts=facts,
+            findings=[],
+            manifest_path=manifest_path,
+        )
+
+    child_paths = parsed.get("child_manifest_paths")
+    child_manifest_paths = (
+        [path for path in child_paths if isinstance(path, str) and path.strip()]
+        if isinstance(child_paths, list)
+        else []
+    )
+    source_manifest_path = parsed.get("source_manifest_path")
+    latest_manifest_path = parsed.get("latest_manifest_path")
+
+    if child_manifest_paths:
+        facts.append(f"生成子包：{len(child_manifest_paths)} 个")
+        for index, child_path in enumerate(child_manifest_paths, start=1):
+            facts.append(f"子包 {index:02d}：{child_path}")
+    if isinstance(source_manifest_path, str) and source_manifest_path:
+        facts.append(f"源任务记录：{source_manifest_path}")
+    if isinstance(latest_manifest_path, str) and latest_manifest_path:
+        facts.append(f"最近任务指针：{latest_manifest_path}")
+
+    findings = [
+        "拆分后 RAG 记忆库为静态快照；各子包需分别 submit，不会自动提交。",
+        "详见 docs/context_systems.md 中 split 与 RAG 说明。",
+    ]
+
+    if not child_manifest_paths:
+        return SplitSummary(
+            status="unknown",
+            heading="拆分结果不明确",
+            message="命令已结束，但未能识别子包路径，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+            manifest_path=manifest_path,
+            source_manifest_path=source_manifest_path if isinstance(source_manifest_path, str) else "",
+            latest_manifest_path=latest_manifest_path if isinstance(latest_manifest_path, str) else "",
+        )
+
+    return SplitSummary(
+        status="ok",
+        heading="拆分翻译包完成",
+        message=(
+            f"已生成 {len(child_manifest_paths)} 个子包。"
+            "可在命令参考中复制各子包的 submit 命令，或在工作台查看拆分包状态。"
+        ),
+        facts=facts,
+        findings=findings,
+        manifest_path=manifest_path,
+        source_manifest_path=source_manifest_path if isinstance(source_manifest_path, str) else "",
+        latest_manifest_path=latest_manifest_path if isinstance(latest_manifest_path, str) else "",
+        child_manifest_paths=child_manifest_paths,
+    )
+
+
+def running_split_summary(*, manifest_path: str = "") -> SplitSummary:
+    facts = [format_manifest_path_fact(manifest_path)] if manifest_path else []
+    return SplitSummary(
+        status="running",
+        heading="正在拆分翻译包",
+        message="正在按所选上限拆分子包；完成后这里会显示子包列表。",
+        facts=facts,
+        findings=[],
+        manifest_path=manifest_path,
+    )
+
+
+def split_summary_to_diagnostics_context(
+    summary: SplitSummary,
+    base: DiagnosticsContext,
+) -> DiagnosticsContext:
+    paths = list(base.paths)
+    for index, child_path in enumerate(summary.child_manifest_paths or [], start=1):
+        paths.append(DiagnosticsPathEntry(label=f"拆分子包 {index:02d}", path=child_path))
+    if summary.source_manifest_path:
+        paths.append(
+            DiagnosticsPathEntry(label="拆分源任务记录", path=summary.source_manifest_path)
+        )
+
+    facts = [*summary.facts, *base.facts]
+    if summary.findings:
+        facts.extend(summary.findings)
+
+    status = summary.status
+    if status == "ok":
+        status = "ready"
+    elif status in {"unchanged", "unknown"}:
+        status = "warning"
+    elif status == "running":
+        status = "running"
+    elif status == "failed":
+        status = "failed"
+
+    message = summary.message
+    if base.message and summary.status not in {"running", "failed"}:
+        message = f"{summary.message}\n\n{base.message}"
+
+    return DiagnosticsContext(
+        status=status,
+        heading=summary.heading,
+        message=message,
+        facts=facts,
+        paths=paths,
+        commands=base.commands,
+        manifest_json_preview=base.manifest_json_preview,
+    )

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -114,6 +114,26 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn(retry_path, by_label["提交补译任务"])
         self.assertIn(retry_path, by_label["合并补译结果"])
 
+    def test_translation_commands_include_split_child_submit_examples(self):
+        child_one = r"C:\logs\batch_jobs\job1\split_parts\part01_of_02\manifest.json"
+        child_two = r"C:\logs\batch_jobs\job1\split_parts\part02_of_02\manifest.json"
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\logs\batch_jobs\job1\manifest.json",
+            manifest={
+                "mode": "translation",
+                "job_name": "",
+                "split_children": [child_one, child_two],
+            },
+        )
+
+        by_label = {command.label: command.command for command in commands}
+        self.assertIn("提交拆分包 01", by_label)
+        self.assertIn("提交拆分包 02", by_label)
+        self.assertIn(child_one, by_label["提交拆分包 01"])
+        self.assertIn(child_two, by_label["提交拆分包 02"])
+
     def test_warn_without_existing_retry_includes_build_retry(self):
         commands = build_cli_commands(
             python_exe="python",

--- a/tests/test_gui_split_report.py
+++ b/tests/test_gui_split_report.py
@@ -1,0 +1,89 @@
+import unittest
+
+from gui_qt.split_report import (
+    build_split_cli_args,
+    parse_split_output,
+    summarize_split_output,
+    translation_split_ready,
+)
+
+
+SPLIT_OUTPUT_OK = """
+Created split package: C:\\pkg\\split_parts\\part01_of_02
+Chunks: 400
+Items: 1200
+Created split package: C:\\pkg\\split_parts\\part02_of_02
+Chunks: 350
+Items: 980
+Source manifest updated: C:\\pkg\\manifest.json
+Latest manifest set to first split package: C:\\pkg\\split_parts\\part01_of_02\\manifest.json
+"""
+
+SPLIT_OUTPUT_UNCHANGED = "Split not needed; current package already fits the requested limits."
+
+
+class GuiSplitReportTests(unittest.TestCase):
+    def test_build_split_cli_args_uses_default_max_chunks(self):
+        args = build_split_cli_args(r"C:\pkg\manifest.json")
+        self.assertEqual(args, ["split", r"C:\pkg\manifest.json", "--max-chunks", "600"])
+
+    def test_build_split_cli_args_includes_optional_limits(self):
+        args = build_split_cli_args(
+            r"C:\pkg\manifest.json",
+            max_chunks=400,
+            max_items=1000,
+            display_name_prefix="demo-game",
+        )
+        self.assertIn("--max-items", args)
+        self.assertIn("1000", args)
+        self.assertIn("--display-name-prefix", args)
+        self.assertIn("demo-game", args)
+
+    def test_parse_split_output_collects_child_manifest_paths(self):
+        parsed = parse_split_output(SPLIT_OUTPUT_OK)
+        self.assertEqual(len(parsed["child_manifest_paths"]), 2)
+        self.assertTrue(
+            str(parsed["child_manifest_paths"][0]).endswith("manifest.json")
+        )
+        self.assertEqual(
+            parsed["latest_manifest_path"],
+            r"C:\pkg\split_parts\part01_of_02\manifest.json",
+        )
+
+    def test_summarize_split_output_marks_success(self):
+        summary = summarize_split_output(
+            SPLIT_OUTPUT_OK,
+            0,
+            manifest_path=r"C:\pkg\manifest.json",
+        )
+        self.assertEqual(summary.status, "ok")
+        self.assertEqual(len(summary.child_manifest_paths or []), 2)
+        self.assertTrue(any("RAG" in finding for finding in summary.findings))
+
+    def test_summarize_split_output_marks_unchanged(self):
+        summary = summarize_split_output(SPLIT_OUTPUT_UNCHANGED, 0)
+        self.assertEqual(summary.status, "unchanged")
+
+    def test_summarize_split_output_nonzero_exit_is_failed(self):
+        summary = summarize_split_output(SPLIT_OUTPUT_OK, 1)
+        self.assertEqual(summary.status, "failed")
+
+    def test_translation_split_ready_requires_chunks(self):
+        ready, message = translation_split_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "translation", "version": 1, "chunks": []},
+        )
+        self.assertFalse(ready)
+        self.assertIn("块", message)
+
+    def test_translation_split_ready_accepts_translation_manifest(self):
+        ready, message = translation_split_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "translation", "version": 1, "chunks": [{"key": "a"}]},
+        )
+        self.assertTrue(ready)
+        self.assertEqual(message, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a diagnostics toolbar entry to run `gemini_translate_batch.py split` for oversized translation packages.

- New `gui_qt/split_report.py` for CLI arg building, output parsing, and summaries
- Diagnostics button **拆分翻译包** with optional advanced options (`--max-chunks`, `--max-items`, `--display-name-prefix`)
- After split: refresh workflow/split status UI; list child manifest paths; command reference includes per-child `submit` examples
- Unit tests in `tests/test_gui_split_report.py` and diagnostics context coverage
- Docs update in `docs/gui_workbench.md` (cross-ref `docs/context_systems.md`)

## Test plan

- [x] `python -m unittest tests.test_gui_split_report -v`
- [x] diagnostics context split-child submit test
- [ ] GUI manual: split a large package and verify child paths + submit commands

Refs #42
Refs #108
Refs #112
Closes #112