### PR TITLE
fix(gui): resolve keyword candidates across work modes

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2676,6 +2676,45 @@ class MainWindow(QMainWindow):
             tool_root=tool_root,
         )
 
+    def _validated_cached_keyword_merge_candidates_path(self) -> str:
+        cached_candidates = getattr(self, "_keyword_merge_candidates_path", "")
+        if not cached_candidates or not os.path.isfile(cached_candidates):
+            if cached_candidates:
+                self._keyword_merge_candidates_path = ""
+            return ""
+
+        state = getattr(self, "state", None)
+        if state is None:
+            return cached_candidates
+
+        game_root = state.get_game_root()
+        if game_root is not None:
+            try:
+                root = Path(canonical_abs_path(str(game_root)))
+                candidate = Path(canonical_abs_path(cached_candidates))
+                if candidate == root or root in candidate.parents:
+                    return cached_candidates
+            except (OSError, ValueError):
+                pass
+
+        keyword_manifest_path, keyword_manifest = self._latest_keyword_extraction_manifest()
+        expected = keyword_merge_candidates_path_from_manifest(
+            keyword_manifest_path,
+            keyword_manifest,
+        )
+        if expected:
+            try:
+                if (
+                    canonical_abs_path(cached_candidates).lower()
+                    == canonical_abs_path(expected).lower()
+                ):
+                    return cached_candidates
+            except (OSError, ValueError):
+                pass
+
+        self._keyword_merge_candidates_path = ""
+        return ""
+
     def _latest_keyword_extraction_manifest(
         self,
     ) -> tuple[str, dict[str, object] | None]:
@@ -2700,8 +2739,8 @@ class MainWindow(QMainWindow):
         manifest_path: str = "",
         manifest: dict[str, object] | None = None,
     ) -> str:
-        cached_candidates = getattr(self, "_keyword_merge_candidates_path", "")
-        if cached_candidates and os.path.isfile(cached_candidates):
+        cached_candidates = self._validated_cached_keyword_merge_candidates_path()
+        if cached_candidates:
             return cached_candidates
         if manifest is None and manifest_path:
             state = getattr(self, "state", None)
@@ -3692,6 +3731,7 @@ class MainWindow(QMainWindow):
                 "任务状态已清空；请先针对新项目重新检查。",
             )
         self._writeback_manifest_path = ""
+        self._keyword_merge_candidates_path = ""
         if spec.supports_translation_writeback:
             self._set_writeback_summary(stale_writeback_summary())
         else:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2252,15 +2252,10 @@ class MainWindow(QMainWindow):
                 except ValueError:
                     manifest = None
 
-            candidates_path = ""
-            cached_candidates = getattr(self, "_keyword_merge_candidates_path", "")
-            if cached_candidates and os.path.isfile(cached_candidates):
-                candidates_path = cached_candidates
-            elif summary.manifest_path:
-                candidates_path = keyword_merge_candidates_path_from_manifest(
-                    summary.manifest_path,
-                    manifest,
-                )
+            candidates_path = self._resolve_keyword_merge_candidates_path(
+                manifest_path=summary.manifest_path,
+                manifest=manifest,
+            )
 
             glossary_path = ""
             if state is not None:
@@ -2681,31 +2676,67 @@ class MainWindow(QMainWindow):
             tool_root=tool_root,
         )
 
+    def _latest_keyword_extraction_manifest(
+        self,
+    ) -> tuple[str, dict[str, object] | None]:
+        state = getattr(self, "state", None)
+        if state is None:
+            return "", None
+        game_root = state.get_game_root()
+        if game_root is None:
+            return "", None
+        latest_manifest = state.get_latest_manifest_path_for_mode(
+            game_root,
+            WorkMode.KEYWORD_EXTRACTION,
+        )
+        if latest_manifest is None:
+            return "", None
+        manifest_path = str(latest_manifest)
+        return manifest_path, self._load_diagnostics_manifest(manifest_path)
+
     def _resolve_keyword_merge_candidates_path(
         self,
         *,
         manifest_path: str = "",
         manifest: dict[str, object] | None = None,
     ) -> str:
-        if self._keyword_merge_candidates_path and os.path.isfile(
-            self._keyword_merge_candidates_path
-        ):
-            return self._keyword_merge_candidates_path
-        if not manifest_path or manifest is None:
+        cached_candidates = getattr(self, "_keyword_merge_candidates_path", "")
+        if cached_candidates and os.path.isfile(cached_candidates):
+            return cached_candidates
+        if manifest is None and manifest_path:
+            state = getattr(self, "state", None)
+            if state is not None:
+                try:
+                    manifest = state.load_manifest_file(manifest_path)
+                except ValueError:
+                    manifest = None
+        if not manifest_path:
             manifest_path, manifest = self._current_diagnostics_manifest()
+        elif manifest is None and getattr(self, "state", None) is None:
+            manifest_path = ""
         resolved = keyword_merge_candidates_path_from_manifest(manifest_path, manifest)
         if resolved:
             return resolved
-        if self._writeback_manifest_path:
-            try:
-                writeback_manifest = self.state.load_manifest_file(self._writeback_manifest_path)
-            except ValueError:
-                writeback_manifest = None
-            return keyword_merge_candidates_path_from_manifest(
-                self._writeback_manifest_path,
+        writeback_manifest_path = getattr(self, "_writeback_manifest_path", "")
+        if writeback_manifest_path:
+            writeback_manifest = None
+            state = getattr(self, "state", None)
+            if state is not None:
+                try:
+                    writeback_manifest = state.load_manifest_file(writeback_manifest_path)
+                except ValueError:
+                    writeback_manifest = None
+            resolved = keyword_merge_candidates_path_from_manifest(
+                writeback_manifest_path,
                 writeback_manifest,
             )
-        return ""
+            if resolved:
+                return resolved
+        keyword_manifest_path, keyword_manifest = self._latest_keyword_extraction_manifest()
+        return keyword_merge_candidates_path_from_manifest(
+            keyword_manifest_path,
+            keyword_manifest,
+        )
 
     def _update_keyword_merge_btn_enabled(self, *, running: bool | None = None) -> None:
         if not hasattr(self, "keyword_merge_btn"):

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -2172,6 +2172,39 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             self.assertFalse(button.visible, name)
             self.assertFalse(button.enabled, name)
 
+    def test_resolve_keyword_merge_candidates_path_uses_latest_keyword_manifest(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from gui_qt.work_modes import WorkMode
+
+        jsonl_path = "C:/dummy/game/logs/keyword_candidates.jsonl"
+        keyword_manifest = {
+            "mode": "keyword_extraction",
+            "keyword_export": {"jsonl_path": jsonl_path},
+        }
+
+        class FakeState:
+            def get_game_root(self):
+                return Path("C:/dummy/game")
+
+            def get_latest_manifest_path_for_mode(self, game_root, mode):
+                if mode == WorkMode.KEYWORD_EXTRACTION:
+                    return Path("C:/dummy/game/logs/keyword_manifest.json")
+                return None
+
+        self.window.state = FakeState()
+        self.window._keyword_merge_candidates_path = ""
+        self.window._writeback_manifest_path = ""
+        self.window._workflow = None
+        self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
+        self.window._load_diagnostics_manifest = lambda _path: keyword_manifest
+
+        with patch("os.path.isfile", return_value=True):
+            resolved = self.window._resolve_keyword_merge_candidates_path()
+
+        self.assertEqual(resolved, jsonl_path)
+
     def test_recheck_button_enabled_for_batch_translation_with_manifest(self):
         from gui_qt.check_report import WritebackSummary
         from gui_qt.work_modes import WorkMode

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -2177,12 +2177,15 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         from unittest.mock import patch
 
         from gui_qt.work_modes import WorkMode
+        from project_asset_paths import canonical_abs_path
 
         jsonl_path = "C:/dummy/game/logs/keyword_candidates.jsonl"
+        keyword_manifest_path = "C:/dummy/game/logs/keyword_manifest.json"
         keyword_manifest = {
             "mode": "keyword_extraction",
             "keyword_export": {"jsonl_path": jsonl_path},
         }
+        expected_manifest_path = canonical_abs_path(keyword_manifest_path).lower()
 
         class FakeState:
             def get_game_root(self):
@@ -2190,20 +2193,73 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
             def get_latest_manifest_path_for_mode(self, game_root, mode):
                 if mode == WorkMode.KEYWORD_EXTRACTION:
-                    return Path("C:/dummy/game/logs/keyword_manifest.json")
+                    return Path(keyword_manifest_path)
                 return None
+
+        def load_manifest(path):
+            if (
+                path
+                and canonical_abs_path(path).lower() == expected_manifest_path
+            ):
+                return keyword_manifest
+            return None
 
         self.window.state = FakeState()
         self.window._keyword_merge_candidates_path = ""
         self.window._writeback_manifest_path = ""
         self.window._workflow = None
         self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
-        self.window._load_diagnostics_manifest = lambda _path: keyword_manifest
+        self.window._load_diagnostics_manifest = load_manifest
 
         with patch("os.path.isfile", return_value=True):
             resolved = self.window._resolve_keyword_merge_candidates_path()
 
         self.assertEqual(resolved, jsonl_path)
+
+    def test_resolve_keyword_merge_ignores_stale_cached_path_from_other_project(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from gui_qt.work_modes import WorkMode
+        from project_asset_paths import canonical_abs_path
+
+        jsonl_path = "C:/dummy/game/logs/keyword_candidates.jsonl"
+        keyword_manifest_path = "C:/dummy/game/logs/keyword_manifest.json"
+        keyword_manifest = {
+            "mode": "keyword_extraction",
+            "keyword_export": {"jsonl_path": jsonl_path},
+        }
+        expected_manifest_path = canonical_abs_path(keyword_manifest_path).lower()
+
+        class FakeState:
+            def get_game_root(self):
+                return Path("C:/dummy/game")
+
+            def get_latest_manifest_path_for_mode(self, game_root, mode):
+                if mode == WorkMode.KEYWORD_EXTRACTION:
+                    return Path(keyword_manifest_path)
+                return None
+
+        def load_manifest(path):
+            if (
+                path
+                and canonical_abs_path(path).lower() == expected_manifest_path
+            ):
+                return keyword_manifest
+            return None
+
+        self.window.state = FakeState()
+        self.window._keyword_merge_candidates_path = "C:/other/project/keyword_candidates.jsonl"
+        self.window._writeback_manifest_path = ""
+        self.window._workflow = None
+        self.window._current_work_mode = lambda: WorkMode.BATCH_TRANSLATION
+        self.window._load_diagnostics_manifest = load_manifest
+
+        with patch("os.path.isfile", return_value=True):
+            resolved = self.window._resolve_keyword_merge_candidates_path()
+
+        self.assertEqual(resolved, jsonl_path)
+        self.assertEqual(self.window._keyword_merge_candidates_path, "")
 
     def test_recheck_button_enabled_for_batch_translation_with_manifest(self):
         from gui_qt.check_report import WritebackSummary


### PR DESCRIPTION
## Summary

Fixes keyword merge-to-glossary only finding candidate JSONL when the workbench is set to **分析与准备 → 批量关键词**. In other modes the merge button fell through to the manual file picker even after a successful keyword extraction run.

## Changes

- Add `_latest_keyword_extraction_manifest()` to look up the most recent `keyword_extraction` manifest for the current project, independent of the active work mode.
- Extend `_resolve_keyword_merge_candidates_path()` to fall back to that manifest after cache/current-mode/writeback lookups.
- Harden path resolution for lightweight test stubs (`getattr` guards).
- Reuse the shared resolver in the keyword-only writeback button path.
- Add regression test for batch-translation mode resolving keyword candidates.

## Test plan

- [x] `test_resolve_keyword_merge_candidates_path_uses_latest_keyword_manifest`
- [x] `test_keyword_result_hides_writeback_action_buttons`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了关键词写回候选文件的定位逻辑，在部分路径缺失或缓存不完整时，能更稳定地找到可用的候选 JSONL 文件。
  * 增强了回退查找机制，优先使用最新的关键词提取结果，减少写回功能因路径解析失败而受影响的情况。

* **Tests**
  * 新增覆盖，验证在使用最新关键词提取结果时，候选文件路径能够正确解析。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->