### PR TITLE
Add revision workbench page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -263,6 +263,7 @@ from .work_modes import (
 from .workbench import WorkbenchPageActions
 from .workbench.context_library_page import ContextLibraryPage
 from .workbench.keywords_page import KeywordsPage
+from .workbench.revision_page import RevisionPage
 from .workbench.sync_translation_page import SyncTranslationPage
 from .workbench_session import WorkbenchModeSession
 from .batch_workflow_support import resolve_submit_max_cost
@@ -745,6 +746,18 @@ class MainWindow(QMainWindow):
                     )
                 )
                 self.keywords_page = page
+            elif nav_item == WorkbenchNavItem.REVISION:
+                page = RevisionPage()
+                page.set_action_callbacks(
+                    WorkbenchPageActions(
+                        start=self._on_start_translation,
+                        resume=self._on_resume_translation,
+                        stop=self._on_kill,
+                        writeback=self._on_apply_revision,
+                        select_mode=self._on_revision_page_mode_selected,
+                    )
+                )
+                self.revision_page = page
             else:
                 page = QWidget()
                 page.setObjectName(f"workbench_page_{nav_item.value}")
@@ -1328,7 +1341,8 @@ class MainWindow(QMainWindow):
         is_sync = mode == WorkMode.SYNC_TRANSLATION
         is_context = nav == WorkbenchNavItem.CONTEXT
         is_keywords = nav == WorkbenchNavItem.KEYWORDS
-        is_real_page = is_context or nav in {WorkbenchNavItem.SYNC_TRANSLATION, WorkbenchNavItem.KEYWORDS}
+        is_revision = nav == WorkbenchNavItem.REVISION
+        is_real_page = is_context or nav in {WorkbenchNavItem.SYNC_TRANSLATION, WorkbenchNavItem.KEYWORDS, WorkbenchNavItem.REVISION}
 
         if hasattr(self, "sync_mode_warning"):
             self.sync_mode_warning.setVisible(is_sync and not is_real_page)
@@ -1364,6 +1378,18 @@ class MainWindow(QMainWindow):
                     QSizePolicy.Policy.Expanding,
                     QSizePolicy.Policy.Maximum,
                 )
+            elif is_revision:
+                page = getattr(self, "revision_page", None)
+                hint_h = (
+                    page.preferred_height(self.workbench_stack.width())
+                    if page is not None
+                    else 96
+                )
+                self.workbench_stack.setMaximumHeight(max(hint_h, 48))
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Maximum,
+                )
             else:
                 self.workbench_stack.setMaximumHeight(16_777_215)
                 self.workbench_stack.setSizePolicy(
@@ -1388,6 +1414,9 @@ class MainWindow(QMainWindow):
         if hasattr(self, "keyword_merge_writeback_btn") and is_keywords:
             self.keyword_merge_writeback_btn.setVisible(False)
             self.keyword_merge_writeback_btn.setEnabled(False)
+        if hasattr(self, "apply_revision_btn") and is_revision:
+            self.apply_revision_btn.setVisible(False)
+            self.apply_revision_btn.setEnabled(False)
         # mode_frame only stays for submode row and/or legacy sync risk banner.
         if hasattr(self, "work_mode_hint_label"):
             self.work_mode_hint_label.setVisible(False)
@@ -3257,8 +3286,11 @@ class MainWindow(QMainWindow):
         if hasattr(self, "apply_btn"):
             self.apply_btn.setVisible(spec.supports_translation_writeback)
         if hasattr(self, "apply_revision_btn"):
-            self.apply_revision_btn.setVisible(uses_revision_writeback)
-
+            self.apply_revision_btn.setVisible(
+                uses_revision_writeback
+                and workbench_nav_for_work_mode(self._current_work_mode())
+                != WorkbenchNavItem.REVISION
+            )
         keyword_merge_ready_flag = False
         if uses_keyword_merge:
             candidates_path = self._resolve_keyword_merge_candidates_path(
@@ -4249,11 +4281,13 @@ class MainWindow(QMainWindow):
             WorkbenchNavItem.CONTEXT,
             WorkbenchNavItem.SYNC_TRANSLATION,
             WorkbenchNavItem.KEYWORDS,
+            WorkbenchNavItem.REVISION,
         }:
             page = {
                 WorkbenchNavItem.CONTEXT: getattr(self, "context_library_page", None),
                 WorkbenchNavItem.SYNC_TRANSLATION: getattr(self, "sync_translation_page", None),
                 WorkbenchNavItem.KEYWORDS: getattr(self, "keywords_page", None),
+                WorkbenchNavItem.REVISION: getattr(self, "revision_page", None),
             }[nav_item]
             sessions = getattr(self, "_mode_sessions", None)
             session = sessions.get(mode) if isinstance(sessions, dict) else None
@@ -4263,6 +4297,8 @@ class MainWindow(QMainWindow):
                     self._sync_sync_translation_page_controls()
                 elif nav_item == WorkbenchNavItem.KEYWORDS:
                     self._sync_keywords_page_controls()
+                elif nav_item == WorkbenchNavItem.REVISION:
+                    self._sync_revision_page_controls()
                 else:
                     page.set_task_running(
                         bool(getattr(self, "_task_running", False))
@@ -4331,6 +4367,14 @@ class MainWindow(QMainWindow):
             self._sync_task_selectors_from_work_mode()
             return
         if mode in {WorkMode.KEYWORD_EXTRACTION, WorkMode.SYNC_KEYWORD_EXTRACTION}:
+            self._set_work_mode(mode, refresh_manifest_writeback=True)
+
+    def _on_revision_page_mode_selected(self, mode: WorkMode) -> None:
+        """Apply the page-local revision batch/sync selector through the coordinator."""
+        if self.kill_btn.isEnabled() or bool(getattr(self, "_task_running", False)):
+            self._sync_task_selectors_from_work_mode()
+            return
+        if mode in {WorkMode.REVISION, WorkMode.SYNC_REVISION}:
             self._set_work_mode(mode, refresh_manifest_writeback=True)
 
     def _on_task_category_changed(self) -> None:
@@ -4665,6 +4709,35 @@ class MainWindow(QMainWindow):
         if workbench_nav_for_work_mode(mode) == WorkbenchNavItem.KEYWORDS:
             self._apply_task_page_chrome(work_mode_spec(mode))
 
+    def _sync_revision_page_controls(self, *, running: bool | None = None) -> None:
+        """Mirror coordinator-owned revision actions onto the real page."""
+        page = getattr(self, "revision_page", None)
+        if page is None:
+            return
+        mode = self._current_work_mode()
+        if mode not in {WorkMode.REVISION, WorkMode.SYNC_REVISION}:
+            return
+        if running is None:
+            running = bool(getattr(self, "_task_running", False)) or self.kill_btn.isEnabled()
+        summary = self._current_writeback_summary()
+        if summary.can_apply:
+            result_message = summary.message or "订正预览已通过，可安全写回。"
+        elif summary.message:
+            result_message = f"订正结果：{summary.message}"
+        else:
+            result_message = "生成预览后，可在此确认订正结果并安全写回。"
+        page.set_task_running(running)
+        page.set_controls(
+            start_enabled=self.translate_btn.isEnabled(),
+            resume_enabled=self.resume_btn.isEnabled(),
+            resume_visible=work_mode_spec(mode).supports_resume,
+            resume_label=self.resume_btn.text(),
+            writeback_enabled=summary.can_apply,
+            result_message=result_message,
+        )
+        if workbench_nav_for_work_mode(mode) == WorkbenchNavItem.REVISION:
+            self._apply_task_page_chrome(work_mode_spec(mode))
+
     def _sync_sync_translation_page_controls(
         self,
         *,
@@ -4818,6 +4891,7 @@ class MainWindow(QMainWindow):
             resume_available=resume_available,
         )
         self._sync_keywords_page_controls(running=running)
+        self._sync_revision_page_controls(running=running)
         self._update_split_submit_btn(running=running)
         self._sync_task_shortcuts()
         # Re-apply page chrome after enable flags so context cards stay correct.
@@ -5351,6 +5425,9 @@ class MainWindow(QMainWindow):
         keywords_page = getattr(self, "keywords_page", None)
         if keywords_page is not None:
             keywords_page.reset_project()
+        revision_page = getattr(self, "revision_page", None)
+        if revision_page is not None:
+            revision_page.reset_project()
         self._workflow = None
         self._workflow_step_output_lines = []
         self._clear_completed_manifest_snapshot()
@@ -7307,6 +7384,7 @@ class MainWindow(QMainWindow):
         self.kill_btn.setEnabled(running)
         self._sync_sync_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)
+        self._sync_revision_page_controls(running=running)
         # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
         if hasattr(self, "context_library_panel"):
             self._refresh_context_library_panel(running=running)
@@ -7343,6 +7421,7 @@ class MainWindow(QMainWindow):
         resume_available = self._resume_task_available()
         self._update_resume_btn_enabled(resume_available=resume_available)
         self._sync_keywords_page_controls()
+        self._sync_revision_page_controls()
         self._sync_workbench_empty_states(resume_available=resume_available)
         self._sync_layout_sizes()
 
@@ -7416,6 +7495,7 @@ class MainWindow(QMainWindow):
             running=self.kill_btn.isEnabled(),
         )
         self._sync_keywords_page_controls()
+        self._sync_revision_page_controls()
         if not self.kill_btn.isEnabled():
             self.apply_btn.setEnabled(
                 summary.can_apply and not self._uses_revision_writeback()
@@ -7470,6 +7550,7 @@ class MainWindow(QMainWindow):
         )
         self._sync_sync_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)
+        self._sync_revision_page_controls(running=running)
         self._sync_task_shortcuts()
         self._sync_workbench_empty_states()
         self._sync_layout_sizes()

--- a/gui_qt/workbench/revision_page.py
+++ b/gui_qt/workbench/revision_page.py
@@ -1,0 +1,168 @@
+"""Persistent revision page for the workbench stack (#176 P4)."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..work_modes import WorkMode, work_mode_submode_label
+from ..workbench_session import WorkbenchModeSession
+from .page_contract import WorkbenchPageActions
+
+
+class RevisionPage(QFrame):
+    """Page-local controls for batch and synchronous revision workflows."""
+
+    supported_modes = (WorkMode.REVISION, WorkMode.SYNC_REVISION)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("revision_page")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._actions = WorkbenchPageActions()
+        self._running = False
+        self._active_mode = WorkMode.REVISION
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(6)
+
+        mode_row = QHBoxLayout()
+        mode_row.setSpacing(8)
+        mode_row.addWidget(QLabel("订正模式："))
+        self.mode_combo = QComboBox()
+        self.mode_combo.setObjectName("revision_mode_combo")
+        for mode in self.supported_modes:
+            self.mode_combo.addItem(work_mode_submode_label(mode), mode.value)
+        self.mode_combo.currentIndexChanged.connect(self._trigger_mode_change)
+        mode_row.addWidget(self.mode_combo, 1)
+        outer.addLayout(mode_row)
+
+        actions = QFrame()
+        actions.setObjectName("action_frame")
+        action_layout = QHBoxLayout(actions)
+        action_layout.setContentsMargins(12, 8, 12, 8)
+        action_layout.setSpacing(8)
+        self.start_btn = QPushButton("生成订正预览")
+        self.start_btn.setObjectName("revision_start_btn")
+        self.start_btn.setEnabled(False)
+        self.start_btn.clicked.connect(self._trigger_start)
+        action_layout.addWidget(self.start_btn)
+        self.resume_btn = QPushButton("继续订正")
+        self.resume_btn.setObjectName("revision_resume_btn")
+        self.resume_btn.setEnabled(False)
+        self.resume_btn.clicked.connect(self._trigger_resume)
+        action_layout.addWidget(self.resume_btn)
+        self.stop_btn = QPushButton("停止")
+        self.stop_btn.setObjectName("revision_stop_btn")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self._trigger_stop)
+        action_layout.addWidget(self.stop_btn)
+        self.writeback_btn = QPushButton("写回订正")
+        self.writeback_btn.setObjectName("revision_writeback_btn")
+        self.writeback_btn.setEnabled(False)
+        self.writeback_btn.setToolTip("仅在订正预览通过后写回；不会使用翻译写回入口。")
+        self.writeback_btn.clicked.connect(self._trigger_writeback)
+        action_layout.addWidget(self.writeback_btn)
+        action_layout.addStretch()
+        outer.addWidget(actions)
+
+        self.result_hint = QLabel("生成预览后，可在此确认订正结果并安全写回。")
+        self.result_hint.setObjectName("config_hint_label")
+        self.result_hint.setWordWrap(True)
+        outer.addWidget(self.result_hint)
+
+    def preferred_height(self, width: int) -> int:
+        """Return the layout's word-wrap-aware height for the current page width."""
+        layout = self.layout()
+        if layout is None:
+            return self.sizeHint().height()
+        return max(self.minimumSizeHint().height(), layout.heightForWidth(max(width, 260)))
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        self._actions = actions
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        if mode not in self.supported_modes:
+            raise ValueError(f"Unsupported revision mode: {mode.value}")
+        self._active_mode = mode
+        index = self.mode_combo.findData(mode.value)
+        if index >= 0:
+            blocked = self.mode_combo.blockSignals(True)
+            self.mode_combo.setCurrentIndex(index)
+            self.mode_combo.blockSignals(blocked)
+        del session
+
+    def set_task_running(self, running: bool) -> None:
+        self._running = running
+        self.mode_combo.setEnabled(not running)
+        self.stop_btn.setEnabled(running)
+        if running:
+            self.start_btn.setEnabled(False)
+            self.resume_btn.setEnabled(False)
+            self.writeback_btn.setEnabled(False)
+
+    def set_controls(
+        self,
+        *,
+        start_enabled: bool,
+        resume_enabled: bool,
+        resume_visible: bool,
+        resume_label: str,
+        writeback_enabled: bool,
+        result_message: str,
+    ) -> None:
+        self.start_btn.setEnabled(start_enabled and not self._running)
+        self.resume_btn.setVisible(resume_visible)
+        self.resume_btn.setText(resume_label)
+        self.resume_btn.setEnabled(resume_enabled and not self._running)
+        self.writeback_btn.setEnabled(writeback_enabled and not self._running)
+        self.result_hint.setText(result_message)
+        self.updateGeometry()
+
+    def reset_project(self) -> None:
+        self.set_task_running(False)
+        self.set_controls(
+            start_enabled=False,
+            resume_enabled=False,
+            resume_visible=self._active_mode == WorkMode.REVISION,
+            resume_label="继续订正",
+            writeback_enabled=False,
+            result_message="项目已切换；请先完成环境检查并重新生成订正预览。",
+        )
+
+    def _trigger_mode_change(self) -> None:
+        mode = WorkMode(str(self.mode_combo.currentData()))
+        if (
+            not self._running
+            and mode != self._active_mode
+            and self._actions.select_mode is not None
+        ):
+            self._actions.select_mode(mode)
+
+    def _trigger_start(self) -> None:
+        if not self._running and self._actions.start is not None:
+            self._actions.start()
+
+    def _trigger_resume(self) -> None:
+        if not self._running and self._actions.resume is not None:
+            self._actions.resume()
+
+    def _trigger_stop(self) -> None:
+        if self._running and self._actions.stop is not None:
+            self._actions.stop()
+
+    def _trigger_writeback(self) -> None:
+        if (
+            not self._running
+            and self.writeback_btn.isEnabled()
+            and self._actions.writeback is not None
+        ):
+            self._actions.writeback()

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -312,10 +312,69 @@ class GuiTaskPageTests(unittest.TestCase):
             manifest_path="C:/rev/manifest.json",
         )
         self.window._set_writeback_summary(summary)
-        self.assertFalse(self.window.apply_revision_btn.isHidden())
-        self.assertTrue(self.window.apply_revision_btn.isEnabled())
+        page = self.window.revision_page
+        self.assertIs(self.window.workbench_stack.currentWidget(), page)
+        self.assertFalse(self.window.workbench_stack.isHidden())
+        self.assertTrue(self.window._mode_frame.isHidden())
+        self.assertTrue(self.window._workbench_actions_column.isHidden())
+        self.assertFalse(self.window.workbench_status_card.isHidden())
+        self.assertTrue(self.window.apply_revision_btn.isHidden())
+        self.assertTrue(page.writeback_btn.isEnabled())
         self.assertTrue(self.window.apply_btn.isHidden())
         self.assertTrue(self.window.keyword_merge_writeback_btn.isHidden())
+
+    def test_revision_page_uses_callbacks_and_local_mode_selector(self) -> None:
+        page = self.window.revision_page
+        starts: list[bool] = []
+        resumes: list[bool] = []
+        stops: list[bool] = []
+        writebacks: list[bool] = []
+        selected: list[WorkMode] = []
+        page.set_action_callbacks(
+            WorkbenchPageActions(
+                start=lambda: starts.append(True),
+                resume=lambda: resumes.append(True),
+                stop=lambda: stops.append(True),
+                writeback=lambda: writebacks.append(True),
+                select_mode=selected.append,
+            )
+        )
+        page.activate(WorkMode.REVISION, WorkbenchModeSession())
+        page.set_controls(
+            start_enabled=True,
+            resume_enabled=True,
+            resume_visible=True,
+            resume_label="继续订正",
+            writeback_enabled=True,
+            result_message="订正预览已通过。",
+        )
+        page.start_btn.click()
+        page.resume_btn.click()
+        page.writeback_btn.click()
+        page.set_task_running(True)
+        page.stop_btn.click()
+        page.set_task_running(False)
+        page.mode_combo.setCurrentIndex(
+            page.mode_combo.findData(WorkMode.SYNC_REVISION.value)
+        )
+
+        self.assertEqual(starts, [True])
+        self.assertEqual(resumes, [True])
+        self.assertEqual(writebacks, [True])
+        self.assertEqual(stops, [True])
+        self.assertEqual(selected, [WorkMode.SYNC_REVISION])
+
+    def test_revision_page_mode_selector_and_running_lock(self) -> None:
+        self.window._set_work_mode(WorkMode.REVISION, refresh_manifest_writeback=False)
+        page = self.window.revision_page
+        page.mode_combo.setCurrentIndex(page.mode_combo.findData(WorkMode.SYNC_REVISION.value))
+        self.assertEqual(self.window._work_mode, WorkMode.SYNC_REVISION)
+        self.window._set_task_running(True)
+        self.assertFalse(page.mode_combo.isEnabled())
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertFalse(page.resume_btn.isEnabled())
+        self.assertFalse(page.writeback_btn.isEnabled())
+        self.assertTrue(page.stop_btn.isEnabled())
 
     def test_batch_page_hides_revision_apply(self) -> None:
         self.window._set_work_mode(
@@ -505,8 +564,8 @@ class GuiTaskPageTests(unittest.TestCase):
             refresh_manifest_writeback=True,
         )
         self.assertEqual(self.window._writeback_manifest_path, "C:/rev/manifest.json")
-        self.assertFalse(self.window.apply_revision_btn.isHidden())
-        self.assertTrue(self.window.apply_revision_btn.isEnabled())
+        self.assertTrue(self.window.apply_revision_btn.isHidden())
+        self.assertTrue(self.window.revision_page.writeback_btn.isEnabled())
 
     def test_roundtrip_preserves_workflow_progress_ui(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_workbench_nav.py
+++ b/tests/test_gui_workbench_nav.py
@@ -248,6 +248,40 @@ class GuiWorkbenchNavTests(unittest.TestCase):
         self.assertFalse(page.merge_btn.isEnabled())
         self.assertIn("项目已切换", page.result_hint.text())
 
+    def test_project_switch_resets_dormant_revision_page(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.revision_page
+        page.set_controls(
+            start_enabled=True,
+            resume_enabled=True,
+            resume_visible=True,
+            resume_label="继续订正",
+            writeback_enabled=True,
+            result_message="订正预览已通过。",
+        )
+
+        with (
+            mock.patch.object(
+                self.window.state,
+                "set_game_root",
+                return_value=(Path("C:/Games/Example/work"), False),
+            ),
+            mock.patch.object(self.window.runner, "is_running", return_value=False),
+            mock.patch.object(self.window, "_is_doctor_running", return_value=False),
+            mock.patch.object(self.window, "_load_config_to_ui"),
+            mock.patch.object(self.window, "_refresh_diagnostics_context"),
+            mock.patch.object(self.window, "_invalidate_manifest_caches"),
+            mock.patch.object(self.window, "_apply_work_mode_ui"),
+        ):
+            self.assertTrue(self.window._switch_game_root("C:/Games/Example/work"))
+
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertFalse(page.writeback_btn.isEnabled())
+        self.assertIn("项目已切换", page.result_hint.text())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 内容

- 新增订正真实页面，承载批量 / 同步选择、生成预览、继续、停止与独立的订正写回入口。
- 页面继续通过 MainWindow callback、WorkbenchModeSession 和既有订正写回门控工作；不复刻 CLI、manifest 或翻译写回逻辑。
- 订正页激活时隐藏 legacy 子模式与共享写回订正按钮，状态卡与日志抽屉继续复用。

## 验证

- `python -m unittest tests.test_gui_task_pages tests.test_gui_workbench_nav tests.test_gui_app_config -q`
- `python tests/run_gui_tests.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Revision workbench page for generating previews, resuming or stopping revisions, and writing back results.
  * Added revision mode selection with status, progress, and result messaging.
  * Revision controls now update automatically when switching modes or projects.

* **Bug Fixes**
  * Prevented duplicate revision writeback actions from appearing on the main task page.
  * Reset revision controls and status when switching projects.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->