### PR TITLE
feat(gui): compare-variants A/B experiment entry (#139 PR2)

### DIFF
--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -32,6 +32,18 @@ class AbExperimentSummary:
     dry_run: bool | None = None
 
 
+def manifest_chunk_count(manifest: dict[str, object]) -> int:
+    chunks = manifest.get("chunks")
+    if isinstance(chunks, list) and chunks:
+        return len(chunks)
+    summary = manifest.get("summary")
+    if isinstance(summary, dict):
+        chunk_count = summary.get("chunk_count")
+        if isinstance(chunk_count, int) and chunk_count > 0:
+            return chunk_count
+    return 0
+
+
 def translation_ab_experiment_ready(
     manifest_path: str,
     manifest: dict[str, object] | None,
@@ -44,8 +56,7 @@ def translation_ab_experiment_ready(
     mode_text = mode.strip() if isinstance(mode, str) else _MANIFEST_MODE_TRANSLATION
     if mode_text != _MANIFEST_MODE_TRANSLATION:
         return False, "翻译 A/B 对比仅支持批量翻译任务记录。"
-    chunks = manifest.get("chunks")
-    if not isinstance(chunks, list) or not chunks:
+    if manifest_chunk_count(manifest) <= 0:
         return False, "任务记录中没有可采样的翻译块。"
     return True, ""
 

--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -1,0 +1,254 @@
+"""Translation A/B experiment summaries and CLI helpers for the diagnostics tab."""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+
+from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
+from .user_copy import format_manifest_path_fact
+
+_MANIFEST_MODE_TRANSLATION = "translation"
+_COMPARE_VARIANTS_LINE_RE = re.compile(
+    r"^\s*-\s*(output_dir|chunks|variants|dry_run|report|results|settings):\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class AbExperimentSummary:
+    status: str
+    heading: str
+    message: str
+    facts: list[str]
+    findings: list[str]
+    manifest_path: str = ""
+    output_dir: str = ""
+    report_path: str = ""
+    results_path: str = ""
+    settings_path: str = ""
+    chunk_count: int | None = None
+    variant_count: int | None = None
+    dry_run: bool | None = None
+
+
+def translation_ab_experiment_ready(
+    manifest_path: str,
+    manifest: dict[str, object] | None,
+) -> tuple[bool, str]:
+    if not manifest_path.strip():
+        return False, "没有可对比的翻译任务记录。"
+    if manifest is None:
+        return False, "无法读取任务记录，请先在诊断页刷新上下文。"
+    mode = manifest.get("mode")
+    mode_text = mode.strip() if isinstance(mode, str) else _MANIFEST_MODE_TRANSLATION
+    if mode_text != _MANIFEST_MODE_TRANSLATION:
+        return False, "翻译 A/B 对比仅支持批量翻译任务记录。"
+    chunks = manifest.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        return False, "任务记录中没有可采样的翻译块。"
+    return True, ""
+
+
+def build_compare_variants_cli_args(
+    manifest_path: str,
+    variants_file: str,
+    *,
+    limit: int = 3,
+    offset: int = 0,
+    output_dir: str = "",
+    dry_run: bool = False,
+    api_key_index: int | None = None,
+) -> list[str]:
+    args = [
+        "compare-variants",
+        manifest_path,
+        "--variants-file",
+        variants_file,
+        "--limit",
+        str(limit),
+        "--offset",
+        str(offset),
+    ]
+    if output_dir.strip():
+        args.extend(["--output-dir", output_dir.strip()])
+    if dry_run:
+        args.append("--dry-run")
+    if api_key_index is not None:
+        args.extend(["--api-key-index", str(api_key_index)])
+    return args
+
+
+def parse_compare_variants_output(output: str) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    for match in _COMPARE_VARIANTS_LINE_RE.finditer(output):
+        key = match.group(1)
+        value = match.group(2).strip()
+        if key in {"chunks", "variants"}:
+            try:
+                parsed[key] = int(value)
+            except ValueError:
+                parsed[key] = value
+        elif key == "dry_run":
+            parsed[key] = value.lower() in {"true", "1", "yes"}
+        else:
+            parsed[key] = value
+    return parsed
+
+
+def summarize_compare_variants_output(
+    output: str,
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+    variants_file: str = "",
+) -> AbExperimentSummary:
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(format_manifest_path_fact(manifest_path))
+    if variants_file:
+        facts.append(f"变体文件：{variants_file}")
+
+    if exit_code != 0:
+        return AbExperimentSummary(
+            status="failed",
+            heading="翻译 A/B 对比失败",
+            message="实验没有正常完成，请查看诊断日志中的配置或 API 错误。",
+            facts=facts,
+            findings=[],
+            manifest_path=manifest_path,
+        )
+
+    parsed = parse_compare_variants_output(output)
+    output_dir = parsed.get("output_dir")
+    report_path = parsed.get("report")
+    results_path = parsed.get("results")
+    settings_path = parsed.get("settings")
+    chunk_count = parsed.get("chunks")
+    variant_count = parsed.get("variants")
+    dry_run = parsed.get("dry_run")
+
+    if isinstance(output_dir, str) and output_dir:
+        facts.append(f"输出目录：{output_dir}")
+    if isinstance(chunk_count, int):
+        facts.append(f"采样块数：{chunk_count}")
+    if isinstance(variant_count, int):
+        facts.append(f"变体数：{variant_count}")
+    if isinstance(dry_run, bool):
+        facts.append(f"试跑模式：{'是' if dry_run else '否'}")
+    if isinstance(report_path, str) and report_path:
+        facts.append(f"报告：{report_path}")
+
+    findings: list[str] = []
+    if isinstance(report_path, str) and report_path and not os.path.isfile(report_path):
+        findings.append("命令已结束，但报告文件尚未找到。")
+
+    if isinstance(report_path, str) and report_path and os.path.isfile(report_path):
+        if isinstance(dry_run, bool) and dry_run:
+            message = (
+                "试跑已完成：各变体 prompt 已重建并写入报告，未调用翻译 API。"
+                "确认配置无误后可取消“仅试跑”再正式对比。"
+            )
+            heading = "翻译 A/B 试跑完成"
+        else:
+            message = (
+                "实验已完成：请打开并排 Markdown 报告，人工比较各变体译文与配置差异。"
+            )
+            heading = "翻译 A/B 对比完成"
+        return AbExperimentSummary(
+            status="ok",
+            heading=heading,
+            message=message,
+            facts=facts,
+            findings=findings,
+            manifest_path=manifest_path,
+            output_dir=output_dir if isinstance(output_dir, str) else "",
+            report_path=report_path,
+            results_path=results_path if isinstance(results_path, str) else "",
+            settings_path=settings_path if isinstance(settings_path, str) else "",
+            chunk_count=chunk_count if isinstance(chunk_count, int) else None,
+            variant_count=variant_count if isinstance(variant_count, int) else None,
+            dry_run=dry_run if isinstance(dry_run, bool) else None,
+        )
+
+    return AbExperimentSummary(
+        status="unknown",
+        heading="翻译 A/B 结果不明确",
+        message="命令已结束，但未能识别实验摘要，请查看诊断日志。",
+        facts=facts,
+        findings=findings,
+        manifest_path=manifest_path,
+    )
+
+
+def running_ab_experiment_summary(
+    *,
+    manifest_path: str = "",
+    variants_file: str = "",
+    dry_run: bool = False,
+) -> AbExperimentSummary:
+    facts: list[str] = []
+    if manifest_path:
+        facts.append(format_manifest_path_fact(manifest_path))
+    if variants_file:
+        facts.append(f"变体文件：{variants_file}")
+    if dry_run:
+        facts.append("试跑模式：是")
+
+    if dry_run:
+        message = "正在重建各变体 prompt 并生成报告，不会调用翻译 API。"
+        heading = "正在试跑翻译 A/B 对比"
+    else:
+        message = "正在对多个配置变体执行同步翻译；完成后这里会显示报告路径。"
+        heading = "正在运行翻译 A/B 对比"
+
+    return AbExperimentSummary(
+        status="running",
+        heading=heading,
+        message=message,
+        facts=facts,
+        findings=[],
+        manifest_path=manifest_path,
+        dry_run=dry_run,
+    )
+
+
+def ab_experiment_summary_to_diagnostics_context(
+    summary: AbExperimentSummary,
+    base: DiagnosticsContext,
+) -> DiagnosticsContext:
+    paths = list(base.paths)
+    if summary.report_path:
+        paths.append(DiagnosticsPathEntry(label="A/B 报告", path=summary.report_path))
+    if summary.results_path:
+        paths.append(DiagnosticsPathEntry(label="A/B 结果", path=summary.results_path))
+    if summary.settings_path:
+        paths.append(DiagnosticsPathEntry(label="A/B 设置", path=summary.settings_path))
+    if summary.output_dir and not any(entry.path == summary.output_dir for entry in paths):
+        paths.append(DiagnosticsPathEntry(label="A/B 输出目录", path=summary.output_dir))
+
+    facts = [*summary.facts, *base.facts]
+    if summary.findings:
+        facts.extend(summary.findings)
+
+    status = summary.status
+    if status == "ok":
+        status = "ready"
+    elif status in {"warn", "unknown"}:
+        status = "warning"
+    elif status == "running":
+        status = "running"
+
+    message = summary.message
+    if base.message and summary.status not in {"running", "failed"}:
+        message = f"{summary.message}\n\n{base.message}"
+
+    return DiagnosticsContext(
+        status=status,
+        heading=summary.heading,
+        message=message,
+        facts=facts,
+        paths=paths,
+        commands=base.commands,
+        manifest_json_preview=base.manifest_json_preview,
+    )

--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -251,7 +251,10 @@ def collect_ab_experiment_issues(
                     line = line.strip()
                     if not line:
                         continue
-                    row = json.loads(line)
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
                     variants = row.get("variants")
                     if not isinstance(variants, list):
                         continue
@@ -265,7 +268,7 @@ def collect_ab_experiment_issues(
                         if isinstance(error, str) and error.strip():
                             label = "/".join(part for part in (chunk_key, name) if part) or "variant"
                             variant_errors.append(f"{label}: {error.strip()}")
-        except (OSError, json.JSONDecodeError):
+        except OSError:
             findings.append("无法读取 ab_results.jsonl。")
             if severity != "failed":
                 severity = "warn"
@@ -339,6 +342,21 @@ def summarize_compare_variants_output(
     findings: list[str] = []
     if isinstance(report_path, str) and report_path and not os.path.isfile(report_path):
         findings.append("命令已结束，但报告文件尚未找到。")
+        return AbExperimentSummary(
+            status="warn",
+            heading="翻译 A/B 报告未找到",
+            message="命令已结束，但报告文件尚未找到，请查看诊断日志。",
+            facts=facts,
+            findings=findings,
+            manifest_path=manifest_path,
+            output_dir=output_dir if isinstance(output_dir, str) else "",
+            report_path=report_path,
+            results_path=results_path if isinstance(results_path, str) else "",
+            settings_path=settings_path if isinstance(settings_path, str) else "",
+            chunk_count=chunk_count if isinstance(chunk_count, int) else None,
+            variant_count=variant_count if isinstance(variant_count, int) else None,
+            dry_run=dry_run if isinstance(dry_run, bool) else None,
+        )
 
     if isinstance(report_path, str) and report_path and os.path.isfile(report_path):
         resolved_settings_path = resolve_ab_settings_path(

--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -7,67 +7,69 @@ import re
 import tempfile
 from dataclasses import dataclass
 
+from .bootstrap_report import coerce_bool
 from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
 from .user_copy import format_manifest_path_fact
 
 _MANIFEST_MODE_TRANSLATION = "translation"
 _COMPARE_VARIANTS_LINE_RE = re.compile(
-    r"^\s*-\s*(output_dir|chunks|variants|dry_run|report|results|settings):\s*(.+?)\s*$",
+    r"^\s*-\s*(output_dir|chunks|variants|dry_run|report|results|settings|experiment_error):\s*(.+?)\s*$",
     re.MULTILINE,
 )
 
 BASELINE_VARIANT = {"name": "baseline", "overrides": {}}
 
-AB_VARIANT_OPTION_SPECS: tuple[dict[str, object], ...] = (
+AB_VARIANT_CHOICE_SKIP = "skip"
+AB_VARIANT_CHOICE_FORCE_ON = "force_on"
+AB_VARIANT_CHOICE_FORCE_OFF = "force_off"
+
+AB_VARIANT_DIMENSIONS: tuple[dict[str, object], ...] = (
     {
-        "id": "story_memory_on",
-        "label": "Story Memory 开启",
-        "name": "story_memory_on",
-        "overrides": {"batch": {"story_memory": {"enabled": True}}},
+        "id": "story_memory",
+        "label": "Story Memory",
+        "overrides_key": "story_memory",
     },
     {
-        "id": "story_memory_off",
-        "label": "Story Memory 关闭",
-        "name": "story_memory_off",
-        "overrides": {"batch": {"story_memory": {"enabled": False}}},
+        "id": "rag",
+        "label": "RAG",
+        "overrides_key": "rag",
     },
     {
-        "id": "rag_on",
-        "label": "RAG 开启",
-        "name": "rag_on",
-        "overrides": {"batch": {"rag": {"enabled": True}}},
-    },
-    {
-        "id": "rag_off",
-        "label": "RAG 关闭",
-        "name": "rag_off",
-        "overrides": {"batch": {"rag": {"enabled": False}}},
-    },
-    {
-        "id": "source_index_on",
-        "label": "原文索引 开启",
-        "name": "source_index_on",
-        "overrides": {"batch": {"source_index": {"enabled": True}}},
-    },
-    {
-        "id": "source_index_off",
-        "label": "原文索引 关闭",
-        "name": "source_index_off",
-        "overrides": {"batch": {"source_index": {"enabled": False}}},
+        "id": "source_index",
+        "label": "原文索引",
+        "overrides_key": "source_index",
     },
 )
 
 
-def build_variants_from_gui_selection(selected_option_ids: set[str]) -> list[dict]:
+def read_ab_dimension_enabled_states(config: dict[str, object]) -> dict[str, bool]:
+    batch = config.get("batch")
+    if not isinstance(batch, dict):
+        batch = {}
+    states: dict[str, bool] = {}
+    for dimension in AB_VARIANT_DIMENSIONS:
+        dimension_id = str(dimension["id"])
+        overrides_key = str(dimension["overrides_key"])
+        section = batch.get(overrides_key)
+        if not isinstance(section, dict):
+            section = {}
+        states[dimension_id] = coerce_bool(section.get("enabled"), False)
+    return states
+
+
+def build_variants_from_gui_selection(dimension_choices: dict[str, str]) -> list[dict]:
     variants = [dict(BASELINE_VARIANT)]
-    for spec in AB_VARIANT_OPTION_SPECS:
-        option_id = str(spec["id"])
-        if option_id not in selected_option_ids:
+    for dimension in AB_VARIANT_DIMENSIONS:
+        dimension_id = str(dimension["id"])
+        choice = dimension_choices.get(dimension_id, AB_VARIANT_CHOICE_SKIP)
+        if choice == AB_VARIANT_CHOICE_SKIP:
             continue
+        overrides_key = str(dimension["overrides_key"])
+        enabled = choice == AB_VARIANT_CHOICE_FORCE_ON
         variants.append(
             {
-                "name": str(spec["name"]),
-                "overrides": spec["overrides"],
+                "name": f"{dimension_id}_{'on' if enabled else 'off'}",
+                "overrides": {"batch": {overrides_key: {"enabled": enabled}}},
             },
         )
     return variants
@@ -75,7 +77,10 @@ def build_variants_from_gui_selection(selected_option_ids: set[str]) -> list[dic
 
 def validate_ab_experiment_variants(variants: list[dict]) -> tuple[bool, str]:
     if len(variants) < 2:
-        return False, "请至少勾选一个对比项；baseline（当前配置）会自动包含。"
+        return False, (
+            "请至少选择一个对比项（将某维度设为「强制开启」或「强制关闭」）；"
+            "baseline（当前配置）会自动包含。"
+        )
     names = [str(entry.get("name") or "") for entry in variants]
     if len(set(names)) != len(names):
         return False, "变体名称重复，请调整勾选项。"
@@ -191,6 +196,102 @@ def parse_compare_variants_output(output: str) -> dict[str, object]:
     return parsed
 
 
+def resolve_ab_settings_path(
+    report_path: str,
+    results_path: str,
+    settings_path: str = "",
+) -> str:
+    candidates: list[str] = []
+    if isinstance(settings_path, str) and settings_path.strip():
+        candidates.append(settings_path.strip())
+    for base_path in (report_path, results_path):
+        if isinstance(base_path, str) and base_path.strip():
+            candidates.append(os.path.join(os.path.dirname(base_path), "ab_settings.json"))
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    return candidates[0] if candidates else ""
+
+
+def collect_ab_experiment_issues(
+    *,
+    settings_path: str = "",
+    results_path: str = "",
+    expected_variant_count: int | None = None,
+    stdout_experiment_error: str = "",
+) -> tuple[str, list[str]]:
+    findings: list[str] = []
+    severity = ""
+
+    if isinstance(stdout_experiment_error, str) and stdout_experiment_error.strip():
+        findings.append(f"实验中断：{stdout_experiment_error.strip()}")
+        severity = "failed"
+
+    if settings_path and os.path.isfile(settings_path):
+        try:
+            with open(settings_path, encoding="utf-8") as handle:
+                settings = json.load(handle)
+            experiment_error = settings.get("experiment_error")
+            if isinstance(experiment_error, str) and experiment_error.strip():
+                message = f"实验中断：{experiment_error.strip()}"
+                if message not in findings:
+                    findings.append(message)
+                severity = "failed"
+        except (OSError, json.JSONDecodeError):
+            findings.append("无法读取 ab_settings.json。")
+            if severity != "failed":
+                severity = "warn"
+
+    if results_path and os.path.isfile(results_path):
+        variant_errors: list[str] = []
+        max_variants_seen = 0
+        try:
+            with open(results_path, encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    row = json.loads(line)
+                    variants = row.get("variants")
+                    if not isinstance(variants, list):
+                        continue
+                    max_variants_seen = max(max_variants_seen, len(variants))
+                    chunk_key = str(row.get("chunk_key") or "")
+                    for variant in variants:
+                        if not isinstance(variant, dict):
+                            continue
+                        error = variant.get("error")
+                        name = str(variant.get("name") or "")
+                        if isinstance(error, str) and error.strip():
+                            label = "/".join(part for part in (chunk_key, name) if part) or "variant"
+                            variant_errors.append(f"{label}: {error.strip()}")
+        except (OSError, json.JSONDecodeError):
+            findings.append("无法读取 ab_results.jsonl。")
+            if severity != "failed":
+                severity = "warn"
+        else:
+            if variant_errors:
+                preview = "; ".join(variant_errors[:3])
+                if len(variant_errors) > 3:
+                    preview += f"；另有 {len(variant_errors) - 3} 条，见 ab_results.jsonl"
+                findings.append(f"部分变体出错：{preview}")
+                if severity != "failed":
+                    severity = "warn"
+            if (
+                isinstance(expected_variant_count, int)
+                and expected_variant_count > 0
+                and max_variants_seen > 0
+                and max_variants_seen < expected_variant_count
+            ):
+                findings.append(
+                    f"仅完成 {max_variants_seen}/{expected_variant_count} 个变体，报告可能不完整。",
+                )
+                if severity != "failed":
+                    severity = "warn"
+
+    return severity, findings
+
+
 def summarize_compare_variants_output(
     output: str,
     exit_code: int,
@@ -219,6 +320,7 @@ def summarize_compare_variants_output(
     report_path = parsed.get("report")
     results_path = parsed.get("results")
     settings_path = parsed.get("settings")
+    stdout_experiment_error = parsed.get("experiment_error")
     chunk_count = parsed.get("chunks")
     variant_count = parsed.get("variants")
     dry_run = parsed.get("dry_run")
@@ -239,6 +341,23 @@ def summarize_compare_variants_output(
         findings.append("命令已结束，但报告文件尚未找到。")
 
     if isinstance(report_path, str) and report_path and os.path.isfile(report_path):
+        resolved_settings_path = resolve_ab_settings_path(
+            report_path,
+            results_path if isinstance(results_path, str) else "",
+            settings_path if isinstance(settings_path, str) else "",
+        )
+        issue_severity, issue_findings = collect_ab_experiment_issues(
+            settings_path=resolved_settings_path,
+            results_path=results_path if isinstance(results_path, str) else "",
+            expected_variant_count=variant_count if isinstance(variant_count, int) else None,
+            stdout_experiment_error=(
+                stdout_experiment_error
+                if isinstance(stdout_experiment_error, str)
+                else ""
+            ),
+        )
+        findings.extend(issue_findings)
+
         if isinstance(dry_run, bool) and dry_run:
             message = (
                 "试跑已完成：各变体 prompt 已重建并写入报告，未调用翻译 API。"
@@ -250,8 +369,18 @@ def summarize_compare_variants_output(
                 "实验已完成：请打开并排 Markdown 报告，人工比较各变体译文与配置差异。"
             )
             heading = "翻译 A/B 对比完成"
+
+        status = "ok"
+        if issue_severity == "failed":
+            status = "failed"
+            heading = "翻译 A/B 对比失败"
+            message = "实验报告已生成，但部分变体未完成或实验中断，请查看诊断日志。"
+        elif issue_severity == "warn":
+            status = "warn"
+            message = f"{message} 部分变体可能不完整，请查看下方详情。"
+
         return AbExperimentSummary(
-            status="ok",
+            status=status,
             heading=heading,
             message=message,
             facts=facts,
@@ -260,7 +389,7 @@ def summarize_compare_variants_output(
             output_dir=output_dir if isinstance(output_dir, str) else "",
             report_path=report_path,
             results_path=results_path if isinstance(results_path, str) else "",
-            settings_path=settings_path if isinstance(settings_path, str) else "",
+            settings_path=resolved_settings_path,
             chunk_count=chunk_count if isinstance(chunk_count, int) else None,
             variant_count=variant_count if isinstance(variant_count, int) else None,
             dry_run=dry_run if isinstance(dry_run, bool) else None,

--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -1,8 +1,10 @@
 """Translation A/B experiment summaries and CLI helpers for the diagnostics tab."""
 from __future__ import annotations
 
+import json
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 
 from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
@@ -13,6 +15,88 @@ _COMPARE_VARIANTS_LINE_RE = re.compile(
     r"^\s*-\s*(output_dir|chunks|variants|dry_run|report|results|settings):\s*(.+?)\s*$",
     re.MULTILINE,
 )
+
+BASELINE_VARIANT = {"name": "baseline", "overrides": {}}
+
+AB_VARIANT_OPTION_SPECS: tuple[dict[str, object], ...] = (
+    {
+        "id": "story_memory_on",
+        "label": "Story Memory 开启",
+        "name": "story_memory_on",
+        "overrides": {"batch": {"story_memory": {"enabled": True}}},
+    },
+    {
+        "id": "story_memory_off",
+        "label": "Story Memory 关闭",
+        "name": "story_memory_off",
+        "overrides": {"batch": {"story_memory": {"enabled": False}}},
+    },
+    {
+        "id": "rag_on",
+        "label": "RAG 开启",
+        "name": "rag_on",
+        "overrides": {"batch": {"rag": {"enabled": True}}},
+    },
+    {
+        "id": "rag_off",
+        "label": "RAG 关闭",
+        "name": "rag_off",
+        "overrides": {"batch": {"rag": {"enabled": False}}},
+    },
+    {
+        "id": "source_index_on",
+        "label": "原文索引 开启",
+        "name": "source_index_on",
+        "overrides": {"batch": {"source_index": {"enabled": True}}},
+    },
+    {
+        "id": "source_index_off",
+        "label": "原文索引 关闭",
+        "name": "source_index_off",
+        "overrides": {"batch": {"source_index": {"enabled": False}}},
+    },
+)
+
+
+def build_variants_from_gui_selection(selected_option_ids: set[str]) -> list[dict]:
+    variants = [dict(BASELINE_VARIANT)]
+    for spec in AB_VARIANT_OPTION_SPECS:
+        option_id = str(spec["id"])
+        if option_id not in selected_option_ids:
+            continue
+        variants.append(
+            {
+                "name": str(spec["name"]),
+                "overrides": spec["overrides"],
+            },
+        )
+    return variants
+
+
+def validate_ab_experiment_variants(variants: list[dict]) -> tuple[bool, str]:
+    if len(variants) < 2:
+        return False, "请至少勾选一个对比项；baseline（当前配置）会自动包含。"
+    names = [str(entry.get("name") or "") for entry in variants]
+    if len(set(names)) != len(names):
+        return False, "变体名称重复，请调整勾选项。"
+    return True, ""
+
+
+def write_variants_to_temp_file(variants: list[dict]) -> str:
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        suffix=".json",
+        prefix="ab_variants_",
+        delete=False,
+    )
+    with handle:
+        json.dump(variants, handle, ensure_ascii=False, indent=2)
+        return handle.name
+
+
+def format_variant_names(variants: list[dict]) -> str:
+    return ", ".join(str(entry.get("name") or "") for entry in variants if entry.get("name"))
 
 
 @dataclass(frozen=True)
@@ -112,13 +196,13 @@ def summarize_compare_variants_output(
     exit_code: int,
     *,
     manifest_path: str = "",
-    variants_file: str = "",
+    variant_names: str = "",
 ) -> AbExperimentSummary:
     facts: list[str] = []
     if manifest_path:
         facts.append(format_manifest_path_fact(manifest_path))
-    if variants_file:
-        facts.append(f"变体文件：{variants_file}")
+    if variant_names:
+        facts.append(f"对比变体：{variant_names}")
 
     if exit_code != 0:
         return AbExperimentSummary(
@@ -195,14 +279,14 @@ def summarize_compare_variants_output(
 def running_ab_experiment_summary(
     *,
     manifest_path: str = "",
-    variants_file: str = "",
+    variant_names: str = "",
     dry_run: bool = False,
 ) -> AbExperimentSummary:
     facts: list[str] = []
     if manifest_path:
         facts.append(format_manifest_path_fact(manifest_path))
-    if variants_file:
-        facts.append(f"变体文件：{variants_file}")
+    if variant_names:
+        facts.append(f"对比变体：{variant_names}")
     if dry_run:
         facts.append("试跑模式：是")
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -99,6 +99,13 @@ from .probe_report import (
     summarize_probe_output,
     translation_probe_ready,
 )
+from .ab_experiment_report import (
+    ab_experiment_summary_to_diagnostics_context,
+    build_compare_variants_cli_args,
+    running_ab_experiment_summary,
+    summarize_compare_variants_output,
+    translation_ab_experiment_ready,
+)
 from .keyword_report import summarize_keyword_result_from_manifest
 from .revision_report import summarize_revision_apply_output
 from .revision_writeback_report import (
@@ -293,6 +300,8 @@ class MainWindow(QMainWindow):
         self._apply_output_lines: list[str] = []
         self._recheck_output_lines: list[str] = []
         self._probe_output_lines: list[str] = []
+        self._compare_variants_output_lines: list[str] = []
+        self._compare_variants_file = ""
         self._split_output_lines: list[str] = []
         self._repair_output_lines: list[str] = []
         self._apply_revision_output_lines: list[str] = []
@@ -1291,6 +1300,15 @@ class MainWindow(QMainWindow):
         self.probe_btn.clicked.connect(self._on_run_probe)
         self.probe_btn.setEnabled(False)
         toolbar.addWidget(self.probe_btn)
+
+        self.compare_variants_btn = QPushButton("翻译 A/B 对比")
+        self.compare_variants_btn.setObjectName("secondary_btn")
+        self.compare_variants_btn.setToolTip(
+            "用同一批 manifest chunk 并排比较多个配置变体的同步译文，不会写回游戏文件。"
+        )
+        self.compare_variants_btn.clicked.connect(self._on_run_compare_variants)
+        self.compare_variants_btn.setEnabled(False)
+        toolbar.addWidget(self.compare_variants_btn)
 
         self.split_btn = QPushButton("拆分翻译包")
         self.split_btn.setObjectName("secondary_btn")
@@ -2503,6 +2521,15 @@ class MainWindow(QMainWindow):
         ready, _message = translation_probe_ready(manifest_path, manifest)
         self.probe_btn.setEnabled(not running and ready)
 
+    def _update_compare_variants_btn_enabled(self, *, running: bool | None = None) -> None:
+        if not hasattr(self, "compare_variants_btn"):
+            return
+        if running is None:
+            running = self.kill_btn.isEnabled()
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, _message = translation_ab_experiment_ready(manifest_path, manifest)
+        self.compare_variants_btn.setEnabled(not running and ready)
+
     def _update_split_btn_enabled(self, *, running: bool | None = None) -> None:
         if not hasattr(self, "split_btn"):
             return
@@ -2563,6 +2590,7 @@ class MainWindow(QMainWindow):
             )
             self._set_diagnostics_context(context)
             self._update_probe_btn_enabled()
+            self._update_compare_variants_btn_enabled()
             self._update_split_btn_enabled()
             return
 
@@ -2595,6 +2623,7 @@ class MainWindow(QMainWindow):
         )
         self._set_diagnostics_context(context)
         self._update_probe_btn_enabled()
+        self._update_compare_variants_btn_enabled()
         self._update_split_btn_enabled()
 
     def _set_diagnostics_context(self, context: DiagnosticsContext) -> None:
@@ -4248,6 +4277,98 @@ class MainWindow(QMainWindow):
             "api_key_index": api_key_index,
         }
 
+    def _prompt_compare_variants_options(self) -> dict[str, object] | None:
+        dialog = QDialog(self)
+        dialog.setWindowTitle("翻译 A/B 对比")
+        layout = QVBoxLayout(dialog)
+
+        hint = QLabel(
+            "将对当前翻译包采样若干 chunk，按变体文件中的配置并排生成译文报告。"
+            "不会写回 .rpy 或 glossary.json。"
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        form = QFormLayout()
+        variants_edit = QLineEdit()
+        variants_edit.setPlaceholderText("选择至少包含 2 个变体的 JSON 文件")
+        browse_btn = QPushButton("浏览…")
+        variants_row = QHBoxLayout()
+        variants_row.addWidget(variants_edit, stretch=1)
+        variants_row.addWidget(browse_btn)
+        variants_host = QWidget()
+        variants_host.setLayout(variants_row)
+        form.addRow("变体文件 (--variants-file)", variants_host)
+
+        def browse_variants_file() -> None:
+            path, _filter = QFileDialog.getOpenFileName(
+                dialog,
+                "选择变体 JSON 文件",
+                "",
+                "JSON 文件 (*.json);;所有文件 (*)",
+            )
+            if path:
+                variants_edit.setText(path)
+
+        browse_btn.clicked.connect(browse_variants_file)
+
+        limit_spin = QSpinBox()
+        limit_spin.setRange(1, 50)
+        limit_spin.setValue(3)
+        form.addRow("采样块数 (--limit)", limit_spin)
+
+        offset_spin = QSpinBox()
+        offset_spin.setRange(0, 1_000_000)
+        offset_spin.setValue(0)
+        form.addRow("起始偏移 (--offset)", offset_spin)
+
+        output_dir_edit = QLineEdit()
+        output_dir_edit.setPlaceholderText("留空则写入 logs/experiments/")
+        form.addRow("输出目录 (--output-dir)", output_dir_edit)
+
+        dry_run_check = QCheckBox("仅试跑（不调用翻译 API）")
+        dry_run_check.setChecked(True)
+        form.addRow("", dry_run_check)
+
+        api_key_spin = QSpinBox()
+        api_key_spin.setRange(-1, 99)
+        api_key_spin.setValue(-1)
+        api_key_spin.setSpecialValueText("默认")
+        form.addRow("API Key 索引 (--api-key-index)", api_key_spin)
+        layout.addLayout(form)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        cancel_btn = QPushButton("取消")
+        cancel_btn.clicked.connect(dialog.reject)
+        buttons.addWidget(cancel_btn)
+        run_btn = QPushButton("开始对比")
+        run_btn.setObjectName("primary_btn")
+        run_btn.clicked.connect(dialog.accept)
+        buttons.addWidget(run_btn)
+        layout.addLayout(buttons)
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return None
+
+        variants_file = variants_edit.text().strip()
+        if not variants_file:
+            QMessageBox.warning(dialog, "缺少变体文件", "请选择变体 JSON 文件。")
+            return None
+        if not Path(variants_file).is_file():
+            QMessageBox.warning(dialog, "变体文件无效", f"找不到文件：{variants_file}")
+            return None
+
+        api_key_index = None if api_key_spin.value() < 0 else api_key_spin.value()
+        return {
+            "variants_file": variants_file,
+            "limit": limit_spin.value(),
+            "offset": offset_spin.value(),
+            "output_dir": output_dir_edit.text().strip(),
+            "dry_run": dry_run_check.isChecked(),
+            "api_key_index": api_key_index,
+        }
+
     def _prompt_split_options(self) -> dict[str, int | str] | None:
         dialog = QDialog(self)
         dialog.setWindowTitle("拆分翻译包")
@@ -4334,6 +4455,57 @@ class MainWindow(QMainWindow):
         )
         self._append_log(
             f"=== 正在试跑样本请求：gemini_translate_batch.py {' '.join(args)} ===\n"
+        )
+        self._set_task_running(True)
+        self.runner.run(self.state.get_batch_script_path(), args)
+
+    def _on_run_compare_variants(self) -> None:
+        manifest_path, manifest = self._current_diagnostics_manifest()
+        ready, message = translation_ab_experiment_ready(manifest_path, manifest)
+        if not ready:
+            QMessageBox.information(self, "无法运行翻译 A/B 对比", message)
+            return
+
+        options = self._prompt_compare_variants_options()
+        if options is None:
+            return
+
+        self._clear_log_view()
+        self._focus_log_tab()
+        self._active_command = "compare_variants"
+        self._compare_variants_output_lines = []
+        variants_file = str(options["variants_file"])
+        self._compare_variants_file = variants_file
+        dry_run = bool(options["dry_run"])
+        base_context = build_diagnostics_context(
+            latest_manifest_path=manifest_path,
+            manifest=manifest,
+            batch_script_path=str(self.state.get_batch_script_path()),
+            logs_dir=str(self.state.get_logs_dir()),
+            python_exe=sys.executable,
+            submit_max_cost=self._submit_max_cost_from_config(),
+        )
+        self._set_diagnostics_context(
+            ab_experiment_summary_to_diagnostics_context(
+                running_ab_experiment_summary(
+                    manifest_path=manifest_path,
+                    variants_file=variants_file,
+                    dry_run=dry_run,
+                ),
+                base_context,
+            )
+        )
+        args = build_compare_variants_cli_args(
+            manifest_path,
+            variants_file,
+            limit=int(options["limit"]),
+            offset=int(options["offset"]),
+            output_dir=str(options["output_dir"]),
+            dry_run=dry_run,
+            api_key_index=options["api_key_index"],  # type: ignore[arg-type]
+        )
+        self._append_log(
+            f"=== 正在运行翻译 A/B 对比：gemini_translate_batch.py {' '.join(args)} ===\n"
         )
         self._set_task_running(True)
         self.runner.run(self.state.get_batch_script_path(), args)
@@ -4817,6 +4989,8 @@ class MainWindow(QMainWindow):
             self._recheck_output_lines.append(text)
         elif self._active_command == "probe":
             self._probe_output_lines.append(text)
+        elif self._active_command == "compare_variants":
+            self._compare_variants_output_lines.append(text)
         elif self._active_command == "split":
             self._split_output_lines.append(text)
         elif self._active_command == "repair":
@@ -4949,6 +5123,7 @@ class MainWindow(QMainWindow):
             )
         self._update_writeback_action_buttons(writeback_summary, running=running)
         self._update_probe_btn_enabled(running=running)
+        self._update_compare_variants_btn_enabled(running=running)
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
         self._sync_task_shortcuts()
@@ -5112,6 +5287,8 @@ class MainWindow(QMainWindow):
             self._recheck_output_lines.append(message)
         elif self._active_command == "probe":
             self._probe_output_lines.append(message)
+        elif self._active_command == "compare_variants":
+            self._compare_variants_output_lines.append(message)
         elif self._active_command == "split":
             self._split_output_lines.append(message)
         elif self._active_command == "repair":
@@ -5205,6 +5382,38 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("样本试跑失败，请查看诊断日志。", 8000)
             else:
                 self.statusBar().showMessage("样本试跑已结束。", 6000)
+            return
+
+        if self._active_command == "compare_variants":
+            manifest_path, manifest = self._current_diagnostics_manifest()
+            ab_summary = summarize_compare_variants_output(
+                "\n".join(self._compare_variants_output_lines),
+                exit_code,
+                manifest_path=manifest_path,
+                variants_file=self._compare_variants_file,
+            )
+            base_context = build_diagnostics_context(
+                latest_manifest_path=manifest_path or None,
+                manifest=manifest,
+                batch_script_path=str(self.state.get_batch_script_path()),
+                logs_dir=str(self.state.get_logs_dir()),
+                python_exe=sys.executable,
+                submit_max_cost=self._submit_max_cost_from_config(),
+            )
+            self._set_diagnostics_context(
+                ab_experiment_summary_to_diagnostics_context(ab_summary, base_context)
+            )
+            self._active_command = ""
+            self._set_task_running(False)
+            if ab_summary.status == "ok":
+                if ab_summary.dry_run:
+                    self.statusBar().showMessage("翻译 A/B 试跑完成。", 6000)
+                else:
+                    self.statusBar().showMessage("翻译 A/B 对比完成。", 6000)
+            elif ab_summary.status == "failed":
+                self.statusBar().showMessage("翻译 A/B 对比失败，请查看诊断日志。", 8000)
+            else:
+                self.statusBar().showMessage("翻译 A/B 对比已结束。", 6000)
             return
 
         if self._active_command == "split":

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -46,6 +46,8 @@ from PySide6.QtWidgets import (
     QSpinBox,
     QDoubleSpinBox,
     QComboBox,
+    QRadioButton,
+    QButtonGroup,
 )
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
@@ -100,11 +102,15 @@ from .probe_report import (
     translation_probe_ready,
 )
 from .ab_experiment_report import (
-    AB_VARIANT_OPTION_SPECS,
+    AB_VARIANT_CHOICE_FORCE_OFF,
+    AB_VARIANT_CHOICE_FORCE_ON,
+    AB_VARIANT_CHOICE_SKIP,
+    AB_VARIANT_DIMENSIONS,
     ab_experiment_summary_to_diagnostics_context,
     build_compare_variants_cli_args,
     build_variants_from_gui_selection,
     format_variant_names,
+    read_ab_dimension_enabled_states,
     running_ab_experiment_summary,
     summarize_compare_variants_output,
     translation_ab_experiment_ready,
@@ -4294,8 +4300,9 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(dialog)
 
         hint = QLabel(
-            "将对当前翻译包采样若干 chunk，用勾选配置与 baseline（当前 translator_config）"
-            "并排生成译文报告；不会写回 .rpy 或 glossary.json。"
+            "将对当前翻译包采样若干 chunk，用 baseline（当前 translator_config）"
+            "与所选配置变体并排生成译文报告；不会写回 .rpy 或 glossary.json。"
+            "每个对比项只能选一种：不参与、强制开启或强制关闭。"
         )
         hint.setWordWrap(True)
         layout.addWidget(hint)
@@ -4307,12 +4314,33 @@ class MainWindow(QMainWindow):
         baseline_check.setChecked(True)
         baseline_check.setEnabled(False)
         variants_layout.addWidget(baseline_check)
-        option_checks: dict[str, QCheckBox] = {}
-        for spec in AB_VARIANT_OPTION_SPECS:
-            option_id = str(spec["id"])
-            checkbox = QCheckBox(str(spec["label"]))
-            option_checks[option_id] = checkbox
-            variants_layout.addWidget(checkbox)
+
+        current_states = read_ab_dimension_enabled_states(self.state.load_translator_config())
+        dimension_button_groups: dict[str, QButtonGroup] = {}
+        for dimension in AB_VARIANT_DIMENSIONS:
+            dimension_id = str(dimension["id"])
+            label = str(dimension["label"])
+            current_enabled = current_states.get(dimension_id, False)
+            current_text = "当前：开启" if current_enabled else "当前：关闭"
+
+            row = QHBoxLayout()
+            row.addWidget(QLabel(f"{label}（{current_text}）"))
+
+            button_group = QButtonGroup(dialog)
+            skip_radio = QRadioButton("不参与")
+            on_radio = QRadioButton("强制开启")
+            off_radio = QRadioButton("强制关闭")
+            skip_radio.setChecked(True)
+            button_group.addButton(skip_radio, 0)
+            button_group.addButton(on_radio, 1)
+            button_group.addButton(off_radio, 2)
+            row.addWidget(skip_radio)
+            row.addWidget(on_radio)
+            row.addWidget(off_radio)
+            row.addStretch(1)
+            variants_layout.addLayout(row)
+            dimension_button_groups[dimension_id] = button_group
+
         form.addRow(variants_group)
 
         limit_spin = QSpinBox()
@@ -4354,12 +4382,16 @@ class MainWindow(QMainWindow):
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return None
 
-        selected_option_ids = {
-            option_id
-            for option_id, checkbox in option_checks.items()
-            if checkbox.isChecked()
-        }
-        variants = build_variants_from_gui_selection(selected_option_ids)
+        dimension_choices: dict[str, str] = {}
+        for dimension_id, button_group in dimension_button_groups.items():
+            checked_id = button_group.checkedId()
+            if checked_id == 1:
+                dimension_choices[dimension_id] = AB_VARIANT_CHOICE_FORCE_ON
+            elif checked_id == 2:
+                dimension_choices[dimension_id] = AB_VARIANT_CHOICE_FORCE_OFF
+            else:
+                dimension_choices[dimension_id] = AB_VARIANT_CHOICE_SKIP
+        variants = build_variants_from_gui_selection(dimension_choices)
         valid, validation_message = validate_ab_experiment_variants(variants)
         if not valid:
             QMessageBox.warning(dialog, "对比项不足", validation_message)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2527,8 +2527,14 @@ class MainWindow(QMainWindow):
         if running is None:
             running = self.kill_btn.isEnabled()
         manifest_path, manifest = self._current_diagnostics_manifest()
-        ready, _message = translation_ab_experiment_ready(manifest_path, manifest)
+        ready, message = translation_ab_experiment_ready(manifest_path, manifest)
         self.compare_variants_btn.setEnabled(not running and ready)
+        if ready:
+            self.compare_variants_btn.setToolTip(
+                "用同一批 manifest chunk 并排比较多个配置变体的同步译文，不会写回游戏文件。",
+            )
+        elif message:
+            self.compare_variants_btn.setToolTip(message)
 
     def _update_split_btn_enabled(self, *, running: bool | None = None) -> None:
         if not hasattr(self, "split_btn"):

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -100,11 +100,16 @@ from .probe_report import (
     translation_probe_ready,
 )
 from .ab_experiment_report import (
+    AB_VARIANT_OPTION_SPECS,
     ab_experiment_summary_to_diagnostics_context,
     build_compare_variants_cli_args,
+    build_variants_from_gui_selection,
+    format_variant_names,
     running_ab_experiment_summary,
     summarize_compare_variants_output,
     translation_ab_experiment_ready,
+    validate_ab_experiment_variants,
+    write_variants_to_temp_file,
 )
 from .keyword_report import summarize_keyword_result_from_manifest
 from .revision_report import summarize_revision_apply_output
@@ -301,7 +306,7 @@ class MainWindow(QMainWindow):
         self._recheck_output_lines: list[str] = []
         self._probe_output_lines: list[str] = []
         self._compare_variants_output_lines: list[str] = []
-        self._compare_variants_file = ""
+        self._compare_variants_names = ""
         self._split_output_lines: list[str] = []
         self._repair_output_lines: list[str] = []
         self._apply_revision_output_lines: list[str] = []
@@ -4289,34 +4294,26 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(dialog)
 
         hint = QLabel(
-            "将对当前翻译包采样若干 chunk，按变体文件中的配置并排生成译文报告。"
-            "不会写回 .rpy 或 glossary.json。"
+            "将对当前翻译包采样若干 chunk，用勾选配置与 baseline（当前 translator_config）"
+            "并排生成译文报告；不会写回 .rpy 或 glossary.json。"
         )
         hint.setWordWrap(True)
         layout.addWidget(hint)
 
         form = QFormLayout()
-        variants_edit = QLineEdit()
-        variants_edit.setPlaceholderText("选择至少包含 2 个变体的 JSON 文件")
-        browse_btn = QPushButton("浏览…")
-        variants_row = QHBoxLayout()
-        variants_row.addWidget(variants_edit, stretch=1)
-        variants_row.addWidget(browse_btn)
-        variants_host = QWidget()
-        variants_host.setLayout(variants_row)
-        form.addRow("变体文件 (--variants-file)", variants_host)
-
-        def browse_variants_file() -> None:
-            path, _filter = QFileDialog.getOpenFileName(
-                dialog,
-                "选择变体 JSON 文件",
-                "",
-                "JSON 文件 (*.json);;所有文件 (*)",
-            )
-            if path:
-                variants_edit.setText(path)
-
-        browse_btn.clicked.connect(browse_variants_file)
+        variants_group = QGroupBox("对比变体")
+        variants_layout = QVBoxLayout(variants_group)
+        baseline_check = QCheckBox("baseline（当前配置，始终包含）")
+        baseline_check.setChecked(True)
+        baseline_check.setEnabled(False)
+        variants_layout.addWidget(baseline_check)
+        option_checks: dict[str, QCheckBox] = {}
+        for spec in AB_VARIANT_OPTION_SPECS:
+            option_id = str(spec["id"])
+            checkbox = QCheckBox(str(spec["label"]))
+            option_checks[option_id] = checkbox
+            variants_layout.addWidget(checkbox)
+        form.addRow(variants_group)
 
         limit_spin = QSpinBox()
         limit_spin.setRange(1, 50)
@@ -4357,17 +4354,20 @@ class MainWindow(QMainWindow):
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return None
 
-        variants_file = variants_edit.text().strip()
-        if not variants_file:
-            QMessageBox.warning(dialog, "缺少变体文件", "请选择变体 JSON 文件。")
-            return None
-        if not Path(variants_file).is_file():
-            QMessageBox.warning(dialog, "变体文件无效", f"找不到文件：{variants_file}")
+        selected_option_ids = {
+            option_id
+            for option_id, checkbox in option_checks.items()
+            if checkbox.isChecked()
+        }
+        variants = build_variants_from_gui_selection(selected_option_ids)
+        valid, validation_message = validate_ab_experiment_variants(variants)
+        if not valid:
+            QMessageBox.warning(dialog, "对比项不足", validation_message)
             return None
 
         api_key_index = None if api_key_spin.value() < 0 else api_key_spin.value()
         return {
-            "variants_file": variants_file,
+            "variants": variants,
             "limit": limit_spin.value(),
             "offset": offset_spin.value(),
             "output_dir": output_dir_edit.text().strip(),
@@ -4480,8 +4480,10 @@ class MainWindow(QMainWindow):
         self._focus_log_tab()
         self._active_command = "compare_variants"
         self._compare_variants_output_lines = []
-        variants_file = str(options["variants_file"])
-        self._compare_variants_file = variants_file
+        variants = list(options["variants"])
+        variant_names = format_variant_names(variants)
+        self._compare_variants_names = variant_names
+        variants_file = write_variants_to_temp_file(variants)
         dry_run = bool(options["dry_run"])
         base_context = build_diagnostics_context(
             latest_manifest_path=manifest_path,
@@ -4495,7 +4497,7 @@ class MainWindow(QMainWindow):
             ab_experiment_summary_to_diagnostics_context(
                 running_ab_experiment_summary(
                     manifest_path=manifest_path,
-                    variants_file=variants_file,
+                    variant_names=variant_names,
                     dry_run=dry_run,
                 ),
                 base_context,
@@ -5396,7 +5398,7 @@ class MainWindow(QMainWindow):
                 "\n".join(self._compare_variants_output_lines),
                 exit_code,
                 manifest_path=manifest_path,
-                variants_file=self._compare_variants_file,
+                variant_names=self._compare_variants_names,
             )
             base_context = build_diagnostics_context(
                 latest_manifest_path=manifest_path or None,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -313,6 +313,7 @@ class MainWindow(QMainWindow):
         self._probe_output_lines: list[str] = []
         self._compare_variants_output_lines: list[str] = []
         self._compare_variants_names = ""
+        self._compare_variants_temp_file = ""
         self._split_output_lines: list[str] = []
         self._repair_output_lines: list[str] = []
         self._apply_revision_output_lines: list[str] = []
@@ -4497,6 +4498,13 @@ class MainWindow(QMainWindow):
         self._set_task_running(True)
         self.runner.run(self.state.get_batch_script_path(), args)
 
+    def _cleanup_compare_variants_temp_file(self) -> None:
+        temp_file = self._compare_variants_temp_file
+        self._compare_variants_temp_file = ""
+        if not temp_file:
+            return
+        Path(temp_file).unlink(missing_ok=True)
+
     def _on_run_compare_variants(self) -> None:
         manifest_path, manifest = self._current_diagnostics_manifest()
         ready, message = translation_ab_experiment_ready(manifest_path, manifest)
@@ -4516,6 +4524,7 @@ class MainWindow(QMainWindow):
         variant_names = format_variant_names(variants)
         self._compare_variants_names = variant_names
         variants_file = write_variants_to_temp_file(variants)
+        self._compare_variants_temp_file = variants_file
         dry_run = bool(options["dry_run"])
         base_context = build_diagnostics_context(
             latest_manifest_path=manifest_path,
@@ -5329,6 +5338,7 @@ class MainWindow(QMainWindow):
             self._probe_output_lines.append(message)
         elif self._active_command == "compare_variants":
             self._compare_variants_output_lines.append(message)
+            self._cleanup_compare_variants_temp_file()
         elif self._active_command == "split":
             self._split_output_lines.append(message)
         elif self._active_command == "repair":
@@ -5452,8 +5462,11 @@ class MainWindow(QMainWindow):
                     self.statusBar().showMessage("翻译 A/B 对比完成。", 6000)
             elif ab_summary.status == "failed":
                 self.statusBar().showMessage("翻译 A/B 对比失败，请查看诊断日志。", 8000)
+            elif ab_summary.status == "warn":
+                self.statusBar().showMessage("翻译 A/B 对比完成，但需关注部分结果。", 6000)
             else:
                 self.statusBar().showMessage("翻译 A/B 对比已结束。", 6000)
+            self._cleanup_compare_variants_temp_file()
             return
 
         if self._active_command == "split":

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -368,6 +368,26 @@ def build_cli_commands(
             ),
         )
     )
+    commands.append(
+        DiagnosticsCommand(
+            label="翻译 A/B 对比（试跑）",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                [
+                    "compare-variants",
+                    manifest_path,
+                    "--variants-file",
+                    "<variants.json>",
+                    "--limit",
+                    "3",
+                    "--offset",
+                    "0",
+                    "--dry-run",
+                ],
+            ),
+        )
+    )
 
     safety_level = manifest_check_safety_level(manifest)
     if not manifest.get("applied_at") and safety_level not in {"warn", "block"}:

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -368,23 +368,19 @@ def build_cli_commands(
             ),
         )
     )
+    from .ab_experiment_report import build_compare_variants_cli_args
+
     commands.append(
         DiagnosticsCommand(
             label="翻译 A/B 对比（试跑）",
             command=format_cli_command(
                 python_exe,
                 batch_script_path,
-                [
-                    "compare-variants",
+                build_compare_variants_cli_args(
                     manifest_path,
-                    "--variants-file",
                     "<variants.json>",
-                    "--limit",
-                    "3",
-                    "--offset",
-                    "0",
-                    "--dry-run",
-                ],
+                    dry_run=True,
+                ),
             ),
         )
     )

--- a/tests/test_gui_ab_experiment_report.py
+++ b/tests/test_gui_ab_experiment_report.py
@@ -73,6 +73,38 @@ class GuiAbExperimentReportTests(unittest.TestCase):
         summary = summarize_compare_variants_output(COMPARE_VARIANTS_OUTPUT_OK, 1)
         self.assertEqual(summary.status, "failed")
 
+    def test_summarize_compare_variants_output_missing_report_is_warn(self):
+        summary = summarize_compare_variants_output(
+            COMPARE_VARIANTS_OUTPUT_OK,
+            0,
+            manifest_path=r"C:\pkg\manifest.json",
+            variant_names="baseline, story_memory_on",
+        )
+        self.assertEqual(summary.status, "warn")
+        self.assertEqual(summary.heading, "翻译 A/B 报告未找到")
+        self.assertTrue(any("报告文件尚未找到" in finding for finding in summary.findings))
+        self.assertTrue(str(summary.report_path).endswith("ab_report.md"))
+
+    def test_collect_ab_experiment_issues_skips_malformed_jsonl_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results_path = os.path.join(tmp, "ab_results.jsonl")
+            with open(results_path, "w", encoding="utf-8") as handle:
+                handle.write("not-json\n")
+                handle.write(
+                    json.dumps(
+                        {
+                            "chunk_key": "chunk-1",
+                            "variants": [
+                                {"name": "rag_off", "error": "API timeout"},
+                            ],
+                        },
+                    )
+                    + "\n",
+                )
+            severity, findings = collect_ab_experiment_issues(results_path=results_path)
+        self.assertEqual(severity, "warn")
+        self.assertTrue(any("部分变体出错" in finding for finding in findings))
+
     def test_translation_ab_experiment_ready_rejects_non_translation_manifest(self):
         ready, message = translation_ab_experiment_ready(
             r"C:\pkg\manifest.json",

--- a/tests/test_gui_ab_experiment_report.py
+++ b/tests/test_gui_ab_experiment_report.py
@@ -5,10 +5,12 @@ import unittest
 from gui_qt.ab_experiment_report import (
     ab_experiment_summary_to_diagnostics_context,
     build_compare_variants_cli_args,
+    build_variants_from_gui_selection,
     manifest_chunk_count,
     parse_compare_variants_output,
     summarize_compare_variants_output,
     translation_ab_experiment_ready,
+    validate_ab_experiment_variants,
 )
 from gui_qt.diagnostics_context import DiagnosticsContext
 
@@ -54,7 +56,7 @@ class GuiAbExperimentReportTests(unittest.TestCase):
                 output,
                 0,
                 manifest_path=r"C:\pkg\manifest.json",
-                variants_file=r"C:\pkg\variants.json",
+                variant_names="baseline, story_memory_on",
             )
         self.assertEqual(summary.status, "ok")
         self.assertEqual(summary.chunk_count, 1)
@@ -106,6 +108,22 @@ class GuiAbExperimentReportTests(unittest.TestCase):
         )
         self.assertTrue(ready)
         self.assertEqual(message, "")
+
+    def test_build_variants_from_gui_selection_includes_baseline_and_selected(self):
+        variants = build_variants_from_gui_selection({"story_memory_on", "rag_off"})
+        self.assertEqual(variants[0]["name"], "baseline")
+        names = [entry["name"] for entry in variants]
+        self.assertEqual(names, ["baseline", "story_memory_on", "rag_off"])
+        valid, message = validate_ab_experiment_variants(variants)
+        self.assertTrue(valid)
+        self.assertEqual(message, "")
+
+    def test_validate_ab_experiment_variants_requires_second_variant(self):
+        valid, message = validate_ab_experiment_variants(
+            build_variants_from_gui_selection(set()),
+        )
+        self.assertFalse(valid)
+        self.assertIn("至少勾选", message)
 
     def test_ab_experiment_summary_to_diagnostics_context_adds_report_paths(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_gui_ab_experiment_report.py
+++ b/tests/test_gui_ab_experiment_report.py
@@ -1,13 +1,19 @@
+import json
 import os
 import tempfile
 import unittest
 
 from gui_qt.ab_experiment_report import (
+    AB_VARIANT_CHOICE_FORCE_OFF,
+    AB_VARIANT_CHOICE_FORCE_ON,
+    AB_VARIANT_CHOICE_SKIP,
     ab_experiment_summary_to_diagnostics_context,
     build_compare_variants_cli_args,
     build_variants_from_gui_selection,
+    collect_ab_experiment_issues,
     manifest_chunk_count,
     parse_compare_variants_output,
+    read_ab_dimension_enabled_states,
     summarize_compare_variants_output,
     translation_ab_experiment_ready,
     validate_ab_experiment_variants,
@@ -109,21 +115,105 @@ class GuiAbExperimentReportTests(unittest.TestCase):
         self.assertTrue(ready)
         self.assertEqual(message, "")
 
+    def test_read_ab_dimension_enabled_states_reads_batch_config(self):
+        states = read_ab_dimension_enabled_states(
+            {
+                "batch": {
+                    "story_memory": {"enabled": True},
+                    "rag": {"enabled": False},
+                    "source_index": {"enabled": True},
+                },
+            },
+        )
+        self.assertTrue(states["story_memory"])
+        self.assertFalse(states["rag"])
+        self.assertTrue(states["source_index"])
+
     def test_build_variants_from_gui_selection_includes_baseline_and_selected(self):
-        variants = build_variants_from_gui_selection({"story_memory_on", "rag_off"})
+        variants = build_variants_from_gui_selection(
+            {
+                "story_memory": AB_VARIANT_CHOICE_FORCE_ON,
+                "rag": AB_VARIANT_CHOICE_SKIP,
+                "source_index": AB_VARIANT_CHOICE_FORCE_OFF,
+            },
+        )
         self.assertEqual(variants[0]["name"], "baseline")
         names = [entry["name"] for entry in variants]
-        self.assertEqual(names, ["baseline", "story_memory_on", "rag_off"])
+        self.assertEqual(names, ["baseline", "story_memory_on", "source_index_off"])
         valid, message = validate_ab_experiment_variants(variants)
         self.assertTrue(valid)
         self.assertEqual(message, "")
 
     def test_validate_ab_experiment_variants_requires_second_variant(self):
         valid, message = validate_ab_experiment_variants(
-            build_variants_from_gui_selection(set()),
+            build_variants_from_gui_selection(
+                {
+                    "story_memory": AB_VARIANT_CHOICE_SKIP,
+                    "rag": AB_VARIANT_CHOICE_SKIP,
+                    "source_index": AB_VARIANT_CHOICE_SKIP,
+                },
+            ),
         )
         self.assertFalse(valid)
-        self.assertIn("至少勾选", message)
+        self.assertIn("至少选择", message)
+
+    def test_collect_ab_experiment_issues_detects_variant_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results_path = os.path.join(tmp, "ab_results.jsonl")
+            with open(results_path, "w", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "chunk_key": "chunk-1",
+                            "variants": [
+                                {"name": "baseline", "error": ""},
+                                {"name": "rag_off", "error": "API timeout"},
+                            ],
+                        },
+                    )
+                    + "\n",
+                )
+            severity, findings = collect_ab_experiment_issues(
+                results_path=results_path,
+                expected_variant_count=2,
+            )
+        self.assertEqual(severity, "warn")
+        self.assertTrue(any("部分变体出错" in finding for finding in findings))
+
+    def test_summarize_compare_variants_output_marks_partial_variant_errors_as_warn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = os.path.join(tmp, "ab_report.md")
+            results_path = os.path.join(tmp, "ab_results.jsonl")
+            with open(report_path, "w", encoding="utf-8") as handle:
+                handle.write("# report\n")
+            with open(results_path, "w", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "chunk_key": "chunk-1",
+                            "variants": [
+                                {"name": "baseline"},
+                                {"name": "story_memory_on", "error": "quota exceeded"},
+                            ],
+                        },
+                    )
+                    + "\n",
+                )
+            output = COMPARE_VARIANTS_OUTPUT_OK.replace(
+                r"C:\logs\experiments\20260707_ab\ab_report.md",
+                report_path,
+            ).replace(
+                r"C:\logs\experiments\20260707_ab\ab_results.jsonl",
+                results_path,
+            )
+            summary = summarize_compare_variants_output(
+                output,
+                0,
+                manifest_path=r"C:\pkg\manifest.json",
+                variant_names="baseline, story_memory_on",
+            )
+        self.assertEqual(summary.status, "warn")
+        self.assertTrue(any("部分变体出错" in finding for finding in summary.findings))
 
     def test_ab_experiment_summary_to_diagnostics_context_adds_report_paths(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_gui_ab_experiment_report.py
+++ b/tests/test_gui_ab_experiment_report.py
@@ -5,6 +5,7 @@ import unittest
 from gui_qt.ab_experiment_report import (
     ab_experiment_summary_to_diagnostics_context,
     build_compare_variants_cli_args,
+    manifest_chunk_count,
     parse_compare_variants_output,
     summarize_compare_variants_output,
     translation_ab_experiment_ready,
@@ -79,6 +80,24 @@ class GuiAbExperimentReportTests(unittest.TestCase):
         )
         self.assertFalse(ready)
         self.assertIn("翻译块", message)
+
+    def test_manifest_chunk_count_uses_summary_when_chunks_omitted(self):
+        manifest = {
+            "mode": "translation",
+            "summary": {"chunk_count": 42},
+        }
+        self.assertEqual(manifest_chunk_count(manifest), 42)
+
+    def test_translation_ab_experiment_ready_accepts_lite_manifest_with_summary(self):
+        ready, message = translation_ab_experiment_ready(
+            r"C:\pkg\manifest.json",
+            {
+                "mode": "translation",
+                "summary": {"chunk_count": 120},
+            },
+        )
+        self.assertTrue(ready)
+        self.assertEqual(message, "")
 
     def test_translation_ab_experiment_ready_accepts_translation_manifest(self):
         ready, message = translation_ab_experiment_ready(

--- a/tests/test_gui_ab_experiment_report.py
+++ b/tests/test_gui_ab_experiment_report.py
@@ -1,0 +1,127 @@
+import os
+import tempfile
+import unittest
+
+from gui_qt.ab_experiment_report import (
+    ab_experiment_summary_to_diagnostics_context,
+    build_compare_variants_cli_args,
+    parse_compare_variants_output,
+    summarize_compare_variants_output,
+    translation_ab_experiment_ready,
+)
+from gui_qt.diagnostics_context import DiagnosticsContext
+
+
+COMPARE_VARIANTS_OUTPUT_OK = """
+Translation A/B experiment:
+- output_dir: C:\\logs\\experiments\\20260707_ab
+- chunks: 1
+- variants: 2
+- dry_run: True
+- report: C:\\logs\\experiments\\20260707_ab\\ab_report.md
+- results: C:\\logs\\experiments\\20260707_ab\\ab_results.jsonl
+"""
+
+
+class GuiAbExperimentReportTests(unittest.TestCase):
+    def test_build_compare_variants_cli_args_includes_dry_run(self):
+        args = build_compare_variants_cli_args(
+            r"C:\pkg\manifest.json",
+            r"C:\pkg\variants.json",
+            dry_run=True,
+        )
+        self.assertEqual(args[:4], ["compare-variants", r"C:\pkg\manifest.json", "--variants-file", r"C:\pkg\variants.json"])
+        self.assertIn("--dry-run", args)
+
+    def test_parse_compare_variants_output_extracts_paths_and_counts(self):
+        parsed = parse_compare_variants_output(COMPARE_VARIANTS_OUTPUT_OK)
+        self.assertEqual(parsed["chunks"], 1)
+        self.assertEqual(parsed["variants"], 2)
+        self.assertTrue(parsed["dry_run"])
+        self.assertTrue(str(parsed["report"]).endswith("ab_report.md"))
+
+    def test_summarize_compare_variants_output_marks_existing_report_as_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = os.path.join(tmp, "ab_report.md")
+            with open(report_path, "w", encoding="utf-8") as handle:
+                handle.write("# report\n")
+            output = COMPARE_VARIANTS_OUTPUT_OK.replace(
+                r"C:\logs\experiments\20260707_ab\ab_report.md",
+                report_path,
+            )
+            summary = summarize_compare_variants_output(
+                output,
+                0,
+                manifest_path=r"C:\pkg\manifest.json",
+                variants_file=r"C:\pkg\variants.json",
+            )
+        self.assertEqual(summary.status, "ok")
+        self.assertEqual(summary.chunk_count, 1)
+        self.assertEqual(summary.variant_count, 2)
+        self.assertTrue(summary.dry_run)
+
+    def test_summarize_compare_variants_output_nonzero_exit_is_failed(self):
+        summary = summarize_compare_variants_output(COMPARE_VARIANTS_OUTPUT_OK, 1)
+        self.assertEqual(summary.status, "failed")
+
+    def test_translation_ab_experiment_ready_rejects_non_translation_manifest(self):
+        ready, message = translation_ab_experiment_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "revision", "chunks": [{"key": "chunk-1"}]},
+        )
+        self.assertFalse(ready)
+        self.assertIn("批量翻译", message)
+
+    def test_translation_ab_experiment_ready_requires_chunks(self):
+        ready, message = translation_ab_experiment_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "translation", "chunks": []},
+        )
+        self.assertFalse(ready)
+        self.assertIn("翻译块", message)
+
+    def test_translation_ab_experiment_ready_accepts_translation_manifest(self):
+        ready, message = translation_ab_experiment_ready(
+            r"C:\pkg\manifest.json",
+            {"mode": "translation", "chunks": [{"key": "chunk-1"}]},
+        )
+        self.assertTrue(ready)
+        self.assertEqual(message, "")
+
+    def test_ab_experiment_summary_to_diagnostics_context_adds_report_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = os.path.join(tmp, "ab_report.md")
+            results_path = os.path.join(tmp, "ab_results.jsonl")
+            with open(report_path, "w", encoding="utf-8") as handle:
+                handle.write("# report\n")
+            with open(results_path, "w", encoding="utf-8") as handle:
+                handle.write("{}\n")
+            output = COMPARE_VARIANTS_OUTPUT_OK.replace(
+                r"C:\logs\experiments\20260707_ab\ab_report.md",
+                report_path,
+            ).replace(
+                r"C:\logs\experiments\20260707_ab\ab_results.jsonl",
+                results_path,
+            )
+            base = DiagnosticsContext(
+                status="ready",
+                heading="诊断上下文",
+                message="base",
+                facts=["fact-a"],
+                paths=[],
+                commands=[],
+                manifest_json_preview="",
+            )
+            summary = summarize_compare_variants_output(
+                output,
+                0,
+                manifest_path=r"C:\pkg\manifest.json",
+            )
+            context = ab_experiment_summary_to_diagnostics_context(summary, base)
+            labels = [entry.label for entry in context.paths]
+            self.assertIn("A/B 报告", labels)
+            self.assertIn("A/B 结果", labels)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -81,6 +81,18 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn("提交批量任务", labels)
         self.assertIn("查询任务状态", labels)
 
+    def test_build_cli_commands_includes_compare_variants_dry_run(self):
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\jobs\manifest.json",
+            manifest={"mode": "translation", "job_name": ""},
+        )
+        by_label = {command.label: command.command for command in commands}
+        self.assertIn("翻译 A/B 对比（试跑）", by_label)
+        self.assertIn("compare-variants", by_label["翻译 A/B 对比（试跑）"])
+        self.assertIn("--dry-run", by_label["翻译 A/B 对比（试跑）"])
+
     def test_build_cli_commands_includes_recover_submit_when_journal_has_job(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             package_dir = os.path.join(tmp_dir, "package")


### PR DESCRIPTION
## Summary

Adds GUI entry for the merged \compare-variants\ CLI (#149 / #139 PR1).

## Changes

- **\gui_qt/ab_experiment_report.py\** — readiness checks, CLI arg builder, output parsing, diagnostics context merge
- **\gui_qt/app.py\** — Diagnostics toolbar button **翻译 A/B 对比** with options dialog (variants file, limit/offset, dry-run, output dir)
- **\gui_qt/diagnostics_context.py\** — copy-paste dry-run CLI command for translation manifests
- **Tests** — \	est_gui_ab_experiment_report.py\ + diagnostics context coverage

## Usage

1. Open **诊断** tab with a translation batch manifest loaded
2. Click **翻译 A/B 对比**
3. Pick a variants JSON (≥2 variants), tune sample size; default **仅试跑** skips API calls
4. Open generated \b_report.md\ from the diagnostics paths list

Follow-up to #149; completes #139 GUI parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 诊断页新增“翻译 A/B 对比”入口，支持生成对比变体、试跑与正式运行，并在界面中展示运行状态与结果摘要。
  * 诊断日志中新增 A/B 对比相关命令，可直接发起试跑任务。

* **Bug 修复**
  * 增强了任务就绪检查与结果解析，能更准确提示清单模式、采样内容不足、部分变体出错等问题。
  * 完善了对比结果与诊断上下文的关联展示，方便查看报告与结果路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->