### PR TITLE
feat: compare-variants translation A/B experiment CLI (#139)

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -100,6 +100,44 @@ python gemini_translate_batch.py merge-keywords-to-glossary logs/batch_jobs/<pac
 
 订正 manifest 的 `mode=revision`，关键词 manifest 的 `mode=keyword_extraction`，普通 `check/apply` 会拒绝处理，避免把非翻译结果误写回 `.rpy`。
 
+## 翻译质量 A/B 实验
+
+`compare-variants` 用同一批 manifest chunk 在**同步模式**下跑多个配置变体，生成并排 Markdown 报告，**不会写回** `.rpy` 或 `glossary.json`。适合比较 Story Memory、RAG、macro setting 等上下文层对译文的影响。
+
+```bash
+python gemini_translate_batch.py compare-variants logs/batch_jobs/<package>/manifest.json \
+  --variants-file experiment_variants.json \
+  --limit 3 \
+  --offset 0
+```
+
+`experiment_variants.json` 示例：
+
+```json
+[
+  {
+    "name": "baseline",
+    "overrides": {
+      "batch": {
+        "story_memory": { "enabled": false }
+      }
+    }
+  },
+  {
+    "name": "story_memory",
+    "overrides": {
+      "batch": {
+        "story_memory": { "enabled": true }
+      }
+    }
+  }
+]
+```
+
+- `--dry-run` 只重建各变体 prompt 并写报告，不调用 API。
+- 默认输出到 `logs/experiments/<timestamp>_ab/`，包含 `ab_report.md`、`ab_results.jsonl`、`ab_settings.json`。
+- API 用量约为 `chunks × variants` 次同步请求；先用小 `--limit` 试跑。
+
 ## Manifest 与 identity v2
 
 Batch `build` 会生成：

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -134,7 +134,8 @@ python gemini_translate_batch.py compare-variants logs/batch_jobs/<package>/mani
 ]
 ```
 
-- `--dry-run` 只重建各变体 prompt 并写报告，不调用 API。
+- 变体文件至少需要 **2 个**命名变体，以便并排比较。
+- `--dry-run` 只重建各变体 prompt 并写报告，不调用翻译 API，也不会触发 RAG / source index / story memory 检索。
 - 默认输出到 `logs/experiments/<timestamp>_ab/`，包含 `ab_report.md`、`ab_results.jsonl`、`ab_settings.json`。
 - API 用量约为 `chunks × variants` 次同步请求；先用小 `--limit` 试跑。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -23,6 +23,7 @@ import batch_non_chinese_rules
 import batch_submit_recovery
 import keyword_glossary_merge
 import prompt_context
+import translation_ab_experiment
 import story_memory
 import translation_core
 import translator_runtime as runtime
@@ -9253,6 +9254,36 @@ def build_arg_parser():
         help='Skip creating a timestamped glossary backup before writing.',
     )
 
+    compare_variants_parser = subparsers.add_parser(
+        'compare-variants',
+        help='Run a synchronous translation A/B experiment from a batch manifest without writing game files.',
+    )
+    compare_variants_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Translation manifest path or package dir. Defaults to latest package.',
+    )
+    compare_variants_parser.add_argument(
+        '--variants-file',
+        required=True,
+        help='JSON file describing experiment variants and config overrides.',
+    )
+    compare_variants_parser.add_argument('--limit', type=int, default=3, help='Number of manifest chunks to sample.')
+    compare_variants_parser.add_argument('--offset', type=int, default=0, help='Chunk offset within the manifest.')
+    compare_variants_parser.add_argument(
+        '--output-dir',
+        default='',
+        help='Directory for ab_report.md and ab_results.jsonl. Defaults to logs/experiments/<timestamp>_ab/.',
+    )
+    compare_variants_parser.add_argument('--model', default='', help='Optional model override for all variants.')
+    compare_variants_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
+    compare_variants_parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Build per-variant prompts and reports without calling the API.',
+    )
+
     revision_preview_parser = subparsers.add_parser(
         'preview-revisions',
         help='Dry-run downloaded revision results and export JSONL/Markdown preview reports.',
@@ -9563,6 +9594,28 @@ def main(argv=None):
             interactive=not args.yes and not dry_run,
             backup=not args.no_backup,
         )
+        return
+
+    if command == 'compare-variants':
+        manifest = load_manifest(args.target or None)
+        variants = translation_ab_experiment.load_variants_file(args.variants_file)
+        summary = translation_ab_experiment.run_translation_ab_experiment(
+            manifest,
+            variants,
+            limit=args.limit,
+            offset=args.offset,
+            output_dir=args.output_dir.strip(),
+            model_override=args.model,
+            api_key_index=args.api_key_index,
+            dry_run=args.dry_run,
+        )
+        print('Translation A/B experiment:')
+        print(f"- output_dir: {summary['output_dir']}")
+        print(f"- chunks: {summary['chunk_count']}")
+        print(f"- variants: {summary['variant_count']}")
+        print(f"- dry_run: {summary['dry_run']}")
+        print(f"- report: {summary['report_path']}")
+        print(f"- results: {summary['results_path']}")
         return
 
     if command == 'preview-revisions':

--- a/tests/fixtures/ab_variants_minimal.json
+++ b/tests/fixtures/ab_variants_minimal.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "baseline",
+    "overrides": {
+      "batch": {
+        "story_memory": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  {
+    "name": "story_memory",
+    "overrides": {
+      "batch": {
+        "story_memory": {
+          "enabled": true
+        }
+      }
+    }
+  }
+]

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import tempfile
@@ -13,7 +14,19 @@ FIXTURE_MANIFEST = (
     Path(__file__).parent / 'fixtures' / 'golden_batch_minimal' / 'expected' / 'manifest_snapshot.json'
 )
 SAMPLE_ITEM_ID = 'chapter01/dialogue.rpy:chapter01_start:1:8dfe92d9'
+SAMPLE_ITEM_IDS = [
+    'chapter01/dialogue.rpy:chapter01_start:1:8dfe92d9',
+    'chapter01/dialogue.rpy:chapter01_start:2:3fbd4128',
+    'chapter01/dialogue.rpy:chapter01_start:3:2ecaab1c',
+    'chapter01/dialogue.rpy:chapter01_start:4:8c8bd881',
+]
 FIXTURE_VARIANTS = Path(__file__).parent / 'fixtures' / 'ab_variants_minimal.json'
+
+
+def _full_chunk_translations() -> str:
+    return json.dumps(
+        [{'id': item_id, 'translation': '你好'} for item_id in SAMPLE_ITEM_IDS],
+    )
 
 
 class TranslationAbExperimentTests(unittest.TestCase):
@@ -32,6 +45,55 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 json.dump([{'name': 'a'}, {'name': 'a'}], handle)
             with self.assertRaises(SystemExit):
                 ab_mod.load_variants_file(path)
+
+    def test_load_variants_file_requires_at_least_two_variants(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'variants.json')
+            with open(path, 'w', encoding='utf-8') as handle:
+                json.dump([{'name': 'only_one'}], handle)
+            with self.assertRaises(SystemExit) as ctx:
+                ab_mod.load_variants_file(path)
+            self.assertIn('at least two', str(ctx.exception))
+
+    def test_extract_translation_map_detects_missing_and_extra_ids(self):
+        items = [{'id': 'line-1', 'text': 'Hello'}, {'id': 'line-2', 'text': 'World'}]
+        response_text = json.dumps(
+            [
+                {'id': 'line-1', 'translation': '你好'},
+                {'id': 'line-3', 'translation': '多余'},
+            ],
+        )
+        translations, error = ab_mod.extract_translation_map(response_text, items)
+        self.assertEqual(translations['line-1'], '你好')
+        self.assertIn('Missing translations for ids: line-2', error)
+        self.assertIn('Unexpected result ids: line-3', error)
+
+    def test_variant_batch_settings_restores_baseline_globals(self):
+        baseline_rag = batch_mod.RAG_ENABLED
+        with ab_mod.variant_batch_settings({'batch': {'rag': {'enabled': True}}}):
+            self.assertTrue(batch_mod.RAG_ENABLED)
+        self.assertEqual(batch_mod.RAG_ENABLED, baseline_rag)
+
+    def test_dry_run_skips_retrieval_calls(self):
+        chunk = {
+            'items': [{'id': 'line-1', 'text': 'Hello'}],
+            'context_past': [],
+            'context_future': [],
+            'file_rel_path': 'script.rpy',
+        }
+        with mock.patch.object(batch_mod, 'retrieve_glossary_hits') as glossary_mock, \
+             mock.patch.object(batch_mod, 'retrieve_history_hits') as history_mock, \
+             mock.patch.object(batch_mod, 'retrieve_source_hits') as source_mock, \
+             mock.patch.object(batch_mod, 'retrieve_batch_story_hits') as story_mock:
+            enriched = ab_mod.enrich_chunk_for_current_settings(chunk, dry_run=True)
+        glossary_mock.assert_not_called()
+        history_mock.assert_not_called()
+        source_mock.assert_not_called()
+        story_mock.assert_not_called()
+        self.assertEqual(enriched['glossary_hits'], [])
+        self.assertEqual(enriched['history_hits'], [])
+        self.assertEqual(enriched['source_hits'], [])
+        self.assertNotIn('story_hits', enriched)
 
     def test_render_markdown_report_includes_variant_columns(self):
         chunk_results = [
@@ -121,7 +183,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
             def fake_sync_runner(request_payload, model_name, api_key_index=None):
                 calls.append(model_name)
                 return {
-                    'response_text': json.dumps([{'id': SAMPLE_ITEM_ID, 'translation': '你好'}]),
+                    'response_text': _full_chunk_translations(),
                     'finish_reason': 'STOP',
                     'usage_metadata': {'total_tokens': 12},
                 }
@@ -141,6 +203,86 @@ class TranslationAbExperimentTests(unittest.TestCase):
             translations = {variant['name']: variant['translations'] for variant in row['variants']}
             self.assertEqual(translations['baseline'][SAMPLE_ITEM_ID], '你好')
             self.assertEqual(translations['story_memory'][SAMPLE_ITEM_ID], '你好')
+
+    def test_run_translation_ab_experiment_records_variant_sync_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            call_count = {'value': 0}
+
+            def flaky_sync_runner(request_payload, model_name, api_key_index=None):
+                call_count['value'] += 1
+                if call_count['value'] == 1:
+                    return {
+                        'response_text': _full_chunk_translations(),
+                        'finish_reason': 'STOP',
+                        'usage_metadata': {},
+                    }
+                raise RuntimeError('sync failed')
+
+            summary = ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                offset=0,
+                output_dir=os.path.join(tmp, 'experiment'),
+                dry_run=False,
+                sync_runner=flaky_sync_runner,
+            )
+            self.assertTrue(os.path.isfile(summary['report_path']))
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                row = json.loads(handle.readline())
+            self.assertEqual(len(row['variants']), 2)
+            errors = {variant['name']: variant.get('error', '') for variant in row['variants']}
+            self.assertEqual(errors['baseline'], '')
+            self.assertIn('sync failed', errors['story_memory'])
+
+    def test_run_translation_ab_experiment_writes_partial_outputs_on_experiment_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            original_context = ab_mod.variant_batch_settings
+            entered = {'value': 0}
+
+            @contextlib.contextmanager
+            def flaky_context(overrides):
+                entered['value'] += 1
+                if entered['value'] == 2:
+                    raise RuntimeError('variant settings failed')
+                with original_context(overrides) as settings:
+                    yield settings
+
+            with mock.patch.object(ab_mod, 'variant_batch_settings', side_effect=flaky_context):
+                summary = ab_mod.run_translation_ab_experiment(
+                    loaded,
+                    variants,
+                    limit=1,
+                    offset=0,
+                    output_dir=os.path.join(tmp, 'experiment'),
+                    dry_run=True,
+                )
+            self.assertTrue(os.path.isfile(summary['report_path']))
+            self.assertIn('experiment_error', summary)
+            with open(summary['settings_path'], 'r', encoding='utf-8') as handle:
+                settings_payload = json.load(handle)
+            self.assertIn('experiment_error', settings_payload)
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                row = json.loads(handle.readline())
+            self.assertEqual(len(row['variants']), 1)
 
     def test_compare_variants_cli_dry_run(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -1,0 +1,177 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+import translation_ab_experiment as ab_mod
+
+
+FIXTURE_MANIFEST = (
+    Path(__file__).parent / 'fixtures' / 'golden_batch_minimal' / 'expected' / 'manifest_snapshot.json'
+)
+SAMPLE_ITEM_ID = 'chapter01/dialogue.rpy:chapter01_start:1:8dfe92d9'
+FIXTURE_VARIANTS = Path(__file__).parent / 'fixtures' / 'ab_variants_minimal.json'
+
+
+class TranslationAbExperimentTests(unittest.TestCase):
+    def test_deep_merge_dict_merges_nested_batch_settings(self):
+        merged = ab_mod.deep_merge_dict(
+            {'batch': {'story_memory': {'enabled': False, 'max_context_chars': 800}}},
+            {'batch': {'story_memory': {'enabled': True}}},
+        )
+        self.assertTrue(merged['batch']['story_memory']['enabled'])
+        self.assertEqual(merged['batch']['story_memory']['max_context_chars'], 800)
+
+    def test_load_variants_file_requires_unique_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'variants.json')
+            with open(path, 'w', encoding='utf-8') as handle:
+                json.dump([{'name': 'a'}, {'name': 'a'}], handle)
+            with self.assertRaises(SystemExit):
+                ab_mod.load_variants_file(path)
+
+    def test_render_markdown_report_includes_variant_columns(self):
+        chunk_results = [
+            ab_mod.ChunkExperimentResult(
+                chunk_key='chunk-1',
+                file_rel_path='script.rpy',
+                items=[{'id': 'line-1', 'text': 'Hello'}],
+                variant_results=[
+                    ab_mod.VariantRunResult(
+                        variant_name='baseline',
+                        settings={
+                            'model': 'test-model',
+                            'story_memory_enabled': False,
+                            'rag_enabled': False,
+                            'source_index_enabled': False,
+                            'macro_setting_preview': 'Base',
+                        },
+                        translations={'line-1': '你好'},
+                    ),
+                    ab_mod.VariantRunResult(
+                        variant_name='story_memory',
+                        settings={
+                            'model': 'test-model',
+                            'story_memory_enabled': True,
+                            'rag_enabled': False,
+                            'source_index_enabled': False,
+                            'macro_setting_preview': 'Base',
+                        },
+                        translations={'line-1': '你好啊'},
+                    ),
+                ],
+            )
+        ]
+        variants = [{'name': 'baseline', 'overrides': {}}, {'name': 'story_memory', 'overrides': {}}]
+        report = ab_mod.render_markdown_report(
+            manifest_path='manifest.json',
+            variants=variants,
+            chunk_results=chunk_results,
+            experiment_settings={'dry_run': True},
+        )
+        self.assertIn('baseline', report)
+        self.assertIn('story_memory', report)
+        self.assertIn('| line-1 | Hello | 你好 | 你好啊 |', report)
+
+    def test_run_translation_ab_experiment_dry_run_writes_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            output_dir = os.path.join(tmp, 'experiment')
+            summary = ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                offset=0,
+                output_dir=output_dir,
+                dry_run=True,
+            )
+            self.assertTrue(os.path.isfile(summary['report_path']))
+            self.assertTrue(os.path.isfile(summary['results_path']))
+            self.assertTrue(os.path.isfile(summary['settings_path']))
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                rows = [json.loads(line) for line in handle if line.strip()]
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(len(rows[0]['variants']), 2)
+            self.assertTrue(all(variant['dry_run'] for variant in rows[0]['variants']))
+
+    def test_run_translation_ab_experiment_calls_sync_runner_per_variant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            calls = []
+
+            def fake_sync_runner(request_payload, model_name, api_key_index=None):
+                calls.append(model_name)
+                return {
+                    'response_text': json.dumps([{'id': SAMPLE_ITEM_ID, 'translation': '你好'}]),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {'total_tokens': 12},
+                }
+
+            summary = ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                offset=0,
+                output_dir=os.path.join(tmp, 'experiment'),
+                dry_run=False,
+                sync_runner=fake_sync_runner,
+            )
+            self.assertEqual(len(calls), 2)
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                row = json.loads(handle.readline())
+            translations = {variant['name']: variant['translations'] for variant in row['variants']}
+            self.assertEqual(translations['baseline'][SAMPLE_ITEM_ID], '你好')
+            self.assertEqual(translations['story_memory'][SAMPLE_ITEM_ID], '你好')
+
+    def test_compare_variants_cli_dry_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            output_dir = os.path.join(tmp, 'out')
+            argv = [
+                'compare-variants',
+                manifest_path,
+                '--variants-file',
+                str(FIXTURE_VARIANTS),
+                '--limit',
+                '1',
+                '--dry-run',
+                '--output-dir',
+                output_dir,
+            ]
+            with mock.patch.object(batch_mod, 'initialize_batch_logging'), \
+                 mock.patch.object(batch_mod.legacy, 'load_config'), \
+                 mock.patch.object(batch_mod.legacy, 'load_translator_settings'), \
+                 mock.patch.object(batch_mod.legacy, 'load_glossary'), \
+                 mock.patch.object(batch_mod, 'load_batch_settings'), \
+                 mock.patch.object(batch_mod, 'print_banner'):
+                batch_mod.main(argv)
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, 'ab_report.md')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -1,0 +1,499 @@
+# -*- coding: utf-8 -*-
+"""Run synchronous translation A/B experiments without writing game files."""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Callable
+
+import story_memory
+import translator_runtime as legacy
+
+_TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
+EXPERIMENTS_DIR = os.path.join(_TOOL_DIR, 'logs', 'experiments')
+
+
+def _batch():
+    import gemini_translate_batch as batch_mod
+
+    return batch_mod
+
+
+def deep_merge_dict(base: object, override: object) -> object:
+    if not isinstance(override, dict):
+        return copy.deepcopy(override)
+    if not isinstance(base, dict):
+        base = {}
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = deep_merge_dict(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def load_variants_file(path: str) -> list[dict]:
+    if not path or not os.path.isfile(path):
+        raise SystemExit(f'Variants file not found: {path}')
+    with open(path, 'r', encoding='utf-8-sig') as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict):
+        variants = payload.get('variants')
+        if isinstance(variants, list):
+            payload = variants
+        else:
+            raise SystemExit('Variants JSON must be a list or an object with a "variants" array.')
+    if not isinstance(payload, list) or not payload:
+        raise SystemExit('Variants file must contain at least one variant.')
+    normalized = []
+    for index, entry in enumerate(payload, start=1):
+        if not isinstance(entry, dict):
+            raise SystemExit(f'Variant #{index} must be an object.')
+        name = _compact_text(entry.get('name') or entry.get('id') or f'variant_{index}')
+        if not name:
+            raise SystemExit(f'Variant #{index} is missing a name.')
+        overrides = entry.get('overrides')
+        if overrides is None:
+            overrides = {key: value for key, value in entry.items() if key not in {'name', 'id'}}
+        if not isinstance(overrides, dict):
+            raise SystemExit(f'Variant "{name}" overrides must be an object.')
+        normalized.append({'name': name, 'overrides': overrides})
+    names = [entry['name'] for entry in normalized]
+    if len(set(names)) != len(names):
+        raise SystemExit('Variant names must be unique.')
+    return normalized
+
+
+def select_manifest_chunks(manifest: dict, *, limit: int = 3, offset: int = 0) -> list[dict]:
+    chunks = manifest.get('chunks')
+    if not isinstance(chunks, list) or not chunks:
+        raise SystemExit('Manifest does not contain translation chunks.')
+    if offset < 0:
+        offset = 0
+    if limit <= 0:
+        raise SystemExit('--limit must be greater than 0.')
+    selected = chunks[offset:offset + limit]
+    if not selected:
+        raise SystemExit('No chunks available for the requested limit/offset.')
+    return [copy.deepcopy(chunk) for chunk in selected]
+
+
+def _compact_text(value: object) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+
+def _macro_preview(text: object, limit: int = 120) -> str:
+    compact = _compact_text(text).replace('\n', ' ')
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + '...'
+
+
+def summarize_variant_settings() -> dict:
+    batch_mod = _batch()
+    return {
+        'model': batch_mod.BATCH_MODEL,
+        'story_memory_enabled': batch_mod.STORY_MEMORY_ENABLED,
+        'story_memory_graph_file': batch_mod.STORY_MEMORY_GRAPH_FILE if batch_mod.STORY_MEMORY_ENABLED else '',
+        'rag_enabled': batch_mod.RAG_ENABLED,
+        'source_index_enabled': batch_mod.SOURCE_INDEX_ENABLED,
+        'macro_setting_preview': _macro_preview(batch_mod.BATCH_MACRO_SETTING),
+        'temperature': batch_mod.BATCH_TEMPERATURE,
+        'max_output_tokens': batch_mod.BATCH_MAX_OUTPUT_TOKENS,
+    }
+
+
+@contextmanager
+def variant_batch_settings(overrides: dict):
+    batch_mod = _batch()
+    base_translator = batch_mod.load_json_file(legacy.TRANSLATOR_CONFIG)
+    base_legacy = batch_mod.load_json_file(legacy.CONFIG_FILE)
+    merged_translator = deep_merge_dict(base_translator, overrides)
+    original_load = batch_mod.load_json_file
+
+    def patched_load(path):
+        if path == legacy.TRANSLATOR_CONFIG:
+            return copy.deepcopy(merged_translator)
+        if path == legacy.CONFIG_FILE:
+            return copy.deepcopy(base_legacy)
+        return original_load(path)
+
+    batch_mod.load_json_file = patched_load
+    batch_mod._STORY_GRAPH = None
+    batch_mod._STORY_GRAPH_PATH = ''
+    batch_mod._RAG_STORE = None
+    batch_mod._SOURCE_INDEX_STORE = None
+    try:
+        batch_mod.load_batch_settings()
+        yield summarize_variant_settings()
+    finally:
+        batch_mod.load_json_file = original_load
+        batch_mod._STORY_GRAPH = None
+        batch_mod._STORY_GRAPH_PATH = ''
+        batch_mod._RAG_STORE = None
+        batch_mod._SOURCE_INDEX_STORE = None
+        batch_mod.load_batch_settings()
+
+
+def enrich_chunk_for_current_settings(chunk: dict) -> dict:
+    batch_mod = _batch()
+    enriched = copy.deepcopy(chunk)
+    target_items = enriched.get('items') or []
+    context_past = enriched.get('context_past') or []
+    context_future = enriched.get('context_future') or []
+    file_rel_path = enriched.get('file_rel_path') or ''
+
+    if batch_mod.RAG_ENABLED:
+        enriched['glossary_hits'] = batch_mod.retrieve_glossary_hits(target_items)
+        enriched['history_hits'], enriched['rag_stats'] = batch_mod.retrieve_history_hits(
+            target_items,
+            context_past,
+        )
+    else:
+        enriched['glossary_hits'] = []
+        enriched['history_hits'] = []
+        enriched.pop('rag_stats', None)
+
+    if batch_mod.SOURCE_INDEX_ENABLED:
+        enriched['source_hits'], enriched['source_index_stats'] = batch_mod.retrieve_source_hits(
+            target_items,
+            context_past,
+        )
+    else:
+        enriched['source_hits'] = []
+        enriched.pop('source_index_stats', None)
+
+    enriched.pop('story_hits', None)
+    if batch_mod.STORY_MEMORY_ENABLED:
+        story_hits = batch_mod.retrieve_batch_story_hits(
+            file_rel_path,
+            target_items,
+            context_past,
+            context_future,
+        )
+        if story_memory.has_story_hits(story_hits):
+            enriched['story_hits'] = story_hits
+
+    return enriched
+
+
+def extract_translation_map(response_text: str, items: list[dict]) -> tuple[dict[str, str], str]:
+    if not response_text:
+        return {}, 'Missing response text.'
+    try:
+        batch_mod = _batch()
+        payload = batch_mod.parse_json_payload(response_text)
+        result_items = batch_mod.normalize_result_items(payload)
+    except Exception as exc:
+        return {}, str(exc)
+
+    expected_ids = [str(item.get('id') or '') for item in items if item.get('id')]
+    translations = {}
+    for row in result_items:
+        item_id = str(row.get('id') or '')
+        translation = _compact_text(row.get('translation'))
+        if item_id and translation:
+            translations[item_id] = translation
+    if not translations:
+        return {}, 'No translation items parsed from response.'
+    return translations, ''
+
+
+@dataclass
+class VariantRunResult:
+    variant_name: str
+    settings: dict
+    translations: dict[str, str] = field(default_factory=dict)
+    usage_metadata: dict = field(default_factory=dict)
+    finish_reason: str = ''
+    error: str = ''
+    dry_run: bool = False
+
+
+@dataclass
+class ChunkExperimentResult:
+    chunk_key: str
+    file_rel_path: str
+    items: list[dict]
+    variant_results: list[VariantRunResult] = field(default_factory=list)
+
+
+def _ensure_experiments_dir() -> str:
+    os.makedirs(EXPERIMENTS_DIR, exist_ok=True)
+    return EXPERIMENTS_DIR
+
+
+def create_experiment_output_dir(prefix: str = 'ab') -> str:
+    _ensure_experiments_dir()
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+    base = os.path.join(EXPERIMENTS_DIR, f'{timestamp}_{prefix}')
+    suffix = 0
+    candidate = base
+    while os.path.exists(candidate):
+        suffix += 1
+        candidate = f'{base}_{suffix:02d}'
+    os.makedirs(candidate, exist_ok=False)
+    return candidate
+
+
+def render_markdown_report(
+    *,
+    manifest_path: str,
+    variants: list[dict],
+    chunk_results: list[ChunkExperimentResult],
+    experiment_settings: dict,
+) -> str:
+    variant_names = [entry['name'] for entry in variants]
+    settings_by_variant: dict[str, dict] = {}
+    for chunk in chunk_results:
+        for result in chunk.variant_results:
+            settings_by_variant.setdefault(result.variant_name, result.settings)
+
+    lines = [
+        '# Translation A/B Experiment',
+        '',
+        f'- Manifest: `{manifest_path}`',
+        f'- Generated: {datetime.now().isoformat(timespec="seconds")}',
+        f'- Chunks: {len(chunk_results)}',
+        f'- Variants: {len(variants)}',
+        '',
+        '## Variant Settings',
+        '',
+        '| Variant | Model | Story Memory | RAG | Source Index | Macro (preview) |',
+        '| --- | --- | --- | --- | --- | --- |',
+    ]
+    for name in variant_names:
+        settings = settings_by_variant.get(name, {})
+        lines.append(
+            '| {name} | {model} | {story} | {rag} | {source_index} | {macro} |'.format(
+                name=_escape_table_cell(name),
+                model=_escape_table_cell(settings.get('model', '')),
+                story='yes' if settings.get('story_memory_enabled') else 'no',
+                rag='yes' if settings.get('rag_enabled') else 'no',
+                source_index='yes' if settings.get('source_index_enabled') else 'no',
+                macro=_escape_table_cell(settings.get('macro_setting_preview', '')),
+            )
+        )
+    lines.extend(['', '## Samples', ''])
+
+    for sample_index, chunk in enumerate(chunk_results, start=1):
+        lines.append(f'### Sample {sample_index}: `{chunk.chunk_key}` ({chunk.file_rel_path})')
+        lines.append('')
+        lines.append('| Item ID | Source | ' + ' | '.join(variant_names) + ' |')
+        lines.append('| --- | --- | ' + ' | '.join(['---'] * len(variant_names)) + ' |')
+        translation_maps = {
+            result.variant_name: result.translations for result in chunk.variant_results
+        }
+        for item in chunk.items:
+            item_id = str(item.get('id') or '')
+            source_text = _escape_table_cell(item.get('text') or '')
+            row_cells = [
+                _escape_table_cell(translation_maps.get(name, {}).get(item_id, ''))
+                for name in variant_names
+            ]
+            lines.append(
+                '| {id} | {source} | {variants} |'.format(
+                    id=_escape_table_cell(item_id),
+                    source=source_text,
+                    variants=' | '.join(row_cells),
+                )
+            )
+        lines.append('')
+        lines.append('#### Metadata')
+        for result in chunk.variant_results:
+            meta_bits = [
+                f'finish_reason={result.finish_reason or "(none)"}',
+                f'usage={json.dumps(result.usage_metadata, ensure_ascii=False)}',
+            ]
+            if result.error:
+                meta_bits.append(f'error={result.error}')
+            if result.dry_run:
+                meta_bits.append('dry_run=true')
+            lines.append(f'- **{result.variant_name}**: ' + '; '.join(meta_bits))
+        lines.append('')
+
+    if experiment_settings:
+        lines.extend(['## Run Settings', '', '```json', json.dumps(experiment_settings, ensure_ascii=False, indent=2), '```', ''])
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def _escape_table_cell(value: object) -> str:
+    text = _compact_text(value).replace('|', '\\|')
+    return text.replace('\n', '<br>')
+
+
+def write_experiment_outputs(
+    output_dir: str,
+    *,
+    manifest_path: str,
+    variants: list[dict],
+    chunk_results: list[ChunkExperimentResult],
+    experiment_settings: dict,
+) -> dict[str, str]:
+    os.makedirs(output_dir, exist_ok=True)
+    report_path = os.path.join(output_dir, 'ab_report.md')
+    results_path = os.path.join(output_dir, 'ab_results.jsonl')
+    settings_path = os.path.join(output_dir, 'ab_settings.json')
+
+    report_text = render_markdown_report(
+        manifest_path=manifest_path,
+        variants=variants,
+        chunk_results=chunk_results,
+        experiment_settings=experiment_settings,
+    )
+    with open(report_path, 'w', encoding='utf-8') as handle:
+        handle.write(report_text)
+
+    with open(results_path, 'w', encoding='utf-8') as handle:
+        for chunk in chunk_results:
+            handle.write(
+                json.dumps(
+                    {
+                        'chunk_key': chunk.chunk_key,
+                        'file_rel_path': chunk.file_rel_path,
+                        'items': chunk.items,
+                        'variants': [
+                            {
+                                'name': result.variant_name,
+                                'settings': result.settings,
+                                'translations': result.translations,
+                                'usage_metadata': result.usage_metadata,
+                                'finish_reason': result.finish_reason,
+                                'error': result.error,
+                                'dry_run': result.dry_run,
+                            }
+                            for result in chunk.variant_results
+                        ],
+                    },
+                    ensure_ascii=False,
+                )
+                + '\n'
+            )
+
+    with open(settings_path, 'w', encoding='utf-8') as handle:
+        json.dump(experiment_settings, handle, ensure_ascii=False, indent=2)
+
+    return {
+        'report_path': report_path,
+        'results_path': results_path,
+        'settings_path': settings_path,
+    }
+
+
+def run_variant_for_chunk(
+    chunk: dict,
+    *,
+    variant_name: str,
+    overrides: dict,
+    model_name: str,
+    api_key_index: int | None = None,
+    dry_run: bool = False,
+    sync_runner: Callable[..., dict] | None = None,
+) -> VariantRunResult:
+    with variant_batch_settings(overrides) as settings:
+        enriched = enrich_chunk_for_current_settings(chunk)
+        request_row = _batch().build_batch_request(enriched)
+        request_payload = request_row.get('request') or {}
+        if dry_run:
+            return VariantRunResult(
+                variant_name=variant_name,
+                settings=settings,
+                dry_run=True,
+            )
+
+        runner = sync_runner or _batch().run_sync_request
+        try:
+            response = runner(request_payload, model_name, api_key_index=api_key_index)
+        except Exception as exc:
+            return VariantRunResult(
+                variant_name=variant_name,
+                settings=settings,
+                error=str(exc),
+            )
+
+        translations, parse_error = extract_translation_map(
+            response.get('response_text') or '',
+            enriched.get('items') or [],
+        )
+        return VariantRunResult(
+            variant_name=variant_name,
+            settings=settings,
+            translations=translations,
+            usage_metadata=response.get('usage_metadata') or {},
+            finish_reason=response.get('finish_reason') or '',
+            error=parse_error,
+        )
+
+
+def run_translation_ab_experiment(
+    manifest: dict,
+    variants: list[dict],
+    *,
+    limit: int = 3,
+    offset: int = 0,
+    output_dir: str = '',
+    model_override: str = '',
+    api_key_index: int | None = None,
+    dry_run: bool = False,
+    sync_runner: Callable[..., dict] | None = None,
+) -> dict:
+    batch_mod = _batch()
+    batch_mod.require_manifest_mode(manifest, batch_mod.MANIFEST_MODE_TRANSLATION, 'compare-variants')
+    chunks = select_manifest_chunks(manifest, limit=limit, offset=offset)
+    model_name = model_override.strip() or manifest.get('batch_model') or batch_mod.BATCH_MODEL
+
+    if not output_dir:
+        slug = batch_mod.guess_project_slug()
+        output_dir = create_experiment_output_dir(f'{slug}_ab')
+
+    chunk_results: list[ChunkExperimentResult] = []
+    for chunk in chunks:
+        chunk_result = ChunkExperimentResult(
+            chunk_key=str(chunk.get('key') or ''),
+            file_rel_path=str(chunk.get('file_rel_path') or ''),
+            items=copy.deepcopy(chunk.get('items') or []),
+        )
+        for variant in variants:
+            chunk_result.variant_results.append(
+                run_variant_for_chunk(
+                    chunk,
+                    variant_name=variant['name'],
+                    overrides=variant.get('overrides') or {},
+                    model_name=model_name,
+                    api_key_index=api_key_index,
+                    dry_run=dry_run,
+                    sync_runner=sync_runner,
+                )
+            )
+        chunk_results.append(chunk_result)
+
+    experiment_settings = {
+        'manifest_path': manifest.get('_manifest_path', ''),
+        'model': model_name,
+        'limit': limit,
+        'offset': offset,
+        'dry_run': dry_run,
+        'variants': variants,
+        'chunk_keys': [chunk.chunk_key for chunk in chunk_results],
+    }
+    output_paths = write_experiment_outputs(
+        output_dir,
+        manifest_path=manifest.get('_manifest_path', ''),
+        variants=variants,
+        chunk_results=chunk_results,
+        experiment_settings=experiment_settings,
+    )
+
+    return {
+        'output_dir': output_dir,
+        'chunk_count': len(chunk_results),
+        'variant_count': len(variants),
+        'dry_run': dry_run,
+        **output_paths,
+    }

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -49,8 +49,8 @@ def load_variants_file(path: str) -> list[dict]:
             payload = variants
         else:
             raise SystemExit('Variants JSON must be a list or an object with a "variants" array.')
-    if not isinstance(payload, list) or not payload:
-        raise SystemExit('Variants file must contain at least one variant.')
+    if not isinstance(payload, list) or len(payload) < 2:
+        raise SystemExit('Variants file must contain at least two variants.')
     normalized = []
     for index, entry in enumerate(payload, start=1):
         if not isinstance(entry, dict):
@@ -109,13 +109,79 @@ def summarize_variant_settings() -> dict:
     }
 
 
+_BATCH_GLOBAL_KEYS = (
+    'BATCH_MODEL',
+    'BATCH_TARGET_SIZE',
+    'BATCH_CONTEXT_BEFORE',
+    'BATCH_CONTEXT_AFTER',
+    'BATCH_TARGET_CHARS',
+    'BATCH_RETRY_TARGET_SIZE',
+    'BATCH_RETRY_TARGET_CHARS',
+    'BATCH_MAX_OUTPUT_TOKENS',
+    'BATCH_TEMPERATURE',
+    'BATCH_THINKING_LEVEL',
+    'BATCH_SAFETY_SETTINGS',
+    'BATCH_DISPLAY_NAME_PREFIX',
+    'BATCH_MACRO_SETTING',
+    'KEYWORD_DISPLAY_NAME_PREFIX',
+    'KEYWORD_CHUNK_SIZE',
+    'KEYWORD_MAX_CANDIDATES_PER_CHUNK',
+    'REVISION_DISPLAY_NAME_PREFIX',
+    'REVISION_CHUNK_SIZE',
+    'RAG_ENABLED',
+    'RAG_STORE_DIR',
+    'RAG_EMBEDDING_MODEL',
+    'RAG_QUERY_TASK_TYPE',
+    'RAG_DOCUMENT_TASK_TYPE',
+    'RAG_OUTPUT_DIMENSIONALITY',
+    'RAG_TOP_K_HISTORY',
+    'RAG_TOP_K_TERMS',
+    'RAG_MIN_SIMILARITY',
+    'RAG_SEGMENT_LINES',
+    'RAG_BOOTSTRAP_ON_BUILD',
+    'RAG_HISTORY_CHAR_LIMIT',
+    'SOURCE_INDEX_ENABLED',
+    'SOURCE_INDEX_STORE_DIR',
+    'SOURCE_INDEX_TOP_K',
+    'SOURCE_INDEX_MIN_SIMILARITY',
+    'SOURCE_INDEX_CHAR_LIMIT',
+    'STORY_MEMORY_ENABLED',
+    'STORY_MEMORY_GRAPH_FILE',
+    'STORY_MEMORY_MAX_CONTEXT_CHARS',
+    'STORY_MEMORY_TOP_K_RELATIONS',
+    'STORY_MEMORY_TOP_K_TERMS',
+    'STORY_MEMORY_INCLUDE_SCENE_SUMMARY',
+    'BATCH_NON_CHINESE_RULES',
+    '_RAG_STORE',
+    '_SOURCE_INDEX_STORE',
+    '_STORY_GRAPH',
+    '_STORY_GRAPH_PATH',
+)
+
+
+def _snapshot_batch_globals() -> dict:
+    batch_mod = _batch()
+    snapshot = {key: getattr(batch_mod, key) for key in _BATCH_GLOBAL_KEYS}
+    snapshot['load_json_file'] = batch_mod.load_json_file
+    return snapshot
+
+
+def _restore_batch_globals(snapshot: dict) -> None:
+    batch_mod = _batch()
+    load_json_file = snapshot.pop('load_json_file')
+    for key, value in snapshot.items():
+        setattr(batch_mod, key, copy.deepcopy(value))
+    batch_mod.load_json_file = load_json_file
+
+
 @contextmanager
 def variant_batch_settings(overrides: dict):
     batch_mod = _batch()
-    base_translator = batch_mod.load_json_file(legacy.TRANSLATOR_CONFIG)
-    base_legacy = batch_mod.load_json_file(legacy.CONFIG_FILE)
+    baseline = _snapshot_batch_globals()
+    base_translator = baseline['load_json_file'](legacy.TRANSLATOR_CONFIG)
+    base_legacy = baseline['load_json_file'](legacy.CONFIG_FILE)
     merged_translator = deep_merge_dict(base_translator, overrides)
-    original_load = batch_mod.load_json_file
+    original_load = baseline['load_json_file']
 
     def patched_load(path):
         if path == legacy.TRANSLATOR_CONFIG:
@@ -133,21 +199,25 @@ def variant_batch_settings(overrides: dict):
         batch_mod.load_batch_settings()
         yield summarize_variant_settings()
     finally:
-        batch_mod.load_json_file = original_load
-        batch_mod._STORY_GRAPH = None
-        batch_mod._STORY_GRAPH_PATH = ''
-        batch_mod._RAG_STORE = None
-        batch_mod._SOURCE_INDEX_STORE = None
-        batch_mod.load_batch_settings()
+        _restore_batch_globals(baseline)
 
 
-def enrich_chunk_for_current_settings(chunk: dict) -> dict:
+def enrich_chunk_for_current_settings(chunk: dict, *, dry_run: bool = False) -> dict:
     batch_mod = _batch()
     enriched = copy.deepcopy(chunk)
     target_items = enriched.get('items') or []
     context_past = enriched.get('context_past') or []
     context_future = enriched.get('context_future') or []
     file_rel_path = enriched.get('file_rel_path') or ''
+
+    if dry_run:
+        enriched['glossary_hits'] = []
+        enriched['history_hits'] = []
+        enriched['source_hits'] = []
+        enriched.pop('rag_stats', None)
+        enriched.pop('source_index_stats', None)
+        enriched.pop('story_hits', None)
+        return enriched
 
     if batch_mod.RAG_ENABLED:
         enriched['glossary_hits'] = batch_mod.retrieve_glossary_hits(target_items)
@@ -194,14 +264,40 @@ def extract_translation_map(response_text: str, items: list[dict]) -> tuple[dict
         return {}, str(exc)
 
     expected_ids = [str(item.get('id') or '') for item in items if item.get('id')]
-    translations = {}
+    if not expected_ids:
+        return {}, 'Chunk has no item ids to validate against.'
+
+    expected_id_set = set(expected_ids)
+    translations: dict[str, str] = {}
+    seen_ids: set[str] = set()
+    duplicate_ids: list[str] = []
     for row in result_items:
         item_id = str(row.get('id') or '')
         translation = _compact_text(row.get('translation'))
-        if item_id and translation:
+        if not item_id:
+            continue
+        if item_id in seen_ids:
+            duplicate_ids.append(item_id)
+        seen_ids.add(item_id)
+        if translation:
             translations[item_id] = translation
-    if not translations:
+
+    errors: list[str] = []
+    if duplicate_ids:
+        errors.append(
+            'Duplicate result ids: ' + ', '.join(sorted(set(duplicate_ids))),
+        )
+    missing_ids = [item_id for item_id in expected_ids if item_id not in translations]
+    if missing_ids:
+        errors.append('Missing translations for ids: ' + ', '.join(missing_ids))
+    extra_ids = [item_id for item_id in translations if item_id not in expected_id_set]
+    if extra_ids:
+        errors.append('Unexpected result ids: ' + ', '.join(extra_ids))
+
+    if not translations and not errors:
         return {}, 'No translation items parsed from response.'
+    if errors:
+        return translations, '; '.join(errors)
     return translations, ''
 
 
@@ -285,7 +381,8 @@ def render_markdown_report(
     for sample_index, chunk in enumerate(chunk_results, start=1):
         lines.append(f'### Sample {sample_index}: `{chunk.chunk_key}` ({chunk.file_rel_path})')
         lines.append('')
-        lines.append('| Item ID | Source | ' + ' | '.join(variant_names) + ' |')
+        escaped_variant_names = [_escape_table_cell(name) for name in variant_names]
+        lines.append('| Item ID | Source | ' + ' | '.join(escaped_variant_names) + ' |')
         lines.append('| --- | --- | ' + ' | '.join(['---'] * len(variant_names)) + ' |')
         translation_maps = {
             result.variant_name: result.translations for result in chunk.variant_results
@@ -315,7 +412,9 @@ def render_markdown_report(
                 meta_bits.append(f'error={result.error}')
             if result.dry_run:
                 meta_bits.append('dry_run=true')
-            lines.append(f'- **{result.variant_name}**: ' + '; '.join(meta_bits))
+            lines.append(
+                f'- **{_escape_table_cell(result.variant_name)}**: ' + '; '.join(meta_bits),
+            )
         lines.append('')
 
     if experiment_settings:
@@ -390,14 +489,15 @@ def run_variant_for_chunk(
     chunk: dict,
     *,
     variant_name: str,
-    overrides: dict,
-    model_name: str,
+    settings: dict,
+    model_override: str = '',
     api_key_index: int | None = None,
     dry_run: bool = False,
     sync_runner: Callable[..., dict] | None = None,
 ) -> VariantRunResult:
-    with variant_batch_settings(overrides) as settings:
-        enriched = enrich_chunk_for_current_settings(chunk)
+    model_name = model_override.strip() or settings.get('model') or _batch().BATCH_MODEL
+    try:
+        enriched = enrich_chunk_for_current_settings(chunk, dry_run=dry_run)
         request_row = _batch().build_batch_request(enriched)
         request_payload = request_row.get('request') or {}
         if dry_run:
@@ -408,15 +508,7 @@ def run_variant_for_chunk(
             )
 
         runner = sync_runner or _batch().run_sync_request
-        try:
-            response = runner(request_payload, model_name, api_key_index=api_key_index)
-        except Exception as exc:
-            return VariantRunResult(
-                variant_name=variant_name,
-                settings=settings,
-                error=str(exc),
-            )
-
+        response = runner(request_payload, model_name, api_key_index=api_key_index)
         translations, parse_error = extract_translation_map(
             response.get('response_text') or '',
             enriched.get('items') or [],
@@ -428,6 +520,12 @@ def run_variant_for_chunk(
             usage_metadata=response.get('usage_metadata') or {},
             finish_reason=response.get('finish_reason') or '',
             error=parse_error,
+        )
+    except Exception as exc:
+        return VariantRunResult(
+            variant_name=variant_name,
+            settings=settings,
+            error=str(exc),
         )
 
 
@@ -446,54 +544,65 @@ def run_translation_ab_experiment(
     batch_mod = _batch()
     batch_mod.require_manifest_mode(manifest, batch_mod.MANIFEST_MODE_TRANSLATION, 'compare-variants')
     chunks = select_manifest_chunks(manifest, limit=limit, offset=offset)
-    model_name = model_override.strip() or manifest.get('batch_model') or batch_mod.BATCH_MODEL
+    default_model = model_override.strip() or manifest.get('batch_model') or batch_mod.BATCH_MODEL
 
     if not output_dir:
         slug = batch_mod.guess_project_slug()
         output_dir = create_experiment_output_dir(f'{slug}_ab')
 
-    chunk_results: list[ChunkExperimentResult] = []
-    for chunk in chunks:
-        chunk_result = ChunkExperimentResult(
+    chunk_results: list[ChunkExperimentResult] = [
+        ChunkExperimentResult(
             chunk_key=str(chunk.get('key') or ''),
             file_rel_path=str(chunk.get('file_rel_path') or ''),
             items=copy.deepcopy(chunk.get('items') or []),
         )
+        for chunk in chunks
+    ]
+    experiment_error = ''
+    try:
         for variant in variants:
-            chunk_result.variant_results.append(
-                run_variant_for_chunk(
-                    chunk,
-                    variant_name=variant['name'],
-                    overrides=variant.get('overrides') or {},
-                    model_name=model_name,
-                    api_key_index=api_key_index,
-                    dry_run=dry_run,
-                    sync_runner=sync_runner,
-                )
-            )
-        chunk_results.append(chunk_result)
+            with variant_batch_settings(variant.get('overrides') or {}) as settings:
+                for chunk_index, chunk in enumerate(chunks):
+                    chunk_results[chunk_index].variant_results.append(
+                        run_variant_for_chunk(
+                            chunk,
+                            variant_name=variant['name'],
+                            settings=settings,
+                            model_override=model_override,
+                            api_key_index=api_key_index,
+                            dry_run=dry_run,
+                            sync_runner=sync_runner,
+                        )
+                    )
+    except Exception as exc:
+        experiment_error = str(exc)
+    finally:
+        experiment_settings = {
+            'manifest_path': manifest.get('_manifest_path', ''),
+            'model': default_model,
+            'limit': limit,
+            'offset': offset,
+            'dry_run': dry_run,
+            'variants': variants,
+            'chunk_keys': [chunk.chunk_key for chunk in chunk_results],
+        }
+        if experiment_error:
+            experiment_settings['experiment_error'] = experiment_error
+        output_paths = write_experiment_outputs(
+            output_dir,
+            manifest_path=manifest.get('_manifest_path', ''),
+            variants=variants,
+            chunk_results=chunk_results,
+            experiment_settings=experiment_settings,
+        )
 
-    experiment_settings = {
-        'manifest_path': manifest.get('_manifest_path', ''),
-        'model': model_name,
-        'limit': limit,
-        'offset': offset,
-        'dry_run': dry_run,
-        'variants': variants,
-        'chunk_keys': [chunk.chunk_key for chunk in chunk_results],
-    }
-    output_paths = write_experiment_outputs(
-        output_dir,
-        manifest_path=manifest.get('_manifest_path', ''),
-        variants=variants,
-        chunk_results=chunk_results,
-        experiment_settings=experiment_settings,
-    )
-
-    return {
+    result = {
         'output_dir': output_dir,
         'chunk_count': len(chunk_results),
         'variant_count': len(variants),
         'dry_run': dry_run,
         **output_paths,
     }
+    if experiment_error:
+        result['experiment_error'] = experiment_error
+    return result


### PR DESCRIPTION
## Summary

Implements **#139 PR1**: a synchronous translation A/B experiment flow for comparing context-layer configurations without writing game files.

Adds `compare-variants`, which samples chunks from an existing **translation** batch manifest, applies per-variant `translator_config.json` overrides, runs sync `generate_content` calls, and writes side-by-side reports.

## Changes

- **`translation_ab_experiment.py`** — core experiment runner
  - variant config merge + temporary batch settings application
  - per-variant chunk context refresh (RAG / source index / story memory)
  - Markdown + JSONL output under `logs/experiments/`
- **`gemini_translate_batch.py`** — new `compare-variants` subcommand
- **`docs/batch_workflows.md`** — usage docs and variants JSON example
- **`tests/test_translation_ab_experiment.py`** — 6 unit tests (dry-run, mocked sync runner, CLI smoke)

## Usage

```bash
python gemini_translate_batch.py compare-variants logs/batch_jobs/<package>/manifest.json \
  --variants-file experiment_variants.json \
  --limit 3 \
  --dry-run
```

Outputs:
- `ab_report.md` — source vs variant translations table
- `ab_results.jsonl` — machine-readable rows
- `ab_settings.json` — experiment metadata

## Testing

```bash
python -m unittest tests.test_translation_ab_experiment -v
```

## Scope notes

- **CLI only** in this PR; GUI entry remains for a follow-up (#139 PR2).
- Samples from **manifest chunks** only (TL include-files sampling can be a later enhancement).
- Does **not** write back `.rpy` / `glossary.json`.

Closes #139 for the CLI MVP; GUI parity can be tracked separately if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“翻译质量 A/B 实验”对比流程，可基于同一批任务生成并排报告，方便比较不同配置变体的翻译结果。
  * 支持生成实验产物，包括报告、结果明细和实验设置摘要，并可先进行试跑查看输出。  
* **文档**
  * 补充了相关使用说明、命令示例、输出说明和试跑建议。  
* **测试**
  * 新增测试覆盖变体合并、报告生成、试跑输出和命令行入口。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->