### PR TITLE
perf: 非中文校验单次调用文件读取缓存 (#140 PR3)

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -20,7 +20,9 @@
 
 可在 `translator_config.json` 的 `batch.non_chinese_validation` 中覆盖或追加路径；GUI 高级设置提供「非中文白名单追加路径」。默认白名单与当前 After Class / Glory Hounds 项目兼容。
 
-若目标语言为日语、韩语等，`No Chinese characters` 失败可能属于预期行为，需要调整校验策略或白名单。换语言前请先跑 `doctor` 确认 TL 路径，并在 `check` 结果中逐项确认失败原因。校验读文件缓存优化见 #140 PR3。
+若目标语言为日语、韩语等，`No Chinese characters` 失败可能属于预期行为，需要调整校验策略或白名单。换语言前请先跑 `doctor` 确认 TL 路径，并在 `check` 结果中逐项确认失败原因。
+
+`allow_non_chinese_batch_translation` 在单次校验调用内会缓存 TL/source 文件读取，避免 short-circuit OR 链重复打开同一文件；pass/fail 结果与缓存前一致。
 
 ## 命令说明
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -769,40 +769,84 @@ def _item_source_line_number(item):
     return line_index + 1 if line_index >= 0 else 0
 
 
-def _read_line_at(path, line_number):
-    if not path or line_number <= 0:
+class NonChineseFileReadCache:
+    """Per-call cache for TL/source reads inside non-Chinese validation helpers."""
+
+    def __init__(self):
+        self._lines_by_path = {}
+        self._line_by_path_and_number = {}
+
+    def read_line(self, path, line_number):
+        if not path or line_number <= 0:
+            return ''
+        cache_key = (path, line_number)
+        if cache_key in self._line_by_path_and_number:
+            return self._line_by_path_and_number[cache_key]
+        line = self._read_line_uncached(path, line_number)
+        self._line_by_path_and_number[cache_key] = line
+        return line
+
+    def read_lines(self, path):
+        if not path:
+            return []
+        if path not in self._lines_by_path:
+            try:
+                with open(path, 'r', encoding='utf-8-sig') as handle:
+                    self._lines_by_path[path] = handle.readlines()
+            except OSError:
+                self._lines_by_path[path] = []
+        return self._lines_by_path[path]
+
+    @staticmethod
+    def _read_line_uncached(path, line_number):
+        if not path or line_number <= 0:
+            return ''
+        try:
+            with open(path, 'r', encoding='utf-8-sig') as handle:
+                for current_number, line in enumerate(handle, 1):
+                    if current_number == line_number:
+                        return line
+        except OSError:
+            return ''
         return ''
-    try:
-        with open(path, 'r', encoding='utf-8-sig') as handle:
-            for current_number, line in enumerate(handle, 1):
-                if current_number == line_number:
-                    return line
-    except OSError:
-        return ''
-    return ''
 
 
-def is_manifest_keyword_argument_item(manifest, chunk, item):
+def _read_line_at(path, line_number, *, file_read_cache=None):
+    if file_read_cache is not None:
+        return file_read_cache.read_line(path, line_number)
+    return NonChineseFileReadCache._read_line_uncached(path, line_number)
+
+
+def _manifest_tl_line_for_item(manifest, chunk, item, *, file_read_cache=None):
+    return _read_line_at(
+        _manifest_file_path_for_chunk(manifest, chunk),
+        _item_source_line_number(item),
+        file_read_cache=file_read_cache,
+    )
+
+
+def is_manifest_keyword_argument_item(manifest, chunk, item, *, file_read_cache=None):
     if not isinstance(item, dict):
         return False
-    line = _read_line_at(_manifest_file_path_for_chunk(manifest, chunk), _item_source_line_number(item))
+    line = _manifest_tl_line_for_item(manifest, chunk, item, file_read_cache=file_read_cache)
     if not line:
         return False
     return legacy.is_keyword_argument_string_span(line, item.get('start'), item.get('end'))
 
 
-def is_manifest_say_speaker_label_item(manifest, chunk, item):
+def is_manifest_say_speaker_label_item(manifest, chunk, item, *, file_read_cache=None):
     if not isinstance(item, dict):
         return False
-    line = _read_line_at(_manifest_file_path_for_chunk(manifest, chunk), _item_source_line_number(item))
+    line = _manifest_tl_line_for_item(manifest, chunk, item, file_read_cache=file_read_cache)
     if not line:
         return False
     return legacy.is_say_speaker_label_string_span(line, item.get('start'), item.get('end'))
 
-def is_manifest_old_new_static_label_item(manifest, chunk, item):
+
+def is_manifest_old_new_static_label_item(manifest, chunk, item, *, file_read_cache=None):
     if not isinstance(item, dict):
         return False
-    line = _read_line_at(_manifest_file_path_for_chunk(manifest, chunk), _item_source_line_number(item))
+    line = _manifest_tl_line_for_item(manifest, chunk, item, file_read_cache=file_read_cache)
     if not line:
         return False
     stripped = line.lstrip()
@@ -914,16 +958,19 @@ def _manifest_base_dir(manifest):
     return legacy.BASE_DIR
 
 
-def _read_source_line_for_tl_item(manifest, chunk, item):
+def _read_source_line_for_tl_item(manifest, chunk, item, *, file_read_cache=None):
     tl_path = _manifest_file_path_for_chunk(manifest, chunk)
     line_number = _item_source_line_number(item)
     if not tl_path or line_number <= 0:
         return ''
-    try:
-        with open(tl_path, 'r', encoding='utf-8-sig') as handle:
-            lines = handle.readlines()
-    except OSError:
-        return ''
+    if file_read_cache is not None:
+        lines = file_read_cache.read_lines(tl_path)
+    else:
+        try:
+            with open(tl_path, 'r', encoding='utf-8-sig') as handle:
+                lines = handle.readlines()
+        except OSError:
+            return ''
     start_index = max(0, line_number - 6)
     end_index = min(len(lines), line_number)
     for index in range(end_index - 1, start_index - 1, -1):
@@ -937,16 +984,25 @@ def _read_source_line_for_tl_item(manifest, chunk, item):
                 source_rel_path,
                 f'game source line {source_rel_path}',
             )
-            return _read_line_at(source_path, int(source_line_number))
+            return _read_line_at(
+                source_path,
+                int(source_line_number),
+                file_read_cache=file_read_cache,
+            )
         except (SystemExit, ValueError):
             return ''
     return ''
 
 
-def is_manifest_player_name_comparison_item(manifest, chunk, original, item):
+def is_manifest_player_name_comparison_item(manifest, chunk, original, item, *, file_read_cache=None):
     if not isinstance(item, dict):
         return False
-    line = _read_source_line_for_tl_item(manifest, chunk, item)
+    line = _read_source_line_for_tl_item(
+        manifest,
+        chunk,
+        item,
+        file_read_cache=file_read_cache,
+    )
     if not line:
         return False
     if not re.search(r'\b(?:Main|main_nm|yourname|persistent\.MainEP)\b\s*==\s*_\(', line):
@@ -960,7 +1016,15 @@ def is_manifest_player_name_comparison_item(manifest, chunk, original, item):
     return looks_like_static_name_or_credit_text(original)
 
 
-def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, item=None):
+def is_manifest_static_non_chinese_item(
+    manifest,
+    chunk,
+    original,
+    translated,
+    item=None,
+    *,
+    file_read_cache=None,
+):
     if not static_name_or_credit_text_matches(original, translated):
         return False
     if legacy.contains_chinese(translated or ''):
@@ -996,8 +1060,18 @@ def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, i
             return False
         return looks_like_static_name_or_credit_text(original)
 
-    if is_manifest_old_new_static_label_item(manifest, chunk, item):
-        line = _read_line_at(_manifest_file_path_for_chunk(manifest, chunk), _item_source_line_number(item))
+    if is_manifest_old_new_static_label_item(
+        manifest,
+        chunk,
+        item,
+        file_read_cache=file_read_cache,
+    ):
+        line = _manifest_tl_line_for_item(
+            manifest,
+            chunk,
+            item,
+            file_read_cache=file_read_cache,
+        )
         label_match = OLD_NEW_LINE_RE.match(line or '')
         if not label_match:
             return False
@@ -1011,7 +1085,13 @@ def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, i
             rel_name,
             rules.get('player_name_comparison_rel_paths', []),
         )
-        and is_manifest_player_name_comparison_item(manifest, chunk, original, item)
+        and is_manifest_player_name_comparison_item(
+            manifest,
+            chunk,
+            original,
+            item,
+            file_read_cache=file_read_cache,
+        )
     ):
         return True
 
@@ -1031,13 +1111,31 @@ def is_manifest_static_non_chinese_item(manifest, chunk, original, translated, i
 
 
 def allow_non_chinese_batch_translation(manifest, chunk, original, translated, item=None):
+    file_read_cache = NonChineseFileReadCache()
     unchanged = (original or '').strip() == (translated or '').strip()
     if (
         (unchanged and (
-            is_manifest_keyword_argument_item(manifest, chunk, item)
-            or is_manifest_say_speaker_label_item(manifest, chunk, item)
+            is_manifest_keyword_argument_item(
+                manifest,
+                chunk,
+                item,
+                file_read_cache=file_read_cache,
+            )
+            or is_manifest_say_speaker_label_item(
+                manifest,
+                chunk,
+                item,
+                file_read_cache=file_read_cache,
+            )
         ))
-        or is_manifest_static_non_chinese_item(manifest, chunk, original, translated, item)
+        or is_manifest_static_non_chinese_item(
+            manifest,
+            chunk,
+            original,
+            translated,
+            item,
+            file_read_cache=file_read_cache,
+        )
         or matching_preserved_or_acronym_non_chinese_text(original, translated)
     ):
         return True

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -782,7 +782,11 @@ class NonChineseFileReadCache:
         cache_key = (path, line_number)
         if cache_key in self._line_by_path_and_number:
             return self._line_by_path_and_number[cache_key]
-        line = self._read_line_uncached(path, line_number)
+        lines = self.read_lines(path)
+        if line_number <= len(lines):
+            line = lines[line_number - 1]
+        else:
+            line = ''
         self._line_by_path_and_number[cache_key] = line
         return line
 
@@ -792,9 +796,12 @@ class NonChineseFileReadCache:
         if path not in self._lines_by_path:
             try:
                 with open(path, 'r', encoding='utf-8-sig') as handle:
-                    self._lines_by_path[path] = handle.readlines()
+                    lines = handle.readlines()
             except OSError:
-                self._lines_by_path[path] = []
+                lines = []
+            self._lines_by_path[path] = lines
+            for index, line in enumerate(lines, 1):
+                self._line_by_path_and_number.setdefault((path, index), line)
         return self._lines_by_path[path]
 
     @staticmethod

--- a/tests/test_batch_non_chinese_file_cache.py
+++ b/tests/test_batch_non_chinese_file_cache.py
@@ -1,0 +1,120 @@
+import copy
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import batch_non_chinese_rules
+import gemini_translate_batch as batch_mod
+
+
+class BatchNonChineseFileCacheTests(unittest.TestCase):
+    def _write_old_new_fixture(self, tl_dir):
+        tl_path = tl_dir / 'misc_labels.rpy'
+        tl_path.write_text(
+            '# game/misc_labels.rpy:10\nold "Avi"\nnew "Avi"\n',
+            encoding='utf-8',
+        )
+        manifest = {
+            'tl_dir': str(tl_dir),
+            'non_chinese_rules': copy.deepcopy(batch_non_chinese_rules.DEFAULT_NON_CHINESE_RULES),
+        }
+        chunk = {'file_rel_path': 'misc_labels.rpy'}
+        item = {'line_number': 2}
+        return manifest, chunk, item
+
+    def test_old_new_static_item_reuses_tl_line_read_within_call(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
+            manifest, chunk, item = self._write_old_new_fixture(Path(tmpdir))
+            cache = batch_mod.NonChineseFileReadCache()
+            open_paths = []
+            real_open = open
+
+            def counting_open(path, *args, **kwargs):
+                open_paths.append(str(path))
+                return real_open(path, *args, **kwargs)
+
+            with mock.patch('builtins.open', side_effect=counting_open):
+                allowed = batch_mod.is_manifest_static_non_chinese_item(
+                    manifest,
+                    chunk,
+                    'Avi',
+                    'Avi',
+                    item=item,
+                    file_read_cache=cache,
+                )
+
+            self.assertTrue(allowed)
+            self.assertEqual(len(open_paths), 1)
+
+    def test_allow_non_chinese_matches_results_with_and_without_cache(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
+            manifest, chunk, item = self._write_old_new_fixture(Path(tmpdir))
+            kwargs = {
+                'manifest': manifest,
+                'chunk': chunk,
+                'original': 'Avi',
+                'translated': 'Avi',
+                'item': item,
+            }
+            with_cache = batch_mod.is_manifest_static_non_chinese_item(
+                **kwargs,
+                file_read_cache=batch_mod.NonChineseFileReadCache(),
+            )
+            without_cache = batch_mod.is_manifest_static_non_chinese_item(**kwargs)
+            via_allow = batch_mod.allow_non_chinese_batch_translation(
+                manifest,
+                chunk,
+                'Avi',
+                'Avi',
+                item=item,
+            )
+
+            self.assertTrue(with_cache)
+            self.assertEqual(with_cache, without_cache)
+            self.assertEqual(via_allow, without_cache)
+
+    def test_player_name_comparison_uses_cached_reads_without_extra_tl_opens(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
+            base_dir = Path(tmpdir)
+            source_path = base_dir / 'game' / 'script.rpy'
+            source_path.parent.mkdir(parents=True)
+            source_path.write_text('if Main == _("Herbert"):\n    pass\n', encoding='utf-8')
+            tl_dir = base_dir / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            tl_path = tl_dir / 'script.rpy'
+            tl_path.write_text('# game/script.rpy:1\n    "Herbert"\n', encoding='utf-8')
+            manifest = {
+                'base_dir': str(base_dir),
+                'tl_dir': str(tl_dir),
+                'non_chinese_rules': copy.deepcopy(batch_non_chinese_rules.DEFAULT_NON_CHINESE_RULES),
+            }
+            chunk = {'file_rel_path': 'script.rpy'}
+            item = {'line_number': 2}
+            cache = batch_mod.NonChineseFileReadCache()
+            open_paths = []
+            real_open = open
+
+            def counting_open(path, *args, **kwargs):
+                open_paths.append(str(path))
+                return real_open(path, *args, **kwargs)
+
+            with mock.patch('builtins.open', side_effect=counting_open):
+                allowed = batch_mod.is_manifest_player_name_comparison_item(
+                    manifest,
+                    chunk,
+                    'Herbert',
+                    item,
+                    file_read_cache=cache,
+                )
+                cached_tl_reads = cache.read_lines(str(tl_path))
+                cached_source_reads = cache.read_line(str(source_path), 1)
+
+            self.assertTrue(allowed)
+            self.assertEqual(len(open_paths), 2)
+            self.assertEqual(len(cached_tl_reads), 2)
+            self.assertIn('Main', cached_source_reads)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_batch_non_chinese_file_cache.py
+++ b/tests/test_batch_non_chinese_file_cache.py
@@ -47,6 +47,28 @@ class BatchNonChineseFileCacheTests(unittest.TestCase):
             self.assertTrue(allowed)
             self.assertEqual(len(open_paths), 1)
 
+    def test_allow_non_chinese_reuses_single_tl_open_end_to_end(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
+            manifest, chunk, item = self._write_old_new_fixture(Path(tmpdir))
+            open_paths = []
+            real_open = open
+
+            def counting_open(path, *args, **kwargs):
+                open_paths.append(str(path))
+                return real_open(path, *args, **kwargs)
+
+            with mock.patch('builtins.open', side_effect=counting_open):
+                allowed = batch_mod.allow_non_chinese_batch_translation(
+                    manifest,
+                    chunk,
+                    'Avi',
+                    'Avi',
+                    item=item,
+                )
+
+            self.assertTrue(allowed)
+            self.assertEqual(len(open_paths), 1)
+
     def test_allow_non_chinese_matches_results_with_and_without_cache(self):
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
             manifest, chunk, item = self._write_old_new_fixture(Path(tmpdir))
@@ -114,6 +136,24 @@ class BatchNonChineseFileCacheTests(unittest.TestCase):
             self.assertEqual(len(open_paths), 2)
             self.assertEqual(len(cached_tl_reads), 2)
             self.assertIn('Main', cached_source_reads)
+
+    def test_read_line_and_read_lines_share_same_path_cache(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmpdir:
+            tl_path = Path(tmpdir) / 'shared.rpy'
+            tl_path.write_text('line one\nline two\n', encoding='utf-8')
+            cache = batch_mod.NonChineseFileReadCache()
+            open_paths = []
+            real_open = open
+
+            def counting_open(path, *args, **kwargs):
+                open_paths.append(str(path))
+                return real_open(path, *args, **kwargs)
+
+            with mock.patch('builtins.open', side_effect=counting_open):
+                self.assertEqual(cache.read_line(str(tl_path), 1), 'line one\n')
+                self.assertEqual(cache.read_lines(str(tl_path))[1], 'line two\n')
+
+            self.assertEqual(len(open_paths), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

**#140 PR3** — per-call file-read cache for `allow_non_chinese_batch_translation` helpers.

### Core
- New `NonChineseFileReadCache` caches TL line/full-file and source line reads within one `allow_non_chinese_batch_translation` call
- Helpers accept optional `file_read_cache`; public API unchanged
- Avoids duplicate `open()` in short-circuit OR chains (e.g. old/new label checks)

### Docs
- `docs/batch_workflows.md` documents cache behavior and unchanged pass/fail semantics

### Tests
- `tests/test_batch_non_chinese_file_cache.py` — cache hit counting + result parity

Closes #140.