### PR TITLE
fix(gui): doctor empty state no longer overlaps summary

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -837,8 +837,20 @@ class MainWindow(QMainWindow):
         doctor_layout = QVBoxLayout(doctor_tab)
         doctor_layout.setContentsMargins(12, 12, 12, 12)
         doctor_layout.setSpacing(6)
+        # Stack empty CTA vs summary so they never share the same column height
+        # (VBox + dual stretch caused multi-line empty description to collapse).
+        self.doctor_page_stack = QStackedWidget()
+        self.doctor_page_stack.setObjectName("doctor_page_stack")
+        doctor_layout.addWidget(self.doctor_page_stack, 1)
+
+        doctor_summary_page = QWidget()
+        doctor_summary_page.setObjectName("doctor_summary_page")
+        self._style_themed_surface(doctor_summary_page)
+        doctor_summary_layout = QVBoxLayout(doctor_summary_page)
+        doctor_summary_layout.setContentsMargins(0, 0, 0, 0)
+        doctor_summary_layout.setSpacing(6)
         self.doctor_status_label = StatusBadge("doctor_status_label")
-        doctor_layout.addWidget(self.doctor_status_label)
+        doctor_summary_layout.addWidget(self.doctor_status_label)
         self.doctor_summary_scroll = QScrollArea()
         self.doctor_summary_scroll.setObjectName("doctor_summary_scroll")
         self._style_themed_surface(self.doctor_summary_scroll)
@@ -869,7 +881,9 @@ class MainWindow(QMainWindow):
         doctor_content_layout.addWidget(self.doctor_details_label)
         doctor_content_layout.addStretch()
         self.doctor_summary_scroll.setWidget(doctor_content)
-        doctor_layout.addWidget(self.doctor_summary_scroll, 1)
+        doctor_summary_layout.addWidget(self.doctor_summary_scroll, 1)
+        self.doctor_page_stack.addWidget(doctor_summary_page)
+
         # P3 / #166: empty CTA before the first environment check.
         self.doctor_empty_state = EmptyStateWidget(
             "🔍",
@@ -879,8 +893,8 @@ class MainWindow(QMainWindow):
         )
         self.doctor_empty_state.setObjectName("doctor_empty_state")
         self.doctor_empty_state.action_clicked.connect(self._on_run_doctor)
-        doctor_layout.addWidget(self.doctor_empty_state, 1)
-        self.doctor_empty_state.setVisible(False)
+        self.doctor_page_stack.addWidget(self.doctor_empty_state)
+        self.doctor_page_stack.setCurrentWidget(self.doctor_empty_state)
         self.workbench_status_tabs.addTab(doctor_tab, "环境检查")
 
         workflow_tab = QWidget()
@@ -4367,15 +4381,24 @@ class MainWindow(QMainWindow):
 
         if hasattr(self, "doctor_empty_state"):
             show_doctor_empty = not doctor_done and not running
-            self.doctor_empty_state.setVisible(show_doctor_empty)
-            # Hide the summary scroll while the empty CTA is front-and-center.
-            for attr in ("doctor_status_label",):
-                widget = getattr(self, attr, None)
-                if widget is not None:
-                    widget.setVisible(not show_doctor_empty)
-            doctor_scroll = getattr(self, "doctor_summary_scroll", None)
-            if doctor_scroll is not None:
-                doctor_scroll.setVisible(not show_doctor_empty)
+            stack = getattr(self, "doctor_page_stack", None)
+            if stack is not None and hasattr(self, "doctor_empty_state"):
+                # Mutual exclusion via stack — no VBox dual-stretch overlap.
+                if show_doctor_empty:
+                    stack.setCurrentWidget(self.doctor_empty_state)
+                else:
+                    # Summary page is index 0 (status + scroll).
+                    stack.setCurrentIndex(0)
+            else:
+                # Fallback if stack is unavailable (older layout).
+                self.doctor_empty_state.setVisible(show_doctor_empty)
+                for attr in ("doctor_status_label",):
+                    widget = getattr(self, attr, None)
+                    if widget is not None:
+                        widget.setVisible(not show_doctor_empty)
+                doctor_scroll = getattr(self, "doctor_summary_scroll", None)
+                if doctor_scroll is not None:
+                    doctor_scroll.setVisible(not show_doctor_empty)
 
         if hasattr(self, "workflow_empty_state"):
             show_wf_empty = (

--- a/gui_qt/empty_state.py
+++ b/gui_qt/empty_state.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QFont
+from PySide6.QtGui import QColor, QFont, QPalette, QResizeEvent
 from PySide6.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -16,6 +16,8 @@ from PySide6.QtWidgets import (
 from .theme import system_prefers_dark
 from .theme_helpers import DEFAULT_THEME_PREFERENCE, THEME_DARK, THEME_LIGHT, resolve_effective_theme
 from .theme_tokens import tokens_for_theme
+
+_DESC_MAX_WIDTH = 360
 
 
 def _effective_theme_name(widget: QWidget) -> str:
@@ -43,11 +45,13 @@ class EmptyStateWidget(QWidget):
     Parameters
     ----------
     icon:
-        A single Unicode emoji / symbol rendered at 48 px.
+        A single Unicode emoji / symbol rendered large.
     title:
-        Short headline (16 px, semi-bold).
+        Short headline (semi-bold).
     description:
-        Explanatory body text (13 px, word-wrapped, max 400 px wide).
+        Explanatory body text (word-wrapped, fixed max width so multi-line
+        height is stable — avoids QLabel wrap height collapse that paints
+        Chinese lines on top of each other).
     action_text:
         If supplied, a secondary-style ``QPushButton`` is added below the
         description and :pyattr:`action_clicked` is emitted on click.
@@ -69,11 +73,22 @@ class EmptyStateWidget(QWidget):
     ) -> None:
         super().__init__(parent)
 
-        # ---- outer layout (centers the content block) --------------------
+        # Outer layout only centers a solid content block — never stretch the
+        # labels themselves, or word-wrapped Chinese collapses to one line.
         outer = QVBoxLayout(self)
-        # Compact margins so CTA fits short workbench status tabs.
         outer.setContentsMargins(8, 8, 8, 8)
-        outer.setSpacing(6)
+        outer.setSpacing(0)
+
+        self._content = QWidget()
+        self._content.setObjectName("empty_state_content")
+        self._content.setSizePolicy(
+            QSizePolicy.Policy.Preferred,
+            QSizePolicy.Policy.Preferred,
+        )
+        content_layout = QVBoxLayout(self._content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(8)
+        content_layout.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
         # ---- icon --------------------------------------------------------
         self._icon_label = QLabel(icon)
@@ -94,9 +109,10 @@ class EmptyStateWidget(QWidget):
         self._title_label.setFont(title_font)
         self._title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._title_label.setWordWrap(True)
+        self._title_label.setFixedWidth(_DESC_MAX_WIDTH)
         self._title_label.setSizePolicy(
-            QSizePolicy.Policy.Preferred,
             QSizePolicy.Policy.Fixed,
+            QSizePolicy.Policy.Preferred,
         )
 
         # ---- description -------------------------------------------------
@@ -106,11 +122,13 @@ class EmptyStateWidget(QWidget):
         self._desc_label.setFont(desc_font)
         self._desc_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._desc_label.setWordWrap(True)
-        self._desc_label.setMaximumWidth(420)
+        # Fixed width + heightForWidth so multi-line Chinese never collapses.
+        self._desc_label.setFixedWidth(_DESC_MAX_WIDTH)
         self._desc_label.setSizePolicy(
+            QSizePolicy.Policy.Fixed,
             QSizePolicy.Policy.Preferred,
-            QSizePolicy.Policy.Minimum,
         )
+        self._reflow_desc_height()
 
         # ---- optional action button --------------------------------------
         self._action_btn: QPushButton | None = None
@@ -122,30 +140,41 @@ class EmptyStateWidget(QWidget):
                 QSizePolicy.Policy.Fixed,
                 QSizePolicy.Policy.Fixed,
             )
-            # Keep full label visible even when parent is height-constrained.
             hint = self._action_btn.sizeHint()
             self._action_btn.setMinimumSize(hint)
             self._action_btn.clicked.connect(self.action_clicked)
 
-        # ---- assemble: stretch centers content; CTA stays after description ----
-        outer.addStretch(1)
-        outer.addWidget(self._icon_label)
-        outer.addWidget(self._title_label)
-        outer.addWidget(self._desc_label, alignment=Qt.AlignmentFlag.AlignCenter)
-
+        content_layout.addWidget(self._icon_label, 0, Qt.AlignmentFlag.AlignHCenter)
+        content_layout.addWidget(self._title_label, 0, Qt.AlignmentFlag.AlignHCenter)
+        content_layout.addWidget(self._desc_label, 0, Qt.AlignmentFlag.AlignHCenter)
         if self._action_btn is not None:
-            btn_row = QHBoxLayout()
-            btn_row.setContentsMargins(0, 0, 0, 0)
-            btn_row.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            btn_row.addWidget(self._action_btn)
-            outer.addSpacing(2)
-            outer.addLayout(btn_row)
+            content_layout.addWidget(self._action_btn, 0, Qt.AlignmentFlag.AlignHCenter)
+
+        outer.addStretch(1)
+        outer.addWidget(self._content, 0, Qt.AlignmentFlag.AlignHCenter)
         outer.addStretch(1)
 
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
             QSizePolicy.Policy.Expanding,
         )
+        # Opaque fill so any residual sibling chrome never bleeds through.
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._content.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+
+    def _reflow_desc_height(self) -> None:
+        """Reserve full multi-line height for the wrapped description."""
+        width = max(1, self._desc_label.width() or _DESC_MAX_WIDTH)
+        needed = max(
+            self._desc_label.fontMetrics().height(),
+            self._desc_label.heightForWidth(width),
+        )
+        if needed > 0:
+            self._desc_label.setMinimumHeight(needed)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:  # noqa: N802
+        super().resizeEvent(event)
+        self._reflow_desc_height()
 
     # ------------------------------------------------------------------
     # Theme-aware colours
@@ -153,19 +182,44 @@ class EmptyStateWidget(QWidget):
 
     def _apply_theme_colors(self) -> None:
         """Set foreground colours from the app's effective theme tokens."""
-        tokens = tokens_for_theme(_effective_theme_name(self))
-        icon_color = tokens["fg_muted"]
-        title_color = tokens["fg_secondary"]
-        desc_color = tokens["fg_muted"]
+        if getattr(self, "_applying_theme_colors", False):
+            return
+        self._applying_theme_colors = True
+        try:
+            tokens = tokens_for_theme(_effective_theme_name(self))
+            icon_color = tokens["fg_muted"]
+            title_color = tokens["fg_secondary"]
+            desc_color = tokens["fg_muted"]
+            bg = tokens.get("bg_surface") or tokens.get("bg_window") or ""
 
-        self._icon_label.setStyleSheet(f"color: {icon_color}; background: transparent;")
-        self._title_label.setStyleSheet(f"color: {title_color}; background: transparent;")
-        self._desc_label.setStyleSheet(f"color: {desc_color}; background: transparent;")
+            # Prefer palette fill over setStyleSheet on self — StyleChange would
+            # re-enter changeEvent and recurse.
+            if bg:
+                color = QColor(bg)
+                if color.isValid():
+                    for widget in (self, self._content):
+                        palette = widget.palette()
+                        palette.setColor(QPalette.ColorRole.Window, color)
+                        widget.setAutoFillBackground(True)
+                        widget.setPalette(palette)
+
+            self._icon_label.setStyleSheet(
+                f"color: {icon_color}; background: transparent;"
+            )
+            self._title_label.setStyleSheet(
+                f"color: {title_color}; background: transparent;"
+            )
+            self._desc_label.setStyleSheet(
+                f"color: {desc_color}; background: transparent;"
+            )
+        finally:
+            self._applying_theme_colors = False
 
     def showEvent(self, event):  # noqa: N802 – Qt naming convention
         """Re-apply theme colours every time the widget becomes visible."""
         super().showEvent(event)
         self._apply_theme_colors()
+        self._reflow_desc_height()
 
     def changeEvent(self, event):  # noqa: N802 – Qt naming convention
         """React to palette / style changes at runtime."""

--- a/tests/test_gui_p3_polish.py
+++ b/tests/test_gui_p3_polish.py
@@ -66,10 +66,56 @@ class GuiP3PolishTests(unittest.TestCase):
     def test_doctor_empty_state_visible_before_check(self) -> None:
         self.window._doctor_check_completed = False
         self.window._sync_workbench_empty_states()
-        self.assertFalse(self.window.doctor_empty_state.isHidden())
+        stack = self.window.doctor_page_stack
+        self.assertEqual(stack.currentWidget(), self.window.doctor_empty_state)
         self.window._doctor_check_completed = True
         self.window._sync_workbench_empty_states()
-        self.assertTrue(self.window.doctor_empty_state.isHidden())
+        self.assertNotEqual(stack.currentWidget(), self.window.doctor_empty_state)
+
+    def test_doctor_empty_no_overlap_with_summary_or_self(self) -> None:
+        """Empty CTA must replace summary (stack) and keep title/desc/btn separate."""
+        from PySide6.QtCore import QPoint, QRect
+
+        self.window.resize(1100, 700)
+        self.window.show()
+        for _ in range(8):
+            self._app.processEvents()
+        self.window._doctor_check_completed = False
+        self.window._sync_workbench_empty_states()
+        if hasattr(self.window, "workbench_status_tabs"):
+            self.window.workbench_status_tabs.setCurrentIndex(0)
+        for _ in range(10):
+            self._app.processEvents()
+
+        empty = self.window.doctor_empty_state
+        stack = self.window.doctor_page_stack
+        self.assertEqual(stack.currentWidget(), empty)
+        # Summary page must not paint while empty is active.
+        summary_page = stack.widget(0)
+        self.assertFalse(summary_page.isVisible())
+        self.assertFalse(self.window.doctor_status_label.isVisible())
+        self.assertFalse(self.window.doctor_message_label.isVisible())
+
+        desc = empty._desc_label
+        title = empty._title_label
+        btn = empty._action_btn
+        self.assertIsNotNone(btn)
+        assert btn is not None
+        self.assertTrue(desc.isVisible())
+        self.assertGreater(desc.height(), 0)
+        # Title / desc / button must not intersect inside the empty widget.
+        rects = [
+            ("title", QRect(title.mapTo(empty, QPoint(0, 0)), title.size())),
+            ("desc", QRect(desc.mapTo(empty, QPoint(0, 0)), desc.size())),
+            ("btn", QRect(btn.mapTo(empty, QPoint(0, 0)), btn.size())),
+        ]
+        for i, (name_a, rect_a) in enumerate(rects):
+            for name_b, rect_b in rects[i + 1 :]:
+                inter = rect_a.intersected(rect_b)
+                self.assertFalse(
+                    inter.width() >= 2 and inter.height() >= 2,
+                    msg=f"{name_a} overlaps {name_b}: {inter}",
+                )
 
     def test_workflow_empty_state_without_project(self) -> None:
         self.window.state.get_game_root = lambda: None  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
- Environment-check empty CTA and idle doctor summary shared a VBox with dual stretch; summary text could show through / look stacked under the empty description.
- Switch doctor page to `QStackedWidget` so empty and summary are mutually exclusive.
- Harden `EmptyStateWidget` layout (solid content block + palette background) so Chinese description and CTA stay readable.

## Test plan
- [x] `tests.test_gui_p3_polish` (Windows offscreen/windows)
- [ ] Manual: open Keywords → 环境检查 before running doctor; confirm single clean empty state with no doubled text