### PR TITLE
fix(doctor): use stable recommendation codes for GUI localization

### DIFF
--- a/doctor_recommendations.py
+++ b/doctor_recommendations.py
@@ -20,6 +20,7 @@ ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT = "enable_source_index_for_new_project"
 START_INCREMENTAL_BATCH = "start_incremental_batch"
 START_PENDING_BATCH = "start_pending_batch"
 NO_PENDING_LINES = "no_pending_lines"
+UNKNOWN = "unknown"
 
 ALL_CODES = frozenset(
     {
@@ -188,7 +189,7 @@ def legacy_string_to_recommendation(text: str) -> dict[str, Any]:
     if code:
         return make_doctor_recommendation(code)
 
-    return {"code": "unknown", "params": {}, "detail": normalized}
+    return {"code": UNKNOWN, "params": {}, "detail": normalized}
 
 
 def normalize_doctor_recommendation(item: Any) -> dict[str, Any]:

--- a/doctor_recommendations.py
+++ b/doctor_recommendations.py
@@ -1,0 +1,220 @@
+"""Stable doctor recommendation codes shared by CLI output and GUI localization."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+SWITCH_TO_WORK = "switch_to_work"
+BOOTSTRAP_WORK = "bootstrap_work"
+GENERATE_TEMPLATE = "generate_template"
+INSTALL_SDK_GENERATE_TEMPLATE = "install_sdk_generate_template"
+ENABLE_PREPARE = "enable_prepare"
+BOOTSTRAP_SOURCE_INDEX = "bootstrap_source_index"
+BOOTSTRAP_SOURCE_INDEX_INCOMPLETE = "bootstrap_source_index_incomplete"
+BOOTSTRAP_RAG = "bootstrap_rag"
+BOOTSTRAP_RAG_OR_WARM_ON_BUILD = "bootstrap_rag_or_warm_on_build"
+ENABLE_RAG_FOR_CONSISTENCY = "enable_rag_for_consistency"
+SUBSTANTIALLY_COMPLETE = "substantially_complete"
+ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT = "enable_source_index_for_new_project"
+START_INCREMENTAL_BATCH = "start_incremental_batch"
+START_PENDING_BATCH = "start_pending_batch"
+NO_PENDING_LINES = "no_pending_lines"
+
+ALL_CODES = frozenset(
+    {
+        SWITCH_TO_WORK,
+        BOOTSTRAP_WORK,
+        GENERATE_TEMPLATE,
+        INSTALL_SDK_GENERATE_TEMPLATE,
+        ENABLE_PREPARE,
+        BOOTSTRAP_SOURCE_INDEX,
+        BOOTSTRAP_SOURCE_INDEX_INCOMPLETE,
+        BOOTSTRAP_RAG,
+        BOOTSTRAP_RAG_OR_WARM_ON_BUILD,
+        ENABLE_RAG_FOR_CONSISTENCY,
+        SUBSTANTIALLY_COMPLETE,
+        ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT,
+        START_INCREMENTAL_BATCH,
+        START_PENDING_BATCH,
+        NO_PENDING_LINES,
+    }
+)
+
+_BOOTSTRAP_WORK_MESSAGE = (
+    "work directory is missing or empty and original/game exists; "
+    "run: python gemini_translate_batch.py bootstrap-work "
+    "(copies original/game into work/game without generating TL)."
+)
+_GENERATE_TEMPLATE_MESSAGE = (
+    "Missing translation files; run: python gemini_translate_batch.py generate-template "
+    "(runs prepare only: unpack RPA if needed, generate tl template)."
+)
+_INSTALL_SDK_MESSAGE = (
+    "Install Ren'Py SDK or set prepare.renpy_sdk_dir, then run: "
+    "python gemini_translate_batch.py generate-template."
+)
+_ENABLE_PREPARE_MESSAGE = (
+    "prepare is disabled; enable prepare.enabled in translator_config.json, then run build."
+)
+_BOOTSTRAP_SOURCE_INDEX_MESSAGE = (
+    "Source index is enabled but not built; run bootstrap-source-index."
+)
+_BOOTSTRAP_SOURCE_INDEX_INCOMPLETE_MESSAGE = (
+    "Source index bootstrap is incomplete; run bootstrap-source-index."
+)
+_BOOTSTRAP_RAG_MESSAGE = (
+    "RAG store is enabled but empty; run bootstrap-rag before batch translation."
+)
+_BOOTSTRAP_RAG_OR_WARM_MESSAGE = (
+    "RAG store is empty; run bootstrap-rag before batch translation, "
+    "or start batch translation to warm the store automatically on build."
+)
+_ENABLE_RAG_MESSAGE = (
+    "Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag "
+    "for better terminology consistency, then start batch translation."
+)
+_SUBSTANTIALLY_COMPLETE_MESSAGE = (
+    "Project is substantially complete; remaining pending lines are minor. "
+    "Batch translation and RAG bootstrap are optional."
+)
+_ENABLE_SOURCE_INDEX_MESSAGE = (
+    "Source index is disabled; enable it and run bootstrap-source-index "
+    "for better story context on a new translation project."
+)
+_START_INCREMENTAL_MESSAGE = (
+    "Incremental translation is ready; start batch translation when API keys are configured."
+)
+_START_PENDING_MESSAGE = (
+    "Pending translation lines are ready; start batch translation when API keys are configured."
+)
+_NO_PENDING_MESSAGE = (
+    "No pending translation lines detected; review TL files or refresh templates "
+    "before starting a new batch."
+)
+
+_LEGACY_EXACT_MESSAGES: dict[str, str] = {
+    _BOOTSTRAP_WORK_MESSAGE: BOOTSTRAP_WORK,
+    _GENERATE_TEMPLATE_MESSAGE: GENERATE_TEMPLATE,
+    _INSTALL_SDK_MESSAGE: INSTALL_SDK_GENERATE_TEMPLATE,
+    _ENABLE_PREPARE_MESSAGE: ENABLE_PREPARE,
+    _BOOTSTRAP_SOURCE_INDEX_MESSAGE: BOOTSTRAP_SOURCE_INDEX,
+    _BOOTSTRAP_SOURCE_INDEX_INCOMPLETE_MESSAGE: BOOTSTRAP_SOURCE_INDEX_INCOMPLETE,
+    _BOOTSTRAP_RAG_MESSAGE: BOOTSTRAP_RAG,
+    _BOOTSTRAP_RAG_OR_WARM_MESSAGE: BOOTSTRAP_RAG_OR_WARM_ON_BUILD,
+    _ENABLE_RAG_MESSAGE: ENABLE_RAG_FOR_CONSISTENCY,
+    _SUBSTANTIALLY_COMPLETE_MESSAGE: SUBSTANTIALLY_COMPLETE,
+    _ENABLE_SOURCE_INDEX_MESSAGE: ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT,
+    _START_INCREMENTAL_MESSAGE: START_INCREMENTAL_BATCH,
+    _START_PENDING_MESSAGE: START_PENDING_BATCH,
+    _NO_PENDING_MESSAGE: NO_PENDING_LINES,
+}
+
+_DETAIL_MESSAGES: dict[str, str] = {
+    BOOTSTRAP_WORK: _BOOTSTRAP_WORK_MESSAGE,
+    GENERATE_TEMPLATE: _GENERATE_TEMPLATE_MESSAGE,
+    INSTALL_SDK_GENERATE_TEMPLATE: _INSTALL_SDK_MESSAGE,
+    ENABLE_PREPARE: _ENABLE_PREPARE_MESSAGE,
+    BOOTSTRAP_SOURCE_INDEX: _BOOTSTRAP_SOURCE_INDEX_MESSAGE,
+    BOOTSTRAP_SOURCE_INDEX_INCOMPLETE: _BOOTSTRAP_SOURCE_INDEX_INCOMPLETE_MESSAGE,
+    BOOTSTRAP_RAG: _BOOTSTRAP_RAG_MESSAGE,
+    BOOTSTRAP_RAG_OR_WARM_ON_BUILD: _BOOTSTRAP_RAG_OR_WARM_MESSAGE,
+    ENABLE_RAG_FOR_CONSISTENCY: _ENABLE_RAG_MESSAGE,
+    SUBSTANTIALLY_COMPLETE: _SUBSTANTIALLY_COMPLETE_MESSAGE,
+    ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT: _ENABLE_SOURCE_INDEX_MESSAGE,
+    START_INCREMENTAL_BATCH: _START_INCREMENTAL_MESSAGE,
+    START_PENDING_BATCH: _START_PENDING_MESSAGE,
+    NO_PENDING_LINES: _NO_PENDING_MESSAGE,
+}
+
+
+def make_doctor_recommendation(code: str, **params: str) -> dict[str, Any]:
+    if code not in ALL_CODES:
+        raise ValueError(f"Unknown doctor recommendation code: {code}")
+    return {"code": code, "params": dict(params)}
+
+
+def doctor_recommendation_detail(rec: dict[str, Any]) -> str:
+    code = str(rec.get("code") or "")
+    params = rec.get("params") if isinstance(rec.get("params"), dict) else {}
+    if code == SWITCH_TO_WORK:
+        work_dir = str(params.get("work_dir") or "").strip()
+        if work_dir:
+            return f"game_root should use work directory; switch to {work_dir}"
+        return "game_root should use work directory; switch to work directory"
+    detail = rec.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()
+    return _DETAIL_MESSAGES.get(code, "")
+
+
+def format_doctor_recommendation_cli_line(rec: dict[str, Any]) -> str:
+    payload: dict[str, Any] = {"code": rec["code"]}
+    params = rec.get("params") if isinstance(rec.get("params"), dict) else {}
+    if params:
+        payload["params"] = params
+    detail = doctor_recommendation_detail(rec)
+    if detail:
+        payload["detail"] = detail
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def parse_doctor_recommendation_cli_line(line: str) -> dict[str, Any] | None:
+    text = line.strip()
+    if not text:
+        return None
+    if text.startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict) and payload.get("code"):
+            return normalize_doctor_recommendation(payload)
+        return None
+    return legacy_string_to_recommendation(text)
+
+
+def legacy_string_to_recommendation(text: str) -> dict[str, Any]:
+    normalized = text.strip()
+    if not normalized:
+        raise ValueError("Doctor recommendation text is empty")
+
+    switch_prefix = "game_root should use work directory; switch to "
+    if normalized.startswith(switch_prefix):
+        work_dir = normalized[len(switch_prefix) :].strip()
+        return make_doctor_recommendation(SWITCH_TO_WORK, work_dir=work_dir)
+
+    code = _LEGACY_EXACT_MESSAGES.get(normalized)
+    if code:
+        return make_doctor_recommendation(code)
+
+    return {"code": "unknown", "params": {}, "detail": normalized}
+
+
+def normalize_doctor_recommendation(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict):
+        code = str(item.get("code") or "").strip()
+        if not code:
+            raise ValueError("Doctor recommendation dict is missing code")
+        params = item.get("params") if isinstance(item.get("params"), dict) else {}
+        rec = {"code": code, "params": dict(params)}
+        detail = item.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            rec["detail"] = detail.strip()
+        return rec
+    if isinstance(item, str):
+        return legacy_string_to_recommendation(item)
+    raise TypeError(f"Unsupported doctor recommendation value: {type(item)!r}")
+
+
+def doctor_recommendation_codes(recommendations: list[Any]) -> list[str]:
+    codes: list[str] = []
+    for item in recommendations:
+        try:
+            rec = normalize_doctor_recommendation(item)
+        except (TypeError, ValueError):
+            continue
+        code = str(rec.get("code") or "").strip()
+        if code:
+            codes.append(code)
+    return codes

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -21,6 +21,7 @@ from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreL
 import batch_cost_estimate
 import batch_non_chinese_rules
 import batch_submit_recovery
+import doctor_recommendations as doctor_rec
 import keyword_glossary_merge
 import prompt_context
 import translation_ab_experiment
@@ -8176,14 +8177,15 @@ def collect_doctor_recommendations(report):
         work_dir = report.get('work_dir', '')
         if work_dir:
             recommendations.append(
-                f'game_root should use work directory; switch to {work_dir}'
+                doctor_rec.make_doctor_recommendation(
+                    doctor_rec.SWITCH_TO_WORK,
+                    work_dir=work_dir,
+                )
             )
         work_missing_or_empty = not report.get('work_exists') or report.get('work_empty')
         if work_missing_or_empty and report.get('work_bootstrap_allowed') and report.get('original_game_dir'):
             recommendations.append(
-                'work directory is missing or empty and original/game exists; '
-                'run: python gemini_translate_batch.py bootstrap-work '
-                '(copies original/game into work/game without generating TL).'
+                doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_WORK)
             )
         return recommendations
 
@@ -8194,23 +8196,19 @@ def collect_doctor_recommendations(report):
 
     if report.get('work_bootstrap_allowed') and report.get('original_game_dir'):
         recommendations.append(
-            'work directory is missing or empty and original/game exists; '
-            'run: python gemini_translate_batch.py bootstrap-work '
-            '(copies original/game into work/game without generating TL).'
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_WORK)
         )
     elif not has_tl and report.get('prepare_enabled') and report.get('can_generate_template'):
         recommendations.append(
-            'Missing translation files; run: python gemini_translate_batch.py generate-template '
-            '(runs prepare only: unpack RPA if needed, generate tl template).'
+            doctor_rec.make_doctor_recommendation(doctor_rec.GENERATE_TEMPLATE)
         )
     elif not has_tl and report.get('prepare_enabled') and mode == 'blocked_missing_template':
         recommendations.append(
-            'Install Ren\'Py SDK or set prepare.renpy_sdk_dir, then run: '
-            'python gemini_translate_batch.py generate-template.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.INSTALL_SDK_GENERATE_TEMPLATE)
         )
     elif not has_tl and not report.get('prepare_enabled'):
         recommendations.append(
-            'prepare is disabled; enable prepare.enabled in translator_config.json, then run build.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.ENABLE_PREPARE)
         )
         return recommendations
 
@@ -8221,24 +8219,23 @@ def collect_doctor_recommendations(report):
     source_index_status = _doctor_source_index_needs_bootstrap(source_index)
     if source_index_status == 'missing':
         recommendations.append(
-            'Source index is enabled but not built; run bootstrap-source-index.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_SOURCE_INDEX)
         )
         return recommendations
     if source_index_status == 'incomplete':
         recommendations.append(
-            'Source index bootstrap is incomplete; run bootstrap-source-index.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE)
         )
         return recommendations
 
     if _doctor_rag_needs_bootstrap(rag):
         if rag.get('bootstrap_on_build'):
             recommendations.append(
-                'RAG store is empty; run bootstrap-rag before batch translation, '
-                'or start batch translation to warm the store automatically on build.'
+                doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_RAG_OR_WARM_ON_BUILD)
             )
         else:
             recommendations.append(
-                'RAG store is enabled but empty; run bootstrap-rag before batch translation.'
+                doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_RAG)
             )
         return recommendations
 
@@ -8249,15 +8246,13 @@ def collect_doctor_recommendations(report):
         and _doctor_should_recommend_enabling_rag(report)
     ):
         recommendations.append(
-            'Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag '
-            'for better terminology consistency, then start batch translation.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.ENABLE_RAG_FOR_CONSISTENCY)
         )
         return recommendations
 
     if has_tl and pending > 0 and has_existing_translations and _doctor_pending_is_minor(report):
         recommendations.append(
-            'Project is substantially complete; remaining pending lines are minor. '
-            'Batch translation and RAG bootstrap are optional.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.SUBSTANTIALLY_COMPLETE)
         )
         return recommendations
 
@@ -8268,25 +8263,24 @@ def collect_doctor_recommendations(report):
         and not has_existing_translations
     ):
         recommendations.append(
-            'Source index is disabled; enable it and run bootstrap-source-index '
-            'for better story context on a new translation project.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT)
         )
         return recommendations
 
     if has_tl and pending > 0:
         if _doctor_is_incremental_translation(report):
             recommendations.append(
-                'Incremental translation is ready; start batch translation when API keys are configured.'
+                doctor_rec.make_doctor_recommendation(doctor_rec.START_INCREMENTAL_BATCH)
             )
         else:
             recommendations.append(
-                'Pending translation lines are ready; start batch translation when API keys are configured.'
+                doctor_rec.make_doctor_recommendation(doctor_rec.START_PENDING_BATCH)
             )
         return recommendations
 
     if has_tl and pending == 0:
         recommendations.append(
-            'No pending translation lines detected; review TL files or refresh templates before starting a new batch.'
+            doctor_rec.make_doctor_recommendation(doctor_rec.NO_PENDING_LINES)
         )
 
     return recommendations
@@ -8833,7 +8827,8 @@ def print_doctor_report(report):
     if report.get('recommendations'):
         print('Recommendations:')
         for recommendation in report['recommendations']:
-            print(f'- {recommendation}')
+            rec = doctor_rec.normalize_doctor_recommendation(recommendation)
+            print(f'- {doctor_rec.format_doctor_recommendation_cli_line(rec)}')
 
 
 def print_work_bootstrap_summary(result):

--- a/gui_qt/doctor_report.py
+++ b/gui_qt/doctor_report.py
@@ -6,6 +6,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+import doctor_recommendations as doctor_rec
+
 from .summary_helpers import append_unique_fact
 from .user_copy import (
     doctor_mode_label,
@@ -256,7 +258,9 @@ def parse_doctor_output(output: str) -> dict[str, object]:
 
         if in_recommendations:
             if line.startswith("- "):
-                parsed.setdefault("recommendations", []).append(line[2:].strip())
+                rec = doctor_rec.parse_doctor_recommendation_cli_line(line[2:].strip())
+                if rec is not None:
+                    parsed.setdefault("recommendations", []).append(rec)
                 continue
             in_recommendations = False
 
@@ -371,9 +375,9 @@ def doctor_report_to_parsed(report: dict[str, Any]) -> dict[str, object]:
             if isinstance(warning, str) and warning.strip()
         ],
         "recommendations": [
-            recommendation
+            doctor_rec.normalize_doctor_recommendation(recommendation)
             for recommendation in (report.get("recommendations") or [])
-            if isinstance(recommendation, str) and recommendation.strip()
+            if recommendation
         ],
     }
 
@@ -416,10 +420,15 @@ def _summarize_doctor_parsed(
         for warning in parsed.get("warnings", [])
         if isinstance(warning, str) and warning.strip()
     ]
+    normalized_recommendations = [
+        doctor_rec.normalize_doctor_recommendation(recommendation)
+        for recommendation in parsed.get("recommendations", [])
+        if recommendation
+    ]
+    recommendation_codes = doctor_rec.doctor_recommendation_codes(normalized_recommendations)
     recommendation_facts = [
         format_doctor_recommendation_fact(recommendation)
-        for recommendation in parsed.get("recommendations", [])
-        if isinstance(recommendation, str) and recommendation.strip()
+        for recommendation in normalized_recommendations
     ]
     counts_value = parsed.get("counts")
     counts = counts_value if isinstance(counts_value, dict) else {}
@@ -508,7 +517,7 @@ def _summarize_doctor_parsed(
     for warning in warnings:
         append_unique_fact(facts, format_doctor_warning_fact(warning))
 
-    recommendation_message = primary_recommendation_message(recommendation_facts)
+    recommendation_message = primary_recommendation_message(recommendation_codes)
 
     if exit_code != 0:
         return DoctorSummary(
@@ -543,7 +552,7 @@ def _summarize_doctor_parsed(
     else:
         needs_attention = (
             findings_require_attention(findings)
-            or recommendation_requires_attention(recommendation_facts)
+            or recommendation_requires_attention(recommendation_codes)
             or (api_key_count is not None and api_key_count == 0)
         )
         if needs_attention:
@@ -556,7 +565,7 @@ def _summarize_doctor_parsed(
 
     if recommendation_message:
         message = recommendation_message
-        if recommendation_requires_attention(recommendation_facts) and status == "ready":
+        if recommendation_requires_attention(recommendation_codes) and status == "ready":
             status = "warning"
             heading = LAYOUT_STATUS_HEADINGS["attention"][1]
 

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -79,6 +79,9 @@ DOCTOR_RECOMMENDATION_CODE_TRANSLATIONS: dict[str, str] = {
     ),
 }
 
+DOCTOR_RECOMMENDATION_UNKNOWN_FACT = "建议：收到未识别的诊断建议，请查看诊断日志了解详情。"
+DOCTOR_RECOMMENDATION_UNKNOWN_SUMMARY = "收到未识别的诊断建议，请查看诊断日志。"
+
 DOCTOR_RECOMMENDATION_PRIMARY_MESSAGES: dict[str, str] = {
     doctor_rec.SUBSTANTIALLY_COMPLETE: "项目已基本译完；剩余待译行很少，可忽略或按需补译。",
     doctor_rec.ENABLE_RAG_FOR_CONSISTENCY: "补译量较大；若要进行批量补译，建议先启用并预建记忆库。",
@@ -91,6 +94,7 @@ DOCTOR_RECOMMENDATION_PRIMARY_MESSAGES: dict[str, str] = {
     doctor_rec.START_INCREMENTAL_BATCH: "补译环境已就绪，可以开始批量翻译。",
     doctor_rec.NO_PENDING_LINES: "当前没有待译条目，请先检查或刷新翻译模板。",
     doctor_rec.START_PENDING_BATCH: "翻译环境已就绪，可以开始批量翻译。",
+    doctor_rec.UNKNOWN: DOCTOR_RECOMMENDATION_UNKNOWN_SUMMARY,
 }
 
 READY_DOCTOR_RECOMMENDATION_CODES = frozenset(
@@ -219,6 +223,8 @@ def format_doctor_recommendation_fact(recommendation: Any) -> str:
     rec = doctor_rec.normalize_doctor_recommendation(recommendation)
     code = str(rec.get("code") or "")
     params = rec.get("params") if isinstance(rec.get("params"), dict) else {}
+    if code == doctor_rec.UNKNOWN:
+        return DOCTOR_RECOMMENDATION_UNKNOWN_FACT
     rendered = DOCTOR_RECOMMENDATION_CODE_TRANSLATIONS.get(code)
     if rendered is not None:
         if code == doctor_rec.SWITCH_TO_WORK:
@@ -227,8 +233,8 @@ def format_doctor_recommendation_fact(recommendation: Any) -> str:
         return rendered
     detail = doctor_rec.doctor_recommendation_detail(rec)
     if detail:
-        return f"建议：{detail}"
-    return f"建议：{code or 'unknown'}"
+        return DOCTOR_RECOMMENDATION_UNKNOWN_FACT
+    return DOCTOR_RECOMMENDATION_UNKNOWN_FACT
 
 
 def translate_doctor_warning(warning: str) -> str:

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -1,6 +1,10 @@
 """Shared Chinese labels and copy helpers for GUI summaries."""
 from __future__ import annotations
 
+from typing import Any
+
+import doctor_recommendations as doctor_rec
+
 SAFETY_LEVEL_LABELS = {
     "safe": "可写回",
     "warn": "需处理",
@@ -43,71 +47,58 @@ BOOTSTRAP_FIELD_LABELS = {
     "external_seed_records": "外部种子记录数",
 }
 
-DOCTOR_RECOMMENDATION_PREFIX_TRANSLATIONS: tuple[tuple[str, str], ...] = (
-    (
-        "game_root should use work directory; switch to",
-        "建议：将项目路径切换到",
+DOCTOR_RECOMMENDATION_CODE_TRANSLATIONS: dict[str, str] = {
+    doctor_rec.SWITCH_TO_WORK: "建议：将项目路径切换到",
+    doctor_rec.BOOTSTRAP_WORK: "建议：点击「准备工作目录」",
+    doctor_rec.GENERATE_TEMPLATE: "建议：点击「生成翻译模板」",
+    doctor_rec.INSTALL_SDK_GENERATE_TEMPLATE: "建议：配置 Ren'Py SDK 后点击「开始翻译」",
+    doctor_rec.ENABLE_PREPARE: "建议：在配置中启用 prepare 后点击「开始翻译」",
+    doctor_rec.BOOTSTRAP_SOURCE_INDEX: "建议：先在「分析与准备」运行「预建原文索引」",
+    doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE: "建议：继续运行「预建原文索引」补全索引库",
+    doctor_rec.BOOTSTRAP_RAG: "建议：先在「分析与准备」运行「预建记忆库」，再开始批量翻译",
+    doctor_rec.BOOTSTRAP_RAG_OR_WARM_ON_BUILD: (
+        "建议：记忆库为空；可先「预建记忆库」，若已勾选「开始翻译时自动暖 RAG 库」也可直接「开始翻译」"
     ),
-    (
-        "work directory is missing or empty and original/game exists;",
-        "建议：点击「准备工作目录」",
+    doctor_rec.ENABLE_RAG_FOR_CONSISTENCY: (
+        "建议：补译量较大且记忆库未启用；若要进行批量补译，建议先在配置页启用并「预建记忆库」"
     ),
-    (
-        "Missing translation files; run: python gemini_translate_batch.py generate-template",
-        "建议：点击「生成翻译模板」",
+    doctor_rec.SUBSTANTIALLY_COMPLETE: (
+        "建议：项目已基本译完；剩余待译行很少（可能含专名/标点），可忽略或按需补译，不必预建记忆库"
     ),
-    (
-        "Install Ren'Py SDK or set prepare.renpy_sdk_dir, then run:",
-        "建议：配置 Ren'Py SDK 后点击「开始翻译」",
+    doctor_rec.ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT: (
+        "建议：全新初译项目建议在配置页启用原文索引并「预建原文索引」，再开始翻译"
     ),
-    (
-        "prepare is disabled; enable prepare.enabled in translator_config.json, then run build.",
-        "建议：在配置中启用 prepare 后点击「开始翻译」",
+    doctor_rec.START_INCREMENTAL_BATCH: (
+        "建议：补译环境已就绪；切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交"
     ),
-    (
-        "Source index is enabled but not built; run bootstrap-source-index.",
-        "建议：先在「分析与准备」运行「预建原文索引」",
+    doctor_rec.NO_PENDING_LINES: (
+        "建议：当前没有待译条目；请检查翻译文件，或重新生成/刷新模板后再开始"
     ),
-    (
-        "Source index bootstrap is incomplete; run bootstrap-source-index.",
-        "建议：继续运行「预建原文索引」补全索引库",
+    doctor_rec.START_PENDING_BATCH: (
+        "建议：切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交云端任务"
     ),
-    (
-        "RAG store is enabled but empty; run bootstrap-rag before batch translation.",
-        "建议：先在「分析与准备」运行「预建记忆库」，再开始批量翻译",
-    ),
-    (
-        "RAG store is empty; run bootstrap-rag before batch translation, "
-        "or start batch translation to warm the store automatically on build.",
-        "建议：记忆库为空；可先「预建记忆库」，若已勾选「开始翻译时自动暖 RAG 库」也可直接「开始翻译」",
-    ),
-    (
-        "Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag "
-        "for better terminology consistency, then start batch translation.",
-        "建议：补译量较大且记忆库未启用；若要进行批量补译，建议先在配置页启用并「预建记忆库」",
-    ),
-    (
-        "Project is substantially complete; remaining pending lines are minor. "
-        "Batch translation and RAG bootstrap are optional.",
-        "建议：项目已基本译完；剩余待译行很少（可能含专名/标点），可忽略或按需补译，不必预建记忆库",
-    ),
-    (
-        "Source index is disabled; enable it and run bootstrap-source-index "
-        "for better story context on a new translation project.",
-        "建议：全新初译项目建议在配置页启用原文索引并「预建原文索引」，再开始翻译",
-    ),
-    (
-        "Incremental translation is ready; start batch translation when API keys are configured.",
-        "建议：补译环境已就绪；切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交",
-    ),
-    (
-        "No pending translation lines detected; review TL files or refresh templates before starting a new batch.",
-        "建议：当前没有待译条目；请检查翻译文件，或重新生成/刷新模板后再开始",
-    ),
-    (
-        "Pending translation lines are ready; start batch translation when API keys are configured.",
-        "建议：切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交云端任务",
-    ),
+}
+
+DOCTOR_RECOMMENDATION_PRIMARY_MESSAGES: dict[str, str] = {
+    doctor_rec.SUBSTANTIALLY_COMPLETE: "项目已基本译完；剩余待译行很少，可忽略或按需补译。",
+    doctor_rec.ENABLE_RAG_FOR_CONSISTENCY: "补译量较大；若要进行批量补译，建议先启用并预建记忆库。",
+    doctor_rec.BOOTSTRAP_RAG: "记忆库尚未建立，建议先预建记忆库再开始翻译。",
+    doctor_rec.BOOTSTRAP_RAG_OR_WARM_ON_BUILD: "记忆库尚未建立，建议先预建记忆库再开始翻译。",
+    doctor_rec.BOOTSTRAP_SOURCE_INDEX: "原文索引尚未就绪，建议先完成预建再开始翻译。",
+    doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE: "原文索引尚未就绪，建议先完成预建再开始翻译。",
+    doctor_rec.BOOTSTRAP_WORK: "请先准备工作目录，再开始翻译流程。",
+    doctor_rec.ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT: "全新项目建议先预建原文索引，再开始批量翻译。",
+    doctor_rec.START_INCREMENTAL_BATCH: "补译环境已就绪，可以开始批量翻译。",
+    doctor_rec.NO_PENDING_LINES: "当前没有待译条目，请先检查或刷新翻译模板。",
+    doctor_rec.START_PENDING_BATCH: "翻译环境已就绪，可以开始批量翻译。",
+}
+
+READY_DOCTOR_RECOMMENDATION_CODES = frozenset(
+    {
+        doctor_rec.START_INCREMENTAL_BATCH,
+        doctor_rec.START_PENDING_BATCH,
+        doctor_rec.SUBSTANTIALLY_COMPLETE,
+    }
 )
 
 DOCTOR_WARNING_TRANSLATIONS: tuple[tuple[str, str], ...] = (
@@ -209,59 +200,35 @@ def findings_require_attention(findings: list[str]) -> bool:
     return False
 
 
-def recommendation_requires_attention(recommendation_facts: list[str]) -> bool:
+def recommendation_requires_attention(recommendation_codes: list[str]) -> bool:
     """Return True when the primary recommendation is a prep step, not ready-to-translate."""
-    ready_messages = {
-        "补译环境已就绪，可以开始批量翻译。",
-        "翻译环境已就绪，可以开始批量翻译。",
-        "项目已基本译完；剩余待译行很少，可忽略或按需补译。",
-    }
-    message = primary_recommendation_message(recommendation_facts)
-    if message in ready_messages:
+    if not recommendation_codes:
         return False
-    return bool(recommendation_facts)
+    return recommendation_codes[0] not in READY_DOCTOR_RECOMMENDATION_CODES
 
 
-def primary_recommendation_message(recommendation_facts: list[str]) -> str:
-    """Map the first rendered recommendation fact to a short summary message."""
-    if not recommendation_facts:
+def primary_recommendation_message(recommendation_codes: list[str]) -> str:
+    """Map the first recommendation code to a short summary message."""
+    if not recommendation_codes:
         return ""
-    first = recommendation_facts[0].strip()
-    if not first.startswith("建议："):
-        return ""
-
-    if "已基本译完" in first:
-        return "项目已基本译完；剩余待译行很少，可忽略或按需补译。"
-    if "补译量较大且记忆库未启用" in first:
-        return "补译量较大；若要进行批量补译，建议先启用并预建记忆库。"
-    if "预建记忆库" in first and "不必预建记忆库" not in first:
-        return "记忆库尚未建立，建议先预建记忆库再开始翻译。"
-    if "预建原文索引" in first:
-        return "原文索引尚未就绪，建议先完成预建再开始翻译。"
-    if "准备工作目录" in first:
-        return "请先准备工作目录，再开始翻译流程。"
-    if "全新初译项目" in first:
-        return "全新项目建议先预建原文索引，再开始批量翻译。"
-    if "补译环境已就绪" in first:
-        return "补译环境已就绪，可以开始批量翻译。"
-    if "没有待译条目" in first:
-        return "当前没有待译条目，请先检查或刷新翻译模板。"
-    if "打包并提交" in first:
-        return "翻译环境已就绪，可以开始批量翻译。"
-    return ""
+    return DOCTOR_RECOMMENDATION_PRIMARY_MESSAGES.get(recommendation_codes[0], "")
 
 
-def format_doctor_recommendation_fact(recommendation: str) -> str:
+def format_doctor_recommendation_fact(recommendation: Any) -> str:
     """Render doctor recommendations in the same `标签：值` style as other facts."""
-    text = recommendation.strip()
-    for prefix, rendered in DOCTOR_RECOMMENDATION_PREFIX_TRANSLATIONS:
-        if text.startswith(prefix):
-            if prefix == "game_root should use work directory; switch to":
-                return f"{rendered}{text[len(prefix):]}"
-            return rendered
-    if "bootstrap-work" in text and "copies original/game" in text:
-        return "建议：点击「准备工作目录」"
-    return f"建议：{text}"
+    rec = doctor_rec.normalize_doctor_recommendation(recommendation)
+    code = str(rec.get("code") or "")
+    params = rec.get("params") if isinstance(rec.get("params"), dict) else {}
+    rendered = DOCTOR_RECOMMENDATION_CODE_TRANSLATIONS.get(code)
+    if rendered is not None:
+        if code == doctor_rec.SWITCH_TO_WORK:
+            work_dir = str(params.get("work_dir") or "").strip()
+            return f"{rendered}{work_dir}" if work_dir else rendered
+        return rendered
+    detail = doctor_rec.doctor_recommendation_detail(rec)
+    if detail:
+        return f"建议：{detail}"
+    return f"建议：{code or 'unknown'}"
 
 
 def translate_doctor_warning(warning: str) -> str:

--- a/tests/test_batch_rag.py
+++ b/tests/test_batch_rag.py
@@ -751,8 +751,10 @@ class BatchRagRegressionTests(unittest.TestCase):
             ):
                 report = batch_mod.collect_doctor_report()
 
-        joined = ' '.join(report.get('recommendations', []))
-        self.assertIn('bootstrap-work', joined)
+        import doctor_recommendations as doctor_rec
+
+        codes = doctor_rec.doctor_recommendation_codes(report.get('recommendations', []))
+        self.assertIn(doctor_rec.BOOTSTRAP_WORK, codes)
 
     def test_doctor_report_prefers_existing_tl_when_files_and_sdk_available(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+import doctor_recommendations as doctor_rec
 import gemini_translate_batch as batch_mod
 
 
@@ -131,12 +132,12 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="switch_to_work",
         )
         recommendations = batch_mod.collect_doctor_recommendations(report)
-        joined = " ".join(recommendations)
+        codes = doctor_rec.doctor_recommendation_codes(recommendations)
 
-        self.assertIn("switch to C:/Games/Example/work", joined)
-        self.assertIn("bootstrap-work", joined)
-        self.assertNotIn("gemini_translate_batch.py build", joined)
-        self.assertNotIn("Ren'Py SDK", joined)
+        self.assertIn(doctor_rec.SWITCH_TO_WORK, codes)
+        self.assertIn(doctor_rec.BOOTSTRAP_WORK, codes)
+        self.assertNotIn(doctor_rec.GENERATE_TEMPLATE, codes)
+        self.assertNotIn(doctor_rec.INSTALL_SDK_GENERATE_TEMPLATE, codes)
 
     def test_switch_to_work_without_original_only_recommends_switch(self):
         report = _layout_report(
@@ -148,7 +149,11 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("switch to C:/Games/Example/work", recommendations[0])
+        self.assertEqual(recommendations[0]["code"], doctor_rec.SWITCH_TO_WORK)
+        self.assertEqual(
+            recommendations[0]["params"]["work_dir"],
+            "C:/Games/Example/work",
+        )
 
     def test_switch_to_work_with_existing_work_does_not_recommend_bootstrap(self):
         report = _layout_report(
@@ -162,10 +167,10 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         report["work_exists"] = True
         report["work_empty"] = False
         recommendations = batch_mod.collect_doctor_recommendations(report)
-        joined = " ".join(recommendations)
+        codes = doctor_rec.doctor_recommendation_codes(recommendations)
 
-        self.assertIn("switch to C:/Games/Example/work", joined)
-        self.assertNotIn("bootstrap-work", joined)
+        self.assertIn(doctor_rec.SWITCH_TO_WORK, codes)
+        self.assertNotIn(doctor_rec.BOOTSTRAP_WORK, codes)
 
     def test_work_root_without_tl_recommends_generate_template_when_available(self):
         report = _layout_report(
@@ -175,10 +180,10 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="attention",
         )
         recommendations = batch_mod.collect_doctor_recommendations(report)
-        joined = " ".join(recommendations)
+        codes = doctor_rec.doctor_recommendation_codes(recommendations)
 
-        self.assertIn("gemini_translate_batch.py generate-template", joined)
-        self.assertNotIn("switch to", joined)
+        self.assertEqual(codes, [doctor_rec.GENERATE_TEMPLATE])
+        self.assertNotIn(doctor_rec.SWITCH_TO_WORK, codes)
 
     def test_resolve_source_index_expected_segments_scans_when_metadata_missing(self):
         with (
@@ -212,8 +217,11 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("incomplete", recommendations[0])
-        self.assertNotIn("Pending translation lines", recommendations[0])
+        self.assertEqual(
+            recommendations[0]["code"],
+            doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE,
+        )
+        self.assertNotIn(doctor_rec.START_PENDING_BATCH, doctor_rec.doctor_recommendation_codes(recommendations))
 
     def test_empty_rag_blocks_batch_translation_when_enabled(self):
         report = _layout_report(
@@ -246,8 +254,8 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("bootstrap-rag", recommendations[0])
-        self.assertNotIn("Pending translation lines", recommendations[0])
+        self.assertEqual(recommendations[0]["code"], doctor_rec.BOOTSTRAP_RAG)
+        self.assertNotIn(doctor_rec.START_PENDING_BATCH, doctor_rec.doctor_recommendation_codes(recommendations))
 
     def test_incremental_translation_uses_incremental_recommendation(self):
         report = _layout_report(
@@ -279,7 +287,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("Incremental translation", recommendations[0])
+        self.assertEqual(recommendations[0]["code"], doctor_rec.START_INCREMENTAL_BATCH)
 
     def test_mostly_complete_project_without_rag_does_not_require_bootstrap(self):
         report = _layout_report(
@@ -308,8 +316,8 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("substantially complete", recommendations[0])
-        self.assertNotIn("RAG disabled", recommendations[0])
+        self.assertEqual(recommendations[0]["code"], doctor_rec.SUBSTANTIALLY_COMPLETE)
+        self.assertNotIn(doctor_rec.ENABLE_RAG_FOR_CONSISTENCY, doctor_rec.doctor_recommendation_codes(recommendations))
 
     def test_existing_translations_without_rag_recommends_enable_rag(self):
         report = _layout_report(
@@ -337,7 +345,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
         recommendations = batch_mod.collect_doctor_recommendations(report)
 
         self.assertEqual(len(recommendations), 1)
-        self.assertIn("RAG disabled", recommendations[0])
+        self.assertEqual(recommendations[0]["code"], doctor_rec.ENABLE_RAG_FOR_CONSISTENCY)
 
 
 if __name__ == "__main__":

--- a/tests/test_doctor_recommendations.py
+++ b/tests/test_doctor_recommendations.py
@@ -1,0 +1,36 @@
+import json
+import unittest
+
+import doctor_recommendations as doctor_rec
+
+
+class DoctorRecommendationTests(unittest.TestCase):
+    def test_make_and_format_cli_line_round_trip(self):
+        rec = doctor_rec.make_doctor_recommendation(
+            doctor_rec.SWITCH_TO_WORK,
+            work_dir="C:/Games/Example/work",
+        )
+        line = doctor_rec.format_doctor_recommendation_cli_line(rec)
+        parsed = doctor_rec.parse_doctor_recommendation_cli_line(line)
+
+        self.assertEqual(parsed["code"], doctor_rec.SWITCH_TO_WORK)
+        self.assertEqual(parsed["params"]["work_dir"], "C:/Games/Example/work")
+
+    def test_legacy_string_maps_to_code(self):
+        rec = doctor_rec.legacy_string_to_recommendation(
+            "RAG store is enabled but empty; run bootstrap-rag before batch translation."
+        )
+
+        self.assertEqual(rec["code"], doctor_rec.BOOTSTRAP_RAG)
+
+    def test_cli_line_json_contains_code_and_detail(self):
+        rec = doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_WORK)
+        payload = json.loads(doctor_rec.format_doctor_recommendation_cli_line(rec))
+
+        self.assertEqual(payload["code"], doctor_rec.BOOTSTRAP_WORK)
+        self.assertIn("detail", payload)
+        self.assertIn("bootstrap-work", payload["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_recommendations.py
+++ b/tests/test_doctor_recommendations.py
@@ -31,6 +31,12 @@ class DoctorRecommendationTests(unittest.TestCase):
         self.assertIn("detail", payload)
         self.assertIn("bootstrap-work", payload["detail"])
 
+    def test_legacy_unknown_string_maps_to_unknown_code(self):
+        rec = doctor_rec.legacy_string_to_recommendation("Totally new recommendation wording.")
+
+        self.assertEqual(rec["code"], doctor_rec.UNKNOWN)
+        self.assertEqual(rec["detail"], "Totally new recommendation wording.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -9,6 +9,8 @@ from gui_qt.doctor_report import (
     summarize_doctor_output,
     summarize_doctor_report,
 )
+import doctor_recommendations as doctor_rec
+
 from gui_qt.user_copy import format_doctor_recommendation_fact, primary_recommendation_message
 
 
@@ -383,16 +385,14 @@ class GuiDoctorReportTests(unittest.TestCase):
 
     def test_format_doctor_recommendation_fact_uses_fact_style(self):
         fact = format_doctor_recommendation_fact(
-            "work directory is missing or empty and original/game exists; "
-            "run: python gemini_translate_batch.py bootstrap-work "
-            "(copies original/game into work/game without generating TL)."
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_WORK)
         )
 
         self.assertEqual(fact, "建议：点击「准备工作目录」")
 
     def test_format_doctor_recommendation_fact_for_ready_pending_lines(self):
         fact = format_doctor_recommendation_fact(
-            "Pending translation lines are ready; start batch translation when API keys are configured."
+            doctor_rec.make_doctor_recommendation(doctor_rec.START_PENDING_BATCH)
         )
 
         self.assertEqual(
@@ -402,7 +402,7 @@ class GuiDoctorReportTests(unittest.TestCase):
 
     def test_format_doctor_recommendation_fact_for_empty_rag(self):
         fact = format_doctor_recommendation_fact(
-            "RAG store is enabled but empty; run bootstrap-rag before batch translation."
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_RAG)
         )
 
         self.assertEqual(
@@ -410,12 +410,18 @@ class GuiDoctorReportTests(unittest.TestCase):
             "建议：先在「分析与准备」运行「预建记忆库」，再开始批量翻译",
         )
 
-    def test_primary_recommendation_message_for_incremental_translation(self):
-        message = primary_recommendation_message(
-            [
-                "建议：补译环境已就绪；切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交",
-            ]
+    def test_format_doctor_recommendation_fact_supports_legacy_english_strings(self):
+        fact = format_doctor_recommendation_fact(
+            "Pending translation lines are ready; start batch translation when API keys are configured."
         )
+
+        self.assertEqual(
+            fact,
+            "建议：切换到「翻译 · 批量翻译」，点击「开始翻译」打包并提交云端任务",
+        )
+
+    def test_primary_recommendation_message_for_incremental_translation(self):
+        message = primary_recommendation_message([doctor_rec.START_INCREMENTAL_BATCH])
 
         self.assertEqual(message, "补译环境已就绪，可以开始批量翻译。")
 

--- a/tests/test_gui_doctor_report.py
+++ b/tests/test_gui_doctor_report.py
@@ -425,6 +425,50 @@ class GuiDoctorReportTests(unittest.TestCase):
 
         self.assertEqual(message, "补译环境已就绪，可以开始批量翻译。")
 
+    def test_summarize_doctor_output_parses_json_cli_recommendations(self):
+        cli_line = doctor_rec.format_doctor_recommendation_cli_line(
+            doctor_rec.make_doctor_recommendation(doctor_rec.BOOTSTRAP_RAG)
+        )
+        output = DOCTOR_OUTPUT + f"\nRecommendations:\n- {cli_line}\n"
+
+        parsed = parse_doctor_output(output)
+        self.assertEqual(len(parsed["recommendations"]), 1)
+        self.assertEqual(parsed["recommendations"][0]["code"], doctor_rec.BOOTSTRAP_RAG)
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=3)
+        self.assertEqual(summary.message, "记忆库尚未建立，建议先预建记忆库再开始翻译。")
+        self.assertEqual(summary.status, "warning")
+        self.assertTrue(any("预建记忆库" in fact for fact in summary.facts))
+
+    def test_summarize_doctor_output_parses_json_cli_switch_to_work(self):
+        cli_line = doctor_rec.format_doctor_recommendation_cli_line(
+            doctor_rec.make_doctor_recommendation(
+                doctor_rec.SWITCH_TO_WORK,
+                work_dir="C:\\Games\\Example\\work",
+            )
+        )
+        output = SWITCH_TO_WORK_OUTPUT.replace(
+            "- game_root should use work directory; switch to C:\\Games\\Example\\work",
+            f"- {cli_line}",
+        )
+
+        summary = summarize_doctor_output(output, exit_code=0, api_key_count=1)
+        self.assertTrue(
+            any(fact == "建议：将项目路径切换到C:\\Games\\Example\\work" for fact in summary.facts)
+        )
+
+    def test_format_doctor_recommendation_fact_for_unknown_code(self):
+        fact = format_doctor_recommendation_fact(
+            {
+                "code": doctor_rec.UNKNOWN,
+                "params": {},
+                "detail": "Some future recommendation text that has no mapping yet.",
+            }
+        )
+
+        self.assertEqual(fact, "建议：收到未识别的诊断建议，请查看诊断日志了解详情。")
+        self.assertNotIn("future recommendation", fact)
+
     def test_summarize_doctor_output_uses_primary_recommendation_message(self):
         output = DOCTOR_OUTPUT + (
             "\nRecommendations:\n"


### PR DESCRIPTION
## Summary

Closes #117.

Doctor recommendations now emit stable codes instead of relying on fragile English prefix matching in the GUI.

## Changes

- Add `doctor_recommendations.py` with 15 stable recommendation codes and CLI JSON serialization
- Update `collect_doctor_recommendations()` to return coded dicts (`code` + optional `params`)
- Print recommendations as JSON in CLI output (with optional English `detail` for debugging)
- Map codes to localized Chinese strings in `gui_qt/user_copy.py`
- Parse coded recommendations in `gui_qt/doctor_report.py`; legacy English strings remain supported

## Test plan

- [x] `tests/test_doctor_recommendations.py`
- [x] `tests/test_doctor_layout_status.py`
- [x] `tests/test_gui_doctor_report.py`
- [x] `tests/test_batch_rag.py`
- [x] `tests/test_gui_batch_workflow_support.py`
- [x] `tests/test_target_language_config.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增结构化“doctor recommendation”支持，推荐内容现在可用统一代码表示、解析和输出。
  * 改进诊断结果展示，可生成更稳定的推荐摘要与可读文案。

* **Bug 修复**
  * 提升对旧格式推荐文本的兼容性，减少解析失败。
  * 诊断状态判定改为基于推荐代码，结果更一致。

* **测试**
  * 新增并更新相关测试，覆盖推荐编码、解析、格式化与展示逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->