### PR TITLE
feat: batch submit 断点恢复 (#135 PR2)

### DIFF
--- a/batch_submit_recovery.py
+++ b/batch_submit_recovery.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Submit journal and recovery helpers for Batch manifest idempotency."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+from datetime import datetime
+from typing import Any
+
+SUBMIT_JOURNAL_FILENAME = 'submit_journal.jsonl'
+
+SUBMIT_STATE_STARTING = 'starting'
+SUBMIT_STATE_UPLOADED = 'uploaded'
+SUBMIT_STATE_JOB_CREATED = 'job_created'
+SUBMIT_STATE_COMMITTED = 'committed'
+
+EVENT_ATTEMPT_STARTED = 'submit_attempt_started'
+EVENT_UPLOAD_COMPLETED = 'upload_completed'
+EVENT_JOB_CREATED = 'job_created'
+EVENT_MANIFEST_COMMITTED = 'manifest_committed'
+
+BLOCKED_MESSAGE_PREFIX = 'Submit blocked:'
+RECOVER_HINT = 'Run recover-submit on this package before submitting again.'
+
+
+def submit_journal_path(package_dir: str) -> str:
+    return os.path.join(package_dir, SUBMIT_JOURNAL_FILENAME)
+
+
+def new_submit_attempt_id() -> str:
+    stamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    return f'{stamp}_{secrets.token_hex(4)}'
+
+
+def compute_request_checksum(manifest: dict[str, Any]) -> str:
+    jsonl_path = manifest.get('input_jsonl_path')
+    if not isinstance(jsonl_path, str) or not jsonl_path.strip():
+        raise FileNotFoundError('Manifest is missing input_jsonl_path.')
+    path = jsonl_path.strip()
+    digest = hashlib.sha256()
+    with open(path, 'rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def append_submit_journal_entry(package_dir: str, entry: dict[str, Any]) -> None:
+    payload = dict(entry)
+    payload.setdefault('at', datetime.now().isoformat(timespec='seconds'))
+    journal_path = submit_journal_path(package_dir)
+    with open(journal_path, 'a', encoding='utf-8') as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + '\n')
+
+
+def read_submit_journal_entries(package_dir: str) -> list[dict[str, Any]]:
+    journal_path = submit_journal_path(package_dir)
+    if not os.path.isfile(journal_path):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    with open(journal_path, 'r', encoding='utf-8') as handle:
+        for line_number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                entries.append(parsed)
+    return entries
+
+
+def begin_submit_attempt(manifest: dict[str, Any], *, package_dir: str) -> str:
+    attempt_id = new_submit_attempt_id()
+    checksum = compute_request_checksum(manifest)
+    manifest['submit_attempt_id'] = attempt_id
+    manifest['request_checksum'] = checksum
+    manifest['submit_state'] = SUBMIT_STATE_STARTING
+    manifest.pop('submit_recovery_hint', None)
+    append_submit_journal_entry(
+        package_dir,
+        {
+            'event': EVENT_ATTEMPT_STARTED,
+            'submit_attempt_id': attempt_id,
+            'display_name': manifest.get('display_name', ''),
+            'batch_model': manifest.get('batch_model', ''),
+            'request_checksum': checksum,
+        },
+    )
+    return attempt_id
+
+
+def record_upload_completed(
+    manifest: dict[str, Any],
+    *,
+    package_dir: str,
+    uploaded_file_name: str,
+) -> None:
+    manifest['uploaded_file_name'] = uploaded_file_name
+    manifest.setdefault('uploaded_file_names', [])
+    if uploaded_file_name and uploaded_file_name not in manifest['uploaded_file_names']:
+        manifest['uploaded_file_names'].append(uploaded_file_name)
+    manifest['submit_state'] = SUBMIT_STATE_UPLOADED
+    append_submit_journal_entry(
+        package_dir,
+        {
+            'event': EVENT_UPLOAD_COMPLETED,
+            'submit_attempt_id': manifest.get('submit_attempt_id', ''),
+            'display_name': manifest.get('display_name', ''),
+            'batch_model': manifest.get('batch_model', ''),
+            'request_checksum': manifest.get('request_checksum', ''),
+            'uploaded_file_name': uploaded_file_name,
+        },
+    )
+
+
+def record_job_created(
+    manifest: dict[str, Any],
+    *,
+    package_dir: str,
+    job_name: str,
+    job_state: str,
+    uploaded_file_name: str,
+) -> None:
+    append_submit_journal_entry(
+        package_dir,
+        {
+            'event': EVENT_JOB_CREATED,
+            'submit_attempt_id': manifest.get('submit_attempt_id', ''),
+            'display_name': manifest.get('display_name', ''),
+            'batch_model': manifest.get('batch_model', ''),
+            'request_checksum': manifest.get('request_checksum', ''),
+            'uploaded_file_name': uploaded_file_name,
+            'job_name': job_name,
+            'job_state': job_state,
+        },
+    )
+    manifest['submit_state'] = SUBMIT_STATE_JOB_CREATED
+
+
+def record_manifest_committed(manifest: dict[str, Any], *, package_dir: str) -> None:
+    manifest['submit_state'] = SUBMIT_STATE_COMMITTED
+    append_submit_journal_entry(
+        package_dir,
+        {
+            'event': EVENT_MANIFEST_COMMITTED,
+            'submit_attempt_id': manifest.get('submit_attempt_id', ''),
+            'job_name': manifest.get('job_name', ''),
+            'request_checksum': manifest.get('request_checksum', ''),
+        },
+    )
+
+
+def _latest_attempt_entries(entries: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    attempt_id = ''
+    for entry in reversed(entries):
+        candidate = entry.get('submit_attempt_id')
+        if isinstance(candidate, str) and candidate.strip():
+            attempt_id = candidate.strip()
+            break
+    if not attempt_id:
+        return '', []
+    return attempt_id, [entry for entry in entries if entry.get('submit_attempt_id') == attempt_id]
+
+
+def find_uncommitted_job_created(
+    entries: list[dict[str, Any]],
+    manifest: dict[str, Any],
+) -> dict[str, Any] | None:
+    if manifest.get('job_name'):
+        return None
+
+    attempt_id, attempt_entries = _latest_attempt_entries(entries)
+    if not attempt_id:
+        return None
+
+    committed = any(
+        entry.get('event') == EVENT_MANIFEST_COMMITTED
+        for entry in attempt_entries
+    )
+    if committed:
+        return None
+
+    job_created_entries = [
+        entry
+        for entry in attempt_entries
+        if entry.get('event') == EVENT_JOB_CREATED and entry.get('job_name')
+    ]
+    if not job_created_entries:
+        return None
+    return job_created_entries[-1]
+
+
+def has_upload_pending_job_create(manifest: dict[str, Any], entries: list[dict[str, Any]]) -> bool:
+    if manifest.get('job_name'):
+        return False
+    if manifest.get('submit_state') != SUBMIT_STATE_UPLOADED:
+        return False
+    uploaded_file_name = manifest.get('uploaded_file_name')
+    if not isinstance(uploaded_file_name, str) or not uploaded_file_name.strip():
+        return False
+
+    attempt_id = manifest.get('submit_attempt_id')
+    if not isinstance(attempt_id, str) or not attempt_id.strip():
+        return False
+
+    attempt_entries = [
+        entry for entry in entries if entry.get('submit_attempt_id') == attempt_id
+    ]
+    if any(entry.get('event') == EVENT_JOB_CREATED for entry in attempt_entries):
+        return False
+    if any(entry.get('event') == EVENT_MANIFEST_COMMITTED for entry in attempt_entries):
+        return False
+    return True
+
+
+def get_uncertain_submit_state(
+    manifest: dict[str, Any],
+    *,
+    package_dir: str | None = None,
+) -> dict[str, Any] | None:
+    if manifest.get('job_name'):
+        return None
+
+    resolved_package_dir = package_dir or manifest.get('_package_dir') or ''
+    entries = read_submit_journal_entries(resolved_package_dir) if resolved_package_dir else []
+
+    pending_job = find_uncommitted_job_created(entries, manifest)
+    if pending_job:
+        return {
+            'kind': 'job_created_uncommitted',
+            'job_name': pending_job.get('job_name', ''),
+            'uploaded_file_name': pending_job.get('uploaded_file_name', ''),
+            'display_name': pending_job.get('display_name', ''),
+            'request_checksum': pending_job.get('request_checksum', ''),
+            'message': (
+                f'{BLOCKED_MESSAGE_PREFIX} a remote batch job was created but manifest was not '
+                f"updated ({pending_job.get('job_name', '')})."
+            ),
+            'recovery_hint': RECOVER_HINT,
+        }
+
+    if has_upload_pending_job_create(manifest, entries):
+        return {
+            'kind': 'upload_pending_job_create',
+            'uploaded_file_name': manifest.get('uploaded_file_name', ''),
+            'display_name': manifest.get('display_name', ''),
+            'request_checksum': manifest.get('request_checksum', ''),
+            'message': (
+                f'{BLOCKED_MESSAGE_PREFIX} input JSONL was uploaded '
+                f"({manifest.get('uploaded_file_name', '')}) but no batch job was created yet."
+            ),
+            'recovery_hint': 'Re-run submit with --resume to continue job creation, or --force to start over.',
+        }
+
+    return None
+
+
+def clear_incomplete_submit_state(manifest: dict[str, Any]) -> None:
+    manifest.pop('submit_attempt_id', None)
+    manifest.pop('request_checksum', None)
+    manifest.pop('submit_state', None)
+    manifest.pop('submit_recovery_hint', None)
+    manifest.pop('uploaded_file_name', None)
+
+
+def format_uncertain_submit_hints(uncertain_state: dict[str, Any] | None) -> list[str]:
+    if not uncertain_state:
+        return []
+
+    hints: list[str] = []
+    kind = uncertain_state.get('kind')
+    if kind == 'job_created_uncommitted':
+        job_name = uncertain_state.get('job_name')
+        if isinstance(job_name, str) and job_name.strip():
+            hints.append(f'Recoverable remote job: {job_name.strip()}')
+    elif kind == 'upload_pending_job_create':
+        uploaded_file_name = uncertain_state.get('uploaded_file_name')
+        if isinstance(uploaded_file_name, str) and uploaded_file_name.strip():
+            hints.append(f'Uploaded input file: {uploaded_file_name.strip()}')
+    display_name = uncertain_state.get('display_name')
+    if isinstance(display_name, str) and display_name.strip():
+        hints.append(f'Display name: {display_name.strip()}')
+    checksum = uncertain_state.get('request_checksum')
+    if isinstance(checksum, str) and checksum.strip():
+        hints.append(f'Request checksum: {checksum.strip()}')
+    recovery_hint = uncertain_state.get('recovery_hint')
+    if isinstance(recovery_hint, str) and recovery_hint.strip():
+        hints.append(recovery_hint.strip())
+    return hints
+
+
+def apply_recovered_job_to_manifest(
+    manifest: dict[str, Any],
+    pending_job: dict[str, Any],
+    *,
+    package_dir: str,
+    submitted_api_key_index: int | None = None,
+) -> None:
+    manifest['job_name'] = pending_job.get('job_name', '')
+    manifest['job_state'] = pending_job.get('job_state') or 'JOB_STATE_PENDING'
+    manifest['submitted_at'] = pending_job.get('at') or datetime.now().isoformat(timespec='seconds')
+    manifest['last_status_checked_at'] = manifest['submitted_at']
+    if submitted_api_key_index is not None:
+        manifest['submitted_api_key_index'] = submitted_api_key_index
+        manifest['submitted_api_key_number'] = submitted_api_key_index + 1
+        manifest['last_status_api_key_index'] = submitted_api_key_index
+
+    uploaded_file_name = pending_job.get('uploaded_file_name')
+    if isinstance(uploaded_file_name, str) and uploaded_file_name.strip():
+        manifest['uploaded_file_name'] = uploaded_file_name.strip()
+        manifest.setdefault('uploaded_file_names', [])
+        if manifest['uploaded_file_name'] not in manifest['uploaded_file_names']:
+            manifest['uploaded_file_names'].append(manifest['uploaded_file_name'])
+
+    attempt_id = pending_job.get('submit_attempt_id')
+    if isinstance(attempt_id, str) and attempt_id.strip():
+        manifest['submit_attempt_id'] = attempt_id.strip()
+    checksum = pending_job.get('request_checksum')
+    if isinstance(checksum, str) and checksum.strip():
+        manifest['request_checksum'] = checksum.strip()
+
+    manifest['last_submit_error'] = ''
+    manifest.pop('last_submit_error_type', None)
+    manifest.pop('split_recommended', None)
+    manifest.pop('last_submit_quota_recommendation', None)
+    record_manifest_committed(manifest, package_dir=package_dir)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -19,6 +19,7 @@ if SCRIPT_DIR not in sys.path:
 
 from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreLockError, hash_text, truncate_text
 import batch_cost_estimate
+import batch_submit_recovery
 import prompt_context
 import story_memory
 import translation_core
@@ -3811,7 +3812,79 @@ def ensure_manifest_cost_estimate(manifest):
         ) from exc
 
 
-def submit_manifest(target=None, display_name_override='', model_override='', max_cost=None):
+def _manifest_package_dir(manifest):
+    package_dir = manifest.get('_package_dir')
+    if package_dir:
+        return package_dir
+    manifest_path = manifest.get('_manifest_path')
+    if manifest_path:
+        return os.path.dirname(manifest_path)
+    raise SystemExit('Manifest package directory is missing.')
+
+
+def _raise_uncertain_submit_blocked(uncertain_state):
+    message = uncertain_state.get('message') or batch_submit_recovery.BLOCKED_MESSAGE_PREFIX
+    recovery_hint = uncertain_state.get('recovery_hint') or batch_submit_recovery.RECOVER_HINT
+    raise SystemExit(f'{message}\n{recovery_hint}')
+
+
+def recover_submit_manifest(target=None, verify_remote=True):
+    manifest = load_manifest(target)
+    if manifest.get('job_name'):
+        print(f"Manifest already submitted: {manifest['job_name']}")
+        print(f"Manifest: {manifest['_manifest_path']}")
+        return manifest['_manifest_path']
+
+    package_dir = _manifest_package_dir(manifest)
+    entries = batch_submit_recovery.read_submit_journal_entries(package_dir)
+    pending_job = batch_submit_recovery.find_uncommitted_job_created(entries, manifest)
+    if pending_job is None:
+        uncertain_state = batch_submit_recovery.get_uncertain_submit_state(
+            manifest,
+            package_dir=package_dir,
+        )
+        if uncertain_state and uncertain_state.get('kind') == 'upload_pending_job_create':
+            for hint in batch_submit_recovery.format_uncertain_submit_hints(uncertain_state):
+                print(hint)
+            raise SystemExit(
+                'No recoverable remote job found. Re-run submit with --resume to continue job creation.'
+            )
+        raise SystemExit('No recoverable submit state found for this manifest.')
+
+    job_name = pending_job.get('job_name', '')
+    if verify_remote:
+        client = create_batch_client()
+        try:
+            batch_job = client.batches.get(name=job_name)
+            remote_state = get_state_name(getattr(batch_job, 'state', None))
+            if remote_state:
+                pending_job['job_state'] = remote_state
+            print(f'Verified remote batch job: {job_name}')
+            if remote_state:
+                print(f'Remote state: {remote_state}')
+        except Exception as exc:
+            print(f'Warning: Could not verify remote job {job_name}: {exc}')
+
+    batch_submit_recovery.apply_recovered_job_to_manifest(
+        manifest,
+        pending_job,
+        package_dir=package_dir,
+        submitted_api_key_index=getattr(legacy, 'CURRENT_KEY_INDEX', 0),
+    )
+    save_manifest(manifest)
+    print(f'Recovered batch job: {manifest["job_name"]}')
+    print(f"Manifest: {manifest['_manifest_path']}")
+    return manifest['_manifest_path']
+
+
+def submit_manifest(
+    target=None,
+    display_name_override='',
+    model_override='',
+    max_cost=None,
+    force_resubmit=False,
+    resume_upload=False,
+):
     manifest = load_manifest(target) if target else None
     if manifest is None:
         manifest_path = create_batch_package(display_name_override=display_name_override)
@@ -3821,6 +3894,29 @@ def submit_manifest(target=None, display_name_override='', model_override='', ma
 
     if manifest.get('job_name'):
         raise SystemExit(f"Manifest already submitted: {manifest['job_name']}")
+
+    package_dir = _manifest_package_dir(manifest)
+    uncertain_state = batch_submit_recovery.get_uncertain_submit_state(
+        manifest,
+        package_dir=package_dir,
+    )
+    if uncertain_state:
+        if uncertain_state.get('kind') == 'job_created_uncommitted':
+            _raise_uncertain_submit_blocked(uncertain_state)
+        if uncertain_state.get('kind') == 'upload_pending_job_create':
+            if resume_upload:
+                current_checksum = batch_submit_recovery.compute_request_checksum(manifest)
+                saved_checksum = manifest.get('request_checksum')
+                if saved_checksum and saved_checksum != current_checksum:
+                    raise SystemExit(
+                        'Submit blocked: input JSONL changed since upload. '
+                        'Re-run submit with --force to start over.'
+                    )
+            elif force_resubmit:
+                batch_submit_recovery.clear_incomplete_submit_state(manifest)
+                uncertain_state = None
+            else:
+                _raise_uncertain_submit_blocked(uncertain_state)
 
     if display_name_override:
         manifest['display_name'] = display_name_override.strip()
@@ -3839,44 +3935,72 @@ def submit_manifest(target=None, display_name_override='', model_override='', ma
                 f'exceeds limit {float(max_cost):.4f} {currency}.'
             )
 
+    resume_existing_upload = (
+        resume_upload
+        and uncertain_state is not None
+        and uncertain_state.get('kind') == 'upload_pending_job_create'
+        and manifest.get('uploaded_file_name')
+    )
+    if not resume_existing_upload:
+        batch_submit_recovery.begin_submit_attempt(manifest, package_dir=package_dir)
+        save_manifest(manifest)
+
     attempts = max(1, len(getattr(legacy, 'API_KEYS', [])))
     last_error = None
 
     for attempt in range(1, attempts + 1):
         client = create_batch_client()
-        uploaded_file = None
+        uploaded_file_name = ''
         try:
-            print(f"Uploading JSONL: {manifest['input_jsonl_path']}")
-            uploaded_file = client.files.upload(
-                file=manifest['input_jsonl_path'],
-                config=genai_types.UploadFileConfig(
-                    display_name=manifest['display_name'],
-                    mime_type='jsonl',
-                ),
-            )
-            manifest['uploaded_file_name'] = getattr(uploaded_file, 'name', '')
-            manifest.setdefault('uploaded_file_names', [])
-            if manifest['uploaded_file_name'] and manifest['uploaded_file_name'] not in manifest['uploaded_file_names']:
-                manifest['uploaded_file_names'].append(manifest['uploaded_file_name'])
-            _clear_submit_failure_metadata(manifest)
-            save_manifest(manifest)
-            print(f'Uploaded file: {uploaded_file.name}')
+            if resume_existing_upload:
+                uploaded_file_name = manifest['uploaded_file_name']
+                print(f"Reusing uploaded JSONL: {uploaded_file_name}")
+            else:
+                print(f"Uploading JSONL: {manifest['input_jsonl_path']}")
+                uploaded_file = client.files.upload(
+                    file=manifest['input_jsonl_path'],
+                    config=genai_types.UploadFileConfig(
+                        display_name=manifest['display_name'],
+                        mime_type='jsonl',
+                    ),
+                )
+                uploaded_file_name = getattr(uploaded_file, 'name', '')
+                batch_submit_recovery.record_upload_completed(
+                    manifest,
+                    package_dir=package_dir,
+                    uploaded_file_name=uploaded_file_name,
+                )
+                _clear_submit_failure_metadata(manifest)
+                save_manifest(manifest)
+                print(f'Uploaded file: {uploaded_file_name}')
 
             print(f"Creating batch job with model: {manifest['batch_model']}")
             batch_job = client.batches.create(
                 model=manifest['batch_model'],
-                src=uploaded_file.name,
+                src=uploaded_file_name,
                 config={'display_name': manifest['display_name']},
             )
 
-            manifest['job_name'] = getattr(batch_job, 'name', '')
-            manifest['job_state'] = get_state_name(getattr(batch_job, 'state', None))
+            job_name = getattr(batch_job, 'name', '')
+            job_state = get_state_name(getattr(batch_job, 'state', None))
+            batch_submit_recovery.record_job_created(
+                manifest,
+                package_dir=package_dir,
+                job_name=job_name,
+                job_state=job_state,
+                uploaded_file_name=uploaded_file_name,
+            )
+
+            manifest['job_name'] = job_name
+            manifest['job_state'] = job_state
             manifest['submitted_at'] = datetime.now().isoformat(timespec='seconds')
             manifest['last_status_checked_at'] = manifest['submitted_at']
             manifest['submitted_api_key_index'] = getattr(legacy, 'CURRENT_KEY_INDEX', 0)
             manifest['submitted_api_key_number'] = manifest['submitted_api_key_index'] + 1
             manifest['last_status_api_key_index'] = manifest['submitted_api_key_index']
             _clear_submit_failure_metadata(manifest)
+            save_manifest(manifest)
+            batch_submit_recovery.record_manifest_committed(manifest, package_dir=package_dir)
             save_manifest(manifest)
 
             print(f"Batch job created: {manifest['job_name']}")
@@ -3894,20 +4018,22 @@ def submit_manifest(target=None, display_name_override='', model_override='', ma
             if not quota_error:
                 manifest.pop('split_recommended', None)
                 manifest.pop('last_submit_quota_recommendation', None)
-            if uploaded_file is not None:
-                manifest['uploaded_file_name'] = getattr(uploaded_file, 'name', '')
+            if uploaded_file_name:
+                manifest['uploaded_file_name'] = uploaded_file_name
                 manifest.setdefault('uploaded_file_names', [])
-                if manifest['uploaded_file_name'] and manifest['uploaded_file_name'] not in manifest['uploaded_file_names']:
-                    manifest['uploaded_file_names'].append(manifest['uploaded_file_name'])
+                if uploaded_file_name not in manifest['uploaded_file_names']:
+                    manifest['uploaded_file_names'].append(uploaded_file_name)
+                if manifest.get('submit_state') != batch_submit_recovery.SUBMIT_STATE_JOB_CREATED:
+                    manifest['submit_state'] = batch_submit_recovery.SUBMIT_STATE_UPLOADED
             save_manifest(manifest)
 
             if quota_error and attempt < attempts and legacy.rotate_api_key():
                 print(f'Quota hit during batch submit. Retrying with next API key ({attempt}/{attempts})...')
+                resume_existing_upload = False
                 continue
             if quota_error:
                 print_submit_split_recommendation(recommendation)
             raise
-
 
     if last_error is not None:
         raise last_error
@@ -3935,7 +4061,13 @@ def refresh_manifest_status(manifest):
 
 def show_status(target=None):
     manifest = load_manifest(target)
-    manifest = refresh_manifest_status(manifest)
+    uncertain_state = batch_submit_recovery.get_uncertain_submit_state(manifest)
+    if uncertain_state:
+        print('Submit recovery required before re-submitting this package.')
+        for hint in batch_submit_recovery.format_uncertain_submit_hints(uncertain_state):
+            print(hint)
+    if manifest.get('job_name'):
+        manifest = refresh_manifest_status(manifest)
     print(f"Manifest: {manifest['_manifest_path']}")
     print(f"Job: {manifest.get('job_name')}")
     print(f"State: {manifest.get('job_state')}")
@@ -8793,6 +8925,32 @@ def build_arg_parser():
         default=None,
         help='Reject submit when estimated max cost exceeds this value (same currency as batch.pricing).',
     )
+    submit_parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Start a fresh submit attempt after an incomplete upload-only state.',
+    )
+    submit_parser.add_argument(
+        '--resume',
+        action='store_true',
+        help='Continue job creation using a previously uploaded input file.',
+    )
+
+    recover_submit_parser = subparsers.add_parser(
+        'recover-submit',
+        help='Recover a batch job from submit journal when manifest was not updated.',
+    )
+    recover_submit_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Manifest path or package dir. Defaults to latest package.',
+    )
+    recover_submit_parser.add_argument(
+        '--no-verify',
+        action='store_true',
+        help='Skip remote job verification before writing manifest.',
+    )
 
     estimate_cost_parser = subparsers.add_parser(
         'estimate-cost',
@@ -9126,6 +9284,15 @@ def main(argv=None):
             display_name_override=args.display_name,
             model_override=args.model,
             max_cost=args.max_cost,
+            force_resubmit=args.force,
+            resume_upload=args.resume,
+        )
+        return
+
+    if command == 'recover-submit':
+        recover_submit_manifest(
+            target=args.target or None,
+            verify_remote=not args.no_verify,
         )
         return
 

--- a/gui_qt/batch_workflow_support.py
+++ b/gui_qt/batch_workflow_support.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
+
+import batch_submit_recovery
 
 
 def resolve_submit_max_cost(translator_config: dict[str, Any] | None) -> float | None:
@@ -21,19 +24,62 @@ def resolve_submit_max_cost(translator_config: dict[str, Any] | None) -> float |
     return value if value > 0 else None
 
 
+def _format_max_cost(value: float) -> str:
+    text = f"{value:.6f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def load_manifest_dict(manifest_path: str) -> dict[str, Any] | None:
+    if not manifest_path:
+        return None
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return manifest if isinstance(manifest, dict) else None
+
+
+def get_uncertain_submit_kind(manifest_path: str) -> str | None:
+    manifest = load_manifest_dict(manifest_path)
+    if not manifest or manifest.get("job_name"):
+        return None
+    package_dir = os.path.dirname(os.path.abspath(manifest_path))
+    uncertain_state = batch_submit_recovery.get_uncertain_submit_state(
+        manifest,
+        package_dir=package_dir,
+    )
+    if not uncertain_state:
+        return None
+    kind = uncertain_state.get("kind")
+    return kind.strip() if isinstance(kind, str) and kind.strip() else None
+
+
+def plan_unsubmitted_workflow_steps(manifest_path: str) -> list[str]:
+    kind = get_uncertain_submit_kind(manifest_path)
+    if kind == "job_created_uncommitted":
+        return ["recover-submit", "status"]
+    return ["submit", "status"]
+
+
 def build_submit_cli_args(
     manifest_path: str,
     submit_max_cost: float | None = None,
+    *,
+    resume: bool | None = None,
 ) -> list[str]:
     args = ["submit", manifest_path]
+    if resume is None:
+        resume = get_uncertain_submit_kind(manifest_path) == "upload_pending_job_create"
+    if resume:
+        args.append("--resume")
     if submit_max_cost is not None and submit_max_cost > 0:
         args.extend(["--max-cost", _format_max_cost(submit_max_cost)])
     return args
 
 
-def _format_max_cost(value: float) -> str:
-    text = f"{value:.6f}".rstrip("0").rstrip(".")
-    return text or "0"
+def build_recover_submit_cli_args(manifest_path: str) -> list[str]:
+    return ["recover-submit", manifest_path]
 
 
 def format_cost_estimate_facts(estimate: dict[str, Any] | None) -> list[str]:
@@ -62,18 +108,45 @@ def format_cost_estimate_facts(estimate: dict[str, Any] | None) -> list[str]:
 
 
 def load_cost_estimate_facts_from_manifest(manifest_path: str) -> list[str]:
-    if not manifest_path:
-        return []
-    try:
-        with open(manifest_path, "r", encoding="utf-8") as handle:
-            manifest = json.load(handle)
-    except (OSError, json.JSONDecodeError):
-        return []
-    if not isinstance(manifest, dict):
+    manifest = load_manifest_dict(manifest_path)
+    if not manifest:
         return []
     estimate = manifest.get("cost_estimate")
     return format_cost_estimate_facts(estimate if isinstance(estimate, dict) else None)
 
 
+def load_uncertain_submit_facts_from_manifest(manifest_path: str) -> list[str]:
+    manifest = load_manifest_dict(manifest_path)
+    if not manifest:
+        return []
+    package_dir = os.path.dirname(os.path.abspath(manifest_path))
+    uncertain_state = batch_submit_recovery.get_uncertain_submit_state(
+        manifest,
+        package_dir=package_dir,
+    )
+    facts = batch_submit_recovery.format_uncertain_submit_hints(uncertain_state)
+    return [f"提交恢复：{fact}" for fact in facts]
+
+
 def output_blocked_by_max_cost(output: str) -> bool:
     return "Submit blocked by --max-cost" in output
+
+
+def output_blocked_by_uncertain_submit(output: str) -> bool:
+    return batch_submit_recovery.BLOCKED_MESSAGE_PREFIX in output
+
+
+def uncertain_submit_failure_message(output: str) -> str:
+    if "recover-submit" in output.lower() or batch_submit_recovery.RECOVER_HINT in output:
+        return (
+            "检测到未完成的提交状态，且可能存在已创建的远端任务。"
+            "请先运行 recover-submit 恢复任务，再刷新状态。"
+        )
+    if "--resume" in output:
+        return (
+            "检测到输入文件已上传但尚未创建批量任务。"
+            "请使用带 --resume 的 submit 继续创建任务，或使用 --force 重新开始。"
+        )
+    return (
+        "提交被未完成状态拦截。请先恢复或确认上次提交，避免重复创建付费任务。"
+    )

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -8,7 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
-from .batch_workflow_support import build_submit_cli_args, format_cost_estimate_facts
+from .batch_workflow_support import (
+    build_recover_submit_cli_args,
+    build_submit_cli_args,
+    format_cost_estimate_facts,
+    get_uncertain_submit_kind,
+    load_uncertain_submit_facts_from_manifest,
+)
 from .user_copy import (
     format_job_fact,
     format_job_state_fact,
@@ -410,6 +416,18 @@ def build_cloud_job_commands(
 ) -> list[DiagnosticsCommand]:
     commands: list[DiagnosticsCommand] = []
     if not manifest.get("job_name"):
+        uncertain_kind = get_uncertain_submit_kind(manifest_path)
+        if uncertain_kind == "job_created_uncommitted":
+            commands.append(
+                DiagnosticsCommand(
+                    label="恢复提交状态",
+                    command=format_cli_command(
+                        python_exe,
+                        batch_script_path,
+                        build_recover_submit_cli_args(manifest_path),
+                    ),
+                )
+            )
         commands.append(
             DiagnosticsCommand(
                 label=submit_label,
@@ -566,6 +584,9 @@ def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> lis
     cost_estimate = manifest.get("cost_estimate")
     if isinstance(cost_estimate, dict):
         facts.extend(format_cost_estimate_facts(cost_estimate))
+
+    if manifest_path and not (isinstance(job_name, str) and job_name.strip()):
+        facts.extend(load_uncertain_submit_facts_from_manifest(manifest_path))
 
     mode = manifest.get("mode")
     if isinstance(mode, str) and mode.strip():

--- a/gui_qt/keyword_workflow.py
+++ b/gui_qt/keyword_workflow.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import re
 
 from .keyword_report import summarize_keyword_export_output
-from .batch_workflow_support import build_submit_cli_args, output_blocked_by_max_cost
+from .batch_workflow_support import (
+    build_recover_submit_cli_args,
+    build_submit_cli_args,
+    output_blocked_by_max_cost,
+    output_blocked_by_uncertain_submit,
+    plan_unsubmitted_workflow_steps,
+    uncertain_submit_failure_message,
+)
 from .translation_workflow import (
     TERMINAL_FAILURE_STATES,
     WorkflowStep,
@@ -29,6 +36,7 @@ def _extract_line_value(output: str, prefix: str) -> str:
 STEP_TEXT = {
     "build-keywords": ("正在准备关键词提取", "正在扫描翻译文本并准备待提交内容。"),
     "submit": ("正在提交关键词提取任务", "正在上传请求文件并创建云端批量任务。"),
+    "recover-submit": ("正在恢复提交状态", "正在从提交日志恢复远端批量任务信息。"),
     "status": ("正在刷新关键词任务状态", "正在查询云端任务处理状态。"),
     "download": ("正在获取关键词提取结果", "任务已完成，正在下载结果文件。"),
     "export-keywords": ("正在导出关键词报告", "正在整理候选术语与剧情概要报告。"),
@@ -78,7 +86,7 @@ class KeywordBatchWorkflow:
             )
         if not manifest.get("job_name"):
             return cls(
-                ["submit", "status"],
+                plan_unsubmitted_workflow_steps(manifest_path),
                 manifest_path=manifest_path,
                 submit_max_cost=submit_max_cost,
             )
@@ -109,11 +117,13 @@ class KeywordBatchWorkflow:
         if exit_code != 0:
             self._pending_steps.clear()
             message = f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。"
-            if key == "submit" and output_blocked_by_max_cost(output):
+            if key in {"submit", "recover-submit"} and output_blocked_by_max_cost(output):
                 message = (
                     "提交被成本上限拦截。请在高级设置中提高「提交成本上限」，"
                     "或先拆分任务包以降低单次提交成本。"
                 )
+            elif key in {"submit", "recover-submit"} and output_blocked_by_uncertain_submit(output):
+                message = uncertain_submit_failure_message(output)
             return WorkflowUpdate(
                 status="failed",
                 heading="关键词提取流程中断",
@@ -123,7 +133,7 @@ class KeywordBatchWorkflow:
 
         if key == "build-keywords":
             return self._finish_build(output)
-        if key == "submit":
+        if key in {"submit", "recover-submit"}:
             manifest_path = extract_manifest_path(output)
             if manifest_path:
                 self.manifest_path = manifest_path
@@ -227,6 +237,8 @@ class KeywordBatchWorkflow:
             return [key]
         if key == "submit":
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
+        if key == "recover-submit":
+            return build_recover_submit_cli_args(self.manifest_path)
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/gui_qt/revision_workflow.py
+++ b/gui_qt/revision_workflow.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import re
 
 from .revision_report import summarize_revision_preview_output
-from .batch_workflow_support import build_submit_cli_args, output_blocked_by_max_cost
+from .batch_workflow_support import (
+    build_recover_submit_cli_args,
+    build_submit_cli_args,
+    output_blocked_by_max_cost,
+    output_blocked_by_uncertain_submit,
+    plan_unsubmitted_workflow_steps,
+    uncertain_submit_failure_message,
+)
 from .translation_workflow import (
     TERMINAL_FAILURE_STATES,
     WorkflowStep,
@@ -29,6 +36,7 @@ def _extract_line_value(output: str, prefix: str) -> str:
 STEP_TEXT = {
     "build-revisions": ("正在准备订正内容", "正在扫描已有译文并准备待提交内容。"),
     "submit": ("正在提交订正任务", "正在上传请求文件并创建云端批量任务。"),
+    "recover-submit": ("正在恢复提交状态", "正在从提交日志恢复远端批量任务信息。"),
     "status": ("正在刷新订正任务状态", "正在查询云端任务处理状态。"),
     "download": ("正在获取订正结果", "任务已完成，正在下载结果文件。"),
     "preview-revisions": ("正在预览订正结果", "正在校验结果并生成订正预览报告。"),
@@ -78,7 +86,7 @@ class RevisionBatchWorkflow:
             )
         if not manifest.get("job_name"):
             return cls(
-                ["submit", "status"],
+                plan_unsubmitted_workflow_steps(manifest_path),
                 manifest_path=manifest_path,
                 submit_max_cost=submit_max_cost,
             )
@@ -109,11 +117,13 @@ class RevisionBatchWorkflow:
         if exit_code != 0:
             self._pending_steps.clear()
             message = f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。"
-            if key == "submit" and output_blocked_by_max_cost(output):
+            if key in {"submit", "recover-submit"} and output_blocked_by_max_cost(output):
                 message = (
                     "提交被成本上限拦截。请在高级设置中提高「提交成本上限」，"
                     "或先拆分任务包以降低单次提交成本。"
                 )
+            elif key in {"submit", "recover-submit"} and output_blocked_by_uncertain_submit(output):
+                message = uncertain_submit_failure_message(output)
             return WorkflowUpdate(
                 status="failed",
                 heading="订正流程中断",
@@ -123,7 +133,7 @@ class RevisionBatchWorkflow:
 
         if key == "build-revisions":
             return self._finish_build(output)
-        if key == "submit":
+        if key in {"submit", "recover-submit"}:
             manifest_path = extract_manifest_path(output)
             if manifest_path:
                 self.manifest_path = manifest_path
@@ -230,6 +240,8 @@ class RevisionBatchWorkflow:
             return [key]
         if key == "submit":
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
+        if key == "recover-submit":
+            return build_recover_submit_cli_args(self.manifest_path)
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -9,9 +9,13 @@ import re
 from dataclasses import dataclass
 
 from .batch_workflow_support import (
+    build_recover_submit_cli_args,
     build_submit_cli_args,
     load_cost_estimate_facts_from_manifest,
     output_blocked_by_max_cost,
+    output_blocked_by_uncertain_submit,
+    plan_unsubmitted_workflow_steps,
+    uncertain_submit_failure_message,
 )
 from .user_copy import (
     format_job_state_fact,
@@ -52,6 +56,7 @@ class WorkflowUpdate:
 STEP_TEXT = {
     "build": ("正在准备翻译内容", "正在扫描待翻译文本并准备待提交内容。"),
     "submit": ("正在提交翻译任务", "正在上传请求文件并创建云端批量任务。"),
+    "recover-submit": ("正在恢复提交状态", "正在从提交日志恢复远端批量任务信息。"),
     "status": ("正在刷新任务状态", "正在查询云端任务处理状态。"),
     "download": ("正在获取翻译结果", "任务已完成，正在下载结果文件。"),
     "check": ("正在检查翻译结果", "正在校验结果是否可以进入写回前预览。"),
@@ -152,7 +157,7 @@ class TranslationWorkflow:
             )
         if not manifest.get("job_name"):
             return cls(
-                ["submit", "status"],
+                plan_unsubmitted_workflow_steps(manifest_path),
                 manifest_path=manifest_path,
                 submit_max_cost=submit_max_cost,
             )
@@ -194,7 +199,7 @@ class TranslationWorkflow:
             )
         if not manifest.get("job_name"):
             return cls(
-                ["submit", "status"],
+                plan_unsubmitted_workflow_steps(manifest_path),
                 manifest_path=manifest_path,
                 submit_max_cost=submit_max_cost,
                 retry_parent_manifest_path=retry_parent_manifest_path,
@@ -234,7 +239,7 @@ class TranslationWorkflow:
 
         if key == "build":
             return self._finish_build(output)
-        if key == "submit":
+        if key in {"submit", "recover-submit"}:
             manifest_path = extract_manifest_path(output)
             if manifest_path:
                 self.manifest_path = manifest_path
@@ -267,12 +272,15 @@ class TranslationWorkflow:
     def _finish_failed_step(self, key: str, output: str) -> WorkflowUpdate:
         message = f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。"
         extra_facts: list[str] = []
-        if key == "submit" and output_blocked_by_max_cost(output):
+        if key in {"submit", "recover-submit"} and output_blocked_by_max_cost(output):
             message = (
                 "提交被成本上限拦截。请在高级设置中提高「提交成本上限」，"
                 "或先拆分任务包以降低单次提交成本。"
             )
             extra_facts.append("建议：检查高级设置中的提交成本上限，或先运行 split 拆包。")
+        elif key in {"submit", "recover-submit"} and output_blocked_by_uncertain_submit(output):
+            message = uncertain_submit_failure_message(output)
+            extra_facts.append("建议：在诊断页运行 recover-submit，或按提示使用 --resume / --force。")
         elif key == "submit" and output_has_quota_error(output):
             message = (
                 "提交云端任务时命中配额或资源限制。当前批量包可能过大，"
@@ -395,6 +403,8 @@ class TranslationWorkflow:
             return [key]
         if key == "submit":
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
+        if key == "recover-submit":
+            return build_recover_submit_cli_args(self.manifest_path)
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/tests/test_batch_submit_recovery.py
+++ b/tests/test_batch_submit_recovery.py
@@ -1,0 +1,287 @@
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import batch_submit_recovery
+import gemini_translate_batch as batch_mod
+
+
+class BatchSubmitRecoveryModuleTests(unittest.TestCase):
+    def test_compute_request_checksum_hashes_jsonl_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl_path = os.path.join(tmp, 'requests.jsonl')
+            with open(jsonl_path, 'w', encoding='utf-8') as handle:
+                handle.write('{"key":"a"}\n')
+            manifest = {'input_jsonl_path': jsonl_path}
+            checksum = batch_submit_recovery.compute_request_checksum(manifest)
+            self.assertEqual(len(checksum), 64)
+
+    def test_get_uncertain_submit_state_detects_upload_pending(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest = {
+                'job_name': '',
+                'submit_state': batch_submit_recovery.SUBMIT_STATE_UPLOADED,
+                'uploaded_file_name': 'files/uploaded-1',
+                'submit_attempt_id': 'attempt-1',
+                'request_checksum': 'abc',
+            }
+            batch_submit_recovery.append_submit_journal_entry(
+                package_dir,
+                {
+                    'event': batch_submit_recovery.EVENT_UPLOAD_COMPLETED,
+                    'submit_attempt_id': 'attempt-1',
+                    'uploaded_file_name': 'files/uploaded-1',
+                },
+            )
+            state = batch_submit_recovery.get_uncertain_submit_state(
+                manifest,
+                package_dir=str(package_dir),
+            )
+            self.assertEqual(state['kind'], 'upload_pending_job_create')
+
+    def test_get_uncertain_submit_state_detects_uncommitted_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest = {'job_name': ''}
+            batch_submit_recovery.append_submit_journal_entry(
+                package_dir,
+                {
+                    'event': batch_submit_recovery.EVENT_JOB_CREATED,
+                    'submit_attempt_id': 'attempt-2',
+                    'job_name': 'batches/job-2',
+                    'job_state': 'JOB_STATE_PENDING',
+                    'uploaded_file_name': 'files/uploaded-2',
+                    'display_name': 'demo',
+                    'request_checksum': 'deadbeef',
+                },
+            )
+            state = batch_submit_recovery.get_uncertain_submit_state(
+                manifest,
+                package_dir=str(package_dir),
+            )
+            self.assertEqual(state['kind'], 'job_created_uncommitted')
+            self.assertEqual(state['job_name'], 'batches/job-2')
+
+
+class BatchSubmitRecoveryFlowTests(unittest.TestCase):
+    def _make_package(self, tmp: str) -> tuple[Path, Path, Path]:
+        root = Path(tmp)
+        package_dir = root / 'package'
+        package_dir.mkdir()
+        input_path = package_dir / 'requests.jsonl'
+        manifest_path = package_dir / 'manifest.json'
+        latest_path = root / 'latest_manifest.txt'
+        input_path.write_text('{}\n', encoding='utf-8')
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    'display_name': 'demo package',
+                    'batch_model': 'gemini-test',
+                    'input_jsonl_path': str(input_path),
+                    'job_name': '',
+                },
+                ensure_ascii=False,
+            ),
+            encoding='utf-8',
+        )
+        return package_dir, manifest_path, latest_path
+
+    def test_submit_blocks_after_upload_without_job_create(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, manifest_path, latest_path = self._make_package(tmp)
+            checksum = batch_submit_recovery.compute_request_checksum(
+                {'input_jsonl_path': str(package_dir / 'requests.jsonl')}
+            )
+            manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+            manifest.update(
+                {
+                    'submit_state': batch_submit_recovery.SUBMIT_STATE_UPLOADED,
+                    'uploaded_file_name': 'files/uploaded-blocked',
+                    'submit_attempt_id': 'attempt-blocked',
+                    'request_checksum': checksum,
+                }
+            )
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False), encoding='utf-8')
+            batch_submit_recovery.append_submit_journal_entry(
+                str(package_dir),
+                {
+                    'event': batch_submit_recovery.EVENT_UPLOAD_COMPLETED,
+                    'submit_attempt_id': 'attempt-blocked',
+                    'uploaded_file_name': 'files/uploaded-blocked',
+                    'request_checksum': checksum,
+                },
+            )
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)):
+                with self.assertRaises(SystemExit) as ctx:
+                    batch_mod.submit_manifest(str(manifest_path))
+            self.assertIn('--resume', str(ctx.exception))
+
+    def test_submit_blocks_when_journal_has_uncommitted_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, manifest_path, latest_path = self._make_package(tmp)
+            batch_submit_recovery.append_submit_journal_entry(
+                str(package_dir),
+                {
+                    'event': batch_submit_recovery.EVENT_JOB_CREATED,
+                    'submit_attempt_id': 'attempt-3',
+                    'job_name': 'batches/job-3',
+                    'job_state': 'JOB_STATE_PENDING',
+                    'uploaded_file_name': 'files/uploaded-3',
+                    'display_name': 'demo package',
+                    'request_checksum': 'abc',
+                },
+            )
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)):
+                with self.assertRaises(SystemExit) as ctx:
+                    batch_mod.submit_manifest(str(manifest_path))
+            self.assertIn(batch_submit_recovery.BLOCKED_MESSAGE_PREFIX, str(ctx.exception))
+            self.assertIn('recover-submit', str(ctx.exception))
+
+    def test_recover_submit_restores_job_name_from_journal(self):
+        class BatchJob:
+            name = 'batches/job-3'
+            state = 'JOB_STATE_PENDING'
+
+        class FakeBatches:
+            def get(self, **_kwargs):
+                return BatchJob()
+
+        class FakeClient:
+            batches = FakeBatches()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, manifest_path, latest_path = self._make_package(tmp)
+            batch_submit_recovery.append_submit_journal_entry(
+                str(package_dir),
+                {
+                    'event': batch_submit_recovery.EVENT_JOB_CREATED,
+                    'submit_attempt_id': 'attempt-3',
+                    'job_name': 'batches/job-3',
+                    'job_state': 'JOB_STATE_PENDING',
+                    'uploaded_file_name': 'files/uploaded-3',
+                    'display_name': 'demo package',
+                    'request_checksum': 'abc',
+                },
+            )
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
+                 mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()):
+                result = batch_mod.recover_submit_manifest(str(manifest_path))
+
+            saved = json.loads(manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(result, str(manifest_path))
+            self.assertEqual(saved['job_name'], 'batches/job-3')
+            self.assertEqual(saved['submit_state'], batch_submit_recovery.SUBMIT_STATE_COMMITTED)
+
+    def test_submit_resume_reuses_uploaded_file_without_reupload(self):
+        class UploadedFile:
+            name = 'files/uploaded-resume'
+
+        class BatchJob:
+            name = 'batches/job-resume'
+            state = 'JOB_STATE_PENDING'
+
+        class FakeFiles:
+            def upload(self, **_kwargs):
+                raise AssertionError('upload should not be called when --resume is used')
+
+        class FakeBatches:
+            def create(self, **_kwargs):
+                self.last_src = _kwargs.get('src')
+                return BatchJob()
+
+        class FakeClient:
+            files = FakeFiles()
+
+            def __init__(self):
+                self.batches = FakeBatches()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, manifest_path, latest_path = self._make_package(tmp)
+            checksum = batch_submit_recovery.compute_request_checksum(
+                {'input_jsonl_path': str(package_dir / 'requests.jsonl')}
+            )
+            manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+            manifest.update(
+                {
+                    'submit_state': batch_submit_recovery.SUBMIT_STATE_UPLOADED,
+                    'uploaded_file_name': 'files/uploaded-resume',
+                    'submit_attempt_id': 'attempt-resume',
+                    'request_checksum': checksum,
+                }
+            )
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False), encoding='utf-8')
+            batch_submit_recovery.append_submit_journal_entry(
+                str(package_dir),
+                {
+                    'event': batch_submit_recovery.EVENT_UPLOAD_COMPLETED,
+                    'submit_attempt_id': 'attempt-resume',
+                    'uploaded_file_name': 'files/uploaded-resume',
+                    'request_checksum': checksum,
+                },
+            )
+            fake_types = mock.Mock(UploadFileConfig=lambda **kwargs: kwargs)
+            stdout = io.StringIO()
+
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
+                 mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key']), \
+                 mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()), \
+                 mock.patch('sys.stdout', stdout):
+                result = batch_mod.submit_manifest(str(manifest_path), resume_upload=True)
+
+            saved = json.loads(manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(result, str(manifest_path))
+            self.assertEqual(saved['job_name'], 'batches/job-resume')
+            self.assertIn('Reusing uploaded JSONL', stdout.getvalue())
+
+    def test_submit_records_journal_before_manifest_commit_on_success(self):
+        class UploadedFile:
+            name = 'files/uploaded-ok'
+
+        class BatchJob:
+            name = 'batches/job-ok'
+            state = 'JOB_STATE_PENDING'
+
+        class FakeFiles:
+            def upload(self, **_kwargs):
+                return UploadedFile()
+
+        class FakeBatches:
+            def create(self, **_kwargs):
+                return BatchJob()
+
+        class FakeClient:
+            files = FakeFiles()
+            batches = FakeBatches()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, manifest_path, latest_path = self._make_package(tmp)
+            fake_types = mock.Mock(UploadFileConfig=lambda **kwargs: kwargs)
+
+            with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
+                 mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key']), \
+                 mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()):
+                batch_mod.submit_manifest(str(manifest_path))
+
+            journal_entries = batch_submit_recovery.read_submit_journal_entries(str(package_dir))
+            events = [entry.get('event') for entry in journal_entries]
+            self.assertIn(batch_submit_recovery.EVENT_JOB_CREATED, events)
+            self.assertIn(batch_submit_recovery.EVENT_MANIFEST_COMMITTED, events)
+            job_created_index = events.index(batch_submit_recovery.EVENT_JOB_CREATED)
+            committed_index = events.index(batch_submit_recovery.EVENT_MANIFEST_COMMITTED)
+            self.assertLess(job_created_index, committed_index)
+
+            saved = json.loads(manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(saved['job_name'], 'batches/job-ok')
+            self.assertEqual(saved['submit_state'], batch_submit_recovery.SUBMIT_STATE_COMMITTED)
+            self.assertTrue(saved.get('request_checksum'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gui_batch_workflow_support.py
+++ b/tests/test_gui_batch_workflow_support.py
@@ -3,10 +3,15 @@ import os
 import tempfile
 import unittest
 
+import batch_submit_recovery
+
 from gui_qt.batch_workflow_support import (
+    build_recover_submit_cli_args,
     build_submit_cli_args,
     format_cost_estimate_facts,
+    get_uncertain_submit_kind,
     load_cost_estimate_facts_from_manifest,
+    plan_unsubmitted_workflow_steps,
     resolve_submit_max_cost,
 )
 from gui_qt.doctor_report import doctor_report_to_parsed, summarize_doctor_report
@@ -64,6 +69,66 @@ class GuiBatchWorkflowSupportTests(unittest.TestCase):
                 )
             facts = load_cost_estimate_facts_from_manifest(manifest_path)
             self.assertIn("估算输入 token：10", facts)
+
+    def test_build_submit_cli_args_appends_resume_for_upload_pending_state(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            package_dir = os.path.join(tmp_dir, "package")
+            os.makedirs(package_dir)
+            jsonl_path = os.path.join(package_dir, "requests.jsonl")
+            manifest_path = os.path.join(package_dir, "manifest.json")
+            with open(jsonl_path, "w", encoding="utf-8") as handle:
+                handle.write("{}\n")
+            with open(manifest_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "job_name": "",
+                        "submit_state": batch_submit_recovery.SUBMIT_STATE_UPLOADED,
+                        "uploaded_file_name": "files/uploaded-1",
+                        "submit_attempt_id": "attempt-1",
+                        "request_checksum": "abc",
+                    },
+                    handle,
+                )
+            batch_submit_recovery.append_submit_journal_entry(
+                package_dir,
+                {
+                    "event": batch_submit_recovery.EVENT_UPLOAD_COMPLETED,
+                    "submit_attempt_id": "attempt-1",
+                    "uploaded_file_name": "files/uploaded-1",
+                },
+            )
+            self.assertEqual(
+                build_submit_cli_args(manifest_path),
+                ["submit", manifest_path, "--resume"],
+            )
+
+    def test_plan_unsubmitted_workflow_steps_prefers_recover_submit(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            package_dir = os.path.join(tmp_dir, "package")
+            os.makedirs(package_dir)
+            manifest_path = os.path.join(package_dir, "manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as handle:
+                json.dump({"job_name": ""}, handle)
+            batch_submit_recovery.append_submit_journal_entry(
+                package_dir,
+                {
+                    "event": batch_submit_recovery.EVENT_JOB_CREATED,
+                    "submit_attempt_id": "attempt-2",
+                    "job_name": "batches/job-2",
+                },
+            )
+            self.assertEqual(
+                plan_unsubmitted_workflow_steps(manifest_path),
+                ["recover-submit", "status"],
+            )
+            self.assertEqual(
+                get_uncertain_submit_kind(manifest_path),
+                "job_created_uncommitted",
+            )
+            self.assertEqual(
+                build_recover_submit_cli_args(manifest_path),
+                ["recover-submit", manifest_path],
+            )
 
     def test_translation_workflow_submit_uses_max_cost(self):
         workflow = TranslationWorkflow.start_new(submit_max_cost=3.5)

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -1,4 +1,9 @@
+import json
+import os
+import tempfile
 import unittest
+
+import batch_submit_recovery
 
 from gui_qt.diagnostics_context import (
     build_cli_commands,
@@ -75,6 +80,34 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         labels = [command.label for command in commands]
         self.assertIn("提交批量任务", labels)
         self.assertIn("查询任务状态", labels)
+
+    def test_build_cli_commands_includes_recover_submit_when_journal_has_job(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            package_dir = os.path.join(tmp_dir, "package")
+            os.makedirs(package_dir)
+            manifest_path = os.path.join(package_dir, "manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as handle:
+                json.dump({"job_name": "", "mode": "translation"}, handle)
+            batch_submit_recovery.append_submit_journal_entry(
+                package_dir,
+                {
+                    "event": batch_submit_recovery.EVENT_JOB_CREATED,
+                    "submit_attempt_id": "attempt-1",
+                    "job_name": "batches/job-1",
+                },
+            )
+            commands = build_cli_commands(
+                python_exe="python",
+                batch_script_path="gemini_translate_batch.py",
+                manifest_path=manifest_path,
+                manifest={"job_name": "", "mode": "translation"},
+            )
+            labels = [command.label for command in commands]
+            self.assertIn("恢复提交状态", labels)
+            recover_command = next(
+                command.command for command in commands if command.label == "恢复提交状态"
+            )
+            self.assertIn("recover-submit", recover_command)
 
     def test_build_cli_commands_omits_apply_after_applied(self):
         commands = build_cli_commands(


### PR DESCRIPTION
## Summary

Implements **#135 PR2 — submit 断点恢复** (PR1 cost estimate merged in #141).

### Core
- New `batch_submit_recovery.py`: submit journal (`submit_journal.jsonl`), request checksum, uncertain-state detection
- `submit_manifest` writes journal entries **before** manifest commit; records `submit_attempt_id`, checksum, upload file, model, display name
- Blocks silent duplicate submits when state is uncertain

### CLI
- `recover-submit` — restore `job_name` from journal (optional remote verify)
- `submit --resume` — continue job creation from prior upload
- `submit --force` — restart after upload-only incomplete state
- `status` — hints when recovery is required

### GUI sync
- `batch_workflow_support.py`: plan steps, `--resume` args, recover-submit helpers
- Translation / keyword / revision workflows: auto `recover-submit` step when needed
- Diagnostics: recover command + uncertain-state facts

### Tests
- `tests/test_batch_submit_recovery.py`
- GUI support + diagnostics coverage

Closes #135