### PR TITLE
feat(gui): establish workbench page contract and nav state

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -343,6 +343,11 @@ class MainWindow(QMainWindow):
         self._work_mode = WorkMode.BATCH_TRANSLATION
         self._mode_sessions: dict[WorkMode, WorkbenchModeSession] = {}
         self._workbench_nav_item = WorkbenchNavItem.BATCH_TRANSLATION
+        # Session emptiness is not navigation state: a user can choose 同步
+        # before it has produced any workflow or manifest to save.
+        self._last_mode_by_nav: dict[WorkbenchNavItem, WorkMode] = {
+            item: default_work_mode_for_nav(item) for item in WORKBENCH_NAV_ORDER
+        }
         self._workflow_step_output_lines: list[str] = []
         self._apply_output_lines: list[str] = []
         self._recheck_output_lines: list[str] = []
@@ -4141,6 +4146,12 @@ class MainWindow(QMainWindow):
             # QObject stubs from unit tests may reject new attributes.
             pass
 
+    def _reset_last_mode_by_nav(self) -> None:
+        """Restore each navigation entry's default mode after a project switch."""
+        self._last_mode_by_nav = {
+            item: default_work_mode_for_nav(item) for item in WORKBENCH_NAV_ORDER
+        }
+
     def _rebuild_work_task_combo(
         self,
         category: TaskCategory,
@@ -4222,16 +4233,10 @@ class MainWindow(QMainWindow):
             self._work_mode
         ) == nav_item:
             return
-        # Prefer last session mode within this nav if present.
-        target_mode = default_work_mode_for_nav(nav_item)
-        for mode in workbench_nav_spec(nav_item).work_modes:
-            session = self._mode_sessions.get(mode)
-            if session is not None and not session.is_empty():
-                target_mode = mode
-                break
-            if mode == self._work_mode:
-                target_mode = mode
-                break
+        target_mode = self._last_mode_by_nav.get(
+            nav_item,
+            default_work_mode_for_nav(nav_item),
+        )
         self._set_work_mode(target_mode, refresh_manifest_writeback=True)
 
     def _on_work_submode_changed(self) -> None:
@@ -4283,6 +4288,7 @@ class MainWindow(QMainWindow):
 
         self._work_mode = mode
         self._workbench_nav_item = workbench_nav_for_work_mode(mode)
+        self._last_mode_by_nav[self._workbench_nav_item] = mode
         self._pending_restore_workflow_ui = None
         self._pending_restore_writeback_summary = None
 
@@ -5185,6 +5191,9 @@ class MainWindow(QMainWindow):
         self._active_command = ""
         self._doctor_output_lines = []
         self._clear_all_mode_sessions()
+        self._reset_last_mode_by_nav()
+        self._workbench_nav_item = workbench_nav_for_work_mode(self._work_mode)
+        self._work_mode = self._last_mode_by_nav[self._workbench_nav_item]
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -4288,7 +4288,11 @@ class MainWindow(QMainWindow):
 
         self._work_mode = mode
         self._workbench_nav_item = workbench_nav_for_work_mode(mode)
-        self._last_mode_by_nav[self._workbench_nav_item] = mode
+        last_mode_by_nav = getattr(self, "_last_mode_by_nav", None)
+        if not isinstance(last_mode_by_nav, dict):
+            self._reset_last_mode_by_nav()
+            last_mode_by_nav = self._last_mode_by_nav
+        last_mode_by_nav[self._workbench_nav_item] = mode
         self._pending_restore_workflow_ui = None
         self._pending_restore_writeback_summary = None
 
@@ -5191,9 +5195,10 @@ class MainWindow(QMainWindow):
         self._active_command = ""
         self._doctor_output_lines = []
         self._clear_all_mode_sessions()
+        previous_mode = getattr(self, "_work_mode", WorkMode.BATCH_TRANSLATION)
+        self._workbench_nav_item = workbench_nav_for_work_mode(previous_mode)
         self._reset_last_mode_by_nav()
-        self._workbench_nav_item = workbench_nav_for_work_mode(self._work_mode)
-        self._work_mode = self._last_mode_by_nav[self._workbench_nav_item]
+        self._work_mode = default_work_mode_for_nav(self._workbench_nav_item)
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()

--- a/gui_qt/workbench/__init__.py
+++ b/gui_qt/workbench/__init__.py
@@ -1,0 +1,5 @@
+"""Shared contracts for the gradually migrated workbench pages."""
+
+from .page_contract import WorkbenchPage, WorkbenchPageActions
+
+__all__ = ("WorkbenchPage", "WorkbenchPageActions")

--- a/gui_qt/workbench/page_contract.py
+++ b/gui_qt/workbench/page_contract.py
@@ -1,0 +1,43 @@
+"""Small page boundary for the workbench migration (#176 P0).
+
+Pages own their widgets and render the session supplied by ``MainWindow``.
+They report user intent through callbacks; workflow state, CLI execution, and
+writeback safety remain in the application coordinator.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..work_modes import WorkMode
+from ..workbench_session import WorkbenchModeSession
+
+
+@dataclass(frozen=True)
+class WorkbenchPageActions:
+    """Coordinator callbacks a page may expose through its own controls."""
+
+    start: Callable[[], None] | None = None
+    resume: Callable[[], None] | None = None
+    stop: Callable[[], None] | None = None
+    writeback: Callable[[], None] | None = None
+    prebuild: Callable[[str], None] | None = None
+
+
+class WorkbenchPage(Protocol):
+    """Contract for one persistent page in the workbench stack."""
+
+    supported_modes: tuple[WorkMode, ...]
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        """Receive coordinator-owned actions for page-local controls."""
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        """Render the active mode using its sole runtime session state."""
+
+    def set_task_running(self, running: bool) -> None:
+        """Reflect the global runner lock in page-local controls."""
+
+    def reset_project(self) -> None:
+        """Clear view-only state after the coordinator changes game_root."""

--- a/tests/test_gui_workbench_nav.py
+++ b/tests/test_gui_workbench_nav.py
@@ -28,6 +28,7 @@ from gui_qt.work_modes import (
     workbench_nav_spec,
 )
 from gui_qt.workbench_session import WorkbenchModeSession
+from gui_qt.workbench import WorkbenchPage, WorkbenchPageActions
 from tests import gui_test_support
 
 
@@ -54,6 +55,12 @@ class WorkbenchNavMetaTests(unittest.TestCase):
     def test_keywords_nav_shows_submode(self) -> None:
         self.assertTrue(workbench_nav_spec(WorkbenchNavItem.KEYWORDS).show_submode)
         self.assertFalse(workbench_nav_spec(WorkbenchNavItem.BATCH_TRANSLATION).show_submode)
+
+    def test_page_contract_exposes_migration_boundary(self) -> None:
+        self.assertIn("supported_modes", WorkbenchPage.__annotations__)
+        for method in ("set_action_callbacks", "activate", "set_task_running", "reset_project"):
+            self.assertTrue(hasattr(WorkbenchPage, method))
+        self.assertIsNone(WorkbenchPageActions().start)
 
 
 class WorkbenchSessionTests(unittest.TestCase):
@@ -150,8 +157,24 @@ class GuiWorkbenchNavTests(unittest.TestCase):
         )
         self.assertTrue(self.window.work_submode_combo.isHidden())
 
+    def test_keywords_nav_restores_last_selected_submode_without_session_data(self) -> None:
+        self.window._set_work_mode(WorkMode.SYNC_KEYWORD_EXTRACTION, refresh_manifest_writeback=False)
+        self.window._set_work_mode(WorkMode.BATCH_TRANSLATION, refresh_manifest_writeback=False)
+        self.window.workbench_nav.setCurrentRow(WORKBENCH_NAV_ORDER.index(WorkbenchNavItem.KEYWORDS))
+        self.assertEqual(self.window._work_mode, WorkMode.SYNC_KEYWORD_EXTRACTION)
+
+    def test_revision_nav_restores_last_selected_submode_without_session_data(self) -> None:
+        self.window._set_work_mode(WorkMode.SYNC_REVISION, refresh_manifest_writeback=False)
+        self.window._set_work_mode(WorkMode.BATCH_TRANSLATION, refresh_manifest_writeback=False)
+        self.window.workbench_nav.setCurrentRow(WORKBENCH_NAV_ORDER.index(WorkbenchNavItem.REVISION))
+        self.assertEqual(self.window._work_mode, WorkMode.SYNC_REVISION)
+
     def test_game_root_switch_clears_sessions(self) -> None:
         """Drive real _switch_game_root wiring, not only the clear helper."""
+        self.window._set_work_mode(
+            WorkMode.SYNC_KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
         self.window._mode_sessions[WorkMode.KEYWORD_EXTRACTION] = WorkbenchModeSession(
             writeback_manifest_path="C:/keyword-old.json",
         )
@@ -176,13 +199,19 @@ class GuiWorkbenchNavTests(unittest.TestCase):
             ok = self.window._switch_game_root("C:/Games/Example/work")
 
         self.assertTrue(ok)
-        # Prior keyword session must not survive the root switch.
-        self.assertNotIn(WorkMode.KEYWORD_EXTRACTION, self.window._mode_sessions)
+        # The active keyword page receives a new stale session, never the old path.
+        keyword_session = self.window._mode_sessions[WorkMode.KEYWORD_EXTRACTION]
+        self.assertEqual(keyword_session.writeback_manifest_path, "")
         # Active mode is re-captured after clear; old writeback path must be gone.
         self.assertEqual(self.window._writeback_manifest_path, "")
         active = self.window._mode_sessions.get(self.window._work_mode)
         if active is not None:
             self.assertEqual(active.writeback_manifest_path, "")
+        self.assertEqual(
+            self.window._last_mode_by_nav[WorkbenchNavItem.KEYWORDS],
+            WorkMode.KEYWORD_EXTRACTION,
+        )
+        self.assertEqual(self.window._work_mode, WorkMode.KEYWORD_EXTRACTION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 内容

- 新增 P0 工作台页面契约，明确页面支持模式、session 渲染、运行锁、项目重置和协调层回调。
- 用显式 last_mode_by_nav 记录关键词与订正页的最后子模式，不再根据 session 是否为空猜测。
- 切换项目时清空 session，并恢复入口默认子模式。

## 验证

- python -m unittest tests.test_gui_workbench_nav tests.test_gui_task_pages -q`n- git diff --check`n
Part of #176 (P0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared workbench page interface for consistent page behavior and controls.
  * Navigation now remembers the last selected mode for each workbench section.

* **Bug Fixes**
  * Preserved selected submodes when switching between navigation sections.
  * Reset remembered modes and related session state when changing projects or work roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->