### PR TITLE
feat: 非中文 batch 校验白名单可配置 (#140 PR2)

### DIFF
--- a/batch_non_chinese_rules.py
+++ b/batch_non_chinese_rules.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""Configurable file-path allowlists for batch non-Chinese validation."""
+from __future__ import annotations
+
+import copy
+
+DEFAULT_NON_CHINESE_RULES = {
+    'static_name_credit_rel_paths': [
+        'screens_menu_about.rpy',
+        'screens_menu_gallery_bg.rpy',
+        'screens_patronlistitem.rpy',
+    ],
+    'static_name_credit_unconditional_rel_paths': [
+        'screens_patronlistitem.rpy',
+    ],
+    'charselect_rel_paths': [
+        'screens_charselect.rpy',
+    ],
+    'player_name_comparison_rel_paths': [
+        'script.rpy',
+    ],
+    'define_rel_path_suffixes': [
+        'script_define.rpy',
+    ],
+    'define_rel_path_prefixes': [
+        'script_characters',
+    ],
+}
+
+_RULE_LIST_KEYS = tuple(DEFAULT_NON_CHINESE_RULES.keys())
+
+
+def _normalize_path_entry(value: object) -> str:
+    if not isinstance(value, str):
+        return ''
+    return value.strip().replace('\\', '/').lower()
+
+
+def _normalize_path_list(values: object) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        entry = _normalize_path_entry(raw)
+        if not entry or entry in seen:
+            continue
+        seen.add(entry)
+        normalized.append(entry)
+    return normalized
+
+
+def _merge_rule_lists(default_values: list[str], configured_values: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for entry in list(default_values) + list(configured_values):
+        if not entry or entry in seen:
+            continue
+        seen.add(entry)
+        merged.append(entry)
+    return merged
+
+
+def normalize_non_chinese_rules(configured: object | None) -> dict[str, list[str]]:
+    rules = {
+        key: list(DEFAULT_NON_CHINESE_RULES[key])
+        for key in _RULE_LIST_KEYS
+    }
+    if not isinstance(configured, dict):
+        return rules
+
+    for key in _RULE_LIST_KEYS:
+        if key not in configured:
+            continue
+        rules[key] = _normalize_path_list(configured.get(key))
+
+    extra_static = _normalize_path_list(configured.get('extra_static_name_credit_rel_paths'))
+    if extra_static:
+        rules['static_name_credit_rel_paths'] = _merge_rule_lists(
+            rules['static_name_credit_rel_paths'],
+            extra_static,
+        )
+
+    return rules
+
+
+def load_non_chinese_rules(translator_config: dict | None) -> dict[str, list[str]]:
+    if not isinstance(translator_config, dict):
+        return normalize_non_chinese_rules(None)
+    batch = translator_config.get('batch')
+    if not isinstance(batch, dict):
+        return normalize_non_chinese_rules(None)
+    configured = batch.get('non_chinese_validation')
+    if configured is None:
+        configured = batch.get('non_chinese_rules')
+    return normalize_non_chinese_rules(configured)
+
+
+def effective_non_chinese_rules(
+    manifest: dict | None,
+    *,
+    runtime_rules: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
+    if isinstance(manifest, dict):
+        manifest_rules = manifest.get('non_chinese_rules')
+        if isinstance(manifest_rules, dict):
+            return normalize_non_chinese_rules(manifest_rules)
+    if isinstance(runtime_rules, dict):
+        return normalize_non_chinese_rules(runtime_rules)
+    return normalize_non_chinese_rules(None)
+
+
+def manifest_non_chinese_rules_fields(source_manifest: dict | None = None) -> dict[str, dict[str, list[str]]]:
+    rules = effective_non_chinese_rules(source_manifest)
+    return {'non_chinese_rules': copy.deepcopy(rules)}
+
+
+def rel_path_matches(rel_path: str, rel_name: str, candidates: list[str]) -> bool:
+    normalized_path = _normalize_path_entry(rel_path)
+    normalized_name = _normalize_path_entry(rel_name)
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if normalized_name == candidate or normalized_path == candidate:
+            return True
+        if normalized_path.endswith('/' + candidate):
+            return True
+    return False
+
+
+def rel_path_has_suffix(rel_path: str, suffixes: list[str]) -> bool:
+    normalized_path = _normalize_path_entry(rel_path)
+    for suffix in suffixes:
+        if normalized_path.endswith(suffix):
+            return True
+    return False
+
+
+def rel_path_has_prefix(rel_path: str, prefixes: list[str]) -> bool:
+    normalized_path = _normalize_path_entry(rel_path)
+    for prefix in prefixes:
+        if normalized_path.startswith(prefix):
+            return True
+    return False

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -16,9 +16,11 @@
 `check` 默认要求译文包含中文字符（实现上检测 Unicode 中文范围，不包含日文假名或韩文），适用于以简体中文为目标的批次。以下情况允许保留非中文译文（无需改配置）：
 
 - 术语表中的固定译法、保留英文名/缩写、玩家名比较行等启发式规则
-- 特定 UI/制作人员名单文件路径上的静态文本（当前为内置白名单，见 #140 PR2 可配置化）
+- 特定 UI/制作人员名单文件路径上的静态文本（`batch.non_chinese_validation` 白名单，build 时写入 manifest `non_chinese_rules`）
 
-若目标语言为日语、韩语等，`No Chinese characters` 失败可能属于预期行为，需要调整校验策略或白名单（见 #140 PR2）。换语言前请先跑 `doctor` 确认 TL 路径，并在 `check` 结果中逐项确认失败原因。非中文白名单与性能优化将在 #140 后续 PR 中继续完善。
+可在 `translator_config.json` 的 `batch.non_chinese_validation` 中覆盖或追加路径；GUI 高级设置提供「非中文白名单追加路径」。默认白名单与当前 After Class / Glory Hounds 项目兼容。
+
+若目标语言为日语、韩语等，`No Chinese characters` 失败可能属于预期行为，需要调整校验策略或白名单。换语言前请先跑 `doctor` 确认 TL 路径，并在 `check` 结果中逐项确认失败原因。校验读文件缓存优化见 #140 PR3。
 
 ## 命令说明
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -19,6 +19,7 @@ if SCRIPT_DIR not in sys.path:
 
 from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreLockError, hash_text, truncate_text
 import batch_cost_estimate
+import batch_non_chinese_rules
 import batch_submit_recovery
 import prompt_context
 import story_memory
@@ -90,6 +91,7 @@ BATCH_DISPLAY_NAME_PREFIX = 'renpy-translate'
 BATCH_SPLIT_RECOMMEND_CHUNKS = 400
 BATCH_SPLIT_RECOMMEND_ITEMS = 12000
 BATCH_MACRO_SETTING = ''
+BATCH_NON_CHINESE_RULES = batch_non_chinese_rules.normalize_non_chinese_rules(None)
 MANIFEST_MODE_TRANSLATION = 'translation'
 MANIFEST_MODE_KEYWORD_EXTRACTION = 'keyword_extraction'
 MANIFEST_MODE_REVISION = 'revision'
@@ -289,6 +291,7 @@ def load_batch_settings():
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
+    global BATCH_NON_CHINESE_RULES
 
     config = load_json_file(legacy.CONFIG_FILE)
     translator_config = load_json_file(legacy.TRANSLATOR_CONFIG)
@@ -330,6 +333,8 @@ def load_batch_settings():
     batch = translator_config.get('batch')
     if not isinstance(batch, dict):
         batch = {}
+
+    BATCH_NON_CHINESE_RULES = batch_non_chinese_rules.load_non_chinese_rules(translator_config)
 
     model_name = batch.get('model')
     if isinstance(model_name, str) and model_name.strip():
@@ -803,11 +808,6 @@ def is_manifest_old_new_static_label_item(manifest, chunk, item):
     stripped = line.lstrip()
     return stripped.startswith('old ') or stripped.startswith('new ')
 
-STATIC_NAME_CREDIT_REL_PATHS = {
-    'screens_menu_about.rpy',
-    'screens_menu_gallery_bg.rpy',
-    'screens_patronlistitem.rpy',
-}
 GAME_LINE_COMMENT_RE = re.compile(r'^\s*#\s+(.+?):(\d+)\s*$')
 OLD_NEW_LINE_RE = re.compile(r'^\s*(?:old|new)\s+"(?P<text>.*)"\s*$')
 STATIC_NAME_PUNCT_TRANSLATION = str.maketrans({
@@ -968,13 +968,30 @@ def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, i
 
     rel_path = str((chunk or {}).get('file_rel_path') or '').replace('\\', '/').lower()
     rel_name = os.path.basename(rel_path)
-    if rel_name == 'screens_patronlistitem.rpy':
+    rules = batch_non_chinese_rules.effective_non_chinese_rules(
+        manifest,
+        runtime_rules=BATCH_NON_CHINESE_RULES,
+    )
+
+    if batch_non_chinese_rules.rel_path_matches(
+        rel_path,
+        rel_name,
+        rules.get('static_name_credit_unconditional_rel_paths', []),
+    ):
         return True
 
-    if rel_name in STATIC_NAME_CREDIT_REL_PATHS:
+    if batch_non_chinese_rules.rel_path_matches(
+        rel_path,
+        rel_name,
+        rules.get('static_name_credit_rel_paths', []),
+    ):
         return looks_like_static_name_or_credit_text(original)
 
-    if rel_name == 'screens_charselect.rpy':
+    if batch_non_chinese_rules.rel_path_matches(
+        rel_path,
+        rel_name,
+        rules.get('charselect_rel_paths', []),
+    ):
         if any(mark in (original or '') for mark in ':!?！？'):
             return False
         return looks_like_static_name_or_credit_text(original)
@@ -988,10 +1005,20 @@ def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, i
             return False
         return looks_like_static_name_or_credit_text(original)
 
-    if rel_name == 'script.rpy' and is_manifest_player_name_comparison_item(manifest, chunk, original, item):
+    if (
+        batch_non_chinese_rules.rel_path_matches(
+            rel_path,
+            rel_name,
+            rules.get('player_name_comparison_rel_paths', []),
+        )
+        and is_manifest_player_name_comparison_item(manifest, chunk, original, item)
+    ):
         return True
 
-    if rel_path.endswith('script_define.rpy') or rel_path.startswith('script_characters'):
+    if (
+        batch_non_chinese_rules.rel_path_has_suffix(rel_path, rules.get('define_rel_path_suffixes', []))
+        or batch_non_chinese_rules.rel_path_has_prefix(rel_path, rules.get('define_rel_path_prefixes', []))
+    ):
         cleaned = legacy.RENPY_TAG_RE.sub('', original or '').strip()
         if legacy.is_non_translatable(cleaned):
             return True
@@ -2462,6 +2489,7 @@ def create_batch_package(display_name_override='', skip_prepare=False):
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
         'input_jsonl_path': input_jsonl_path,
         'result_jsonl_path': '',
         'job_name': '',
@@ -2794,6 +2822,7 @@ def create_revision_package(display_name_override='', skip_prepare=False, chunk_
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
         'input_jsonl_path': input_jsonl_path,
         'result_jsonl_path': '',
         'job_name': '',
@@ -3057,6 +3086,7 @@ def create_keyword_package(display_name_override='', skip_prepare=True, chunk_si
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
         'input_jsonl_path': input_jsonl_path,
         'result_jsonl_path': '',
         'job_name': '',
@@ -3175,6 +3205,7 @@ def split_manifest(target=None, max_chunks=600, max_items=0, display_name_prefix
             'base_dir': manifest.get('base_dir', legacy.BASE_DIR),
             'tl_dir': manifest.get('tl_dir', legacy.TL_DIR),
             **_manifest_target_language_fields(manifest),
+            **batch_non_chinese_rules.manifest_non_chinese_rules_fields(manifest),
             'input_jsonl_path': part_input_jsonl_path,
             'result_jsonl_path': '',
             'job_name': '',
@@ -3515,6 +3546,7 @@ def build_retry_package(target=None, display_name_override=''):
         'base_dir': manifest.get('base_dir', legacy.BASE_DIR),
         'tl_dir': manifest.get('tl_dir', legacy.TL_DIR),
         **_manifest_target_language_fields(manifest),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(manifest),
         'input_jsonl_path': input_jsonl_path,
         'result_jsonl_path': '',
         'job_name': '',
@@ -7411,6 +7443,7 @@ def make_sync_manifest(
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
         'input_jsonl_path': input_jsonl_path,
         'result_jsonl_path': result_jsonl_path,
         'job_name': '',

--- a/gui_qt/batch_workflow_support.py
+++ b/gui_qt/batch_workflow_support.py
@@ -107,6 +107,28 @@ def format_cost_estimate_facts(estimate: dict[str, Any] | None) -> list[str]:
     return facts
 
 
+def format_non_chinese_rules_facts(rules: dict[str, Any] | None) -> list[str]:
+    if not isinstance(rules, dict):
+        return []
+    facts: list[str] = []
+    static_paths = rules.get("static_name_credit_rel_paths")
+    if isinstance(static_paths, list) and static_paths:
+        facts.append(f"静态姓名/名单白名单：{len(static_paths)} 个文件")
+    extra_paths = rules.get("extra_static_name_credit_rel_paths")
+    if isinstance(extra_paths, list) and extra_paths:
+        facts.append(f"追加白名单路径：{', '.join(str(path) for path in extra_paths[:3])}")
+    return facts
+
+
+def load_non_chinese_rules_facts_from_manifest(manifest_path: str) -> list[str]:
+    manifest = load_manifest_dict(manifest_path)
+    if not manifest:
+        return []
+    rules = manifest.get("non_chinese_rules")
+    facts = format_non_chinese_rules_facts(rules if isinstance(rules, dict) else None)
+    return [f"非中文校验：{fact}" for fact in facts]
+
+
 def load_target_language_facts_from_manifest(manifest_path: str) -> list[str]:
     manifest = load_manifest_dict(manifest_path)
     if not manifest:

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -12,6 +12,7 @@ from .batch_workflow_support import (
     build_recover_submit_cli_args,
     build_submit_cli_args,
     format_cost_estimate_facts,
+    format_non_chinese_rules_facts,
     get_uncertain_submit_kind,
     load_uncertain_submit_facts_from_manifest,
 )
@@ -587,6 +588,11 @@ def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> lis
 
     if manifest_path and not (isinstance(job_name, str) and job_name.strip()):
         facts.extend(load_uncertain_submit_facts_from_manifest(manifest_path))
+
+    non_chinese_rules = manifest.get("non_chinese_rules")
+    if isinstance(non_chinese_rules, dict):
+        for fact in format_non_chinese_rules_facts(non_chinese_rules):
+            facts.append(f"非中文校验：{fact}")
 
     mode = manifest.get("mode")
     if isinstance(mode, str) and mode.strip():

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -162,6 +162,16 @@ ADVANCED_SETTING_FIELDS: tuple[SettingField, ...] = (
         allow_empty=True,
     ),
     SettingField(
+        "batch_non_chinese_extra_static_paths",
+        ("batch", "non_chinese_validation", "extra_static_name_credit_rel_paths"),
+        "非中文白名单追加路径",
+        "追加到默认静态姓名/名单文件白名单的相对路径；每行一个，例如 credits.rpy。",
+        "list",
+        [],
+        "翻译吞吐",
+        allow_empty=True,
+    ),
+    SettingField(
         "context_storage_game_dir_name",
         ("context_storage", "game_dir_name"),
         "游戏目录上下文文件夹",

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -12,6 +12,7 @@ from .batch_workflow_support import (
     build_recover_submit_cli_args,
     build_submit_cli_args,
     load_cost_estimate_facts_from_manifest,
+    load_non_chinese_rules_facts_from_manifest,
     load_target_language_facts_from_manifest,
     output_blocked_by_max_cost,
     output_blocked_by_uncertain_submit,
@@ -320,6 +321,7 @@ class TranslationWorkflow:
 
         self.manifest_path = manifest_path_for_package(package_path)
         extra_facts = load_target_language_facts_from_manifest(self.manifest_path)
+        extra_facts.extend(load_non_chinese_rules_facts_from_manifest(self.manifest_path))
         extra_facts.extend(load_cost_estimate_facts_from_manifest(self.manifest_path))
         return self._continue_or_finish(extra_facts=extra_facts)
 

--- a/tests/test_batch_non_chinese_rules.py
+++ b/tests/test_batch_non_chinese_rules.py
@@ -1,0 +1,88 @@
+import copy
+import unittest
+
+import batch_non_chinese_rules
+import gemini_translate_batch as batch_mod
+
+
+class BatchNonChineseRulesTests(unittest.TestCase):
+    def test_defaults_match_legacy_project_paths(self):
+        rules = batch_non_chinese_rules.normalize_non_chinese_rules(None)
+        self.assertIn('screens_menu_about.rpy', rules['static_name_credit_rel_paths'])
+        self.assertIn('screens_patronlistitem.rpy', rules['static_name_credit_unconditional_rel_paths'])
+        self.assertIn('screens_charselect.rpy', rules['charselect_rel_paths'])
+
+    def test_extra_static_paths_merge_into_static_name_credit_list(self):
+        rules = batch_non_chinese_rules.normalize_non_chinese_rules(
+            {
+                'extra_static_name_credit_rel_paths': [
+                    'custom_credits.rpy',
+                    'screens_menu_about.rpy',
+                ],
+            }
+        )
+        self.assertIn('custom_credits.rpy', rules['static_name_credit_rel_paths'])
+        self.assertEqual(
+            rules['static_name_credit_rel_paths'].count('screens_menu_about.rpy'),
+            1,
+        )
+
+    def test_manifest_rules_override_runtime_rules(self):
+        manifest_rules = {
+            'static_name_credit_rel_paths': ['custom_only.rpy'],
+            'static_name_credit_unconditional_rel_paths': [],
+            'charselect_rel_paths': [],
+            'player_name_comparison_rel_paths': [],
+            'define_rel_path_suffixes': [],
+            'define_rel_path_prefixes': [],
+        }
+        effective = batch_non_chinese_rules.effective_non_chinese_rules(
+            {'non_chinese_rules': manifest_rules},
+            runtime_rules=batch_non_chinese_rules.DEFAULT_NON_CHINESE_RULES,
+        )
+        self.assertEqual(effective['static_name_credit_rel_paths'], ['custom_only.rpy'])
+
+    def test_custom_manifest_rule_allows_configured_static_file(self):
+        rules = {
+            'static_name_credit_rel_paths': ['custom_credits.rpy'],
+            'static_name_credit_unconditional_rel_paths': [],
+            'charselect_rel_paths': [],
+            'player_name_comparison_rel_paths': [],
+            'define_rel_path_suffixes': [],
+            'define_rel_path_prefixes': [],
+        }
+        manifest = {'non_chinese_rules': rules}
+        chunk = {'file_rel_path': 'custom_credits.rpy'}
+        self.assertTrue(
+            batch_mod.is_manifest_static_non_chinese_item(
+                manifest,
+                chunk,
+                'Avi, MJ, Sinta, Steven.',
+                'Avi, MJ, Sinta, Steven。',
+            )
+        )
+        self.assertFalse(
+            batch_mod.is_manifest_static_non_chinese_item(
+                manifest,
+                chunk,
+                'Main Writer: Andy Peng',
+                'Main Writer: Andy Peng',
+            )
+        )
+
+    def test_default_rules_still_allow_legacy_static_context_items(self):
+        manifest = {
+            'non_chinese_rules': copy.deepcopy(batch_non_chinese_rules.DEFAULT_NON_CHINESE_RULES),
+        }
+        self.assertTrue(
+            batch_mod.allow_non_chinese_batch_translation(
+                manifest,
+                {'file_rel_path': 'screens_patronlistitem.rpy'},
+                'Alpha, Beta, Gamma',
+                'Alpha, Beta, Gamma',
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gui_batch_workflow_support.py
+++ b/tests/test_gui_batch_workflow_support.py
@@ -9,6 +9,8 @@ from gui_qt.batch_workflow_support import (
     build_recover_submit_cli_args,
     build_submit_cli_args,
     format_cost_estimate_facts,
+    format_non_chinese_rules_facts,
+    load_non_chinese_rules_facts_from_manifest,
     get_uncertain_submit_kind,
     load_cost_estimate_facts_from_manifest,
     load_target_language_facts_from_manifest,
@@ -140,6 +142,26 @@ class GuiBatchWorkflowSupportTests(unittest.TestCase):
             workflow.current_step().args,
             ["submit", r"C:\package\manifest.json", "--max-cost", "3.5"],
         )
+
+    def test_load_non_chinese_rules_facts_from_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest_path = os.path.join(tmp_dir, "manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "non_chinese_rules": {
+                            "static_name_credit_rel_paths": ["a.rpy", "b.rpy"],
+                            "extra_static_name_credit_rel_paths": ["custom.rpy"],
+                        }
+                    },
+                    handle,
+                )
+            facts = load_non_chinese_rules_facts_from_manifest(manifest_path)
+            self.assertTrue(any("静态姓名/名单白名单：2 个文件" in fact for fact in facts))
+            self.assertTrue(any("custom.rpy" in fact for fact in facts))
+
+    def test_format_non_chinese_rules_facts_empty(self):
+        self.assertEqual(format_non_chinese_rules_facts({}), [])
 
     def test_load_target_language_facts_from_manifest(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -87,6 +87,29 @@
       "include_scene_summary": true
     },
     "submit_max_cost": 0,
+    "non_chinese_validation": {
+      "extra_static_name_credit_rel_paths": [],
+      "static_name_credit_rel_paths": [
+        "screens_menu_about.rpy",
+        "screens_menu_gallery_bg.rpy",
+        "screens_patronlistitem.rpy"
+      ],
+      "static_name_credit_unconditional_rel_paths": [
+        "screens_patronlistitem.rpy"
+      ],
+      "charselect_rel_paths": [
+        "screens_charselect.rpy"
+      ],
+      "player_name_comparison_rel_paths": [
+        "script.rpy"
+      ],
+      "define_rel_path_suffixes": [
+        "script_define.rpy"
+      ],
+      "define_rel_path_prefixes": [
+        "script_characters"
+      ]
+    },
     "pricing": {
       "version": 1,
       "currency": "USD",


### PR DESCRIPTION
## Summary

**#140 PR2** — configurable non-Chinese file-path allowlists for batch `check`.

### Core
- New `batch_non_chinese_rules.py` with defaults matching legacy hardcoded paths
- `translator_config.json` → `batch.non_chinese_validation`
- Manifest snapshots `non_chinese_rules` at build/split/retry

### GUI sync
- Advanced setting for extra allowlist paths
- Build/diagnostics facts

### Tests
- `tests/test_batch_non_chinese_rules.py`

Part of #140. PR3: validation file-read cache.