### PR TITLE
Add keywords workbench page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1344,9 +1344,21 @@ class MainWindow(QMainWindow):
                     QSizePolicy.Policy.Expanding,
                     QSizePolicy.Policy.Fixed,
                 )
-            elif is_sync or is_keywords:
-                page = getattr(self, "sync_translation_page", None) if is_sync else getattr(self, "keywords_page", None)
+            elif is_sync:
+                page = getattr(self, "sync_translation_page", None)
                 hint_h = page.sizeHint().height() if page is not None else 72
+                self.workbench_stack.setMaximumHeight(max(hint_h, 48))
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Maximum,
+                )
+            elif is_keywords:
+                page = getattr(self, "keywords_page", None)
+                hint_h = (
+                    page.preferred_height(self.workbench_stack.width())
+                    if page is not None
+                    else 96
+                )
                 self.workbench_stack.setMaximumHeight(max(hint_h, 48))
                 self.workbench_stack.setSizePolicy(
                     QSizePolicy.Policy.Expanding,
@@ -4646,9 +4658,12 @@ class MainWindow(QMainWindow):
             start_enabled=self.translate_btn.isEnabled(),
             resume_enabled=self.resume_btn.isEnabled(),
             resume_visible=work_mode_spec(mode).supports_resume,
+            resume_label=self.resume_btn.text(),
             merge_enabled=merge_ready,
             merge_message=result_hint,
         )
+        if workbench_nav_for_work_mode(mode) == WorkbenchNavItem.KEYWORDS:
+            self._apply_task_page_chrome(work_mode_spec(mode))
 
     def _sync_sync_translation_page_controls(
         self,
@@ -5333,6 +5348,9 @@ class MainWindow(QMainWindow):
         sync_page = getattr(self, "sync_translation_page", None)
         if sync_page is not None:
             sync_page.reset_project()
+        keywords_page = getattr(self, "keywords_page", None)
+        if keywords_page is not None:
+            keywords_page.reset_project()
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()
@@ -7324,6 +7342,7 @@ class MainWindow(QMainWindow):
         self._update_resume_btn_text()
         resume_available = self._resume_task_available()
         self._update_resume_btn_enabled(resume_available=resume_available)
+        self._sync_keywords_page_controls()
         self._sync_workbench_empty_states(resume_available=resume_available)
         self._sync_layout_sizes()
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -262,6 +262,7 @@ from .work_modes import (
 )
 from .workbench import WorkbenchPageActions
 from .workbench.context_library_page import ContextLibraryPage
+from .workbench.keywords_page import KeywordsPage
 from .workbench.sync_translation_page import SyncTranslationPage
 from .workbench_session import WorkbenchModeSession
 from .batch_workflow_support import resolve_submit_max_cost
@@ -732,6 +733,18 @@ class MainWindow(QMainWindow):
                     )
                 )
                 self.sync_translation_page = page
+            elif nav_item == WorkbenchNavItem.KEYWORDS:
+                page = KeywordsPage()
+                page.set_action_callbacks(
+                    WorkbenchPageActions(
+                        start=self._on_start_translation,
+                        resume=self._on_resume_translation,
+                        stop=self._on_kill,
+                        writeback=self._on_open_keyword_merge,
+                        select_mode=self._on_keywords_page_mode_selected,
+                    )
+                )
+                self.keywords_page = page
             else:
                 page = QWidget()
                 page.setObjectName(f"workbench_page_{nav_item.value}")
@@ -1314,7 +1327,8 @@ class MainWindow(QMainWindow):
         nav = workbench_nav_for_work_mode(mode)
         is_sync = mode == WorkMode.SYNC_TRANSLATION
         is_context = nav == WorkbenchNavItem.CONTEXT
-        is_real_page = is_context or nav == WorkbenchNavItem.SYNC_TRANSLATION
+        is_keywords = nav == WorkbenchNavItem.KEYWORDS
+        is_real_page = is_context or nav in {WorkbenchNavItem.SYNC_TRANSLATION, WorkbenchNavItem.KEYWORDS}
 
         if hasattr(self, "sync_mode_warning"):
             self.sync_mode_warning.setVisible(is_sync and not is_real_page)
@@ -1330,8 +1344,8 @@ class MainWindow(QMainWindow):
                     QSizePolicy.Policy.Expanding,
                     QSizePolicy.Policy.Fixed,
                 )
-            elif is_sync:
-                page = getattr(self, "sync_translation_page", None)
+            elif is_sync or is_keywords:
+                page = getattr(self, "sync_translation_page", None) if is_sync else getattr(self, "keywords_page", None)
                 hint_h = page.sizeHint().height() if page is not None else 72
                 self.workbench_stack.setMaximumHeight(max(hint_h, 48))
                 self.workbench_stack.setSizePolicy(
@@ -1355,7 +1369,13 @@ class MainWindow(QMainWindow):
             self.translate_btn.setVisible(not is_real_page)
         if hasattr(self, "resume_btn") and is_real_page:
             self.resume_btn.setVisible(False)
+        if is_real_page:
+            for widget in getattr(self, "_work_submode_row_widgets", ()):
+                widget.setVisible(False)
         # Idle workflow hint is redundant with status-card empty states; hide it.
+        if hasattr(self, "keyword_merge_writeback_btn") and is_keywords:
+            self.keyword_merge_writeback_btn.setVisible(False)
+            self.keyword_merge_writeback_btn.setEnabled(False)
         # mode_frame only stays for submode row and/or legacy sync risk banner.
         if hasattr(self, "work_mode_hint_label"):
             self.work_mode_hint_label.setVisible(False)
@@ -3111,7 +3131,10 @@ class MainWindow(QMainWindow):
                 glossary_path=glossary_path,
             )
             if hasattr(self, "keyword_merge_writeback_btn"):
-                self.keyword_merge_writeback_btn.setVisible(True)
+                self.keyword_merge_writeback_btn.setVisible(
+                    workbench_nav_for_work_mode(self._current_work_mode())
+                    != WorkbenchNavItem.KEYWORDS
+                )
                 self.keyword_merge_writeback_btn.setEnabled(
                     not running and keyword_merge_ready_flag
                 )
@@ -3236,7 +3259,11 @@ class MainWindow(QMainWindow):
                 glossary_path=glossary_path,
             )
         if hasattr(self, "keyword_merge_writeback_btn"):
-            self.keyword_merge_writeback_btn.setVisible(uses_keyword_merge)
+            self.keyword_merge_writeback_btn.setVisible(
+                uses_keyword_merge
+                and workbench_nav_for_work_mode(self._current_work_mode())
+                != WorkbenchNavItem.KEYWORDS
+            )
             self.keyword_merge_writeback_btn.setEnabled(
                 not running and keyword_merge_ready_flag
             )
@@ -4209,18 +4236,21 @@ class MainWindow(QMainWindow):
         if nav_item in {
             WorkbenchNavItem.CONTEXT,
             WorkbenchNavItem.SYNC_TRANSLATION,
+            WorkbenchNavItem.KEYWORDS,
         }:
-            page = (
-                getattr(self, "context_library_page", None)
-                if nav_item == WorkbenchNavItem.CONTEXT
-                else getattr(self, "sync_translation_page", None)
-            )
+            page = {
+                WorkbenchNavItem.CONTEXT: getattr(self, "context_library_page", None),
+                WorkbenchNavItem.SYNC_TRANSLATION: getattr(self, "sync_translation_page", None),
+                WorkbenchNavItem.KEYWORDS: getattr(self, "keywords_page", None),
+            }[nav_item]
             sessions = getattr(self, "_mode_sessions", None)
             session = sessions.get(mode) if isinstance(sessions, dict) else None
             if page is not None:
                 page.activate(mode, session or WorkbenchModeSession())
                 if nav_item == WorkbenchNavItem.SYNC_TRANSLATION:
                     self._sync_sync_translation_page_controls()
+                elif nav_item == WorkbenchNavItem.KEYWORDS:
+                    self._sync_keywords_page_controls()
                 else:
                     page.set_task_running(
                         bool(getattr(self, "_task_running", False))
@@ -4282,6 +4312,14 @@ class MainWindow(QMainWindow):
         if mode == self._work_mode:
             return
         self._set_work_mode(mode, refresh_manifest_writeback=True)
+
+    def _on_keywords_page_mode_selected(self, mode: WorkMode) -> None:
+        """Apply the page-local batch/sync selector through the coordinator."""
+        if self.kill_btn.isEnabled() or bool(getattr(self, "_task_running", False)):
+            self._sync_task_selectors_from_work_mode()
+            return
+        if mode in {WorkMode.KEYWORD_EXTRACTION, WorkMode.SYNC_KEYWORD_EXTRACTION}:
+            self._set_work_mode(mode, refresh_manifest_writeback=True)
 
     def _on_task_category_changed(self) -> None:
         # Legacy path (hidden combo); keep behavior for residual callers.
@@ -4581,6 +4619,37 @@ class MainWindow(QMainWindow):
         self.translate_btn.setText(self._translate_button_label())
         self._sync_sync_translation_page_controls(label_only=True)
 
+    def _sync_keywords_page_controls(self, *, running: bool | None = None) -> None:
+        """Mirror coordinator-owned keyword actions onto the real page."""
+        page = getattr(self, "keywords_page", None)
+        if page is None:
+            return
+        mode = self._current_work_mode()
+        if mode not in {WorkMode.KEYWORD_EXTRACTION, WorkMode.SYNC_KEYWORD_EXTRACTION}:
+            return
+        if running is None:
+            running = bool(getattr(self, "_task_running", False)) or self.kill_btn.isEnabled()
+        candidates_path = self._resolve_keyword_merge_candidates_path()
+        glossary_path = self._resolve_keyword_merge_glossary_path()
+        merge_ready, merge_message = keyword_merge_ready(
+            candidates_path=candidates_path,
+            glossary_path=glossary_path,
+        )
+        if merge_ready:
+            result_hint = "关键词候选已就绪；可审核并合并到 glossary.json。"
+        elif merge_message:
+            result_hint = f"关键词结果：{merge_message}"
+        else:
+            result_hint = "提取完成后，可在此合并审核通过的术语候选。"
+        page.set_task_running(running)
+        page.set_controls(
+            start_enabled=self.translate_btn.isEnabled(),
+            resume_enabled=self.resume_btn.isEnabled(),
+            resume_visible=work_mode_spec(mode).supports_resume,
+            merge_enabled=merge_ready,
+            merge_message=result_hint,
+        )
+
     def _sync_sync_translation_page_controls(
         self,
         *,
@@ -4733,6 +4802,7 @@ class MainWindow(QMainWindow):
             running=running,
             resume_available=resume_available,
         )
+        self._sync_keywords_page_controls(running=running)
         self._update_split_submit_btn(running=running)
         self._sync_task_shortcuts()
         # Re-apply page chrome after enable flags so context cards stay correct.
@@ -7218,6 +7288,7 @@ class MainWindow(QMainWindow):
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
         self._sync_sync_translation_page_controls(running=running)
+        self._sync_keywords_page_controls(running=running)
         # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
         if hasattr(self, "context_library_panel"):
             self._refresh_context_library_panel(running=running)
@@ -7325,6 +7396,7 @@ class MainWindow(QMainWindow):
             summary,
             running=self.kill_btn.isEnabled(),
         )
+        self._sync_keywords_page_controls()
         if not self.kill_btn.isEnabled():
             self.apply_btn.setEnabled(
                 summary.can_apply and not self._uses_revision_writeback()
@@ -7378,6 +7450,7 @@ class MainWindow(QMainWindow):
             )
         )
         self._sync_sync_translation_page_controls(running=running)
+        self._sync_keywords_page_controls(running=running)
         self._sync_task_shortcuts()
         self._sync_workbench_empty_states()
         self._sync_layout_sizes()

--- a/gui_qt/workbench/keywords_page.py
+++ b/gui_qt/workbench/keywords_page.py
@@ -1,0 +1,161 @@
+"""Persistent keywords/terminology page for the workbench stack (#176 P3)."""
+from __future__ import annotations
+
+from PySide6.QtCore import QSize
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..work_modes import WorkMode, work_mode_submode_label
+from ..workbench_session import WorkbenchModeSession
+from .page_contract import WorkbenchPageActions
+
+
+class KeywordsPage(QFrame):
+    """Page-local controls for batch and synchronous keyword extraction."""
+
+    supported_modes = (
+        WorkMode.KEYWORD_EXTRACTION,
+        WorkMode.SYNC_KEYWORD_EXTRACTION,
+    )
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("keywords_page")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._actions = WorkbenchPageActions()
+        self._running = False
+        self._active_mode = WorkMode.KEYWORD_EXTRACTION
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(6)
+
+        mode_row = QHBoxLayout()
+        mode_row.setSpacing(8)
+        mode_row.addWidget(QLabel("关键词 / 术语模式："))
+        self.mode_combo = QComboBox()
+        self.mode_combo.setObjectName("keywords_mode_combo")
+        for mode in self.supported_modes:
+            self.mode_combo.addItem(work_mode_submode_label(mode), mode.value)
+        self.mode_combo.currentIndexChanged.connect(self._trigger_mode_change)
+        mode_row.addWidget(self.mode_combo, 1)
+        outer.addLayout(mode_row)
+
+        actions = QFrame()
+        actions.setObjectName("action_frame")
+        action_layout = QHBoxLayout(actions)
+        action_layout.setContentsMargins(12, 8, 12, 8)
+        action_layout.setSpacing(8)
+        self.start_btn = QPushButton("提取关键词")
+        self.start_btn.setObjectName("keywords_start_btn")
+        self.start_btn.setEnabled(False)
+        self.start_btn.clicked.connect(self._trigger_start)
+        action_layout.addWidget(self.start_btn)
+        self.resume_btn = QPushButton("继续提取")
+        self.resume_btn.setObjectName("keywords_resume_btn")
+        self.resume_btn.setEnabled(False)
+        self.resume_btn.clicked.connect(self._trigger_resume)
+        action_layout.addWidget(self.resume_btn)
+        self.stop_btn = QPushButton("停止")
+        self.stop_btn.setObjectName("keywords_stop_btn")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self._trigger_stop)
+        action_layout.addWidget(self.stop_btn)
+        self.merge_btn = QPushButton("合并到 glossary")
+        self.merge_btn.setObjectName("keywords_merge_btn")
+        self.merge_btn.setEnabled(False)
+        self.merge_btn.setToolTip("提取完成后，审核候选并写入 glossary.json；不会修改 .rpy 脚本。")
+        self.merge_btn.clicked.connect(self._trigger_merge)
+        action_layout.addWidget(self.merge_btn)
+        action_layout.addStretch()
+        outer.addWidget(actions)
+
+        self.result_hint = QLabel("提取完成后，可在此合并审核通过的术语候选。")
+        self.result_hint.setObjectName("config_hint_label")
+        self.result_hint.setWordWrap(True)
+        outer.addWidget(self.result_hint)
+
+    def sizeHint(self):  # noqa: N802
+        return self.minimumSizeHint()
+
+    def minimumSizeHint(self):  # noqa: N802
+        width = super().minimumSizeHint().width()
+        controls_h = max(self.start_btn.sizeHint().height(), 32) + 16
+        return QSize(max(width, 260), self.mode_combo.sizeHint().height() + controls_h + 40)
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        self._actions = actions
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        if mode not in self.supported_modes:
+            raise ValueError(f"Unsupported keywords mode: {mode.value}")
+        self._active_mode = mode
+        index = self.mode_combo.findData(mode.value)
+        if index >= 0:
+            blocked = self.mode_combo.blockSignals(True)
+            self.mode_combo.setCurrentIndex(index)
+            self.mode_combo.blockSignals(blocked)
+        del session
+
+    def set_task_running(self, running: bool) -> None:
+        self._running = running
+        self.mode_combo.setEnabled(not running)
+        self.stop_btn.setEnabled(running)
+        if running:
+            self.start_btn.setEnabled(False)
+            self.resume_btn.setEnabled(False)
+            self.merge_btn.setEnabled(False)
+
+    def set_controls(
+        self,
+        *,
+        start_enabled: bool,
+        resume_enabled: bool,
+        resume_visible: bool,
+        merge_enabled: bool,
+        merge_message: str,
+    ) -> None:
+        self.start_btn.setEnabled(start_enabled and not self._running)
+        self.resume_btn.setVisible(resume_visible)
+        self.resume_btn.setEnabled(resume_enabled and not self._running)
+        self.merge_btn.setEnabled(merge_enabled and not self._running)
+        self.result_hint.setText(merge_message)
+
+    def reset_project(self) -> None:
+        self.set_task_running(False)
+        self.set_controls(
+            start_enabled=False,
+            resume_enabled=False,
+            resume_visible=self._active_mode == WorkMode.KEYWORD_EXTRACTION,
+            merge_enabled=False,
+            merge_message="项目已切换；请先完成环境检查并重新提取关键词。",
+        )
+
+    def _trigger_mode_change(self) -> None:
+        mode = WorkMode(str(self.mode_combo.currentData()))
+        if not self._running and mode != self._active_mode and self._actions.select_mode:
+            self._actions.select_mode(mode)
+
+    def _trigger_start(self) -> None:
+        if not self._running and self._actions.start is not None:
+            self._actions.start()
+
+    def _trigger_resume(self) -> None:
+        if not self._running and self._actions.resume is not None:
+            self._actions.resume()
+
+    def _trigger_stop(self) -> None:
+        if self._running and self._actions.stop is not None:
+            self._actions.stop()
+
+    def _trigger_merge(self) -> None:
+        if not self._running and self.merge_btn.isEnabled() and self._actions.writeback:
+            self._actions.writeback()

--- a/gui_qt/workbench/keywords_page.py
+++ b/gui_qt/workbench/keywords_page.py
@@ -1,7 +1,6 @@
 """Persistent keywords/terminology page for the workbench stack (#176 P3)."""
 from __future__ import annotations
 
-from PySide6.QtCore import QSize
 from PySide6.QtWidgets import (
     QComboBox,
     QFrame,
@@ -83,13 +82,13 @@ class KeywordsPage(QFrame):
         self.result_hint.setWordWrap(True)
         outer.addWidget(self.result_hint)
 
-    def sizeHint(self):  # noqa: N802
-        return self.minimumSizeHint()
-
-    def minimumSizeHint(self):  # noqa: N802
-        width = super().minimumSizeHint().width()
-        controls_h = max(self.start_btn.sizeHint().height(), 32) + 16
-        return QSize(max(width, 260), self.mode_combo.sizeHint().height() + controls_h + 40)
+    def preferred_height(self, width: int) -> int:
+        """Return the layout's word-wrap-aware height for the current page width."""
+        layout = self.layout()
+        if layout is None:
+            return self.sizeHint().height()
+        content_width = max(width, 260)
+        return max(self.minimumSizeHint().height(), layout.heightForWidth(content_width))
 
     def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
         self._actions = actions
@@ -120,14 +119,17 @@ class KeywordsPage(QFrame):
         start_enabled: bool,
         resume_enabled: bool,
         resume_visible: bool,
+        resume_label: str,
         merge_enabled: bool,
         merge_message: str,
     ) -> None:
         self.start_btn.setEnabled(start_enabled and not self._running)
         self.resume_btn.setVisible(resume_visible)
+        self.resume_btn.setText(resume_label)
         self.resume_btn.setEnabled(resume_enabled and not self._running)
         self.merge_btn.setEnabled(merge_enabled and not self._running)
         self.result_hint.setText(merge_message)
+        self.updateGeometry()
 
     def reset_project(self) -> None:
         self.set_task_running(False)
@@ -135,13 +137,14 @@ class KeywordsPage(QFrame):
             start_enabled=False,
             resume_enabled=False,
             resume_visible=self._active_mode == WorkMode.KEYWORD_EXTRACTION,
+            resume_label="继续提取",
             merge_enabled=False,
             merge_message="项目已切换；请先完成环境检查并重新提取关键词。",
         )
 
     def _trigger_mode_change(self) -> None:
         mode = WorkMode(str(self.mode_combo.currentData()))
-        if not self._running and mode != self._active_mode and self._actions.select_mode:
+        if not self._running and mode != self._active_mode and self._actions.select_mode is not None:
             self._actions.select_mode(mode)
 
     def _trigger_start(self) -> None:
@@ -157,5 +160,5 @@ class KeywordsPage(QFrame):
             self._actions.stop()
 
     def _trigger_merge(self) -> None:
-        if not self._running and self.merge_btn.isEnabled() and self._actions.writeback:
+        if not self._running and self.merge_btn.isEnabled() and self._actions.writeback is not None:
             self._actions.writeback()

--- a/gui_qt/workbench/page_contract.py
+++ b/gui_qt/workbench/page_contract.py
@@ -24,6 +24,7 @@ class WorkbenchPageActions:
     writeback: Callable[[], None] | None = None
     prebuild: Callable[[str], None] | None = None
     open_settings: Callable[[], None] | None = None
+    select_mode: Callable[[WorkMode], None] | None = None
 
 
 class WorkbenchPage(Protocol):

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -204,11 +204,57 @@ class GuiTaskPageTests(unittest.TestCase):
         ):
             self.window._set_writeback_summary(summary)
 
-        self.assertFalse(self.window.keyword_merge_writeback_btn.isHidden())
-        self.assertTrue(self.window.keyword_merge_writeback_btn.isEnabled())
+        page = self.window.keywords_page
+        self.assertIs(self.window.workbench_stack.currentWidget(), page)
+        self.assertFalse(self.window.workbench_stack.isHidden())
+        self.assertTrue(self.window._mode_frame.isHidden())
+        self.assertTrue(self.window._workbench_actions_column.isHidden())
+        self.assertFalse(self.window.workbench_status_card.isHidden())
+        self.assertTrue(self.window.keyword_merge_writeback_btn.isHidden())
+        self.assertTrue(page.merge_btn.isEnabled())
         self.assertTrue(self.window.apply_revision_btn.isHidden())
         self.assertTrue(self.window.apply_btn.isHidden())
-        self.assertFalse(self.window.work_submode_combo.isHidden())
+        self.assertTrue(self.window.work_submode_combo.isHidden())
+
+    def test_keywords_page_uses_callbacks_and_local_mode_selector(self) -> None:
+        page = self.window.keywords_page
+        starts: list[bool] = []
+        resumes: list[bool] = []
+        stops: list[bool] = []
+        merges: list[bool] = []
+        selected: list[WorkMode] = []
+        page.set_action_callbacks(
+            WorkbenchPageActions(
+                start=lambda: starts.append(True),
+                resume=lambda: resumes.append(True),
+                stop=lambda: stops.append(True),
+                writeback=lambda: merges.append(True),
+                select_mode=selected.append,
+            )
+        )
+        page.activate(WorkMode.KEYWORD_EXTRACTION, WorkbenchModeSession())
+        page.set_controls(
+            start_enabled=True,
+            resume_enabled=True,
+            resume_visible=True,
+            merge_enabled=True,
+            merge_message="关键词候选已就绪。",
+        )
+        page.start_btn.click()
+        page.resume_btn.click()
+        page.merge_btn.click()
+        page.set_task_running(True)
+        page.stop_btn.click()
+        page.set_task_running(False)
+        page.mode_combo.setCurrentIndex(
+            page.mode_combo.findData(WorkMode.SYNC_KEYWORD_EXTRACTION.value)
+        )
+
+        self.assertEqual(starts, [True])
+        self.assertEqual(resumes, [True])
+        self.assertEqual(merges, [True])
+        self.assertEqual(stops, [True])
+        self.assertEqual(selected, [WorkMode.SYNC_KEYWORD_EXTRACTION])
 
     def test_revision_page_shows_apply_revision_not_translation_apply(self) -> None:
         self.window._set_work_mode(
@@ -390,8 +436,8 @@ class GuiTaskPageTests(unittest.TestCase):
                 "C:/kw/manifest.json",
             )
             # Snapshot should restore merge readiness without needing the file on disk.
-            self.assertFalse(self.window.keyword_merge_writeback_btn.isHidden())
-            self.assertTrue(self.window.keyword_merge_writeback_btn.isEnabled())
+            self.assertTrue(self.window.keyword_merge_writeback_btn.isHidden())
+            self.assertTrue(self.window.keywords_page.merge_btn.isEnabled())
 
     def test_roundtrip_revision_writeback_state(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -237,6 +237,7 @@ class GuiTaskPageTests(unittest.TestCase):
             start_enabled=True,
             resume_enabled=True,
             resume_visible=True,
+            resume_label="继续提取",
             merge_enabled=True,
             merge_message="关键词候选已就绪。",
         )
@@ -255,6 +256,46 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertEqual(merges, [True])
         self.assertEqual(stops, [True])
         self.assertEqual(selected, [WorkMode.SYNC_KEYWORD_EXTRACTION])
+
+    def test_keywords_page_mode_selector_switches_main_window(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.keywords_page
+        page.mode_combo.setCurrentIndex(
+            page.mode_combo.findData(WorkMode.SYNC_KEYWORD_EXTRACTION.value)
+        )
+
+        self.assertEqual(self.window._work_mode, WorkMode.SYNC_KEYWORD_EXTRACTION)
+        self.assertTrue(self.window.work_submode_combo.isHidden())
+        self.assertFalse(page.mode_combo.isHidden())
+
+    def test_keywords_page_mirrors_waiting_resume_and_running_lock(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        workflow = mock.Mock()
+        step = mock.Mock()
+        step.key = "status"
+        workflow.current_step.return_value = step
+        workflow.manifest_path = ""
+        self.window._workflow = workflow
+        self.window._set_workflow_summary(
+            "waiting",
+            "正在等待云端结果",
+            "可查询状态。",
+        )
+        page = self.window.keywords_page
+
+        self.assertEqual(page.resume_btn.text(), "查询云端状态")
+        self.window._set_task_running(True)
+        self.assertFalse(page.mode_combo.isEnabled())
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertFalse(page.resume_btn.isEnabled())
+        self.assertFalse(page.merge_btn.isEnabled())
+        self.assertTrue(page.stop_btn.isEnabled())
 
     def test_revision_page_shows_apply_revision_not_translation_apply(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_workbench_nav.py
+++ b/tests/test_gui_workbench_nav.py
@@ -214,6 +214,40 @@ class GuiWorkbenchNavTests(unittest.TestCase):
         )
         self.assertEqual(self.window._work_mode, WorkMode.KEYWORD_EXTRACTION)
 
+    def test_project_switch_resets_dormant_keywords_page(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.keywords_page
+        page.set_controls(
+            start_enabled=True,
+            resume_enabled=True,
+            resume_visible=True,
+            resume_label="继续提取",
+            merge_enabled=True,
+            merge_message="关键词候选已就绪。",
+        )
+
+        with (
+            mock.patch.object(
+                self.window.state,
+                "set_game_root",
+                return_value=(Path("C:/Games/Example/work"), False),
+            ),
+            mock.patch.object(self.window.runner, "is_running", return_value=False),
+            mock.patch.object(self.window, "_is_doctor_running", return_value=False),
+            mock.patch.object(self.window, "_load_config_to_ui"),
+            mock.patch.object(self.window, "_refresh_diagnostics_context"),
+            mock.patch.object(self.window, "_invalidate_manifest_caches"),
+            mock.patch.object(self.window, "_apply_work_mode_ui"),
+        ):
+            self.assertTrue(self.window._switch_game_root("C:/Games/Example/work"))
+
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertFalse(page.merge_btn.isEnabled())
+        self.assertIn("项目已切换", page.result_hint.text())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_workbench_nav.py
+++ b/tests/test_gui_workbench_nav.py
@@ -148,8 +148,9 @@ class GuiWorkbenchNavTests(unittest.TestCase):
             WorkMode.KEYWORD_EXTRACTION,
             refresh_manifest_writeback=False,
         )
-        self.assertFalse(self.window.work_submode_combo.isHidden())
-        self.assertGreaterEqual(self.window.work_submode_combo.count(), 2)
+        self.assertTrue(self.window.work_submode_combo.isHidden())
+        self.assertFalse(self.window.keywords_page.mode_combo.isHidden())
+        self.assertGreaterEqual(self.window.keywords_page.mode_combo.count(), 2)
 
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,


### PR DESCRIPTION
## 内容

- 新增关键词 / 术语真实页面，承载批量 / 同步选择、提取、继续、停止及 glossary 合并入口。
- 页面通过既有 MainWindow 回调和 WorkbenchModeSession 工作，不复制 CLI、manifest 或合并状态。
- 关键词页激活时隐藏 legacy 子模式与共享合并按钮；环境检查、进度、结果和日志继续复用共享状态面。

## 验证

- `python -m unittest tests.test_gui_task_pages tests.test_gui_keyword_merge_report tests.test_gui_workbench_nav -q`
- `python tests/run_gui_tests.py -q`