### PR TITLE
feat(gui): add real sync translation page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2938,8 +2938,9 @@ class MainWindow(QMainWindow):
                 reflow(force=True)
         self._sync_action_frame_min_height()
         # Deferred second pass: parent widths settle after min-height changes.
-        # Context object cancels the callback if this window is already gone.
-        QTimer.singleShot(0, self, self._reflow_button_bars_deferred)
+        # Use the 2-arg form: helper tests construct MainWindow via __new__ without
+        # QObject init, and the 3-arg context overload requires a live C++ base.
+        QTimer.singleShot(0, self._reflow_button_bars_deferred)
 
     def _reflow_button_bars_deferred(self) -> None:
         for name in (

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2895,12 +2895,12 @@ class MainWindow(QMainWindow):
         column = getattr(self, "_workbench_actions_column", None)
         if column is not None:
             col_layout = column.layout()
-            if col_layout is not None:
+            if isinstance(col_layout, QLayout):
                 col_layout.invalidate()
                 col_layout.activate()
             # Explicit column min height = sum of visible children mins + spacing.
             col_h = 0
-            if col_layout is not None:
+            if isinstance(col_layout, QLayout):
                 spacing = col_layout.spacing()
                 visible_kids = 0
                 for i in range(col_layout.count()):
@@ -2916,9 +2916,11 @@ class MainWindow(QMainWindow):
                 column.setMinimumHeight(col_h)
             column.updateGeometry()
             parent = column.parentWidget()
-            if parent is not None and parent.layout() is not None:
-                parent.layout().invalidate()
-                parent.layout().activate()
+            if parent is not None:
+                layout = parent.layout()
+                if isinstance(layout, QLayout):
+                    layout.invalidate()
+                    layout.activate()
 
     def _reflow_button_bars(self) -> None:
         """Re-pack all flow/responsive button strips after visibility or size changes."""
@@ -2936,7 +2938,8 @@ class MainWindow(QMainWindow):
                 reflow(force=True)
         self._sync_action_frame_min_height()
         # Deferred second pass: parent widths settle after min-height changes.
-        QTimer.singleShot(0, self._reflow_button_bars_deferred)
+        # Context object cancels the callback if this window is already gone.
+        QTimer.singleShot(0, self, self._reflow_button_bars_deferred)
 
     def _reflow_button_bars_deferred(self) -> None:
         for name in (

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -262,6 +262,7 @@ from .work_modes import (
 )
 from .workbench import WorkbenchPageActions
 from .workbench.context_library_page import ContextLibraryPage
+from .workbench.sync_translation_page import SyncTranslationPage
 from .workbench_session import WorkbenchModeSession
 from .batch_workflow_support import resolve_submit_max_cost
 from .workflow_factory import create_workflow, resume_workflow
@@ -721,6 +722,15 @@ class MainWindow(QMainWindow):
                 self.context_bootstrap_rag_btn = page.bootstrap_rag_btn
                 self.context_bootstrap_source_index_btn = page.bootstrap_source_index_btn
                 self.context_open_settings_btn = page.open_settings_btn
+            elif nav_item == WorkbenchNavItem.SYNC_TRANSLATION:
+                page = SyncTranslationPage()
+                page.set_action_callbacks(
+                    WorkbenchPageActions(
+                        start=self._on_start_translation,
+                        stop=self._on_kill,
+                    )
+                )
+                self.sync_translation_page = page
             else:
                 page = QWidget()
                 page.setObjectName(f"workbench_page_{nav_item.value}")
@@ -1304,23 +1314,24 @@ class MainWindow(QMainWindow):
         nav = workbench_nav_for_work_mode(mode)
         is_sync = mode == WorkMode.SYNC_TRANSLATION
         is_context = nav == WorkbenchNavItem.CONTEXT
+        is_real_page = is_context or nav == WorkbenchNavItem.SYNC_TRANSLATION
 
         if hasattr(self, "sync_mode_warning"):
-            self.sync_mode_warning.setVisible(is_sync)
+            self.sync_mode_warning.setVisible(is_sync and not is_real_page)
         if hasattr(self, "workbench_stack"):
-            self.workbench_stack.setVisible(is_context)
+            self.workbench_stack.setVisible(is_real_page)
             self.workbench_stack.setMinimumHeight(0)
-            self.workbench_stack.setMaximumHeight(16_777_215 if is_context else 0)
+            self.workbench_stack.setMaximumHeight(16_777_215 if is_real_page else 0)
         for widget in getattr(self, "_legacy_workbench_shell_widgets", ()):
-            widget.setVisible(not is_context)
+            widget.setVisible(not is_real_page)
         if is_context:
             self._refresh_context_library_panel()
 
         # Doctor / bootstrap live on the global project bar (always available).
 
         if hasattr(self, "translate_btn"):
-            self.translate_btn.setVisible(not is_context)
-        if hasattr(self, "resume_btn") and is_context:
+            self.translate_btn.setVisible(not is_real_page)
+        if hasattr(self, "resume_btn") and is_real_page:
             self.resume_btn.setVisible(False)
         if hasattr(self, "action_panel"):
             reflow = getattr(self.action_panel, "reflow", None)
@@ -4154,13 +4165,20 @@ class MainWindow(QMainWindow):
             page = self._workbench_stack_pages.get(nav_item)
             if page is not None:
                 self.workbench_stack.setCurrentWidget(page)
-        if nav_item == WorkbenchNavItem.CONTEXT:
-            context_page = getattr(self, "context_library_page", None)
+        if nav_item in {
+            WorkbenchNavItem.CONTEXT,
+            WorkbenchNavItem.SYNC_TRANSLATION,
+        }:
+            page = (
+                getattr(self, "context_library_page", None)
+                if nav_item == WorkbenchNavItem.CONTEXT
+                else getattr(self, "sync_translation_page", None)
+            )
             sessions = getattr(self, "_mode_sessions", None)
             session = sessions.get(mode) if isinstance(sessions, dict) else None
-            if context_page is not None:
-                context_page.activate(mode, session or WorkbenchModeSession())
-                context_page.set_task_running(
+            if page is not None:
+                page.activate(mode, session or WorkbenchModeSession())
+                page.set_task_running(
                     bool(getattr(self, "_task_running", False))
                 )
 
@@ -4641,6 +4659,10 @@ class MainWindow(QMainWindow):
                 running=running,
             )
         )
+        sync_page = getattr(self, "sync_translation_page", None)
+        if spec.mode == WorkMode.SYNC_TRANSLATION and sync_page is not None:
+            sync_page.set_task_running(running)
+            sync_page.set_start_enabled(self.translate_btn.isEnabled())
         resume_available = (
             (False, "任务运行中。") if running else self._resume_task_available()
         )
@@ -5175,6 +5197,9 @@ class MainWindow(QMainWindow):
         context_page = getattr(self, "context_library_page", None)
         if context_page is not None:
             context_page.reset_project()
+        sync_page = getattr(self, "sync_translation_page", None)
+        if sync_page is not None:
+            sync_page.reset_project()
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()
@@ -6004,7 +6029,8 @@ class MainWindow(QMainWindow):
             return
 
         self._clear_log_view()
-        self._show_workbench_log_drawer()
+        if spec.mode != WorkMode.SYNC_TRANSLATION:
+            self._show_workbench_log_drawer()
         self._clear_completed_manifest_snapshot()
         self._writeback_manifest_path = ""
         if spec.supports_translation_writeback:
@@ -7129,6 +7155,10 @@ class MainWindow(QMainWindow):
         self._update_keyword_merge_btn_enabled(running=running)
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
+        sync_page = getattr(self, "sync_translation_page", None)
+        if sync_page is not None:
+            sync_page.set_task_running(running)
+            sync_page.set_start_enabled(self.translate_btn.isEnabled())
         # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
         if hasattr(self, "context_library_panel"):
             self._refresh_context_library_panel(running=running)
@@ -7161,6 +7191,10 @@ class MainWindow(QMainWindow):
         self.workflow_status_label.set_status(status, heading)
         self.workflow_message_label.setText(message)
         self.workflow_facts_label.setText("\n".join(facts or []))
+        if self._current_work_mode() == WorkMode.SYNC_TRANSLATION:
+            sync_page = getattr(self, "sync_translation_page", None)
+            if sync_page is not None:
+                sync_page.render_summary(status, heading, message, list(facts or []))
         self._update_resume_btn_text()
         resume_available = self._resume_task_available()
         self._update_resume_btn_enabled(resume_available=resume_available)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1224,10 +1224,10 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(self._build_workbench_log_drawer())
 
+        # Log drawer stays available on real pages (sync / context CLI runs).
         self._legacy_workbench_shell_widgets = (
             self._mode_frame,
             self._workbench_actions_column,
-            self.workbench_log_drawer,
         )
 
         self._workbench_tab = tab
@@ -4178,9 +4178,12 @@ class MainWindow(QMainWindow):
             session = sessions.get(mode) if isinstance(sessions, dict) else None
             if page is not None:
                 page.activate(mode, session or WorkbenchModeSession())
-                page.set_task_running(
-                    bool(getattr(self, "_task_running", False))
-                )
+                if nav_item == WorkbenchNavItem.SYNC_TRANSLATION:
+                    self._sync_sync_translation_page_controls()
+                else:
+                    page.set_task_running(
+                        bool(getattr(self, "_task_running", False))
+                    )
 
         nav_spec = workbench_nav_spec(nav_item)
         show_sub = nav_spec.show_submode
@@ -4535,6 +4538,27 @@ class MainWindow(QMainWindow):
 
     def _update_translate_button_label(self) -> None:
         self.translate_btn.setText(self._translate_button_label())
+        self._sync_sync_translation_page_controls(label_only=True)
+
+    def _sync_sync_translation_page_controls(
+        self,
+        *,
+        running: bool | None = None,
+        label_only: bool = False,
+    ) -> None:
+        """Keep page-local Start/Stop aligned with the legacy translate/kill buttons."""
+        sync_page = getattr(self, "sync_translation_page", None)
+        if sync_page is None:
+            return
+        sync_page.set_start_label(self._translate_button_label())
+        if label_only:
+            return
+        if running is None:
+            running = bool(getattr(self, "_task_running", False)) or (
+                hasattr(self, "kill_btn") and self.kill_btn.isEnabled()
+            )
+        sync_page.set_task_running(running)
+        sync_page.set_start_enabled(self.translate_btn.isEnabled())
 
     def _apply_work_mode_ui(
         self,
@@ -4659,10 +4683,8 @@ class MainWindow(QMainWindow):
                 running=running,
             )
         )
-        sync_page = getattr(self, "sync_translation_page", None)
-        if spec.mode == WorkMode.SYNC_TRANSLATION and sync_page is not None:
-            sync_page.set_task_running(running)
-            sync_page.set_start_enabled(self.translate_btn.isEnabled())
+        if spec.mode == WorkMode.SYNC_TRANSLATION:
+            self._sync_sync_translation_page_controls(running=running)
         resume_available = (
             (False, "任务运行中。") if running else self._resume_task_available()
         )
@@ -6029,8 +6051,7 @@ class MainWindow(QMainWindow):
             return
 
         self._clear_log_view()
-        if spec.mode != WorkMode.SYNC_TRANSLATION:
-            self._show_workbench_log_drawer()
+        self._show_workbench_log_drawer()
         self._clear_completed_manifest_snapshot()
         self._writeback_manifest_path = ""
         if spec.supports_translation_writeback:
@@ -7155,10 +7176,7 @@ class MainWindow(QMainWindow):
         self._update_keyword_merge_btn_enabled(running=running)
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
-        sync_page = getattr(self, "sync_translation_page", None)
-        if sync_page is not None:
-            sync_page.set_task_running(running)
-            sync_page.set_start_enabled(self.translate_btn.isEnabled())
+        self._sync_sync_translation_page_controls(running=running)
         # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
         if hasattr(self, "context_library_panel"):
             self._refresh_context_library_panel(running=running)
@@ -7191,10 +7209,6 @@ class MainWindow(QMainWindow):
         self.workflow_status_label.set_status(status, heading)
         self.workflow_message_label.setText(message)
         self.workflow_facts_label.setText("\n".join(facts or []))
-        if self._current_work_mode() == WorkMode.SYNC_TRANSLATION:
-            sync_page = getattr(self, "sync_translation_page", None)
-            if sync_page is not None:
-                sync_page.render_summary(status, heading, message, list(facts or []))
         self._update_resume_btn_text()
         resume_available = self._resume_task_available()
         self._update_resume_btn_enabled(resume_available=resume_available)
@@ -7322,6 +7336,7 @@ class MainWindow(QMainWindow):
                 running=running,
             )
         )
+        self._sync_sync_translation_page_controls(running=running)
         self._sync_task_shortcuts()
         self._sync_workbench_empty_states()
         self._sync_layout_sizes()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1321,7 +1321,29 @@ class MainWindow(QMainWindow):
         if hasattr(self, "workbench_stack"):
             self.workbench_stack.setVisible(is_real_page)
             self.workbench_stack.setMinimumHeight(0)
-            self.workbench_stack.setMaximumHeight(16_777_215 if is_real_page else 0)
+            # QStackedWidget sizeHint = max(all pages). Sync is a short strip; pin
+            # the stack to the current page so a tall context sibling cannot leave
+            # a huge empty action band above the shared status card.
+            if not is_real_page:
+                self.workbench_stack.setMaximumHeight(0)
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Fixed,
+                )
+            elif is_sync:
+                page = getattr(self, "sync_translation_page", None)
+                hint_h = page.sizeHint().height() if page is not None else 72
+                self.workbench_stack.setMaximumHeight(max(hint_h, 48))
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Maximum,
+                )
+            else:
+                self.workbench_stack.setMaximumHeight(16_777_215)
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Preferred,
+                )
         for widget in getattr(self, "_legacy_workbench_shell_widgets", ()):
             widget.setVisible(not is_real_page)
         if is_context:
@@ -1333,6 +1355,18 @@ class MainWindow(QMainWindow):
             self.translate_btn.setVisible(not is_real_page)
         if hasattr(self, "resume_btn") and is_real_page:
             self.resume_btn.setVisible(False)
+        # Idle workflow hint is redundant with status-card empty states; hide it.
+        # mode_frame only stays for submode row and/or legacy sync risk banner.
+        if hasattr(self, "work_mode_hint_label"):
+            self.work_mode_hint_label.setVisible(False)
+        if hasattr(self, "_mode_frame") and not is_real_page:
+            show_sub = workbench_nav_spec(nav).show_submode
+            show_sync_warn = bool(
+                is_sync
+                and hasattr(self, "sync_mode_warning")
+                and self.sync_mode_warning.isVisible()
+            )
+            self._mode_frame.setVisible(show_sub or show_sync_warn)
         if hasattr(self, "action_panel"):
             reflow = getattr(self.action_panel, "reflow", None)
             if callable(reflow):
@@ -2177,13 +2211,16 @@ class MainWindow(QMainWindow):
         self._sync_workbench_status_chrome(stage_index=stage_index)
 
     def _sync_batch_advanced_tools_chrome(self, *, stage_index: int | None = None) -> None:
-        """Show probe/split only on batch translation · 翻译进度 (P2a / #164)."""
+        """Show probe/split whenever batch translation is active (under main actions).
+
+        Stays on the workbench action column (not diagnostics): batch-only tools that
+        prepare packages before / around a run, always reachable without tab switching.
+        """
         if not hasattr(self, "batch_advanced_frame"):
             return
+        del stage_index  # kept for call-site compat; visibility is mode-based
         is_batch = self._batch_stage_mode_active()
-        if stage_index is None:
-            stage_index = self._current_batch_stage_index()
-        show = is_batch and stage_index == _BATCH_STAGE_EXECUTE
+        show = is_batch
         self.batch_advanced_frame.setVisible(show)
         if show and hasattr(self, "batch_advanced_bar"):
             reflow = getattr(self.batch_advanced_bar, "reflow", None)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -713,6 +713,7 @@ class MainWindow(QMainWindow):
                     WorkbenchPageActions(
                         prebuild=self._on_context_bootstrap_clicked,
                         open_settings=self._on_open_context_settings,
+                        stop=self._on_kill,
                     )
                 )
                 self.context_library_page = page
@@ -1226,7 +1227,6 @@ class MainWindow(QMainWindow):
         self._legacy_workbench_shell_widgets = (
             self._mode_frame,
             self._workbench_actions_column,
-            self.workbench_status_card,
             self.workbench_log_drawer,
         )
 

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -209,7 +209,8 @@ QLabel#workbench_page_title {
     font-weight: 700;
 }
 
-QLabel#sync_mode_warning {
+QLabel#sync_mode_warning,
+QLabel#sync_translation_risk_warning {
     color: ${badge_warning_fg};
     background-color: ${badge_warning_bg};
     border: 1px solid ${badge_warning_border};
@@ -653,7 +654,8 @@ QPushButton:disabled {
 /* Primary Action Buttons - Aurora Gradient */
 QPushButton#save_config_btn,
 QPushButton#api_btn,
-QPushButton#translate_btn {
+QPushButton#translate_btn,
+QPushButton#sync_translation_start_btn {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_start}, stop:1 ${gradient_primary_end});
     border: none;
     color: ${fg_on_accent};
@@ -663,19 +665,22 @@ QPushButton#translate_btn {
 
 QPushButton#save_config_btn:hover,
 QPushButton#api_btn:hover,
-QPushButton#translate_btn:hover {
+QPushButton#translate_btn:hover,
+QPushButton#sync_translation_start_btn:hover {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_hover_start}, stop:1 ${gradient_primary_hover_end});
 }
 
 QPushButton#save_config_btn:pressed,
 QPushButton#api_btn:pressed,
-QPushButton#translate_btn:pressed {
+QPushButton#translate_btn:pressed,
+QPushButton#sync_translation_start_btn:pressed {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_pressed_start}, stop:1 ${gradient_primary_pressed_end});
 }
 
 QPushButton#save_config_btn:disabled,
 QPushButton#api_btn:disabled,
-QPushButton#translate_btn:disabled {
+QPushButton#translate_btn:disabled,
+QPushButton#sync_translation_start_btn:disabled {
     background-color: ${bg_button_disabled};
     border: 1px solid ${border_button_disabled};
     color: ${fg_button_disabled};
@@ -742,22 +747,26 @@ QPushButton#split_select_btn:disabled {
 }
 
 /* Danger Action Button */
-QPushButton#kill_btn {
+QPushButton#kill_btn,
+QPushButton#sync_translation_stop_btn {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_start}, stop:1 ${gradient_danger_end});
     border: none;
     color: ${fg_on_accent};
     font-weight: 700;
 }
 
-QPushButton#kill_btn:hover {
+QPushButton#kill_btn:hover,
+QPushButton#sync_translation_stop_btn:hover {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_hover_start}, stop:1 ${gradient_danger_hover_end});
 }
 
-QPushButton#kill_btn:pressed {
+QPushButton#kill_btn:pressed,
+QPushButton#sync_translation_stop_btn:pressed {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_pressed_start}, stop:1 ${gradient_danger_pressed_end});
 }
 
-QPushButton#kill_btn:disabled {
+QPushButton#kill_btn:disabled,
+QPushButton#sync_translation_stop_btn:disabled {
     background-color: ${bg_danger_disabled};
     border: 1px solid ${border_danger_disabled};
     color: ${fg_danger_disabled};

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -209,8 +209,7 @@ QLabel#workbench_page_title {
     font-weight: 700;
 }
 
-QLabel#sync_mode_warning,
-QLabel#sync_translation_risk_warning {
+QLabel#sync_mode_warning {
     color: ${badge_warning_fg};
     background-color: ${badge_warning_bg};
     border: 1px solid ${badge_warning_border};
@@ -219,9 +218,34 @@ QLabel#sync_translation_risk_warning {
     font-weight: 600;
 }
 
+/* Page-local banner: single compact strip. */
+QLabel#sync_translation_risk_warning {
+    color: ${badge_warning_fg};
+    background-color: ${badge_warning_bg};
+    border: 1px solid ${badge_warning_border};
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+/* Real workbench pages sit above the shared status card. */
+QFrame#sync_translation_page,
+QStackedWidget#workbench_stack {
+    background-color: transparent;
+    border: none;
+}
+
+/* Transparent like sync page — status rows / status card carry the chrome. */
 QFrame#context_library_panel {
-    background-color: ${bg_surface_alt};
-    border: 1px solid ${border_light};
+    background-color: transparent;
+    border: none;
+}
+
+QFrame#context_library_status_row {
+    background-color: ${bg_card};
+    border: 1px solid ${border_card};
+    border-top: 1px solid ${border_card_top};
     border-radius: 10px;
 }
 
@@ -651,11 +675,14 @@ QPushButton:disabled {
     color: ${fg_button_disabled};
 }
 
-/* Primary Action Buttons - Aurora Gradient */
+/* Primary Action Buttons - Aurora Gradient (start / prebuild / diagnostics run) */
 QPushButton#save_config_btn,
 QPushButton#api_btn,
 QPushButton#translate_btn,
-QPushButton#sync_translation_start_btn {
+QPushButton#primary_btn,
+QPushButton#sync_translation_start_btn,
+QPushButton#context_bootstrap_rag_btn,
+QPushButton#context_bootstrap_source_index_btn {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_start}, stop:1 ${gradient_primary_end});
     border: none;
     color: ${fg_on_accent};
@@ -666,21 +693,30 @@ QPushButton#sync_translation_start_btn {
 QPushButton#save_config_btn:hover,
 QPushButton#api_btn:hover,
 QPushButton#translate_btn:hover,
-QPushButton#sync_translation_start_btn:hover {
+QPushButton#primary_btn:hover,
+QPushButton#sync_translation_start_btn:hover,
+QPushButton#context_bootstrap_rag_btn:hover,
+QPushButton#context_bootstrap_source_index_btn:hover {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_hover_start}, stop:1 ${gradient_primary_hover_end});
 }
 
 QPushButton#save_config_btn:pressed,
 QPushButton#api_btn:pressed,
 QPushButton#translate_btn:pressed,
-QPushButton#sync_translation_start_btn:pressed {
+QPushButton#primary_btn:pressed,
+QPushButton#sync_translation_start_btn:pressed,
+QPushButton#context_bootstrap_rag_btn:pressed,
+QPushButton#context_bootstrap_source_index_btn:pressed {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_pressed_start}, stop:1 ${gradient_primary_pressed_end});
 }
 
 QPushButton#save_config_btn:disabled,
 QPushButton#api_btn:disabled,
 QPushButton#translate_btn:disabled,
-QPushButton#sync_translation_start_btn:disabled {
+QPushButton#primary_btn:disabled,
+QPushButton#sync_translation_start_btn:disabled,
+QPushButton#context_bootstrap_rag_btn:disabled,
+QPushButton#context_bootstrap_source_index_btn:disabled {
     background-color: ${bg_button_disabled};
     border: 1px solid ${border_button_disabled};
     color: ${fg_button_disabled};
@@ -746,9 +782,10 @@ QPushButton#split_select_btn:disabled {
     color: ${fg_split_select_disabled};
 }
 
-/* Danger Action Button */
+/* Danger Action Button (stop / kill) */
 QPushButton#kill_btn,
-QPushButton#sync_translation_stop_btn {
+QPushButton#sync_translation_stop_btn,
+QPushButton#context_library_stop_btn {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_start}, stop:1 ${gradient_danger_end});
     border: none;
     color: ${fg_on_accent};
@@ -756,17 +793,20 @@ QPushButton#sync_translation_stop_btn {
 }
 
 QPushButton#kill_btn:hover,
-QPushButton#sync_translation_stop_btn:hover {
+QPushButton#sync_translation_stop_btn:hover,
+QPushButton#context_library_stop_btn:hover {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_hover_start}, stop:1 ${gradient_danger_hover_end});
 }
 
 QPushButton#kill_btn:pressed,
-QPushButton#sync_translation_stop_btn:pressed {
+QPushButton#sync_translation_stop_btn:pressed,
+QPushButton#context_library_stop_btn:pressed {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_danger_pressed_start}, stop:1 ${gradient_danger_pressed_end});
 }
 
 QPushButton#kill_btn:disabled,
-QPushButton#sync_translation_stop_btn:disabled {
+QPushButton#sync_translation_stop_btn:disabled,
+QPushButton#context_library_stop_btn:disabled {
     background-color: ${bg_danger_disabled};
     border: 1px solid ${border_danger_disabled};
     color: ${fg_danger_disabled};

--- a/gui_qt/responsive_layout.py
+++ b/gui_qt/responsive_layout.py
@@ -107,6 +107,31 @@ def clear_layout(layout: QLayout) -> None:
             widget.deleteLater()
 
 
+def _activate_ancestor_layouts(
+    widget: QWidget,
+    *,
+    max_depth: int = 6,
+    invalidate: bool = False,
+) -> None:
+    """Invalidate/activate installed QLayouts on ancestor widgets.
+
+    ``QWidget.layout()`` is expected to return a ``QLayout``, but during nested
+    reflow / teardown some PySide builds can surface a stale ``QLayoutItem``
+    wrapper. Only call layout APIs on real ``QLayout`` instances.
+    """
+    parent = widget.parentWidget()
+    depth = 0
+    while parent is not None and depth < max_depth:
+        parent.updateGeometry()
+        layout = parent.layout()
+        if isinstance(layout, QLayout):
+            if invalidate:
+                layout.invalidate()
+            layout.activate()
+        parent = parent.parentWidget()
+        depth += 1
+
+
 def _make_action_separator(*, vertical: bool) -> QFrame:
     """Create a thin separator that never steals mouse events or grows to 640x480."""
     separator = QFrame()
@@ -309,15 +334,7 @@ class ResponsiveActionPanel(QFrame):
         self.setMinimumHeight(height)
         self.updateGeometry()
         # Bubble size change so siblings (e.g. batch advanced tools) reflow below us.
-        parent = self.parentWidget()
-        depth = 0
-        while parent is not None and depth < 4:
-            parent.updateGeometry()
-            layout = parent.layout()
-            if layout is not None:
-                layout.activate()
-            parent = parent.parentWidget()
-            depth += 1
+        _activate_ancestor_layouts(self, max_depth=4)
 
 
 class FlowButtonBar(QFrame):
@@ -372,7 +389,8 @@ class FlowButtonBar(QFrame):
 
     def _schedule_reflow(self) -> None:
         """Reflow after the current event so parent/tab geometry is final."""
-        QTimer.singleShot(0, lambda: self.reflow(force=True))
+        # Bind to self so the timer is cancelled if this bar is destroyed.
+        QTimer.singleShot(0, self, lambda: self.reflow(force=True))
 
     def resizeEvent(self, event) -> None:  # noqa: N802
         super().resizeEvent(event)
@@ -447,16 +465,7 @@ class FlowButtonBar(QFrame):
             height = max(height, hint.height())
         self.setMinimumHeight(height)
         self.updateGeometry()
-        parent = self.parentWidget()
-        depth = 0
-        while parent is not None and depth < 6:
-            parent.updateGeometry()
-            layout = parent.layout()
-            if layout is not None:
-                layout.invalidate()
-                layout.activate()
-            parent = parent.parentWidget()
-            depth += 1
+        _activate_ancestor_layouts(self, max_depth=6, invalidate=True)
 
     def sizeHint(self) -> QSize:  # noqa: N802
         hint = super().sizeHint()

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -36,12 +36,9 @@ class ContextLibraryPage(QFrame):
         self._active_mode = WorkMode.BOOTSTRAP_RAG
 
         outer = QVBoxLayout(self)
-        outer.setContentsMargins(12, 12, 12, 12)
-        outer.setSpacing(10)
-
-        title = QLabel("上下文库")
-        title.setObjectName("diagnostics_section_label")
-        outer.addWidget(title)
+        # No page title — left nav already names the task (same as sync page).
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(8)
 
         self.page_stack = QStackedWidget()
         self.page_stack.setObjectName("context_library_page_stack")
@@ -71,12 +68,18 @@ class ContextLibraryPage(QFrame):
             "开关须在设置中保存后才能预建；打开设置的「上下文」分区。"
         )
         self.open_settings_btn.clicked.connect(self._trigger_open_settings)
+        # Secondary style + hidden when idle: page already has no legacy kill row,
+        # so stop is only revealed while a prebuild is running (less visual noise).
+        # Danger stop, same family as kill_btn / sync stop; always visible, enabled while running.
         self.stop_btn = QPushButton("停止")
-        self.stop_btn.setObjectName("kill_btn")
+        self.stop_btn.setObjectName("context_library_stop_btn")
+        self.stop_btn.setToolTip("停止当前预建任务")
         self.stop_btn.setEnabled(False)
         self.stop_btn.clicked.connect(self._trigger_stop)
         action_row = QHBoxLayout()
+        action_row.setSpacing(8)
         action_row.addWidget(self.open_settings_btn)
+        action_row.addStretch()
         action_row.addWidget(self.stop_btn)
         status_layout.addLayout(action_row)
         status_layout.addStretch()
@@ -94,7 +97,7 @@ class ContextLibraryPage(QFrame):
         self.rag_status_label.setWordWrap(True)
         row.addWidget(self.rag_status_label, 1)
         self.bootstrap_rag_btn = QPushButton("预建记忆库")
-        self.bootstrap_rag_btn.setObjectName("secondary_btn")
+        self.bootstrap_rag_btn.setObjectName("context_bootstrap_rag_btn")
         self.bootstrap_rag_btn.clicked.connect(lambda: self._trigger_prebuild("rag"))
         row.addWidget(self.bootstrap_rag_btn)
         return row_frame
@@ -110,7 +113,7 @@ class ContextLibraryPage(QFrame):
         self.source_index_status_label.setWordWrap(True)
         row.addWidget(self.source_index_status_label, 1)
         self.bootstrap_source_index_btn = QPushButton("预建原文索引")
-        self.bootstrap_source_index_btn.setObjectName("secondary_btn")
+        self.bootstrap_source_index_btn.setObjectName("context_bootstrap_source_index_btn")
         self.bootstrap_source_index_btn.clicked.connect(
             lambda: self._trigger_prebuild("source_index")
         )

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -71,7 +71,14 @@ class ContextLibraryPage(QFrame):
             "开关须在设置中保存后才能预建；打开设置的「上下文」分区。"
         )
         self.open_settings_btn.clicked.connect(self._trigger_open_settings)
-        status_layout.addWidget(self.open_settings_btn, 0, Qt.AlignmentFlag.AlignLeft)
+        self.stop_btn = QPushButton("停止")
+        self.stop_btn.setObjectName("kill_btn")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self._trigger_stop)
+        action_row = QHBoxLayout()
+        action_row.addWidget(self.open_settings_btn)
+        action_row.addWidget(self.stop_btn)
+        status_layout.addLayout(action_row)
         status_layout.addStretch()
         self.page_stack.addWidget(self.status_page)
         self.page_stack.setCurrentWidget(self.empty_state)
@@ -161,6 +168,7 @@ class ContextLibraryPage(QFrame):
             not self._running and self._source_index_enabled
         )
         self.open_settings_btn.setEnabled(not self._running)
+        self.stop_btn.setEnabled(self._running)
 
     def _trigger_prebuild(self, kind: str) -> None:
         if self._running or self._actions.prebuild is None:
@@ -170,3 +178,7 @@ class ContextLibraryPage(QFrame):
     def _trigger_open_settings(self) -> None:
         if not self._running and self._actions.open_settings is not None:
             self._actions.open_settings()
+
+    def _trigger_stop(self) -> None:
+        if self._running and self._actions.stop is not None:
+            self._actions.stop()

--- a/gui_qt/workbench/sync_translation_page.py
+++ b/gui_qt/workbench/sync_translation_page.py
@@ -1,17 +1,19 @@
 """Persistent synchronous-translation page for the workbench stack (#176 P2)."""
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
-from ..status_icons import StatusBadge
 from ..work_modes import WorkMode
 from ..workbench_session import WorkbenchModeSession
 from .page_contract import WorkbenchPageActions
 
 
 class SyncTranslationPage(QFrame):
-    """Page-local controls and summary for direct synchronous translation."""
+    """Page-local risk notice and start/stop for direct synchronous translation.
+
+    Live progress, doctor status, and writeback stay on the shared workbench
+    status card so the page does not duplicate that surface.
+    """
 
     supported_modes = (WorkMode.SYNC_TRANSLATION,)
 
@@ -32,7 +34,7 @@ class SyncTranslationPage(QFrame):
         self.risk_warning = QLabel(
             "警告：同步翻译可能直接修改项目文件，请先备份或在副本上试跑。"
         )
-        self.risk_warning.setObjectName("sync_mode_warning")
+        self.risk_warning.setObjectName("sync_translation_risk_warning")
         self.risk_warning.setWordWrap(True)
         outer.addWidget(self.risk_warning)
 
@@ -42,40 +44,17 @@ class SyncTranslationPage(QFrame):
         action_layout.setContentsMargins(10, 8, 10, 8)
         action_layout.setSpacing(8)
         self.start_btn = QPushButton("开始同步翻译")
-        self.start_btn.setObjectName("translate_btn")
+        self.start_btn.setObjectName("sync_translation_start_btn")
         self.start_btn.clicked.connect(self._trigger_start)
         self.start_btn.setEnabled(False)
         action_layout.addWidget(self.start_btn)
         self.stop_btn = QPushButton("停止")
-        self.stop_btn.setObjectName("kill_btn")
+        self.stop_btn.setObjectName("sync_translation_stop_btn")
         self.stop_btn.clicked.connect(self._trigger_stop)
         self.stop_btn.setEnabled(False)
         action_layout.addWidget(self.stop_btn)
         action_layout.addStretch()
         outer.addWidget(actions)
-
-        summary = QFrame()
-        summary.setObjectName("workbench_status_card")
-        summary_layout = QVBoxLayout(summary)
-        summary_layout.setContentsMargins(12, 12, 12, 12)
-        summary_layout.setSpacing(6)
-        self.status_label = StatusBadge("sync_translation_status_label")
-        summary_layout.addWidget(self.status_label)
-        self.heading_label = QLabel("尚未开始同步翻译")
-        self.heading_label.setObjectName("action_group_label")
-        self.heading_label.setWordWrap(True)
-        summary_layout.addWidget(self.heading_label)
-        self.message_label = QLabel(
-            "完成环境检查后即可开始；同步翻译会直接写入项目文件。"
-        )
-        self.message_label.setObjectName("summary_body_label")
-        self.message_label.setWordWrap(True)
-        summary_layout.addWidget(self.message_label)
-        self.facts_label = QLabel()
-        self.facts_label.setObjectName("workflow_facts_label")
-        self.facts_label.setWordWrap(True)
-        summary_layout.addWidget(self.facts_label)
-        outer.addWidget(summary)
         outer.addStretch()
 
     def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
@@ -84,12 +63,8 @@ class SyncTranslationPage(QFrame):
     def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
         if mode not in self.supported_modes:
             raise ValueError(f"Unsupported sync-translation mode: {mode.value}")
-        self.render_summary(
-            session.workflow_status or "idle",
-            session.workflow_heading or "尚未开始同步翻译",
-            session.workflow_message or "完成环境检查后即可开始；同步翻译会直接写入项目文件。",
-            session.workflow_facts,
-        )
+        # Progress / doctor / writeback live on the shared status card.
+        del session
 
     def set_task_running(self, running: bool) -> None:
         self._running = running
@@ -100,25 +75,13 @@ class SyncTranslationPage(QFrame):
     def set_start_enabled(self, enabled: bool) -> None:
         self.start_btn.setEnabled(enabled and not self._running)
 
-    def reset_project(self) -> None:
-        self.render_summary(
-            "stale",
-            "项目已切换",
-            "任务状态已清空；请先针对新项目重新检查。",
-            [],
-        )
+    def set_start_label(self, text: str) -> None:
+        self.start_btn.setText(text)
 
-    def render_summary(
-        self,
-        status: str,
-        heading: str,
-        message: str,
-        facts: list[str],
-    ) -> None:
-        self.status_label.set_status(status, heading)
-        self.heading_label.setText(heading)
-        self.message_label.setText(message)
-        self.facts_label.setText("\n".join(facts))
+    def reset_project(self) -> None:
+        """Page-local chrome has no project-bound state beyond button enablement."""
+        self.set_task_running(False)
+        self.set_start_enabled(False)
 
     def _trigger_start(self) -> None:
         if not self._running and self._actions.start is not None:

--- a/gui_qt/workbench/sync_translation_page.py
+++ b/gui_qt/workbench/sync_translation_page.py
@@ -1,0 +1,129 @@
+"""Persistent synchronous-translation page for the workbench stack (#176 P2)."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from ..status_icons import StatusBadge
+from ..work_modes import WorkMode
+from ..workbench_session import WorkbenchModeSession
+from .page_contract import WorkbenchPageActions
+
+
+class SyncTranslationPage(QFrame):
+    """Page-local controls and summary for direct synchronous translation."""
+
+    supported_modes = (WorkMode.SYNC_TRANSLATION,)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("sync_translation_page")
+        self._actions = WorkbenchPageActions()
+        self._running = False
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(12, 12, 12, 12)
+        outer.setSpacing(10)
+
+        title = QLabel("同步翻译")
+        title.setObjectName("diagnostics_section_label")
+        outer.addWidget(title)
+
+        self.risk_warning = QLabel(
+            "警告：同步翻译可能直接修改项目文件，请先备份或在副本上试跑。"
+        )
+        self.risk_warning.setObjectName("sync_mode_warning")
+        self.risk_warning.setWordWrap(True)
+        outer.addWidget(self.risk_warning)
+
+        actions = QFrame()
+        actions.setObjectName("action_frame")
+        action_layout = QHBoxLayout(actions)
+        action_layout.setContentsMargins(10, 8, 10, 8)
+        action_layout.setSpacing(8)
+        self.start_btn = QPushButton("开始同步翻译")
+        self.start_btn.setObjectName("translate_btn")
+        self.start_btn.clicked.connect(self._trigger_start)
+        self.start_btn.setEnabled(False)
+        action_layout.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("停止")
+        self.stop_btn.setObjectName("kill_btn")
+        self.stop_btn.clicked.connect(self._trigger_stop)
+        self.stop_btn.setEnabled(False)
+        action_layout.addWidget(self.stop_btn)
+        action_layout.addStretch()
+        outer.addWidget(actions)
+
+        summary = QFrame()
+        summary.setObjectName("workbench_status_card")
+        summary_layout = QVBoxLayout(summary)
+        summary_layout.setContentsMargins(12, 12, 12, 12)
+        summary_layout.setSpacing(6)
+        self.status_label = StatusBadge("sync_translation_status_label")
+        summary_layout.addWidget(self.status_label)
+        self.heading_label = QLabel("尚未开始同步翻译")
+        self.heading_label.setObjectName("action_group_label")
+        self.heading_label.setWordWrap(True)
+        summary_layout.addWidget(self.heading_label)
+        self.message_label = QLabel(
+            "完成环境检查后即可开始；同步翻译会直接写入项目文件。"
+        )
+        self.message_label.setObjectName("summary_body_label")
+        self.message_label.setWordWrap(True)
+        summary_layout.addWidget(self.message_label)
+        self.facts_label = QLabel()
+        self.facts_label.setObjectName("workflow_facts_label")
+        self.facts_label.setWordWrap(True)
+        summary_layout.addWidget(self.facts_label)
+        outer.addWidget(summary)
+        outer.addStretch()
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        self._actions = actions
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        if mode not in self.supported_modes:
+            raise ValueError(f"Unsupported sync-translation mode: {mode.value}")
+        self.render_summary(
+            session.workflow_status or "idle",
+            session.workflow_heading or "尚未开始同步翻译",
+            session.workflow_message or "完成环境检查后即可开始；同步翻译会直接写入项目文件。",
+            session.workflow_facts,
+        )
+
+    def set_task_running(self, running: bool) -> None:
+        self._running = running
+        self.stop_btn.setEnabled(running)
+        if running:
+            self.start_btn.setEnabled(False)
+
+    def set_start_enabled(self, enabled: bool) -> None:
+        self.start_btn.setEnabled(enabled and not self._running)
+
+    def reset_project(self) -> None:
+        self.render_summary(
+            "stale",
+            "项目已切换",
+            "任务状态已清空；请先针对新项目重新检查。",
+            [],
+        )
+
+    def render_summary(
+        self,
+        status: str,
+        heading: str,
+        message: str,
+        facts: list[str],
+    ) -> None:
+        self.status_label.set_status(status, heading)
+        self.heading_label.setText(heading)
+        self.message_label.setText(message)
+        self.facts_label.setText("\n".join(facts))
+
+    def _trigger_start(self) -> None:
+        if not self._running and self._actions.start is not None:
+            self._actions.start()
+
+    def _trigger_stop(self) -> None:
+        if self._running and self._actions.stop is not None:
+            self._actions.stop()

--- a/gui_qt/workbench/sync_translation_page.py
+++ b/gui_qt/workbench/sync_translation_page.py
@@ -1,7 +1,15 @@
 """Persistent synchronous-translation page for the workbench stack (#176 P2)."""
 from __future__ import annotations
 
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ..work_modes import WorkMode
 from ..workbench_session import WorkbenchModeSession
@@ -9,39 +17,39 @@ from .page_contract import WorkbenchPageActions
 
 
 class SyncTranslationPage(QFrame):
-    """Page-local risk notice and start/stop for direct synchronous translation.
-
-    Live progress, doctor status, and writeback stay on the shared workbench
-    status card so the page does not duplicate that surface.
-    """
+    """Compact risk notice + start/stop; shared status card holds doctor/progress."""
 
     supported_modes = (WorkMode.SYNC_TRANSLATION,)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("sync_translation_page")
+        # Height-for-content only — never eat space meant for the status card.
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self._actions = WorkbenchPageActions()
         self._running = False
 
         outer = QVBoxLayout(self)
-        outer.setContentsMargins(12, 12, 12, 12)
-        outer.setSpacing(10)
-
-        title = QLabel("同步翻译")
-        title.setObjectName("diagnostics_section_label")
-        outer.addWidget(title)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(6)
 
         self.risk_warning = QLabel(
-            "警告：同步翻译可能直接修改项目文件，请先备份或在副本上试跑。"
+            "警告：可能直接修改项目文件，请先备份或在副本上试跑。"
         )
         self.risk_warning.setObjectName("sync_translation_risk_warning")
         self.risk_warning.setWordWrap(True)
+        self.risk_warning.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Fixed,
+        )
         outer.addWidget(self.risk_warning)
 
+        # Compact glass action card (same look as legacy action_frame, fixed height).
         actions = QFrame()
         actions.setObjectName("action_frame")
+        actions.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         action_layout = QHBoxLayout(actions)
-        action_layout.setContentsMargins(10, 8, 10, 8)
+        action_layout.setContentsMargins(12, 8, 12, 8)
         action_layout.setSpacing(8)
         self.start_btn = QPushButton("开始同步翻译")
         self.start_btn.setObjectName("sync_translation_start_btn")
@@ -55,7 +63,20 @@ class SyncTranslationPage(QFrame):
         action_layout.addWidget(self.stop_btn)
         action_layout.addStretch()
         outer.addWidget(actions)
-        outer.addStretch()
+
+    def sizeHint(self):  # noqa: N802
+        """Keep stack sizing honest — QStackedWidget takes max of all pages."""
+        return self.minimumSizeHint()
+
+    def minimumSizeHint(self):  # noqa: N802
+        from PySide6.QtCore import QSize
+
+        # warning + spacing + compact action card (padding + button)
+        w = super().minimumSizeHint().width()
+        btn_h = max(self.start_btn.sizeHint().height(), 32)
+        action_h = btn_h + 16  # 8px vertical padding × 2
+        h = self.risk_warning.sizeHint().height() + 6 + action_h
+        return QSize(max(w, 200), h)
 
     def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
         self._actions = actions
@@ -63,7 +84,6 @@ class SyncTranslationPage(QFrame):
     def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
         if mode not in self.supported_modes:
             raise ValueError(f"Unsupported sync-translation mode: {mode.value}")
-        # Progress / doctor / writeback live on the shared status card.
         del session
 
     def set_task_running(self, running: bool) -> None:
@@ -79,7 +99,6 @@ class SyncTranslationPage(QFrame):
         self.start_btn.setText(text)
 
     def reset_project(self) -> None:
-        """Page-local chrome has no project-bound state beyond button enablement."""
         self.set_task_running(False)
         self.set_start_enabled(False)
 

--- a/tests/test_gui_batch_advanced_tools.py
+++ b/tests/test_gui_batch_advanced_tools.py
@@ -49,19 +49,17 @@ class GuiBatchAdvancedToolsTests(unittest.TestCase):
         self.assertNotIn("拆分翻译包", diag_buttons)
         self.assertIn("翻译 A/B 对比", diag_buttons)
 
-    def test_advanced_bar_only_on_batch_execute_stage(self) -> None:
+    def test_advanced_bar_stays_on_batch_across_status_tabs(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,
             refresh_manifest_writeback=False,
         )
-        self.window._focus_workbench_status_tab(1)  # EXECUTE
-        self.assertFalse(self.window.batch_advanced_frame.isHidden())
-
-        self.window._focus_workbench_status_tab(0)  # PREPARE
-        self.assertTrue(self.window.batch_advanced_frame.isHidden())
-
-        self.window._focus_workbench_status_tab(2)  # RESULT
-        self.assertTrue(self.window.batch_advanced_frame.isHidden())
+        for tab in (0, 1, 2):
+            self.window._focus_workbench_status_tab(tab)
+            self.assertFalse(
+                self.window.batch_advanced_frame.isHidden(),
+                msg=f"advanced tools should stay on batch (status tab {tab})",
+            )
 
         self.window._set_work_mode(
             WorkMode.SYNC_TRANSLATION,

--- a/tests/test_gui_batch_stages.py
+++ b/tests/test_gui_batch_stages.py
@@ -146,19 +146,21 @@ class GuiBatchStageTests(unittest.TestCase):
         self.window._focus_workbench_status_tab(2)
         self.assertEqual(self.window._current_batch_stage_index(), _BATCH_STAGE_RESULT)
 
-    def test_advanced_tools_only_on_batch_progress_tab(self) -> None:
+    def test_advanced_tools_stay_on_batch_across_status_tabs(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,
             refresh_manifest_writeback=False,
         )
-        self.window._focus_workbench_status_tab(_BATCH_STAGE_EXECUTE)
-        self.assertFalse(self.window.batch_advanced_frame.isHidden())
-
-        self.window._focus_workbench_status_tab(_BATCH_STAGE_PREPARE)
-        self.assertTrue(self.window.batch_advanced_frame.isHidden())
-
-        self.window._focus_workbench_status_tab(_BATCH_STAGE_RESULT)
-        self.assertTrue(self.window.batch_advanced_frame.isHidden())
+        for stage in (
+            _BATCH_STAGE_PREPARE,
+            _BATCH_STAGE_EXECUTE,
+            _BATCH_STAGE_RESULT,
+        ):
+            self.window._focus_workbench_status_tab(stage)
+            self.assertFalse(
+                self.window.batch_advanced_frame.isHidden(),
+                msg=f"advanced tools should stay on batch (stage {stage})",
+            )
 
         self.window._set_work_mode(
             WorkMode.SYNC_TRANSLATION,

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -84,7 +84,7 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertEqual(page.start_btn.text(), "开始同步翻译")
         self.assertTrue(self.window.sync_mode_warning.isHidden())
         self.assertTrue(self.window._workbench_actions_column.isHidden())
-        self.assertTrue(self.window.workbench_status_card.isHidden())
+        self.assertFalse(self.window.workbench_status_card.isHidden())
         self.assertTrue(self.window.context_library_panel.isHidden())
 
     def test_sync_page_uses_start_stop_callbacks_and_owns_summary(self) -> None:
@@ -205,7 +205,7 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(self.window.workbench_stack.isHidden())
         self.assertTrue(self.window._mode_frame.isHidden())
         self.assertTrue(self.window._workbench_actions_column.isHidden())
-        self.assertTrue(self.window.workbench_status_card.isHidden())
+        self.assertFalse(self.window.workbench_status_card.isHidden())
         self.assertTrue(self.window.work_submode_combo.isHidden())
         self.assertTrue(self.window.translate_btn.isHidden())
         # Doctor / bootstrap stay on the global project bar for every task page.
@@ -270,10 +270,12 @@ class GuiTaskPageTests(unittest.TestCase):
             self.window._set_task_running(True)
             self.assertFalse(self.window.context_bootstrap_rag_btn.isEnabled())
             self.assertFalse(self.window.context_bootstrap_source_index_btn.isEnabled())
+            self.assertTrue(self.window.context_library_page.stop_btn.isEnabled())
             # Overlapping start must no-op while a task is already running.
             self.assertFalse(self.window._start_bootstrap_task("source_index"))
             self.window._set_task_running(False)
             self.assertTrue(self.window.context_bootstrap_rag_btn.isEnabled())
+            self.assertFalse(self.window.context_library_page.stop_btn.isEnabled())
 
     def test_roundtrip_keyword_candidates_and_merge_button(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -323,14 +323,22 @@ class GuiTaskPageTests(unittest.TestCase):
         ):
             self.window._refresh_context_library_panel()
             self.assertTrue(self.window.context_bootstrap_rag_btn.isEnabled())
+            self.assertFalse(self.window.context_library_page.stop_btn.isHidden())
+            self.assertFalse(self.window.context_library_page.stop_btn.isEnabled())
             self.window._set_task_running(True)
             self.assertFalse(self.window.context_bootstrap_rag_btn.isEnabled())
             self.assertFalse(self.window.context_bootstrap_source_index_btn.isEnabled())
+            self.assertFalse(self.window.context_library_page.stop_btn.isHidden())
             self.assertTrue(self.window.context_library_page.stop_btn.isEnabled())
+            self.assertEqual(
+                self.window.context_library_page.stop_btn.objectName(),
+                "context_library_stop_btn",
+            )
             # Overlapping start must no-op while a task is already running.
             self.assertFalse(self.window._start_bootstrap_task("source_index"))
             self.window._set_task_running(False)
             self.assertTrue(self.window.context_bootstrap_rag_btn.isEnabled())
+            self.assertFalse(self.window.context_library_page.stop_btn.isHidden())
             self.assertFalse(self.window.context_library_page.stop_btn.isEnabled())
 
     def test_roundtrip_keyword_candidates_and_merge_button(self) -> None:

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -10,11 +10,13 @@ try:
 
     from gui_qt.app import MainWindow
     from gui_qt.check_report import WritebackSummary
+    from gui_qt.doctor_report import DoctorSummary
 except ImportError as exc:
     MainWindow = None  # type: ignore[assignment,misc]
     QApplication = None  # type: ignore[assignment,misc]
     Qt = None  # type: ignore[assignment,misc]
     WritebackSummary = None  # type: ignore[misc,assignment]
+    DoctorSummary = None  # type: ignore[misc,assignment]
     IMPORT_ERROR = exc
 else:
     IMPORT_ERROR = None
@@ -82,12 +84,15 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(page.risk_warning.isHidden())
         self.assertIn("备份", page.risk_warning.text())
         self.assertEqual(page.start_btn.text(), "开始同步翻译")
+        self.assertEqual(page.start_btn.objectName(), "sync_translation_start_btn")
+        self.assertEqual(page.stop_btn.objectName(), "sync_translation_stop_btn")
         self.assertTrue(self.window.sync_mode_warning.isHidden())
         self.assertTrue(self.window._workbench_actions_column.isHidden())
         self.assertFalse(self.window.workbench_status_card.isHidden())
+        self.assertFalse(self.window.workbench_log_drawer.isHidden())
         self.assertTrue(self.window.context_library_panel.isHidden())
 
-    def test_sync_page_uses_start_stop_callbacks_and_owns_summary(self) -> None:
+    def test_sync_page_uses_start_stop_callbacks(self) -> None:
         self.window._set_work_mode(
             WorkMode.SYNC_TRANSLATION,
             refresh_manifest_writeback=False,
@@ -105,12 +110,63 @@ class GuiTaskPageTests(unittest.TestCase):
         page.start_btn.click()
         page.set_task_running(True)
         page.stop_btn.click()
-        page.render_summary("ready", "同步完成", "已写入 3 条译文", ["project: demo"])
 
         self.assertEqual(starts, [True])
         self.assertEqual(stops, [True])
-        self.assertIn("已写入 3 条译文", page.message_label.text())
-        self.assertIn("demo", page.facts_label.text())
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertTrue(page.stop_btn.isEnabled())
+
+    def test_sync_page_start_enabled_after_doctor_summary(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.sync_translation_page
+        self.assertFalse(page.start_btn.isEnabled())
+
+        self.window._doctor_check_completed = True
+        self.window._set_doctor_summary(
+            DoctorSummary(
+                status="ready",
+                heading="项目检查通过",
+                message="可以开始同步翻译。",
+                facts=["game_root: demo"],
+                findings=[],
+                mode="existing_tl_only",
+            )
+        )
+        self.assertTrue(self.window.translate_btn.isEnabled())
+        self.assertTrue(page.start_btn.isEnabled())
+        self.assertEqual(page.start_btn.text(), "开始同步翻译")
+
+        self.window._set_doctor_summary(
+            DoctorSummary(
+                status="warning",
+                heading="可生成模板",
+                message="请先生成翻译模板。",
+                facts=[],
+                findings=[],
+                mode="can_generate_template",
+            )
+        )
+        self.assertTrue(page.start_btn.isEnabled())
+        self.assertEqual(page.start_btn.text(), "生成翻译模板")
+
+    def test_sync_page_defers_progress_to_shared_status_card(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.sync_translation_page
+        self.assertFalse(hasattr(page, "render_summary"))
+        self.window._set_workflow_summary(
+            "running",
+            "正在同步翻译",
+            "处理中…",
+            ["files: 2/10"],
+        )
+        self.assertIn("正在同步翻译", self.window.workflow_status_label.text())
+        self.assertIn("files: 2/10", self.window.workflow_facts_label.text())
 
     def test_batch_hides_sync_warning(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -76,10 +76,41 @@ class GuiTaskPageTests(unittest.TestCase):
             WorkMode.SYNC_TRANSLATION,
             refresh_manifest_writeback=False,
         )
-        self.assertFalse(self.window.sync_mode_warning.isHidden())
-        self.assertIn("备份", self.window.sync_mode_warning.text())
-        self.assertEqual(self.window.translate_btn.text(), "开始同步翻译")
+        page = self.window.sync_translation_page
+        self.assertIs(self.window.workbench_stack.currentWidget(), page)
+        self.assertFalse(self.window.workbench_stack.isHidden())
+        self.assertFalse(page.risk_warning.isHidden())
+        self.assertIn("备份", page.risk_warning.text())
+        self.assertEqual(page.start_btn.text(), "开始同步翻译")
+        self.assertTrue(self.window.sync_mode_warning.isHidden())
+        self.assertTrue(self.window._workbench_actions_column.isHidden())
+        self.assertTrue(self.window.workbench_status_card.isHidden())
         self.assertTrue(self.window.context_library_panel.isHidden())
+
+    def test_sync_page_uses_start_stop_callbacks_and_owns_summary(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.SYNC_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.sync_translation_page
+        starts: list[bool] = []
+        stops: list[bool] = []
+        page.set_action_callbacks(
+            WorkbenchPageActions(
+                start=lambda: starts.append(True),
+                stop=lambda: stops.append(True),
+            )
+        )
+        page.set_start_enabled(True)
+        page.start_btn.click()
+        page.set_task_running(True)
+        page.stop_btn.click()
+        page.render_summary("ready", "同步完成", "已写入 3 条译文", ["project: demo"])
+
+        self.assertEqual(starts, [True])
+        self.assertEqual(stops, [True])
+        self.assertIn("已写入 3 条译文", page.message_label.text())
+        self.assertIn("demo", page.facts_label.text())
 
     def test_batch_hides_sync_warning(self) -> None:
         self.window._set_work_mode(


### PR DESCRIPTION
## 内容

- 将同步翻译迁移为 workbench_stack 中的长期真实页面。
- 页面拥有独立风险提示、开始/停止动作和运行摘要；结果继续来自既有 workflow/session。
- 同步页显示时隐藏 legacy 共享任务壳；未迁移入口仍沿用 legacy 壳。
- 沿用现有环境检查门控、CLI runner 和直接写文件风险边界。

## 验证

- python -m unittest tests.test_gui_task_pages tests.test_gui_sync_translation_report tests.test_gui_workbench_nav -q`n- python tests/run_gui_tests.py -q`n- git diff --check`n
Part of #176 (P2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Sync Translation page with a risk-warning banner plus start/stop controls, integrated into the workbench work-mode navigation and task running state (including project reset).
  * Updated the Context page to include a dedicated Stop button with proper enabled/disabled behavior.
* **Bug Fixes**
  * Improved workbench UI state/visibility syncing across mode switches and refined layout reflow behavior.
  * Adjusted batch advanced tools visibility to stay shown throughout batch translation stages.
* **Tests**
  * Updated and expanded GUI tests for Sync Translation button wiring/state and batch advanced tools visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->