### PR TITLE
feat(gui): add real context library workbench page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -260,6 +260,8 @@ from .work_modes import (
     workbench_nav_for_work_mode,
     workbench_nav_spec,
 )
+from .workbench import WorkbenchPageActions
+from .workbench.context_library_page import ContextLibraryPage
 from .workbench_session import WorkbenchModeSession
 from .batch_workflow_support import resolve_submit_max_cost
 from .workflow_factory import create_workflow, resume_workflow
@@ -698,20 +700,35 @@ class MainWindow(QMainWindow):
         right_scroll.setWidget(right)
         outer.addWidget(right_scroll, 1)
 
-        # Stack keeps page identity for each nav item (shared chrome below).
-        # Keep pages empty/minimal so they do not compete with action buttons for space.
+        # P1: context is the first real, persistent stack page. Other entries
+        # remain migration placeholders until their own phase.
         self.workbench_stack = QStackedWidget()
         self.workbench_stack.setObjectName("workbench_stack")
         self._workbench_stack_pages: dict[WorkbenchNavItem, QWidget] = {}
         for nav_item in WORKBENCH_NAV_ORDER:
-            page = QWidget()
-            page.setObjectName(f"workbench_page_{nav_item.value}")
-            page_layout = QVBoxLayout(page)
-            page_layout.setContentsMargins(0, 0, 0, 0)
-            page_layout.setSpacing(0)
+            if nav_item == WorkbenchNavItem.CONTEXT:
+                page = ContextLibraryPage()
+                page.set_action_callbacks(
+                    WorkbenchPageActions(
+                        prebuild=self._on_context_bootstrap_clicked,
+                        open_settings=self._on_open_context_settings,
+                    )
+                )
+                self.context_library_page = page
+                self.context_library_panel = page
+                self.context_rag_status_label = page.rag_status_label
+                self.context_source_index_status_label = page.source_index_status_label
+                self.context_bootstrap_rag_btn = page.bootstrap_rag_btn
+                self.context_bootstrap_source_index_btn = page.bootstrap_source_index_btn
+                self.context_open_settings_btn = page.open_settings_btn
+            else:
+                page = QWidget()
+                page.setObjectName(f"workbench_page_{nav_item.value}")
+                page_layout = QVBoxLayout(page)
+                page_layout.setContentsMargins(0, 0, 0, 0)
+                page_layout.setSpacing(0)
             self._workbench_stack_pages[nav_item] = page
             self.workbench_stack.addWidget(page)
-        self.workbench_stack.setFixedHeight(0)
         self.workbench_stack.setVisible(False)
         layout.addWidget(self.workbench_stack)
 
@@ -768,9 +785,6 @@ class MainWindow(QMainWindow):
         self.sync_mode_warning.setVisible(False)
         mode_outer.addWidget(self.sync_mode_warning)
         layout.addWidget(mode_frame)
-
-        # Context library dual status cards (P1c / #162 · §3.2.5).
-        layout.addWidget(self._build_context_library_panel())
 
         action_frame = QFrame()
         action_frame.setObjectName("action_frame")
@@ -1199,6 +1213,13 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(self._build_workbench_log_drawer())
 
+        self._legacy_workbench_shell_widgets = (
+            self._mode_frame,
+            self._workbench_actions_column,
+            self.workbench_status_card,
+            self.workbench_log_drawer,
+        )
+
         self._workbench_tab = tab
         self.tab_widget.addTab(tab, "工作台")
         self._sync_workbench_status_chrome()
@@ -1245,59 +1266,6 @@ class MainWindow(QMainWindow):
         frame.setVisible(False)
         return frame
 
-    def _build_context_library_panel(self) -> QFrame:
-        """RAG / source-index status cards for the 上下文库 nav page (P1c / #162)."""
-        frame = QFrame()
-        frame.setObjectName("context_library_panel")
-        self.context_library_panel = frame
-        outer = QVBoxLayout(frame)
-        # Compact so the prebuild progress tab (and empty CTA) still fit at 700px.
-        outer.setContentsMargins(10, 8, 10, 8)
-        outer.setSpacing(6)
-
-        title = QLabel("上下文库状态")
-        title.setObjectName("diagnostics_section_label")
-        outer.addWidget(title)
-
-        rag_row = QHBoxLayout()
-        rag_row.setSpacing(8)
-        self.context_rag_status_label = QLabel("记忆库：—")
-        self.context_rag_status_label.setObjectName("summary_body_label")
-        self.context_rag_status_label.setWordWrap(True)
-        rag_row.addWidget(self.context_rag_status_label, 1)
-        self.context_bootstrap_rag_btn = QPushButton("预建记忆库")
-        self.context_bootstrap_rag_btn.setObjectName("secondary_btn")
-        self.context_bootstrap_rag_btn.clicked.connect(
-            lambda: self._on_context_bootstrap_clicked("rag")
-        )
-        rag_row.addWidget(self.context_bootstrap_rag_btn, 0)
-        outer.addLayout(rag_row)
-
-        idx_row = QHBoxLayout()
-        idx_row.setSpacing(8)
-        self.context_source_index_status_label = QLabel("原文索引：—")
-        self.context_source_index_status_label.setObjectName("summary_body_label")
-        self.context_source_index_status_label.setWordWrap(True)
-        idx_row.addWidget(self.context_source_index_status_label, 1)
-        self.context_bootstrap_source_index_btn = QPushButton("预建原文索引")
-        self.context_bootstrap_source_index_btn.setObjectName("secondary_btn")
-        self.context_bootstrap_source_index_btn.clicked.connect(
-            lambda: self._on_context_bootstrap_clicked("source_index")
-        )
-        idx_row.addWidget(self.context_bootstrap_source_index_btn, 0)
-        outer.addLayout(idx_row)
-
-        self.context_open_settings_btn = QPushButton("打开设置 · 上下文")
-        self.context_open_settings_btn.setObjectName("secondary_btn")
-        self.context_open_settings_btn.setToolTip(
-            "开关须在设置中保存后才能预建；打开设置的「上下文」分区。"
-        )
-        self.context_open_settings_btn.clicked.connect(self._on_open_context_settings)
-        outer.addWidget(self.context_open_settings_btn, 0, Qt.AlignmentFlag.AlignLeft)
-
-        frame.setVisible(False)
-        return frame
-
     def _on_open_context_settings(self) -> None:
         self._focus_settings_section("context")
 
@@ -1312,31 +1280,23 @@ class MainWindow(QMainWindow):
         self._start_bootstrap_task(kind)
 
     def _refresh_context_library_panel(self, *, running: bool | None = None) -> None:
-        if not hasattr(self, "context_library_panel"):
+        page = getattr(self, "context_library_page", None)
+        if page is not None:
+            flags = self._saved_batch_context_flags()
+            rag_on = bool(flags.get("rag_enabled"))
+            idx_on = bool(flags.get("source_index_enabled"))
+            game_root = self.state.get_game_root() if hasattr(self, "state") else None
+            if running is None:
+                running = bool(getattr(self, "_task_running", False)) or (
+                    hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
+                )
+            page.set_context_status(
+                rag_enabled=rag_on,
+                source_index_enabled=idx_on,
+                game_root=str(game_root or ""),
+            )
+            page.set_task_running(running)
             return
-        flags = self._saved_batch_context_flags()
-        rag_on = bool(flags.get("rag_enabled"))
-        idx_on = bool(flags.get("source_index_enabled"))
-        game_root = self.state.get_game_root() if hasattr(self, "state") else None
-        root_hint = str(game_root) if game_root else "未选择项目"
-        if hasattr(self, "context_rag_status_label"):
-            self.context_rag_status_label.setText(
-                f"记忆库：{'已启用' if rag_on else '未启用'} · 项目 {root_hint}"
-                + ("" if rag_on else " · 请先在设置 · 上下文开启并保存")
-            )
-        if hasattr(self, "context_source_index_status_label"):
-            self.context_source_index_status_label.setText(
-                f"原文索引：{'已启用' if idx_on else '未启用'} · 项目 {root_hint}"
-                + ("" if idx_on else " · 请先在设置 · 上下文开启并保存")
-            )
-        if running is None:
-            running = bool(getattr(self, "_task_running", False)) or (
-                hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
-            )
-        if hasattr(self, "context_bootstrap_rag_btn"):
-            self.context_bootstrap_rag_btn.setEnabled(not running and rag_on)
-        if hasattr(self, "context_bootstrap_source_index_btn"):
-            self.context_bootstrap_source_index_btn.setEnabled(not running and idx_on)
 
     def _apply_task_page_chrome(self, spec) -> None:
         """Show/hide per-nav chrome: sync warn, context cards, task actions (P1c)."""
@@ -1347,10 +1307,14 @@ class MainWindow(QMainWindow):
 
         if hasattr(self, "sync_mode_warning"):
             self.sync_mode_warning.setVisible(is_sync)
-        if hasattr(self, "context_library_panel"):
-            self.context_library_panel.setVisible(is_context)
-            if is_context:
-                self._refresh_context_library_panel()
+        if hasattr(self, "workbench_stack"):
+            self.workbench_stack.setVisible(is_context)
+            self.workbench_stack.setMinimumHeight(0)
+            self.workbench_stack.setMaximumHeight(16_777_215 if is_context else 0)
+        for widget in getattr(self, "_legacy_workbench_shell_widgets", ()):
+            widget.setVisible(not is_context)
+        if is_context:
+            self._refresh_context_library_panel()
 
         # Doctor / bootstrap live on the global project bar (always available).
 
@@ -4190,6 +4154,15 @@ class MainWindow(QMainWindow):
             page = self._workbench_stack_pages.get(nav_item)
             if page is not None:
                 self.workbench_stack.setCurrentWidget(page)
+        if nav_item == WorkbenchNavItem.CONTEXT:
+            context_page = getattr(self, "context_library_page", None)
+            sessions = getattr(self, "_mode_sessions", None)
+            session = sessions.get(mode) if isinstance(sessions, dict) else None
+            if context_page is not None:
+                context_page.activate(mode, session or WorkbenchModeSession())
+                context_page.set_task_running(
+                    bool(getattr(self, "_task_running", False))
+                )
 
         nav_spec = workbench_nav_spec(nav_item)
         show_sub = nav_spec.show_submode
@@ -5199,6 +5172,9 @@ class MainWindow(QMainWindow):
         self._workbench_nav_item = workbench_nav_for_work_mode(previous_mode)
         self._reset_last_mode_by_nav()
         self._work_mode = default_work_mode_for_nav(self._workbench_nav_item)
+        context_page = getattr(self, "context_library_page", None)
+        if context_page is not None:
+            context_page.reset_project()
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -1,0 +1,172 @@
+"""Persistent context-library page used by the workbench stack (#176 P1)."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..empty_state import EmptyStateWidget
+from ..work_modes import WorkMode
+from ..workbench_session import WorkbenchModeSession
+from .page_contract import WorkbenchPageActions
+
+
+class ContextLibraryPage(QFrame):
+    """Page-local presentation for RAG and source-index preparation."""
+
+    supported_modes = (
+        WorkMode.BOOTSTRAP_RAG,
+        WorkMode.BOOTSTRAP_SOURCE_INDEX,
+    )
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("context_library_panel")
+        self._actions = WorkbenchPageActions()
+        self._running = False
+        self._rag_enabled = False
+        self._source_index_enabled = False
+        self._active_mode = WorkMode.BOOTSTRAP_RAG
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(12, 12, 12, 12)
+        outer.setSpacing(10)
+
+        title = QLabel("上下文库")
+        title.setObjectName("diagnostics_section_label")
+        outer.addWidget(title)
+
+        self.page_stack = QStackedWidget()
+        self.page_stack.setObjectName("context_library_page_stack")
+        outer.addWidget(self.page_stack)
+
+        self.empty_state = EmptyStateWidget(
+            "📚",
+            "尚未启用上下文库",
+            "请先在设置 · 上下文启用记忆库或原文索引并保存，然后回到这里预建。",
+            action_text="打开设置 · 上下文",
+        )
+        self.empty_state.setObjectName("context_library_empty_state")
+        self.empty_state.action_clicked.connect(self._trigger_open_settings)
+        self.page_stack.addWidget(self.empty_state)
+
+        self.status_page = QWidget()
+        self.status_page.setObjectName("context_library_status_page")
+        status_layout = QVBoxLayout(self.status_page)
+        status_layout.setContentsMargins(0, 0, 0, 0)
+        status_layout.setSpacing(8)
+        status_layout.addWidget(self._build_rag_row())
+        status_layout.addWidget(self._build_source_index_row())
+
+        self.open_settings_btn = QPushButton("打开设置 · 上下文")
+        self.open_settings_btn.setObjectName("secondary_btn")
+        self.open_settings_btn.setToolTip(
+            "开关须在设置中保存后才能预建；打开设置的「上下文」分区。"
+        )
+        self.open_settings_btn.clicked.connect(self._trigger_open_settings)
+        status_layout.addWidget(self.open_settings_btn, 0, Qt.AlignmentFlag.AlignLeft)
+        status_layout.addStretch()
+        self.page_stack.addWidget(self.status_page)
+        self.page_stack.setCurrentWidget(self.empty_state)
+
+    def _build_rag_row(self) -> QFrame:
+        row_frame = QFrame()
+        row_frame.setObjectName("context_library_status_row")
+        row = QHBoxLayout(row_frame)
+        row.setContentsMargins(10, 8, 10, 8)
+        row.setSpacing(8)
+        self.rag_status_label = QLabel("记忆库：—")
+        self.rag_status_label.setObjectName("summary_body_label")
+        self.rag_status_label.setWordWrap(True)
+        row.addWidget(self.rag_status_label, 1)
+        self.bootstrap_rag_btn = QPushButton("预建记忆库")
+        self.bootstrap_rag_btn.setObjectName("secondary_btn")
+        self.bootstrap_rag_btn.clicked.connect(lambda: self._trigger_prebuild("rag"))
+        row.addWidget(self.bootstrap_rag_btn)
+        return row_frame
+
+    def _build_source_index_row(self) -> QFrame:
+        row_frame = QFrame()
+        row_frame.setObjectName("context_library_status_row")
+        row = QHBoxLayout(row_frame)
+        row.setContentsMargins(10, 8, 10, 8)
+        row.setSpacing(8)
+        self.source_index_status_label = QLabel("原文索引：—")
+        self.source_index_status_label.setObjectName("summary_body_label")
+        self.source_index_status_label.setWordWrap(True)
+        row.addWidget(self.source_index_status_label, 1)
+        self.bootstrap_source_index_btn = QPushButton("预建原文索引")
+        self.bootstrap_source_index_btn.setObjectName("secondary_btn")
+        self.bootstrap_source_index_btn.clicked.connect(
+            lambda: self._trigger_prebuild("source_index")
+        )
+        row.addWidget(self.bootstrap_source_index_btn)
+        return row_frame
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        self._actions = actions
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        if mode not in self.supported_modes:
+            raise ValueError(f"Unsupported context-library mode: {mode.value}")
+        self._active_mode = mode
+        # Session remains owned by MainWindow; the page only renders it when P1
+        # eventually gains page-local bootstrap progress presentation.
+        del session
+
+    def set_context_status(
+        self,
+        *,
+        rag_enabled: bool,
+        source_index_enabled: bool,
+        game_root: str,
+    ) -> None:
+        self._rag_enabled = rag_enabled
+        self._source_index_enabled = source_index_enabled
+        root_hint = game_root or "未选择项目"
+        self.rag_status_label.setText(
+            f"记忆库：{'已启用' if rag_enabled else '未启用'} · 项目 {root_hint}"
+            + ("" if rag_enabled else " · 请先在设置 · 上下文开启并保存")
+        )
+        self.source_index_status_label.setText(
+            f"原文索引：{'已启用' if source_index_enabled else '未启用'} · 项目 {root_hint}"
+            + ("" if source_index_enabled else " · 请先在设置 · 上下文开启并保存")
+        )
+        self.page_stack.setCurrentWidget(
+            self.status_page if rag_enabled or source_index_enabled else self.empty_state
+        )
+        self._refresh_action_states()
+
+    def set_task_running(self, running: bool) -> None:
+        self._running = running
+        self._refresh_action_states()
+
+    def reset_project(self) -> None:
+        self.set_context_status(
+            rag_enabled=False,
+            source_index_enabled=False,
+            game_root="",
+        )
+
+    def _refresh_action_states(self) -> None:
+        self.bootstrap_rag_btn.setEnabled(not self._running and self._rag_enabled)
+        self.bootstrap_source_index_btn.setEnabled(
+            not self._running and self._source_index_enabled
+        )
+        self.open_settings_btn.setEnabled(not self._running)
+
+    def _trigger_prebuild(self, kind: str) -> None:
+        if self._running or self._actions.prebuild is None:
+            return
+        self._actions.prebuild(kind)
+
+    def _trigger_open_settings(self) -> None:
+        if not self._running and self._actions.open_settings is not None:
+            self._actions.open_settings()

--- a/gui_qt/workbench/page_contract.py
+++ b/gui_qt/workbench/page_contract.py
@@ -23,6 +23,7 @@ class WorkbenchPageActions:
     stop: Callable[[], None] | None = None
     writeback: Callable[[], None] | None = None
     prebuild: Callable[[str], None] | None = None
+    open_settings: Callable[[], None] | None = None
 
 
 class WorkbenchPage(Protocol):

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -25,6 +25,7 @@ from gui_qt.work_modes import (
     work_mode_submode_label,
     workbench_nav_spec,
 )
+from gui_qt.workbench import WorkbenchPageActions
 from gui_qt.workbench_session import WorkbenchModeSession
 from tests import gui_test_support
 
@@ -166,6 +167,14 @@ class GuiTaskPageTests(unittest.TestCase):
             refresh_manifest_writeback=False,
         )
         self.assertFalse(self.window.context_library_panel.isHidden())
+        self.assertIs(
+            self.window.workbench_stack.currentWidget(),
+            self.window.context_library_page,
+        )
+        self.assertFalse(self.window.workbench_stack.isHidden())
+        self.assertTrue(self.window._mode_frame.isHidden())
+        self.assertTrue(self.window._workbench_actions_column.isHidden())
+        self.assertTrue(self.window.workbench_status_card.isHidden())
         self.assertTrue(self.window.work_submode_combo.isHidden())
         self.assertTrue(self.window.translate_btn.isHidden())
         # Doctor / bootstrap stay on the global project bar for every task page.
@@ -173,6 +182,34 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(self.window.bootstrap_work_btn.isHidden())
         self.assertIn("记忆库", self.window.context_rag_status_label.text())
         self.assertIn("原文索引", self.window.context_source_index_status_label.text())
+
+    def test_context_page_uses_callbacks_and_owns_empty_state(self) -> None:
+        page = self.window.context_library_page
+        prebuilds: list[str] = []
+        opens: list[bool] = []
+        page.set_action_callbacks(
+            WorkbenchPageActions(
+                prebuild=prebuilds.append,
+                open_settings=lambda: opens.append(True),
+            )
+        )
+
+        page.set_context_status(
+            rag_enabled=False,
+            source_index_enabled=False,
+            game_root="",
+        )
+        self.assertIs(page.page_stack.currentWidget(), page.empty_state)
+        page.empty_state.action_clicked.emit()
+        self.assertEqual(opens, [True])
+
+        page.set_context_status(
+            rag_enabled=True,
+            source_index_enabled=False,
+            game_root="C:/Games/Example/work",
+        )
+        page.bootstrap_rag_btn.click()
+        self.assertEqual(prebuilds, ["rag"])
 
     def test_global_prep_buttons_visible_on_all_task_pages(self) -> None:
         for mode in (


### PR DESCRIPTION
## 内容

- 将上下文库迁移为 workbench_stack 中的长期真实页面。
- 页面拥有状态卡、空状态、打开设置和两种预建 CTA；所有动作仍回调既有协调层。
- 切换到上下文页时隐藏 legacy 共享任务壳；未迁移入口继续使用 legacy 壳。
- 复用既有 WorkbenchModeSession、项目切换失效流程和 running 门控。

## 验证

- python -m unittest tests.test_gui_task_pages tests.test_gui_workbench_nav tests.test_gui_project_bar -q`n- python tests/run_gui_tests.py -q`n- git diff --check`n
Part of #176 (P1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Context Library page in the workbench.
  * Displays the status of memory and source indexes, with options to prebuild indexes or open settings.
  * Context Library actions are disabled while tasks are running.
  * The page resets automatically when switching projects.

* **Bug Fixes**
  * Improved navigation and visibility handling when switching between workbench pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->