### PR TITLE
fix(gui): tighten doctor gating and project switch state resets

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -3312,8 +3312,11 @@ class MainWindow(QMainWindow):
         self.timeline.setVisible(True)
 
     def _invalidate_manifest_caches(self, manifest_path: str | Path | None = None) -> None:
-        invalidate_history = getattr(self.state, "invalidate_manifest_history_cache", None)
-        invalidate_file = getattr(self.state, "invalidate_manifest_file_cache", None)
+        state = getattr(self, "state", None)
+        if state is None:
+            return
+        invalidate_history = getattr(state, "invalidate_manifest_history_cache", None)
+        invalidate_file = getattr(state, "invalidate_manifest_file_cache", None)
         if callable(invalidate_history):
             invalidate_history()
         if callable(invalidate_file):
@@ -4002,9 +4005,9 @@ class MainWindow(QMainWindow):
         return snapshot
 
     def _config_tab_has_unsaved_changes(self) -> bool:
-        if self._loading_config_to_ui:
+        if getattr(self, "_loading_config_to_ui", False):
             return False
-        if not self._config_ui_saved_snapshot:
+        if not getattr(self, "_config_ui_saved_snapshot", None):
             return False
         return self._current_config_ui_snapshot() != self._config_ui_saved_snapshot
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -340,6 +340,7 @@ class MainWindow(QMainWindow):
         self._work_bootstrap_output_lines: list[str] = []
         self._template_generation_output_lines: list[str] = []
         self._doctor_summary_mode = ""
+        self._doctor_summary_status = ""
         self._doctor_check_completed = False
         self._doctor_worker: DoctorWorker | None = None
         self._last_doctor_report: dict | None = None
@@ -3173,6 +3174,13 @@ class MainWindow(QMainWindow):
     def _translation_requires_doctor_check(self, mode: WorkMode) -> bool:
         return mode in {WorkMode.BATCH_TRANSLATION, WorkMode.SYNC_TRANSLATION}
 
+    def _doctor_allows_translate_action(self) -> bool:
+        if not self._doctor_check_completed:
+            return False
+        if self._should_generate_template_only():
+            return True
+        return self._doctor_summary_status in {"ready", "warning"}
+
     def _translate_button_enabled(
         self,
         *,
@@ -3183,7 +3191,7 @@ class MainWindow(QMainWindow):
         if running or not spec.implemented or not bootstrap_ready:
             return False
         if self._translation_requires_doctor_check(spec.mode):
-            return self._doctor_check_completed
+            return self._doctor_allows_translate_action()
         return True
 
     def _update_translate_button_label(self) -> None:
@@ -3692,9 +3700,20 @@ class MainWindow(QMainWindow):
             worker.completed.disconnect(self._on_doctor_completed)
         except (RuntimeError, TypeError):
             pass
+        if worker.isRunning():
+            worker.requestInterruption()
+            worker.wait(100)
         self._doctor_worker = None
+        if self._active_command == "doctor":
+            self._active_command = ""
+            self._set_task_running(False)
 
     def _switch_game_root(self, directory: str) -> bool:
+        if self._is_doctor_running():
+            self._invalidate_doctor_worker()
+        if self.runner.is_running():
+            self.runner.kill()
+            self._set_task_running(False)
         self._invalidate_doctor_worker()
         try:
             effective_root, adjusted = self.state.set_game_root(directory)
@@ -3718,6 +3737,7 @@ class MainWindow(QMainWindow):
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()
         self._doctor_check_completed = False
+        self._doctor_summary_status = ""
         self._last_doctor_report = None
         self._last_doctor_report_game_root = ""
         self._set_doctor_summary(stale_summary())
@@ -4397,12 +4417,15 @@ class MainWindow(QMainWindow):
                 "请先选择游戏的 work 目录。",
             )
             return
-        if self._translation_requires_doctor_check(spec.mode) and not self._doctor_check_completed:
-            QMessageBox.information(
-                self,
-                "请先运行环境检查",
-                "批量翻译与同步翻译需要先完成环境检查，确认项目状态后再开始。",
-            )
+        if self._translation_requires_doctor_check(spec.mode) and not self._doctor_allows_translate_action():
+            if not self._doctor_check_completed:
+                detail = "批量翻译与同步翻译需要先完成环境检查，确认项目状态后再开始。"
+            else:
+                detail = (
+                    "当前环境检查未通过或仍有阻塞项，无法开始翻译。"
+                    "请查看环境检查摘要，处理问题后重新运行检查。"
+                )
+            QMessageBox.information(self, "请先运行环境检查", detail)
             return
 
         if spec.mode in self._sync_work_modes_requiring_api_key():
@@ -4585,6 +4608,16 @@ class MainWindow(QMainWindow):
         self._run_workflow_current_step()
 
     def _on_kill(self):
+        if self._is_doctor_running():
+            self._invalidate_doctor_worker()
+            self._append_log("\n[环境检查已取消]\n")
+            self._doctor_check_completed = False
+            self._doctor_summary_status = ""
+            self._last_doctor_report = None
+            self._last_doctor_report_game_root = ""
+            self._set_doctor_summary(stale_summary())
+            self.statusBar().showMessage("环境检查已取消。", 6000)
+            return
         self.runner.kill()
 
     def _prompt_probe_options(self) -> dict[str, int | None] | None:
@@ -5649,6 +5682,7 @@ class MainWindow(QMainWindow):
 
     def _set_doctor_summary(self, summary: DoctorSummary):
         self._doctor_summary_mode = summary.mode
+        self._doctor_summary_status = summary.status
         self.doctor_status_label.set_status(summary.status, summary.heading)
         self.doctor_message_label.setText(summary.message)
         self.doctor_facts_label.setText("\n".join(summary.facts))
@@ -5993,11 +6027,7 @@ class MainWindow(QMainWindow):
             )
             game_root_update_failed = False
             if summary.status == "ready" and summary.work_dir:
-                try:
-                    self.state.set_game_root(summary.work_dir)
-                    self._refresh_project_label()
-                except ValueError as exc:
-                    self._append_log(f"未能保存项目路径：{exc}")
+                if not self._switch_game_root(summary.work_dir):
                     game_root_update_failed = True
                     summary = with_game_root_persist_warning(summary)
             self._set_doctor_summary(work_bootstrap_to_doctor_summary(summary))

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2075,6 +2075,7 @@ class MainWindow(QMainWindow):
         self._set_writeback_summary(summary)
 
     def _select_split_manifest(self, manifest_path: str) -> None:
+        self._invalidate_manifest_caches(manifest_path)
         try:
             self.state.remember_latest_manifest_path(manifest_path)
         except ValueError as exc:
@@ -2789,7 +2790,7 @@ class MainWindow(QMainWindow):
             candidates_path=candidates_path,
             glossary_path=glossary_path,
         )
-        self.keyword_merge_btn.setEnabled(not running)
+        self.keyword_merge_btn.setEnabled(not running and ready)
         if ready:
             self.keyword_merge_btn.setToolTip(
                 "勾选审核关键词候选并写入 glossary.json；不会修改 .rpy 脚本。",
@@ -3310,6 +3311,14 @@ class MainWindow(QMainWindow):
             self.timeline.set_current_step(step_key, status)
         self.timeline.setVisible(True)
 
+    def _invalidate_manifest_caches(self, manifest_path: str | Path | None = None) -> None:
+        invalidate_history = getattr(self.state, "invalidate_manifest_history_cache", None)
+        invalidate_file = getattr(self.state, "invalidate_manifest_file_cache", None)
+        if callable(invalidate_history):
+            invalidate_history()
+        if callable(invalidate_file):
+            invalidate_file(manifest_path)
+
     def _clear_completed_manifest_snapshot(self) -> None:
         self._completed_manifest_snapshot = None
         self._viewing_completed_manifest = False
@@ -3758,6 +3767,7 @@ class MainWindow(QMainWindow):
             self._set_writeback_summary(idle_writeback_summary_for_work_mode(spec.mode))
         self._apply_work_mode_ui(refresh_manifest_writeback=False)
         self._refresh_diagnostics_context()
+        self._invalidate_manifest_caches()
         self._append_log(f"项目目录已设置为：{directory}")
         return True
 
@@ -3998,6 +4008,31 @@ class MainWindow(QMainWindow):
             return False
         return self._current_config_ui_snapshot() != self._config_ui_saved_snapshot
 
+    def _confirm_unsaved_config_before_workflow(self) -> bool:
+        if not self._config_tab_has_unsaved_changes():
+            return True
+
+        message = QMessageBox(self)
+        message.setIcon(QMessageBox.Icon.Warning)
+        message.setWindowTitle("设置尚未保存")
+        message.setText("设置页有未保存的更改。")
+        message.setInformativeText(
+            "当前任务会读取已保存的 translator_config.json；"
+            "未保存的更改不会生效。"
+        )
+        save_btn = message.addButton("保存并继续", QMessageBox.ButtonRole.AcceptRole)
+        discard_btn = message.addButton("不保存继续", QMessageBox.ButtonRole.DestructiveRole)
+        cancel_btn = message.addButton("取消", QMessageBox.ButtonRole.RejectRole)
+        message.setDefaultButton(save_btn)
+        message.exec()
+        clicked = message.clickedButton()
+
+        if clicked is save_btn:
+            return self._on_save_config()
+        if clicked is discard_btn:
+            return True
+        return False
+
     def _confirm_unsaved_config_before_registry_switch(self) -> bool:
         if not self._config_tab_has_unsaved_changes():
             return True
@@ -4181,6 +4216,8 @@ class MainWindow(QMainWindow):
         return self._doctor_worker is not None and self._doctor_worker.isRunning()
 
     def _on_run_doctor(self):
+        if not self._confirm_unsaved_config_before_workflow():
+            return
         if not self.state.get_game_root():
             QMessageBox.information(
                 self, "请先选择项目",
@@ -4267,6 +4304,8 @@ class MainWindow(QMainWindow):
         self._set_doctor_summary(summary)
 
     def _on_bootstrap_work(self):
+        if not self._confirm_unsaved_config_before_workflow():
+            return
         if not self.state.get_game_root():
             QMessageBox.information(
                 self,
@@ -4296,6 +4335,8 @@ class MainWindow(QMainWindow):
         self.runner.run(self.state.get_batch_script_path(), ["bootstrap-work"])
 
     def _on_generate_template(self):
+        if not self._confirm_unsaved_config_before_workflow():
+            return
         if not self.state.get_game_root():
             QMessageBox.information(
                 self,
@@ -4341,6 +4382,8 @@ class MainWindow(QMainWindow):
         return True
 
     def _start_bootstrap_task(self, kind: str) -> bool:
+        if not self._confirm_unsaved_config_before_workflow():
+            return False
         if not self.state.get_game_root():
             QMessageBox.information(self, "请先选择项目", "请先选择游戏的 work 目录。")
             return False
@@ -4428,6 +4471,9 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "请先运行环境检查", detail)
             return
 
+        if not self._confirm_unsaved_config_before_workflow():
+            return
+
         if spec.mode in self._sync_work_modes_requiring_api_key():
             api_key_count, _ = self.state.get_api_key_status()
             if api_key_count == 0:
@@ -4476,6 +4522,8 @@ class MainWindow(QMainWindow):
         self._run_workflow_current_step()
 
     def _on_resume_translation(self):
+        if not self._confirm_unsaved_config_before_workflow():
+            return
         spec = work_mode_spec(self._current_work_mode())
         if not spec.implemented or not spec.supports_resume:
             QMessageBox.information(self, "功能开发中", spec.not_implemented_message)
@@ -5738,6 +5786,7 @@ class MainWindow(QMainWindow):
             return
 
         if self._active_command == "apply":
+            self._invalidate_manifest_caches(self._writeback_manifest_path or None)
             summary = summarize_apply_output(
                 "\n".join(self._apply_output_lines),
                 exit_code,
@@ -5758,6 +5807,7 @@ class MainWindow(QMainWindow):
 
         if self._active_command == "recheck":
             manifest_path = self._writeback_manifest_path
+            self._invalidate_manifest_caches(manifest_path or None)
             self._update_writeback_from_check(
                 "\n".join(self._recheck_output_lines),
                 exit_code,
@@ -6134,6 +6184,7 @@ class MainWindow(QMainWindow):
 
         step_output = "\n".join(self._workflow_step_output_lines)
         manifest_path = self._workflow.manifest_path
+        self._invalidate_manifest_caches(manifest_path or None)
 
         current_step = self._workflow.current_step()
         step_key = current_step.key if current_step else ""

--- a/gui_qt/cli_runner.py
+++ b/gui_qt/cli_runner.py
@@ -72,6 +72,13 @@ class CliRunner(QObject):
             self._fail("启动进程失败（超时）")
             return
 
+    def is_running(self) -> bool:
+        """Return True while a CLI subprocess is active."""
+        return (
+            self._proc is not None
+            and self._proc.state() == QProcess.ProcessState.Running
+        )
+
     def kill(self) -> None:
         """Terminate the running process if any."""
         if self._proc and self._proc.state() == QProcess.ProcessState.Running:

--- a/tests/test_gui_doctor_gating.py
+++ b/tests/test_gui_doctor_gating.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest import mock
+
+try:
+    from PySide6.QtWidgets import QApplication
+
+    from gui_qt.app import MainWindow
+    from gui_qt.doctor_worker import DoctorWorker
+except ImportError as exc:
+    MainWindow = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+@unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiDoctorGatingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication.instance() or QApplication([])
+
+    def test_invalidate_doctor_worker_clears_task_running(self):
+        window = MainWindow()
+        window._active_command = "doctor"
+        window._set_task_running(True)
+        worker = mock.Mock(spec=DoctorWorker)
+        worker.isRunning.return_value = False
+        window._doctor_worker = worker
+
+        window._invalidate_doctor_worker()
+
+        self.assertIsNone(window._doctor_worker)
+        self.assertEqual(window._active_command, "")
+        self.assertFalse(window.kill_btn.isEnabled())
+
+    def test_kill_during_doctor_check_cancels_worker_and_unlocks_ui(self):
+        window = MainWindow()
+        window._active_command = "doctor"
+        window._set_task_running(True)
+        worker = mock.Mock(spec=DoctorWorker)
+        worker.isRunning.return_value = True
+        window._doctor_worker = worker
+
+        window._on_kill()
+
+        self.assertIsNone(window._doctor_worker)
+        self.assertFalse(window._doctor_check_completed)
+        self.assertFalse(window.kill_btn.isEnabled())

--- a/tests/test_gui_translate_button_label.py
+++ b/tests/test_gui_translate_button_label.py
@@ -87,6 +87,41 @@ class GuiTranslateButtonLabelTests(unittest.TestCase):
 
         self.assertTrue(window.translate_btn.isEnabled())
 
+    def test_batch_translation_button_disabled_when_doctor_blocked(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="blocked",
+                heading="项目检查失败",
+                message="环境检查没有正常完成，请查看诊断日志。",
+                facts=[],
+                findings=[],
+                mode="existing_tl_only",
+            )
+        )
+
+        self.assertEqual(window.translate_btn.text(), "开始翻译")
+        self.assertFalse(window.translate_btn.isEnabled())
+
+    def test_batch_translation_button_enabled_with_warning_status(self):
+        window = MainWindow()
+        window._work_mode = WorkMode.BATCH_TRANSLATION
+        window._doctor_check_completed = True
+        window._set_doctor_summary(
+            DoctorSummary(
+                status="warning",
+                heading="检查完成，但有需要处理的事项",
+                message="记忆库尚未建立，建议先预建记忆库再开始翻译。",
+                facts=[],
+                findings=[],
+                mode="existing_tl_only",
+            )
+        )
+
+        self.assertTrue(window.translate_btn.isEnabled())
+
     def test_button_keeps_generate_template_after_unknown_cli_status(self):
         window = MainWindow()
         window._work_mode = WorkMode.BATCH_TRANSLATION

--- a/tests/test_gui_workflow_guards.py
+++ b/tests/test_gui_workflow_guards.py
@@ -26,12 +26,12 @@ class GuiWorkflowGuardTests(unittest.TestCase):
         window._current_config_ui_snapshot = lambda: {"api_key_count": 2}
 
         message_box = mock.Mock()
-        cancel_btn = object()
+        save_btn, discard_btn, cancel_btn = object(), object(), object()
+        message_box.addButton.side_effect = [save_btn, discard_btn, cancel_btn]
         message_box.clickedButton.return_value = cancel_btn
         with (
             mock.patch.object(MainWindow, "_config_tab_has_unsaved_changes", return_value=True),
             mock.patch("gui_qt.app.QMessageBox", return_value=message_box),
-            mock.patch("gui_qt.app.QMessageBox.addButton", side_effect=[object(), object(), cancel_btn]),
         ):
             allowed = window._confirm_unsaved_config_before_workflow()
 

--- a/tests/test_gui_workflow_guards.py
+++ b/tests/test_gui_workflow_guards.py
@@ -1,0 +1,100 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from PySide6.QtWidgets import QApplication, QMessageBox
+
+    from gui_qt.app import MainWindow
+except ImportError as exc:
+    MainWindow = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+@unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiWorkflowGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication.instance() or QApplication([])
+
+    def test_confirm_unsaved_config_before_workflow_cancel_returns_false(self):
+        window = MainWindow.__new__(MainWindow)
+        window._loading_config_to_ui = False
+        window._config_ui_saved_snapshot = {"api_key_count": 1}
+        window._current_config_ui_snapshot = lambda: {"api_key_count": 2}
+
+        message_box = mock.Mock()
+        cancel_btn = object()
+        message_box.clickedButton.return_value = cancel_btn
+        with (
+            mock.patch.object(MainWindow, "_config_tab_has_unsaved_changes", return_value=True),
+            mock.patch("gui_qt.app.QMessageBox", return_value=message_box),
+            mock.patch("gui_qt.app.QMessageBox.addButton", side_effect=[object(), object(), cancel_btn]),
+        ):
+            allowed = window._confirm_unsaved_config_before_workflow()
+
+        self.assertFalse(allowed)
+
+    def test_update_keyword_merge_btn_disabled_when_not_ready(self):
+        window = MainWindow.__new__(MainWindow)
+        window.keyword_merge_btn = mock.Mock()
+        window.kill_btn = mock.Mock()
+        window.kill_btn.isEnabled.return_value = False
+        window._resolve_keyword_merge_candidates_path = mock.Mock(return_value="")
+        window._resolve_keyword_merge_glossary_path = mock.Mock(return_value="")
+
+        window._update_keyword_merge_btn_enabled()
+
+        window.keyword_merge_btn.setEnabled.assert_called_once_with(False)
+
+    def test_switch_game_root_invalidates_manifest_caches(self):
+        window = MainWindow.__new__(MainWindow)
+        window.state = mock.Mock()
+        window.state.set_game_root.return_value = (Path("C:/Games/Example/work"), False)
+        window.runner = mock.Mock()
+        window.runner.is_running.return_value = False
+        window._is_doctor_running = mock.Mock(return_value=False)
+        window._invalidate_doctor_worker = mock.Mock()
+        window._refresh_project_label = mock.Mock()
+        window._load_config_to_ui = mock.Mock()
+        window._current_work_mode = mock.Mock()
+        window._set_doctor_summary = mock.Mock()
+        window._set_workflow_summary = mock.Mock()
+        window._set_writeback_summary = mock.Mock()
+        window._apply_work_mode_ui = mock.Mock()
+        window._refresh_diagnostics_context = mock.Mock()
+        window._append_log = mock.Mock()
+        window._clear_game_root_redirect_notice = mock.Mock()
+        window._doctor_output_lines = []
+        window._workflow = None
+        window._workflow_step_output_lines = []
+        window._clear_completed_manifest_snapshot = mock.Mock()
+        window._writeback_manifest_path = ""
+        window._keyword_merge_candidates_path = ""
+        window._doctor_check_completed = False
+        window._doctor_summary_status = ""
+        window._last_doctor_report = None
+        window._last_doctor_report_game_root = ""
+
+        invalidate_calls: list[Path | None] = []
+
+        def capture_invalidate(manifest_path=None):
+            invalidate_calls.append(manifest_path)
+
+        window._invalidate_manifest_caches = capture_invalidate
+
+        with mock.patch("gui_qt.app.work_mode_spec") as work_mode_spec_mock:
+            spec = mock.Mock()
+            spec.is_bootstrap = False
+            spec.supports_translation_writeback = True
+            spec.mode = mock.Mock()
+            work_mode_spec_mock.return_value = spec
+            self.assertTrue(window._switch_game_root("C:/Games/Example/work"))
+
+        self.assertEqual(invalidate_calls, [None])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses the top three issues from the GUI logic audit: doctor unlock was too permissive, `bootstrap-work` skipped full project-switch resets, and DoctorWorker could not be stopped cleanly.

## Changes

### Doctor gating
- Add `_doctor_allows_translate_action()` so batch/sync translation unlocks only when doctor `status` is `ready` or `warning`
- Keep **生成翻译模板** available when doctor mode is `can_generate_template` (including blocked retry cases)
- Improve start-translation message when doctor ran but still blocks translation

### Project switch / bootstrap
- Route successful `bootstrap-work` through `_switch_game_root()` to reset doctor state, keyword-merge cache, writeback summaries, etc.
- Kill running CLI subprocesses before switching project roots

### DoctorWorker lifecycle
- `_invalidate_doctor_worker()` clears `task_running` when cancelling doctor
- Stop button cancels in-flight environment checks instead of only killing CLI runner
- Add `CliRunner.is_running()` helper

## Test plan

- [x] `tests/test_gui_translate_button_label.py` (blocked + warning cases)
- [x] `tests/test_gui_doctor_gating.py` (cancel + task_running reset)
- [x] `tests/test_gui_doctor_worker.py`

## Follow-ups (not in this PR)

- Unsaved settings prompt before workflow start
- Resume vs fresh doctor policy
- Diagnostics keyword-merge button enable parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation and workflow actions now wait for environment checks to finish and for the app to confirm it’s safe to proceed.
  * Unsaved settings prompts now appear before starting key workflows, helping prevent accidental loss of changes.

* **Bug Fixes**
  * Improved enable/disable behavior for the translate and keyword-merge buttons so they only activate when ready.
  * Cache refreshes now happen more consistently after major workflow steps and game-root changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->