### PR TITLE
feat(gui): sync/keywords/revision/context pages + round-trip (#162)

### DIFF
--- a/docs/gui_ia_redesign.md
+++ b/docs/gui_ia_redesign.md
@@ -2,7 +2,7 @@
 
 文档地图：[docs/README.md](README.md) · 现状说明：[GUI 工作台](gui_workbench.md)
 
-> **状态**：计划已修订；**P0a–P1a (#158–#160) 已合并**；**P1b (#161) 实现中**。  
+> **状态**：计划已修订；**P0a–P1b (#158–#161) 已合并**；**P1c (#162) 实现中**。  
 > **Epic**：[#157](https://github.com/hu-border-collie/renpy-translation-lab/issues/157)  
 > **性质**：仅 GUI 布局 / 信息架构；**不改变** CLI 语义、`check → apply` 安全合约、manifest 字段。  
 > **依据**：2026-07 对 `gui_qt/` 全功能盘点（工作台、设置、诊断、8 种 WorkMode）+ 计划审阅修订。

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -5436,9 +5436,12 @@ class MainWindow(QMainWindow):
         return True
 
     def _start_bootstrap_task(self, kind: str) -> bool:
-        if bool(getattr(self, "_task_running", False)) or (
-            hasattr(self, "runner") and self.runner.is_running()
-        ):
+        if bool(getattr(self, "_task_running", False)):
+            return False
+        # FakeRunner stubs in unit tests may omit is_running(); treat as idle then.
+        runner = getattr(self, "runner", None)
+        is_running = getattr(runner, "is_running", None) if runner is not None else None
+        if callable(is_running) and bool(is_running()):
             return False
         if not self._confirm_unsaved_config_before_workflow():
             return False

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1131,7 +1131,7 @@ class MainWindow(QMainWindow):
             self._set_work_mode(target, refresh_manifest_writeback=False)
         self._start_bootstrap_task(kind)
 
-    def _refresh_context_library_panel(self) -> None:
+    def _refresh_context_library_panel(self, *, running: bool | None = None) -> None:
         if not hasattr(self, "context_library_panel"):
             return
         flags = self._saved_batch_context_flags()
@@ -1149,9 +1149,10 @@ class MainWindow(QMainWindow):
                 f"原文索引：{'已启用' if idx_on else '未启用'} · 项目 {root_hint}"
                 + ("" if idx_on else " · 请先在设置 · 上下文开启并保存")
             )
-        running = bool(getattr(self, "_task_running", False)) or (
-            hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
-        )
+        if running is None:
+            running = bool(getattr(self, "_task_running", False)) or (
+                hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
+            )
         if hasattr(self, "context_bootstrap_rag_btn"):
             self.context_bootstrap_rag_btn.setEnabled(not running and rag_on)
         if hasattr(self, "context_bootstrap_source_index_btn"):
@@ -4195,10 +4196,9 @@ class MainWindow(QMainWindow):
                 restored_workflow_ui = _try_restore_workflow_snapshot()
                 if not restored_workflow_ui:
                     self._refresh_workflow_from_latest_manifest()
+            # Soft switch (no disk refresh): restore frozen writeback UI when present.
             if pending_writeback is not None:
                 _try_restore_writeback_snapshot()
-            elif session_manifest and refresh_manifest_writeback:
-                self._refresh_writeback_from_latest_manifest(latest_manifest=session_manifest)
 
         # Restore stage tab when returning to a page (batch: 准备/执行/结果).
         pending_stage = getattr(self, "_pending_restore_stage_index", None)
@@ -5436,6 +5436,10 @@ class MainWindow(QMainWindow):
         return True
 
     def _start_bootstrap_task(self, kind: str) -> bool:
+        if bool(getattr(self, "_task_running", False)) or (
+            hasattr(self, "runner") and self.runner.is_running()
+        ):
+            return False
         if not self._confirm_unsaved_config_before_workflow():
             return False
         if not self.state.get_game_root():
@@ -6663,6 +6667,9 @@ class MainWindow(QMainWindow):
         self._update_keyword_merge_btn_enabled(running=running)
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
+        # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
+        if hasattr(self, "context_library_panel"):
+            self._refresh_context_library_panel(running=running)
         self._sync_task_shortcuts()
         self._reflow_button_bars()
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -249,6 +249,7 @@ from .work_modes import (
     task_category_spec,
     work_mode_hint_texts,
     work_mode_spec,
+    work_mode_submode_label,
     work_modes_for_category,
     workbench_nav_for_work_mode,
     workbench_nav_spec,
@@ -725,10 +726,23 @@ class MainWindow(QMainWindow):
         )
         self.work_mode_hint_label.installEventFilter(self)
         mode_outer.addWidget(self.work_mode_hint_label)
+
+        # Sync-only risk banner (P1c / #162 · §3.2.2).
+        self.sync_mode_warning = QLabel(
+            "警告：同步翻译可能直接修改项目文件，请先备份或在副本上试跑。"
+        )
+        self.sync_mode_warning.setObjectName("sync_mode_warning")
+        self.sync_mode_warning.setWordWrap(True)
+        self.sync_mode_warning.setVisible(False)
+        mode_outer.addWidget(self.sync_mode_warning)
         layout.addWidget(mode_frame)
+
+        # Context library dual status cards (P1c / #162 · §3.2.5).
+        layout.addWidget(self._build_context_library_panel())
 
         action_frame = QFrame()
         action_frame.setObjectName("action_frame")
+        self._action_frame = action_frame
         action_outer = QVBoxLayout(action_frame)
         action_outer.setContentsMargins(12, 10, 12, 10)
         action_outer.setSpacing(8)
@@ -1051,6 +1065,129 @@ class MainWindow(QMainWindow):
 
         self.tab_widget.addTab(tab, "工作台")
         self._sync_batch_stage_chrome()
+
+    def _build_context_library_panel(self) -> QFrame:
+        """RAG / source-index status cards for the 上下文库 nav page (P1c / #162)."""
+        frame = QFrame()
+        frame.setObjectName("context_library_panel")
+        self.context_library_panel = frame
+        outer = QVBoxLayout(frame)
+        outer.setContentsMargins(12, 10, 12, 10)
+        outer.setSpacing(10)
+
+        title = QLabel("上下文库状态")
+        title.setObjectName("diagnostics_section_label")
+        outer.addWidget(title)
+
+        rag_row = QHBoxLayout()
+        rag_row.setSpacing(8)
+        self.context_rag_status_label = QLabel("记忆库：—")
+        self.context_rag_status_label.setObjectName("summary_body_label")
+        self.context_rag_status_label.setWordWrap(True)
+        rag_row.addWidget(self.context_rag_status_label, 1)
+        self.context_bootstrap_rag_btn = QPushButton("预建记忆库")
+        self.context_bootstrap_rag_btn.setObjectName("secondary_btn")
+        self.context_bootstrap_rag_btn.clicked.connect(
+            lambda: self._on_context_bootstrap_clicked("rag")
+        )
+        rag_row.addWidget(self.context_bootstrap_rag_btn, 0)
+        outer.addLayout(rag_row)
+
+        idx_row = QHBoxLayout()
+        idx_row.setSpacing(8)
+        self.context_source_index_status_label = QLabel("原文索引：—")
+        self.context_source_index_status_label.setObjectName("summary_body_label")
+        self.context_source_index_status_label.setWordWrap(True)
+        idx_row.addWidget(self.context_source_index_status_label, 1)
+        self.context_bootstrap_source_index_btn = QPushButton("预建原文索引")
+        self.context_bootstrap_source_index_btn.setObjectName("secondary_btn")
+        self.context_bootstrap_source_index_btn.clicked.connect(
+            lambda: self._on_context_bootstrap_clicked("source_index")
+        )
+        idx_row.addWidget(self.context_bootstrap_source_index_btn, 0)
+        outer.addLayout(idx_row)
+
+        self.context_open_settings_btn = QPushButton("打开设置 · 上下文")
+        self.context_open_settings_btn.setObjectName("secondary_btn")
+        self.context_open_settings_btn.setToolTip(
+            "开关须在设置中保存后才能预建；打开设置的「上下文」分区。"
+        )
+        self.context_open_settings_btn.clicked.connect(self._on_open_context_settings)
+        outer.addWidget(self.context_open_settings_btn, 0, Qt.AlignmentFlag.AlignLeft)
+
+        frame.setVisible(False)
+        return frame
+
+    def _on_open_context_settings(self) -> None:
+        self._focus_settings_section("context")
+
+    def _on_context_bootstrap_clicked(self, kind: str) -> None:
+        target = (
+            WorkMode.BOOTSTRAP_RAG
+            if kind == "rag"
+            else WorkMode.BOOTSTRAP_SOURCE_INDEX
+        )
+        if self._current_work_mode() != target:
+            self._set_work_mode(target, refresh_manifest_writeback=False)
+        self._start_bootstrap_task(kind)
+
+    def _refresh_context_library_panel(self) -> None:
+        if not hasattr(self, "context_library_panel"):
+            return
+        flags = self._saved_batch_context_flags()
+        rag_on = bool(flags.get("rag_enabled"))
+        idx_on = bool(flags.get("source_index_enabled"))
+        game_root = self.state.get_game_root() if hasattr(self, "state") else None
+        root_hint = str(game_root) if game_root else "未选择项目"
+        if hasattr(self, "context_rag_status_label"):
+            self.context_rag_status_label.setText(
+                f"记忆库：{'已启用' if rag_on else '未启用'} · 项目 {root_hint}"
+                + ("" if rag_on else " · 请先在设置 · 上下文开启并保存")
+            )
+        if hasattr(self, "context_source_index_status_label"):
+            self.context_source_index_status_label.setText(
+                f"原文索引：{'已启用' if idx_on else '未启用'} · 项目 {root_hint}"
+                + ("" if idx_on else " · 请先在设置 · 上下文开启并保存")
+            )
+        running = bool(getattr(self, "_task_running", False)) or (
+            hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
+        )
+        if hasattr(self, "context_bootstrap_rag_btn"):
+            self.context_bootstrap_rag_btn.setEnabled(not running and rag_on)
+        if hasattr(self, "context_bootstrap_source_index_btn"):
+            self.context_bootstrap_source_index_btn.setEnabled(not running and idx_on)
+
+    def _apply_task_page_chrome(self, spec) -> None:
+        """Show/hide per-nav chrome: sync warn, context cards, prep buttons (P1c)."""
+        mode = spec.mode
+        nav = workbench_nav_for_work_mode(mode)
+        is_sync = mode == WorkMode.SYNC_TRANSLATION
+        is_context = nav == WorkbenchNavItem.CONTEXT
+        is_translation = mode in {
+            WorkMode.BATCH_TRANSLATION,
+            WorkMode.SYNC_TRANSLATION,
+        }
+
+        if hasattr(self, "sync_mode_warning"):
+            self.sync_mode_warning.setVisible(is_sync)
+        if hasattr(self, "context_library_panel"):
+            self.context_library_panel.setVisible(is_context)
+            if is_context:
+                self._refresh_context_library_panel()
+
+        if hasattr(self, "doctor_btn"):
+            self.doctor_btn.setVisible(is_translation)
+        if hasattr(self, "bootstrap_work_btn"):
+            self.bootstrap_work_btn.setVisible(is_translation)
+
+        if hasattr(self, "translate_btn"):
+            self.translate_btn.setVisible(not is_context)
+        if hasattr(self, "resume_btn") and is_context:
+            self.resume_btn.setVisible(False)
+        if hasattr(self, "action_panel"):
+            reflow = getattr(self.action_panel, "reflow", None)
+            if callable(reflow):
+                reflow(force=True)
 
     def _build_batch_stage_bar(self) -> QFrame:
         """Step strip for batch translation: 准备 → 执行 → 结果 (P1b / #161)."""
@@ -3655,6 +3792,22 @@ class MainWindow(QMainWindow):
         stage_index = _BATCH_STAGE_EXECUTE
         if hasattr(self, "workbench_status_tabs"):
             stage_index = self._current_batch_stage_index()
+        wf_status = ""
+        wf_heading = ""
+        if hasattr(self, "workflow_status_label"):
+            raw = self.workflow_status_label.property("status")
+            wf_status = str(raw) if raw is not None else ""
+            # StatusBadge text includes an icon prefix; keep raw heading if tracked.
+            wf_heading = str(getattr(self, "_workflow_heading_text", "") or "")
+            if not wf_heading:
+                wf_heading = self.workflow_status_label.text()
+        wf_message = ""
+        if hasattr(self, "workflow_message_label"):
+            wf_message = self.workflow_message_label.text()
+        wf_facts: list[str] = []
+        if hasattr(self, "workflow_facts_label"):
+            facts_text = self.workflow_facts_label.text()
+            wf_facts = [line for line in facts_text.splitlines() if line.strip()]
         return WorkbenchModeSession(
             workflow=getattr(self, "_workflow", None),
             workflow_step_output_lines=list(
@@ -3673,6 +3826,11 @@ class MainWindow(QMainWindow):
                 getattr(self, "_keyword_merge_candidates_path", "") or ""
             ),
             stage_index=stage_index,
+            workflow_status=wf_status,
+            workflow_heading=wf_heading,
+            workflow_message=wf_message,
+            workflow_facts=wf_facts,
+            writeback_summary=getattr(self, "_writeback_summary", None),
         )
 
     def _restore_mode_session(self, session: WorkbenchModeSession) -> None:
@@ -3684,6 +3842,30 @@ class MainWindow(QMainWindow):
         self._keyword_merge_candidates_path = session.keyword_merge_candidates_path
         # Keep 0 (准备) as a real stage — do not use `or` falsy fallback.
         self._pending_restore_stage_index = int(session.stage_index)
+        self._pending_restore_workflow_ui = {
+            "status": session.workflow_status,
+            "heading": session.workflow_heading,
+            "message": session.workflow_message,
+            "facts": list(session.workflow_facts),
+        }
+        self._pending_restore_writeback_summary = session.writeback_summary
+
+    def _apply_session_workflow_ui(self, payload: dict[str, object] | None) -> bool:
+        """Re-paint progress labels from a frozen session; return True if applied."""
+        if not payload:
+            return False
+        status = str(payload.get("status") or "").strip()
+        heading = str(payload.get("heading") or "").strip()
+        message = str(payload.get("message") or "")
+        facts_raw = payload.get("facts") or []
+        facts = [str(x) for x in facts_raw] if isinstance(facts_raw, list) else []
+        if not status and not heading and not message:
+            return False
+        # Skip pure idle placeholders so mode switch can still show mode-specific idle.
+        if status in {"", "idle", "stale"} and not facts and not message.strip():
+            return False
+        self._set_workflow_summary(status or "idle", heading or "任务状态", message, facts)
+        return True
 
     def _clear_all_mode_sessions(self) -> None:
         """Clear per-mode sessions; safe on partially constructed MainWindow test stubs."""
@@ -3744,7 +3926,10 @@ class MainWindow(QMainWindow):
             blocked = self.work_submode_combo.blockSignals(True)
             self.work_submode_combo.clear()
             for sub_mode in nav_spec.work_modes:
-                self.work_submode_combo.addItem(work_mode_spec(sub_mode).label, sub_mode.value)
+                self.work_submode_combo.addItem(
+                    work_mode_submode_label(sub_mode),
+                    sub_mode.value,
+                )
             self._set_combo_value_by_data(self.work_submode_combo, mode.value)
             self.work_submode_combo.blockSignals(blocked)
 
@@ -3836,6 +4021,8 @@ class MainWindow(QMainWindow):
 
         self._work_mode = mode
         self._workbench_nav_item = workbench_nav_for_work_mode(mode)
+        self._pending_restore_workflow_ui = None
+        self._pending_restore_writeback_summary = None
 
         if reset_session or mode not in self._mode_sessions:
             self._mode_sessions[mode] = WorkbenchModeSession()
@@ -3941,8 +4128,26 @@ class MainWindow(QMainWindow):
         else:
             hint = spec.not_implemented_message
         self.work_mode_hint_label.setText(hint)
+        self._apply_task_page_chrome(spec)
+
         # Prefer session-bound writeback path when restoring a page.
         session_manifest = str(self._writeback_manifest_path or "").strip() or None
+        pending_workflow_ui = getattr(self, "_pending_restore_workflow_ui", None)
+        pending_writeback = getattr(self, "_pending_restore_writeback_summary", None)
+        self._pending_restore_workflow_ui = None
+        self._pending_restore_writeback_summary = None
+        restored_workflow_ui = False
+        restored_writeback_ui = False
+
+        def _try_restore_workflow_snapshot() -> bool:
+            return self._apply_session_workflow_ui(pending_workflow_ui)
+
+        def _try_restore_writeback_snapshot() -> bool:
+            if pending_writeback is None:
+                return False
+            self._set_writeback_summary(pending_writeback)
+            return True
+
         if refresh_manifest_writeback or refresh_diagnostics:
             if session_manifest:
                 try:
@@ -3952,15 +4157,25 @@ class MainWindow(QMainWindow):
                     )
                 except ValueError:
                     session_data = None
-                self._refresh_workflow_from_latest_manifest(
-                    latest_manifest=session_manifest,
-                    manifest=session_data,
-                )
-                if refresh_manifest_writeback:
-                    self._refresh_writeback_from_latest_manifest(
+                if session_data is not None:
+                    self._refresh_workflow_from_latest_manifest(
                         latest_manifest=session_manifest,
                         manifest=session_data,
                     )
+                    if refresh_manifest_writeback:
+                        self._refresh_writeback_from_latest_manifest(
+                            latest_manifest=session_manifest,
+                            manifest=session_data,
+                        )
+                else:
+                    # Path remembered but unloadable — keep UI snapshot if any.
+                    restored_workflow_ui = _try_restore_workflow_snapshot()
+                    if not restored_workflow_ui:
+                        self._refresh_workflow_from_latest_manifest()
+                    if refresh_manifest_writeback:
+                        restored_writeback_ui = _try_restore_writeback_snapshot()
+                        if not restored_writeback_ui:
+                            self._refresh_writeback_from_latest_manifest()
                 if refresh_diagnostics:
                     self._refresh_diagnostics_context(force=True)
             else:
@@ -3968,11 +4183,23 @@ class MainWindow(QMainWindow):
                     refresh_writeback=refresh_manifest_writeback,
                     refresh_diagnostics=refresh_diagnostics,
                 )
+                # Non-resume modes have no disk manifest; re-apply progress snapshot.
+                if not restored_workflow_ui:
+                    restored_workflow_ui = _try_restore_workflow_snapshot()
+                if refresh_manifest_writeback and not restored_writeback_ui:
+                    restored_writeback_ui = _try_restore_writeback_snapshot()
         else:
-            if session_manifest:
+            if session_manifest and spec.supports_resume:
                 self._refresh_workflow_from_latest_manifest(latest_manifest=session_manifest)
             else:
-                self._refresh_workflow_from_latest_manifest()
+                restored_workflow_ui = _try_restore_workflow_snapshot()
+                if not restored_workflow_ui:
+                    self._refresh_workflow_from_latest_manifest()
+            if pending_writeback is not None:
+                _try_restore_writeback_snapshot()
+            elif session_manifest and refresh_manifest_writeback:
+                self._refresh_writeback_from_latest_manifest(latest_manifest=session_manifest)
+
         # Restore stage tab when returning to a page (batch: 准备/执行/结果).
         pending_stage = getattr(self, "_pending_restore_stage_index", None)
         self._pending_restore_stage_index = None
@@ -4000,6 +4227,8 @@ class MainWindow(QMainWindow):
         self.resume_btn.setEnabled(spec.implemented and spec.supports_resume and not running)
         self._update_split_submit_btn(running=running)
         self._sync_task_shortcuts()
+        # Re-apply page chrome after enable flags so context cards stay correct.
+        self._apply_task_page_chrome(spec)
 
     def _update_timeline_steps(self, mode: WorkMode) -> None:
         from .work_modes import WorkMode
@@ -6455,6 +6684,7 @@ class MainWindow(QMainWindow):
         message: str,
         facts: list[str] | None = None,
     ):
+        self._workflow_heading_text = heading
         self.workflow_status_label.set_status(status, heading)
         self.workflow_message_label.setText(message)
         self.workflow_facts_label.setText("\n".join(facts or []))

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -189,6 +189,21 @@ QFrame#batch_stage_bar {
     border-radius: 10px;
 }
 
+QLabel#sync_mode_warning {
+    color: ${badge_warning_fg};
+    background-color: ${badge_warning_bg};
+    border: 1px solid ${badge_warning_border};
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-weight: 600;
+}
+
+QFrame#context_library_panel {
+    background-color: ${bg_surface_alt};
+    border: 1px solid ${border_light};
+    border-radius: 10px;
+}
+
 QPushButton#batch_stage_btn {
     background-color: transparent;
     border: 1px solid ${border_default};

--- a/gui_qt/work_modes.py
+++ b/gui_qt/work_modes.py
@@ -111,7 +111,7 @@ WORK_MODE_SPECS: dict[WorkMode, WorkModeSpec] = {
         mode=WorkMode.SYNC_TRANSLATION,
         category=TaskCategory.TRANSLATION,
         label="同步翻译",
-        start_button_label="开始翻译",
+        start_button_label="开始同步翻译",
         resume_button_label="继续翻译",
         task_group_label="同步任务",
         progress_tab_label="翻译进度",
@@ -380,9 +380,26 @@ WORKBENCH_NAV_SPECS: dict[WorkbenchNavItem, WorkbenchNavSpec] = {
         item=WorkbenchNavItem.CONTEXT,
         label="上下文库",
         work_modes=(WorkMode.BOOTSTRAP_RAG, WorkMode.BOOTSTRAP_SOURCE_INDEX),
-        show_submode=True,
+        # Dual status cards replace the submode combo (P1c / #162).
+        show_submode=False,
     ),
 }
+
+# Short labels for 批量|同步 / 记忆库|原文索引 selectors (P1c).
+_WORK_MODE_SUBMODE_LABELS: dict[WorkMode, str] = {
+    WorkMode.KEYWORD_EXTRACTION: "批量",
+    WorkMode.SYNC_KEYWORD_EXTRACTION: "同步",
+    WorkMode.REVISION: "批量",
+    WorkMode.SYNC_REVISION: "同步",
+    WorkMode.BOOTSTRAP_RAG: "记忆库",
+    WorkMode.BOOTSTRAP_SOURCE_INDEX: "原文索引",
+}
+
+
+def work_mode_submode_label(mode: WorkMode | str) -> str:
+    mode = normalize_work_mode(mode)
+    return _WORK_MODE_SUBMODE_LABELS.get(mode, work_mode_spec(mode).label)
+
 
 
 WORKBENCH_NAV_ORDER: tuple[WorkbenchNavItem, ...] = (

--- a/gui_qt/workbench_session.py
+++ b/gui_qt/workbench_session.py
@@ -36,10 +36,15 @@ class WorkbenchModeSession:
             and self.completed_manifest_snapshot is None
             and not self.viewing_completed_manifest
             and not self.keyword_merge_candidates_path
-            and not self.workflow_status
-            and not self.workflow_heading
+            and not self.has_workflow_ui()
+            and not self.workflow_facts
             and self.writeback_summary is None
         )
 
     def has_workflow_ui(self) -> bool:
-        return bool(self.workflow_status or self.workflow_heading or self.workflow_message)
+        return bool(
+            self.workflow_status
+            or self.workflow_heading
+            or self.workflow_message
+            or self.workflow_facts
+        )

--- a/gui_qt/workbench_session.py
+++ b/gui_qt/workbench_session.py
@@ -1,4 +1,4 @@
-"""Per-work-mode session state for the workbench (GUI IA P1a / #160).
+"""Per-work-mode session state for the workbench (GUI IA P1a / #160, P1c / #162).
 
 Switching the left nav must freeze the previous mode's runtime state and restore
 it when the user returns — not globally clear workflow / writeback / snapshots.
@@ -21,6 +21,12 @@ class WorkbenchModeSession:
     keyword_merge_candidates_path: str = ""
     # Workbench status-tab index (batch: 0=准备, 1=执行, 2=结果). Default 执行.
     stage_index: int = 1
+    # UI snapshots so non-resume / offline modes do not fall back to blank idle.
+    workflow_status: str = ""
+    workflow_heading: str = ""
+    workflow_message: str = ""
+    workflow_facts: list[str] = field(default_factory=list)
+    writeback_summary: Any | None = None  # WritebackSummary | None
 
     def is_empty(self) -> bool:
         return (
@@ -30,4 +36,10 @@ class WorkbenchModeSession:
             and self.completed_manifest_snapshot is None
             and not self.viewing_completed_manifest
             and not self.keyword_merge_candidates_path
+            and not self.workflow_status
+            and not self.workflow_heading
+            and self.writeback_summary is None
         )
+
+    def has_workflow_ui(self) -> bool:
+        return bool(self.workflow_status or self.workflow_heading or self.workflow_message)

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -48,6 +48,9 @@ class TaskPageMetaTests(unittest.TestCase):
         )
         self.assertFalse(session.is_empty())
         self.assertTrue(session.has_workflow_ui())
+        facts_only = WorkbenchModeSession(workflow_facts=["project: demo"])
+        self.assertFalse(facts_only.is_empty())
+        self.assertTrue(facts_only.has_workflow_ui())
 
 
 @gui_test_support.skip_unless_gui(MainWindow is None, IMPORT_ERROR)
@@ -168,6 +171,26 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertTrue(self.window.doctor_btn.isHidden())
         self.assertIn("记忆库", self.window.context_rag_status_label.text())
         self.assertIn("原文索引", self.window.context_source_index_status_label.text())
+
+    def test_context_bootstrap_buttons_disabled_while_running(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BOOTSTRAP_RAG,
+            refresh_manifest_writeback=False,
+        )
+        with mock.patch.object(
+            self.window,
+            "_saved_batch_context_flags",
+            return_value={"rag_enabled": True, "source_index_enabled": True},
+        ):
+            self.window._refresh_context_library_panel()
+            self.assertTrue(self.window.context_bootstrap_rag_btn.isEnabled())
+            self.window._set_task_running(True)
+            self.assertFalse(self.window.context_bootstrap_rag_btn.isEnabled())
+            self.assertFalse(self.window.context_bootstrap_source_index_btn.isEnabled())
+            # Overlapping start must no-op while a task is already running.
+            self.assertFalse(self.window._start_bootstrap_task("source_index"))
+            self.window._set_task_running(False)
+            self.assertTrue(self.window.context_bootstrap_rag_btn.isEnabled())
 
     def test_roundtrip_keyword_candidates_and_merge_button(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -1,0 +1,291 @@
+"""Tests for non-batch workbench pages + round-trip sessions (GUI IA P1c / #162)."""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication
+
+    from gui_qt.app import MainWindow
+    from gui_qt.check_report import WritebackSummary
+except ImportError as exc:
+    MainWindow = None  # type: ignore[assignment,misc]
+    QApplication = None  # type: ignore[assignment,misc]
+    Qt = None  # type: ignore[assignment,misc]
+    WritebackSummary = None  # type: ignore[misc,assignment]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+from gui_qt.work_modes import (
+    WorkMode,
+    WorkbenchNavItem,
+    work_mode_submode_label,
+    workbench_nav_spec,
+)
+from gui_qt.workbench_session import WorkbenchModeSession
+from tests import gui_test_support
+
+
+class TaskPageMetaTests(unittest.TestCase):
+    def test_submode_labels_are_short(self) -> None:
+        self.assertEqual(work_mode_submode_label(WorkMode.KEYWORD_EXTRACTION), "批量")
+        self.assertEqual(work_mode_submode_label(WorkMode.SYNC_KEYWORD_EXTRACTION), "同步")
+        self.assertEqual(work_mode_submode_label(WorkMode.REVISION), "批量")
+        self.assertEqual(work_mode_submode_label(WorkMode.BOOTSTRAP_RAG), "记忆库")
+
+    def test_context_nav_hides_submode_combo(self) -> None:
+        self.assertFalse(workbench_nav_spec(WorkbenchNavItem.CONTEXT).show_submode)
+        self.assertTrue(workbench_nav_spec(WorkbenchNavItem.KEYWORDS).show_submode)
+
+    def test_session_tracks_ui_snapshots(self) -> None:
+        session = WorkbenchModeSession(
+            workflow_status="ready",
+            workflow_heading="完成",
+            workflow_message="done",
+        )
+        self.assertFalse(session.is_empty())
+        self.assertTrue(session.has_workflow_ui())
+
+
+@gui_test_support.skip_unless_gui(MainWindow is None, IMPORT_ERROR)
+class GuiTaskPageTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = QApplication.instance()
+        if app is None:
+            cls._app = QApplication([])
+        else:
+            cls._app = app
+
+    def setUp(self) -> None:
+        self.window = MainWindow()
+
+    def tearDown(self) -> None:
+        self.window.close()
+        self.window.deleteLater()
+
+    def test_sync_page_shows_warning_and_start_label(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        self.assertFalse(self.window.sync_mode_warning.isHidden())
+        self.assertIn("备份", self.window.sync_mode_warning.text())
+        self.assertEqual(self.window.translate_btn.text(), "开始同步翻译")
+        self.assertTrue(self.window.context_library_panel.isHidden())
+
+    def test_batch_hides_sync_warning(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        self.assertTrue(self.window.sync_mode_warning.isHidden())
+
+    def test_keywords_page_shows_merge_not_revision(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        # Force writeback buttons for keyword-only path.
+        summary = WritebackSummary(
+            status="ready",
+            heading="关键词完成",
+            message="可合并",
+            facts=[],
+            findings=[],
+            can_apply=False,
+            manifest_path="C:/kw/manifest.json",
+        )
+        with mock.patch.object(
+            self.window,
+            "_resolve_keyword_merge_candidates_path",
+            return_value="C:/kw/candidates.json",
+        ), mock.patch(
+            "gui_qt.app.keyword_merge_ready",
+            return_value=(True, "ok"),
+        ), mock.patch.object(
+            self.window,
+            "_resolve_keyword_merge_glossary_path",
+            return_value="C:/kw/glossary.json",
+        ):
+            self.window._set_writeback_summary(summary)
+
+        self.assertFalse(self.window.keyword_merge_writeback_btn.isHidden())
+        self.assertTrue(self.window.keyword_merge_writeback_btn.isEnabled())
+        self.assertTrue(self.window.apply_revision_btn.isHidden())
+        self.assertTrue(self.window.apply_btn.isHidden())
+        self.assertFalse(self.window.work_submode_combo.isHidden())
+
+    def test_revision_page_shows_apply_revision_not_translation_apply(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.REVISION,
+            refresh_manifest_writeback=False,
+        )
+        summary = WritebackSummary(
+            status="ready",
+            heading="订正可写回",
+            message="预览通过",
+            facts=[],
+            findings=[],
+            can_apply=True,
+            manifest_path="C:/rev/manifest.json",
+        )
+        self.window._set_writeback_summary(summary)
+        self.assertFalse(self.window.apply_revision_btn.isHidden())
+        self.assertTrue(self.window.apply_revision_btn.isEnabled())
+        self.assertTrue(self.window.apply_btn.isHidden())
+        self.assertTrue(self.window.keyword_merge_writeback_btn.isHidden())
+
+    def test_batch_page_hides_revision_apply(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        summary = WritebackSummary(
+            status="ready",
+            heading="可写回",
+            message="ok",
+            facts=[],
+            findings=[],
+            can_apply=True,
+            manifest_path="C:/batch/manifest.json",
+        )
+        self.window._set_writeback_summary(summary)
+        self.assertTrue(self.window.apply_revision_btn.isHidden())
+        self.assertFalse(self.window.apply_btn.isHidden())
+
+    def test_context_page_shows_status_cards(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BOOTSTRAP_RAG,
+            refresh_manifest_writeback=False,
+        )
+        self.assertFalse(self.window.context_library_panel.isHidden())
+        self.assertTrue(self.window.work_submode_combo.isHidden())
+        self.assertTrue(self.window.translate_btn.isHidden())
+        self.assertTrue(self.window.doctor_btn.isHidden())
+        self.assertIn("记忆库", self.window.context_rag_status_label.text())
+        self.assertIn("原文索引", self.window.context_source_index_status_label.text())
+
+    def test_roundtrip_keyword_candidates_and_merge_button(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        self.window._keyword_merge_candidates_path = "C:/kw/candidates.json"
+        self.window._writeback_manifest_path = "C:/kw/manifest.json"
+        summary = WritebackSummary(
+            status="ready",
+            heading="关键词完成",
+            message="可合并",
+            facts=["candidates: C:/kw/candidates.json"],
+            findings=[],
+            can_apply=False,
+            manifest_path="C:/kw/manifest.json",
+        )
+        with mock.patch.object(
+            self.window,
+            "_resolve_keyword_merge_candidates_path",
+            return_value="C:/kw/candidates.json",
+        ), mock.patch(
+            "gui_qt.app.keyword_merge_ready",
+            return_value=(True, "ok"),
+        ), mock.patch.object(
+            self.window,
+            "_resolve_keyword_merge_glossary_path",
+            return_value="C:/kw/glossary.json",
+        ):
+            self.window._set_writeback_summary(summary)
+
+            self.window._set_work_mode(
+                WorkMode.BATCH_TRANSLATION,
+                refresh_manifest_writeback=False,
+            )
+            self.assertEqual(self.window._keyword_merge_candidates_path, "")
+
+            self.window._set_work_mode(
+                WorkMode.KEYWORD_EXTRACTION,
+                refresh_manifest_writeback=True,
+            )
+            self.assertEqual(
+                self.window._keyword_merge_candidates_path,
+                "C:/kw/candidates.json",
+            )
+            self.assertEqual(
+                self.window._writeback_manifest_path,
+                "C:/kw/manifest.json",
+            )
+            # Snapshot should restore merge readiness without needing the file on disk.
+            self.assertFalse(self.window.keyword_merge_writeback_btn.isHidden())
+            self.assertTrue(self.window.keyword_merge_writeback_btn.isEnabled())
+
+    def test_roundtrip_revision_writeback_state(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.REVISION,
+            refresh_manifest_writeback=False,
+        )
+        summary = WritebackSummary(
+            status="ready",
+            heading="订正可写回",
+            message="预览通过",
+            facts=[],
+            findings=[],
+            can_apply=True,
+            manifest_path="C:/rev/manifest.json",
+        )
+        self.window._set_writeback_summary(summary)
+
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        self.window._set_work_mode(
+            WorkMode.REVISION,
+            refresh_manifest_writeback=True,
+        )
+        self.assertEqual(self.window._writeback_manifest_path, "C:/rev/manifest.json")
+        self.assertFalse(self.window.apply_revision_btn.isHidden())
+        self.assertTrue(self.window.apply_revision_btn.isEnabled())
+
+    def test_roundtrip_preserves_workflow_progress_ui(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        self.window._set_workflow_summary(
+            "ready",
+            "同步完成",
+            "已写入 3 条译文",
+            ["project: demo"],
+        )
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=True,
+        )
+        self.assertEqual(
+            self.window.workflow_status_label.property("status"),
+            "ready",
+        )
+        self.assertIn("已写入 3 条译文", self.window.workflow_message_label.text())
+        self.assertIn("demo", self.window.workflow_facts_label.text())
+
+    def test_keywords_submode_uses_short_labels(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        labels = [
+            self.window.work_submode_combo.itemText(i)
+            for i in range(self.window.work_submode_combo.count())
+        ]
+        self.assertEqual(labels, ["批量", "同步"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements GUI IA **P1c / #162** on top of P1a/P1b:

- **同步翻译**: risk warning banner; start label 「开始同步翻译」
- **关键词/术语**: short 批量|同步 submode labels; merge-to-glossary as result CTA (not revision/apply)
- **订正**: 写回订正 primary; no translation apply / keyword merge
- **上下文库**: dual status cards (记忆库 / 原文索引) + settings link; submode combo removed
- **Session**: capture/restore workflow + writeback UI snapshots so non-resume modes do not wipe progress on nav round-trip

## Test plan
- [x] \python -m unittest tests.test_gui_task_pages tests.test_gui_workbench_nav tests.test_gui_batch_stages tests.test_gui_project_bar -v\
- [ ] Manual: switch 批量 → 关键词 → 订正 → 上下文库 → back; confirm state restores
- [ ] Manual: sync page shows backup warning; context cards enable with saved context flags

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visible sync-mode warning banner and a new “context library” status panel.
  - Updated workbench navigation labels and refined which submode controls appear per work area.
- **Bug Fixes**
  - Improved mode/session restoration for workflow progress UI (status, heading, message, facts) and writeback summaries.
  - Kept context-related status cards consistent when switching pages and resuming sessions.
- **Documentation**
  - Updated the GUI IA redesign progress/status notes.
- **Tests**
  - Added GUI-gated tests covering task page UI visibility and round-trip session persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->