### PR TITLE
Add batch translation workbench page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -261,6 +261,7 @@ from .work_modes import (
     workbench_nav_spec,
 )
 from .workbench import WorkbenchPageActions
+from .workbench.batch_translation_page import BatchTranslationPage
 from .workbench.context_library_page import ContextLibraryPage
 from .workbench.keywords_page import KeywordsPage
 from .workbench.revision_page import RevisionPage
@@ -709,7 +710,13 @@ class MainWindow(QMainWindow):
         self.workbench_stack.setObjectName("workbench_stack")
         self._workbench_stack_pages: dict[WorkbenchNavItem, QWidget] = {}
         for nav_item in WORKBENCH_NAV_ORDER:
-            if nav_item == WorkbenchNavItem.CONTEXT:
+            if nav_item == WorkbenchNavItem.BATCH_TRANSLATION:
+                page = BatchTranslationPage()
+                page.set_action_callbacks(
+                    WorkbenchPageActions(action=self._on_batch_translation_page_action)
+                )
+                self.batch_translation_page = page
+            elif nav_item == WorkbenchNavItem.CONTEXT:
                 page = ContextLibraryPage()
                 page.set_action_callbacks(
                     WorkbenchPageActions(
@@ -1339,10 +1346,11 @@ class MainWindow(QMainWindow):
         mode = spec.mode
         nav = workbench_nav_for_work_mode(mode)
         is_sync = mode == WorkMode.SYNC_TRANSLATION
+        is_batch = nav == WorkbenchNavItem.BATCH_TRANSLATION
         is_context = nav == WorkbenchNavItem.CONTEXT
         is_keywords = nav == WorkbenchNavItem.KEYWORDS
         is_revision = nav == WorkbenchNavItem.REVISION
-        is_real_page = is_context or nav in {WorkbenchNavItem.SYNC_TRANSLATION, WorkbenchNavItem.KEYWORDS, WorkbenchNavItem.REVISION}
+        is_real_page = is_batch or is_context or nav in {WorkbenchNavItem.SYNC_TRANSLATION, WorkbenchNavItem.KEYWORDS, WorkbenchNavItem.REVISION}
 
         if hasattr(self, "sync_mode_warning"):
             self.sync_mode_warning.setVisible(is_sync and not is_real_page)
@@ -1378,6 +1386,18 @@ class MainWindow(QMainWindow):
                     QSizePolicy.Policy.Expanding,
                     QSizePolicy.Policy.Maximum,
                 )
+            elif is_batch:
+                page = getattr(self, "batch_translation_page", None)
+                hint_h = (
+                    page.preferred_height(self.workbench_stack.width())
+                    if page is not None
+                    else 96
+                )
+                self.workbench_stack.setMaximumHeight(max(hint_h, 48))
+                self.workbench_stack.setSizePolicy(
+                    QSizePolicy.Policy.Expanding,
+                    QSizePolicy.Policy.Maximum,
+                )
             elif is_revision:
                 page = getattr(self, "revision_page", None)
                 hint_h = (
@@ -1398,6 +1418,18 @@ class MainWindow(QMainWindow):
                 )
         for widget in getattr(self, "_legacy_workbench_shell_widgets", ()):
             widget.setVisible(not is_real_page)
+        if is_batch:
+            # P5 owns batch action widgets; these legacy bars remain only as
+            # coordinator-side readiness sources during the staged migration.
+            for widget_name in (
+                "writeback_primary_bar",
+                "writeback_issues_toggle_btn",
+                "writeback_issues_badge",
+                "writeback_issues_panel",
+            ):
+                widget = getattr(self, widget_name, None)
+                if widget is not None:
+                    widget.setVisible(False)
         if is_context:
             self._refresh_context_library_panel()
 
@@ -4278,12 +4310,14 @@ class MainWindow(QMainWindow):
             if page is not None:
                 self.workbench_stack.setCurrentWidget(page)
         if nav_item in {
+            WorkbenchNavItem.BATCH_TRANSLATION,
             WorkbenchNavItem.CONTEXT,
             WorkbenchNavItem.SYNC_TRANSLATION,
             WorkbenchNavItem.KEYWORDS,
             WorkbenchNavItem.REVISION,
         }:
             page = {
+                WorkbenchNavItem.BATCH_TRANSLATION: getattr(self, "batch_translation_page", None),
                 WorkbenchNavItem.CONTEXT: getattr(self, "context_library_page", None),
                 WorkbenchNavItem.SYNC_TRANSLATION: getattr(self, "sync_translation_page", None),
                 WorkbenchNavItem.KEYWORDS: getattr(self, "keywords_page", None),
@@ -4293,7 +4327,9 @@ class MainWindow(QMainWindow):
             session = sessions.get(mode) if isinstance(sessions, dict) else None
             if page is not None:
                 page.activate(mode, session or WorkbenchModeSession())
-                if nav_item == WorkbenchNavItem.SYNC_TRANSLATION:
+                if nav_item == WorkbenchNavItem.BATCH_TRANSLATION:
+                    self._sync_batch_translation_page_controls()
+                elif nav_item == WorkbenchNavItem.SYNC_TRANSLATION:
                     self._sync_sync_translation_page_controls()
                 elif nav_item == WorkbenchNavItem.KEYWORDS:
                     self._sync_keywords_page_controls()
@@ -4675,6 +4711,65 @@ class MainWindow(QMainWindow):
         self.translate_btn.setText(self._translate_button_label())
         self._sync_sync_translation_page_controls(label_only=True)
 
+    def _on_batch_translation_page_action(self, action: str) -> None:
+        """Route a P5 page-local action to the existing batch coordinator."""
+        callbacks = {
+            "start": self._on_start_translation,
+            "resume": self._on_resume_translation,
+            "stop": self._on_kill,
+            "split_submit": self._on_submit_remaining_split_packages,
+            "apply": self._on_apply_writeback,
+            "recheck": self._on_recheck_writeback,
+            "issues": self._open_check_issues,
+            "retry": self._on_retry_action,
+            "retry_followup": self._on_retry_followup_action,
+            "repair": self._on_run_repair,
+            "failure": self._open_apply_failure_report,
+            "remediation": self._open_remediation_commands,
+            "probe": self._on_run_probe,
+            "split": self._on_run_split,
+        }
+        callback = callbacks.get(action)
+        if callback is not None:
+            callback()
+
+    def _sync_batch_translation_page_controls(
+        self,
+        *,
+        running: bool | None = None,
+    ) -> None:
+        """Mirror batch coordinator readiness onto P5's independent widgets."""
+        page = getattr(self, "batch_translation_page", None)
+        if page is None or self._current_work_mode() != WorkMode.BATCH_TRANSLATION:
+            return
+        if running is None:
+            running = bool(getattr(self, "_task_running", False)) or self.kill_btn.isEnabled()
+
+        def state(source_name: str, *, visible: bool = True) -> tuple[bool, bool, str]:
+            source = getattr(self, source_name)
+            return (visible and not source.isHidden(), source.isEnabled(), source.text())
+
+        page.set_task_running(running)
+        page.set_controls(
+            {
+                "start": (True, self.translate_btn.isEnabled(), self.translate_btn.text()),
+                "resume": (True, self.resume_btn.isEnabled(), self.resume_btn.text()),
+                "stop": (True, self.kill_btn.isEnabled(), self.kill_btn.text()),
+                "split_submit": state("split_submit_btn"),
+                "apply": (True, self.apply_btn.isEnabled(), self.apply_btn.text()),
+                "recheck": state("recheck_btn"),
+                "issues": state("check_issues_btn"),
+                "retry": state("retry_btn"),
+                "retry_followup": state("retry_followup_btn"),
+                "repair": state("repair_btn"),
+                "failure": state("apply_failure_btn"),
+                "remediation": state("remediation_btn"),
+                "probe": (True, self.probe_btn.isEnabled(), self.probe_btn.text()),
+                "split": (True, self.split_btn.isEnabled(), self.split_btn.text()),
+            }
+        )
+        self._apply_task_page_chrome(work_mode_spec(WorkMode.BATCH_TRANSLATION))
+
     def _sync_keywords_page_controls(self, *, running: bool | None = None) -> None:
         """Mirror coordinator-owned keyword actions onto the real page."""
         page = getattr(self, "keywords_page", None)
@@ -4890,6 +4985,7 @@ class MainWindow(QMainWindow):
             running=running,
             resume_available=resume_available,
         )
+        self._sync_batch_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)
         self._sync_revision_page_controls(running=running)
         self._update_split_submit_btn(running=running)
@@ -7383,6 +7479,7 @@ class MainWindow(QMainWindow):
         self._update_split_btn_enabled(running=running)
         self.kill_btn.setEnabled(running)
         self._sync_sync_translation_page_controls(running=running)
+        self._sync_batch_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)
         self._sync_revision_page_controls(running=running)
         # Context-library prebuild CTAs stay on-page while nav is locked; gate them here.
@@ -7420,6 +7517,7 @@ class MainWindow(QMainWindow):
         self._update_resume_btn_text()
         resume_available = self._resume_task_available()
         self._update_resume_btn_enabled(resume_available=resume_available)
+        self._sync_batch_translation_page_controls()
         self._sync_keywords_page_controls()
         self._sync_revision_page_controls()
         self._sync_workbench_empty_states(resume_available=resume_available)
@@ -7494,6 +7592,7 @@ class MainWindow(QMainWindow):
             summary,
             running=self.kill_btn.isEnabled(),
         )
+        self._sync_batch_translation_page_controls()
         self._sync_keywords_page_controls()
         self._sync_revision_page_controls()
         if not self.kill_btn.isEnabled():
@@ -7549,6 +7648,7 @@ class MainWindow(QMainWindow):
             )
         )
         self._sync_sync_translation_page_controls(running=running)
+        self._sync_batch_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)
         self._sync_revision_page_controls(running=running)
         self._sync_task_shortcuts()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -4720,6 +4720,11 @@ class MainWindow(QMainWindow):
     ) -> bool:
         if running or not spec.implemented or not bootstrap_ready:
             return False
+        if (
+            spec.mode == WorkMode.KEYWORD_EXTRACTION
+            and self.workflow_status_label.property("status") == "waiting"
+        ):
+            return False
         if self._translation_requires_doctor_check(spec.mode):
             return self._doctor_allows_translate_action()
         return True

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -715,6 +715,9 @@ class MainWindow(QMainWindow):
                 page.set_action_callbacks(
                     WorkbenchPageActions(action=self._on_batch_translation_page_action)
                 )
+                page.content_height_changed.connect(
+                    self._on_batch_translation_page_height_changed
+                )
                 self.batch_translation_page = page
             elif nav_item == WorkbenchNavItem.CONTEXT:
                 page = ContextLibraryPage()
@@ -4732,6 +4735,13 @@ class MainWindow(QMainWindow):
         callback = callbacks.get(action)
         if callback is not None:
             callback()
+
+    def _on_batch_translation_page_height_changed(self) -> None:
+        """Resize the stack immediately after a page-local disclosure changes."""
+        if self._current_work_mode() == WorkMode.BATCH_TRANSLATION:
+            self._apply_task_page_chrome(
+                work_mode_spec(WorkMode.BATCH_TRANSLATION)
+            )
 
     def _sync_batch_translation_page_controls(
         self,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -4498,6 +4498,20 @@ class MainWindow(QMainWindow):
     def _resume_button_is_query_mode(self) -> bool:
         return hasattr(self, "resume_btn") and self.resume_btn.text() == "查询云端状态"
 
+    def _latest_resume_manifest_path(self, game_root, spec_or_mode):
+        """Choose the cloud task behind an explicit status query when possible."""
+        mode = getattr(spec_or_mode, "mode", spec_or_mode)
+        if self._resume_button_is_query_mode():
+            get_submitted = getattr(
+                self.state,
+                "get_latest_submitted_manifest_path_for_mode",
+                None,
+            )
+            if callable(get_submitted):
+                submitted = get_submitted(game_root, mode)
+                if submitted is not None:
+                    return submitted
+        return self.state.get_latest_manifest_path_for_mode(game_root, mode)
     def _resume_task_available(self) -> tuple[bool, str]:
         """Whether 「继续」 can load a resumable task for the current mode (P3 / #166)."""
         spec = work_mode_spec(self._current_work_mode())
@@ -4511,7 +4525,7 @@ class MainWindow(QMainWindow):
         game_root = self.state.get_game_root() if hasattr(self, "state") else None
         if game_root is None:
             return False, "请先选择游戏的 work 目录。"
-        latest = self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
+        latest = self._latest_resume_manifest_path(game_root, spec)
         if latest is None:
             return False, f"未找到可继续的{spec.label}任务；请先开始一个任务。"
         try:
@@ -6407,7 +6421,7 @@ class MainWindow(QMainWindow):
             return
 
         game_root = self.state.get_game_root()
-        latest_manifest = self.state.get_latest_manifest_path_for_mode(game_root, spec.mode)
+        latest_manifest = self._latest_resume_manifest_path(game_root, spec)
         if latest_manifest is None:
             QMessageBox.information(
                 self,

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -116,6 +116,44 @@ class ProjectState:
 
         return None
 
+    def get_latest_submitted_manifest_path_for_mode(
+        self,
+        game_root: Path,
+        work_mode: Any,
+    ) -> Path | None:
+        """Return the newest same-project manifest that already has a cloud job."""
+        from .work_modes import manifest_mode_for_work_mode
+
+        expected_mode = manifest_mode_for_work_mode(work_mode)
+        if expected_mode is None:
+            return None
+        normalized_game_root = self._normalized_path_text(game_root)
+
+        def has_cloud_job(path: Path) -> bool:
+            try:
+                manifest = self.load_manifest_file(path, lite=True)
+            except ValueError:
+                return False
+            job_name = manifest.get("job_name")
+            return isinstance(job_name, str) and bool(job_name.strip())
+
+        latest = self.get_latest_manifest_path()
+        if latest is not None:
+            manifest = read_manifest_index_fields(latest)
+            if (
+                self._manifest_matches(manifest, expected_mode, normalized_game_root)
+                and has_cloud_job(latest)
+            ):
+                return latest
+
+        for _, path, actual_mode, base_dir in self._manifest_history_index():
+            if not self._manifest_mode_matches(actual_mode, expected_mode):
+                continue
+            if base_dir != normalized_game_root:
+                continue
+            if has_cloud_job(path):
+                return path
+        return None
     def invalidate_manifest_history_cache(self) -> None:
         self._manifest_history_cache_signature = None
         self._manifest_history_entries = None

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -681,6 +681,8 @@ QPushButton#api_btn,
 QPushButton#translate_btn,
 QPushButton#primary_btn,
 QPushButton#sync_translation_start_btn,
+QPushButton#keywords_start_btn,
+QPushButton#revision_start_btn,
 QPushButton#context_bootstrap_rag_btn,
 QPushButton#context_bootstrap_source_index_btn {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_start}, stop:1 ${gradient_primary_end});
@@ -695,6 +697,8 @@ QPushButton#api_btn:hover,
 QPushButton#translate_btn:hover,
 QPushButton#primary_btn:hover,
 QPushButton#sync_translation_start_btn:hover,
+QPushButton#keywords_start_btn:hover,
+QPushButton#revision_start_btn:hover,
 QPushButton#context_bootstrap_rag_btn:hover,
 QPushButton#context_bootstrap_source_index_btn:hover {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_hover_start}, stop:1 ${gradient_primary_hover_end});
@@ -705,6 +709,8 @@ QPushButton#api_btn:pressed,
 QPushButton#translate_btn:pressed,
 QPushButton#primary_btn:pressed,
 QPushButton#sync_translation_start_btn:pressed,
+QPushButton#keywords_start_btn:pressed,
+QPushButton#revision_start_btn:pressed,
 QPushButton#context_bootstrap_rag_btn:pressed,
 QPushButton#context_bootstrap_source_index_btn:pressed {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 ${gradient_primary_pressed_start}, stop:1 ${gradient_primary_pressed_end});
@@ -715,6 +721,8 @@ QPushButton#api_btn:disabled,
 QPushButton#translate_btn:disabled,
 QPushButton#primary_btn:disabled,
 QPushButton#sync_translation_start_btn:disabled,
+QPushButton#keywords_start_btn:disabled,
+QPushButton#revision_start_btn:disabled,
 QPushButton#context_bootstrap_rag_btn:disabled,
 QPushButton#context_bootstrap_source_index_btn:disabled {
     background-color: ${bg_button_disabled};

--- a/gui_qt/workbench/batch_translation_page.py
+++ b/gui_qt/workbench/batch_translation_page.py
@@ -1,0 +1,144 @@
+"""Persistent batch-translation page for the workbench stack (#176 P5)."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import QPushButton, QSizePolicy, QVBoxLayout, QWidget
+
+from ..responsive_layout import FlowButtonBar
+from ..work_modes import WorkMode
+from ..workbench_session import WorkbenchModeSession
+from .page_contract import WorkbenchPageActions
+
+
+ControlState = tuple[bool, bool, str]
+
+
+class BatchTranslationPage(QWidget):
+    """Page-local batch actions; the coordinator remains the state authority."""
+
+    supported_modes = (WorkMode.BATCH_TRANSLATION,)
+    _main_actions = ("start", "resume", "stop", "split_submit")
+    _writeback_actions = ("apply",)
+    _issue_actions = (
+        "issues", "recheck", "retry", "retry_followup", "repair", "failure", "remediation",
+    )
+    _advanced_actions = ("probe", "split")
+    _labels = {
+        "start": "开始翻译", "resume": "继续翻译", "stop": "停止", "split_submit": "提交剩余包",
+        "apply": "写回翻译", "recheck": "重新检查", "issues": "查看问题清单",
+        "retry": "生成补译包", "retry_followup": "继续补译", "repair": "同步修补",
+        "failure": "查看写回失败报告", "remediation": "补救命令",
+        "probe": "试跑样本请求", "split": "拆分翻译包",
+    }
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("batch_translation_page")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._actions = WorkbenchPageActions()
+        self._running = False
+        self._issues_expanded = False
+        self.buttons: dict[str, QPushButton] = {}
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(8)
+        self.main_bar = self._build_bar("batch_main_actions", self._main_actions)
+        outer.addWidget(self.main_bar)
+        self.writeback_bar = self._build_bar("batch_writeback_actions", self._writeback_actions)
+        outer.addWidget(self.writeback_bar)
+        self.issues_toggle_btn = QPushButton("问题处理 ▸")
+        self.issues_toggle_btn.setObjectName("secondary_btn")
+        self.issues_toggle_btn.setToolTip("展开补译、修补、问题清单和重新检查等恢复操作。")
+        self.issues_toggle_btn.clicked.connect(self._toggle_issues)
+        outer.addWidget(self.issues_toggle_btn)
+        self.issues_bar = self._build_bar("batch_issue_actions", self._issue_actions)
+        self.issues_bar.setVisible(False)
+        outer.addWidget(self.issues_bar)
+        # These tools are intentionally always present beneath the main actions.
+        self.advanced_bar = self._build_bar("batch_advanced_actions", self._advanced_actions)
+        outer.addWidget(self.advanced_bar)
+
+    def _build_bar(self, role: str, keys: tuple[str, ...]) -> FlowButtonBar:
+        bar = FlowButtonBar(spacing=8, row_spacing=8)
+        bar.setObjectName("action_frame")
+        bar.setProperty("batch_role", role)
+        for key in keys:
+            button = QPushButton(self._labels[key])
+            button.setObjectName({"start": "translate_btn", "stop": "kill_btn", "apply": "apply_btn"}.get(key, "secondary_btn"))
+            button.setEnabled(False)
+            button.setVisible(False)
+            button.clicked.connect(lambda _checked=False, name=key: self._trigger(name))
+            self.buttons[key] = button
+            bar.add_widget(button, min_width=88)
+        bar.finish_setup()
+        return bar
+
+    def preferred_height(self, width: int) -> int:
+        """Return content height after responsive action rows have reflowed."""
+        for bar in (self.main_bar, self.writeback_bar, self.issues_bar, self.advanced_bar):
+            bar.reflow(force=True)
+        layout = self.layout()
+        if layout is None:
+            return self.sizeHint().height()
+        return max(self.minimumSizeHint().height(), layout.heightForWidth(max(width, 260)))
+
+    def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
+        self._actions = actions
+
+    def activate(self, mode: WorkMode, session: WorkbenchModeSession) -> None:
+        if mode not in self.supported_modes:
+            raise ValueError(f"Unsupported batch mode: {mode.value}")
+        del session
+
+    def set_task_running(self, running: bool) -> None:
+        self._running = running
+        for key, button in self.buttons.items():
+            if key == "stop":
+                button.setEnabled(running)
+            elif running:
+                button.setEnabled(False)
+
+    def set_controls(self, controls: dict[str, ControlState], *, issues_expanded: bool | None = None) -> None:
+        """Render coordinator-derived readiness without owning workflow state."""
+        for key, button in self.buttons.items():
+            visible, enabled, label = controls.get(key, (False, False, self._labels[key]))
+            button.setVisible(visible)
+            button.setText(label)
+            button.setEnabled(enabled and not self._running)
+        self.buttons["stop"].setVisible(True)
+        self.buttons["stop"].setEnabled(self._running)
+        self.main_bar.setVisible(True)
+        self.writeback_bar.setVisible(any(not self.buttons[key].isHidden() for key in self._writeback_actions))
+        self.issues_toggle_btn.setVisible(any(not self.buttons[key].isHidden() for key in self._issue_actions))
+        if issues_expanded is not None and issues_expanded != self._issues_expanded:
+            self._issues_expanded = issues_expanded
+        self.issues_bar.setVisible(self._issues_expanded and not self.issues_toggle_btn.isHidden())
+        self.advanced_bar.setVisible(True)
+        for bar in (self.main_bar, self.writeback_bar, self.issues_bar, self.advanced_bar):
+            bar.reflow(force=True)
+        self.updateGeometry()
+
+    def reset_project(self) -> None:
+        self._issues_expanded = False
+        self.set_task_running(False)
+        self.set_controls(
+            {
+                "probe": (True, False, self._labels["probe"]),
+                "split": (True, False, self._labels["split"]),
+            }
+        )
+
+    def _toggle_issues(self) -> None:
+        self._issues_expanded = not self._issues_expanded
+        self.issues_toggle_btn.setText("问题处理 ▾" if self._issues_expanded else "问题处理 ▸")
+        self.issues_bar.setVisible(self._issues_expanded)
+        self.issues_bar.reflow(force=True)
+        self.updateGeometry()
+
+    def _trigger(self, action: str) -> None:
+        if action == "stop":
+            if self._running and self._actions.action is not None:
+                self._actions.action(action)
+            return
+        if not self._running and self.buttons[action].isEnabled() and self._actions.action is not None:
+            self._actions.action(action)

--- a/gui_qt/workbench/batch_translation_page.py
+++ b/gui_qt/workbench/batch_translation_page.py
@@ -2,9 +2,17 @@
 from __future__ import annotations
 
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QPushButton, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
-from ..responsive_layout import FlowButtonBar
+from ..responsive_layout import FlowButtonBar, ResponsiveActionPanel
 from ..work_modes import WorkMode
 from ..workbench_session import WorkbenchModeSession
 from .page_contract import WorkbenchPageActions
@@ -21,15 +29,30 @@ class BatchTranslationPage(QWidget):
     _main_actions = ("start", "resume", "stop", "split_submit")
     _writeback_actions = ("apply",)
     _issue_actions = (
-        "issues", "recheck", "retry", "retry_followup", "repair", "failure", "remediation",
+        "issues",
+        "recheck",
+        "retry",
+        "retry_followup",
+        "repair",
+        "failure",
+        "remediation",
     )
     _advanced_actions = ("probe", "split")
     _labels = {
-        "start": "开始翻译", "resume": "继续翻译", "stop": "停止", "split_submit": "提交剩余包",
-        "apply": "写回翻译", "recheck": "重新检查", "issues": "查看问题清单",
-        "retry": "生成补译包", "retry_followup": "继续补译", "repair": "同步修补",
-        "failure": "查看写回失败报告", "remediation": "补救命令",
-        "probe": "试跑样本请求", "split": "拆分翻译包",
+        "start": "开始翻译",
+        "resume": "继续翻译",
+        "stop": "停止",
+        "split_submit": "提交剩余包",
+        "apply": "写回翻译",
+        "recheck": "重新检查",
+        "issues": "查看问题清单",
+        "retry": "生成补译包",
+        "retry_followup": "继续补译",
+        "repair": "同步修补",
+        "failure": "查看写回失败报告",
+        "remediation": "补救命令",
+        "probe": "试跑样本请求",
+        "split": "拆分翻译包",
     }
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -44,45 +67,99 @@ class BatchTranslationPage(QWidget):
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
         outer.setSpacing(8)
-        self.main_bar = self._build_bar("batch_main_actions", self._main_actions)
-        outer.addWidget(self.main_bar)
-        self.writeback_bar = self._build_bar("batch_writeback_actions", self._writeback_actions)
-        outer.addWidget(self.writeback_bar)
+
+        # Preserve the legacy workbench hierarchy while moving ownership on-page.
+        self.main_frame = QFrame()
+        self.main_frame.setObjectName("action_frame")
+        main_layout = QVBoxLayout(self.main_frame)
+        main_layout.setContentsMargins(12, 10, 12, 10)
+        main_layout.setSpacing(8)
+        self.main_bar = ResponsiveActionPanel(compact_width=640)
+        self.main_bar.setObjectName("batch_main_actions")
+        for key in self._main_actions:
+            button = self._make_button(key)
+            if key == "stop":
+                self.main_bar.add_translate_trailing(button)
+            else:
+                self.main_bar.add_translate_button(button)
+        self.main_bar.finish_setup()
+        main_layout.addWidget(self.main_bar)
+        outer.addWidget(self.main_frame)
+
+        # Keep writeback and recovery disclosure on the same row as before P5.
+        self.writeback_row = QWidget()
+        writeback_layout = QHBoxLayout(self.writeback_row)
+        writeback_layout.setContentsMargins(0, 0, 0, 0)
+        writeback_layout.setSpacing(8)
+        self.writeback_bar = self._build_bar(
+            "batch_writeback_actions", self._writeback_actions
+        )
+        writeback_layout.addWidget(self.writeback_bar, 1)
         self.issues_toggle_btn = QPushButton("问题处理 ▸")
         self.issues_toggle_btn.setObjectName("secondary_btn")
         self.issues_toggle_btn.setToolTip("展开补译、修补、问题清单和重新检查等恢复操作。")
         self.issues_toggle_btn.clicked.connect(self._toggle_issues)
-        outer.addWidget(self.issues_toggle_btn)
+        writeback_layout.addWidget(self.issues_toggle_btn)
+        outer.addWidget(self.writeback_row)
+
         self.issues_bar = self._build_bar("batch_issue_actions", self._issue_actions)
         self.issues_bar.setVisible(False)
         outer.addWidget(self.issues_bar)
-        # These tools are intentionally always present beneath the main actions.
-        self.advanced_bar = self._build_bar("batch_advanced_actions", self._advanced_actions)
-        outer.addWidget(self.advanced_bar)
+
+        self.advanced_frame = QFrame()
+        self.advanced_frame.setObjectName("batch_advanced_frame")
+        advanced_layout = QVBoxLayout(self.advanced_frame)
+        advanced_layout.setContentsMargins(12, 10, 12, 10)
+        advanced_layout.setSpacing(6)
+        advanced_title = QLabel("高级工具")
+        advanced_title.setObjectName("action_group_label")
+        advanced_layout.addWidget(advanced_title)
+        self.advanced_bar = self._build_bar(
+            "batch_advanced_actions", self._advanced_actions
+        )
+        advanced_layout.addWidget(self.advanced_bar)
+        outer.addWidget(self.advanced_frame)
+
+    def _make_button(self, key: str) -> QPushButton:
+        button = QPushButton(self._labels[key])
+        button.setObjectName(
+            {"start": "translate_btn", "stop": "kill_btn", "apply": "apply_btn"}.get(
+                key, "secondary_btn"
+            )
+        )
+        button.setEnabled(False)
+        button.setVisible(False)
+        button.clicked.connect(
+            lambda _checked=False, name=key: self._trigger(name)
+        )
+        self.buttons[key] = button
+        return button
 
     def _build_bar(self, role: str, keys: tuple[str, ...]) -> FlowButtonBar:
         bar = FlowButtonBar(spacing=8, row_spacing=8)
         bar.setObjectName("action_frame")
         bar.setProperty("batch_role", role)
         for key in keys:
-            button = QPushButton(self._labels[key])
-            button.setObjectName({"start": "translate_btn", "stop": "kill_btn", "apply": "apply_btn"}.get(key, "secondary_btn"))
-            button.setEnabled(False)
-            button.setVisible(False)
-            button.clicked.connect(lambda _checked=False, name=key: self._trigger(name))
-            self.buttons[key] = button
+            button = self._make_button(key)
             bar.add_widget(button, min_width=88)
         bar.finish_setup()
         return bar
 
     def preferred_height(self, width: int) -> int:
         """Return content height after responsive action rows have reflowed."""
-        for bar in (self.main_bar, self.writeback_bar, self.issues_bar, self.advanced_bar):
+        for bar in (
+            self.main_bar,
+            self.writeback_bar,
+            self.issues_bar,
+            self.advanced_bar,
+        ):
             bar.reflow(force=True)
         layout = self.layout()
         if layout is None:
             return self.sizeHint().height()
-        return max(self.minimumSizeHint().height(), layout.heightForWidth(max(width, 260)))
+        return max(
+            self.minimumSizeHint().height(), layout.heightForWidth(max(width, 260))
+        )
 
     def set_action_callbacks(self, actions: WorkbenchPageActions) -> None:
         self._actions = actions
@@ -100,23 +177,41 @@ class BatchTranslationPage(QWidget):
             elif running:
                 button.setEnabled(False)
 
-    def set_controls(self, controls: dict[str, ControlState], *, issues_expanded: bool | None = None) -> None:
+    def set_controls(
+        self,
+        controls: dict[str, ControlState],
+        *,
+        issues_expanded: bool | None = None,
+    ) -> None:
         """Render coordinator-derived readiness without owning workflow state."""
         for key, button in self.buttons.items():
-            visible, enabled, label = controls.get(key, (False, False, self._labels[key]))
+            visible, enabled, label = controls.get(
+                key, (False, False, self._labels[key])
+            )
             button.setVisible(visible)
             button.setText(label)
             button.setEnabled(enabled and not self._running)
         self.buttons["stop"].setVisible(True)
         self.buttons["stop"].setEnabled(self._running)
-        self.main_bar.setVisible(True)
-        self.writeback_bar.setVisible(any(not self.buttons[key].isHidden() for key in self._writeback_actions))
-        self.issues_toggle_btn.setVisible(any(not self.buttons[key].isHidden() for key in self._issue_actions))
+        self.main_frame.setVisible(True)
+        self.writeback_row.setVisible(
+            any(not self.buttons[key].isHidden() for key in self._writeback_actions)
+        )
+        self.issues_toggle_btn.setVisible(
+            any(not self.buttons[key].isHidden() for key in self._issue_actions)
+        )
         if issues_expanded is not None and issues_expanded != self._issues_expanded:
             self._issues_expanded = issues_expanded
-        self.issues_bar.setVisible(self._issues_expanded and not self.issues_toggle_btn.isHidden())
-        self.advanced_bar.setVisible(True)
-        for bar in (self.main_bar, self.writeback_bar, self.issues_bar, self.advanced_bar):
+        self.issues_bar.setVisible(
+            self._issues_expanded and not self.issues_toggle_btn.isHidden()
+        )
+        self.advanced_frame.setVisible(True)
+        for bar in (
+            self.main_bar,
+            self.writeback_bar,
+            self.issues_bar,
+            self.advanced_bar,
+        ):
             bar.reflow(force=True)
         self.updateGeometry()
 
@@ -132,7 +227,9 @@ class BatchTranslationPage(QWidget):
 
     def _toggle_issues(self) -> None:
         self._issues_expanded = not self._issues_expanded
-        self.issues_toggle_btn.setText("问题处理 ▾" if self._issues_expanded else "问题处理 ▸")
+        self.issues_toggle_btn.setText(
+            "问题处理 ▾" if self._issues_expanded else "问题处理 ▸"
+        )
         self.issues_bar.setVisible(self._issues_expanded)
         self.issues_bar.reflow(force=True)
         self.updateGeometry()
@@ -143,5 +240,9 @@ class BatchTranslationPage(QWidget):
             if self._running and self._actions.action is not None:
                 self._actions.action(action)
             return
-        if not self._running and self.buttons[action].isEnabled() and self._actions.action is not None:
+        if (
+            not self._running
+            and self.buttons[action].isEnabled()
+            and self._actions.action is not None
+        ):
             self._actions.action(action)

--- a/gui_qt/workbench/batch_translation_page.py
+++ b/gui_qt/workbench/batch_translation_page.py
@@ -1,6 +1,7 @@
 """Persistent batch-translation page for the workbench stack (#176 P5)."""
 from __future__ import annotations
 
+from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QPushButton, QSizePolicy, QVBoxLayout, QWidget
 
 from ..responsive_layout import FlowButtonBar
@@ -15,6 +16,7 @@ ControlState = tuple[bool, bool, str]
 class BatchTranslationPage(QWidget):
     """Page-local batch actions; the coordinator remains the state authority."""
 
+    content_height_changed = Signal()
     supported_modes = (WorkMode.BATCH_TRANSLATION,)
     _main_actions = ("start", "resume", "stop", "split_submit")
     _writeback_actions = ("apply",)
@@ -134,6 +136,7 @@ class BatchTranslationPage(QWidget):
         self.issues_bar.setVisible(self._issues_expanded)
         self.issues_bar.reflow(force=True)
         self.updateGeometry()
+        self.content_height_changed.emit()
 
     def _trigger(self, action: str) -> None:
         if action == "stop":

--- a/gui_qt/workbench/page_contract.py
+++ b/gui_qt/workbench/page_contract.py
@@ -25,6 +25,7 @@ class WorkbenchPageActions:
     prebuild: Callable[[str], None] | None = None
     open_settings: Callable[[], None] | None = None
     select_mode: Callable[[WorkMode], None] | None = None
+    action: Callable[[str], None] | None = None
 
 
 class WorkbenchPage(Protocol):

--- a/tests/test_gui_button_layout_matrix.py
+++ b/tests/test_gui_button_layout_matrix.py
@@ -185,6 +185,8 @@ class GuiButtonLayoutMatrixTests(unittest.TestCase):
         self.assertFalse(page.writeback_bar.isHidden())
         self.assertFalse(page.buttons["apply"].isHidden())
         self.assertFalse(page.issues_toggle_btn.isHidden())
+        self.assertIs(page.issues_toggle_btn.parentWidget(), page.writeback_row)
+        self.assertIs(page.writeback_bar.parentWidget(), page.writeback_row)
         page.issues_toggle_btn.click()
         self.assertFalse(page.issues_bar.isHidden())
 

--- a/tests/test_gui_button_layout_matrix.py
+++ b/tests/test_gui_button_layout_matrix.py
@@ -159,58 +159,46 @@ class GuiButtonLayoutMatrixTests(unittest.TestCase):
         self.assertIsInstance(self.window.writeback_primary_bar, FlowButtonBar)
         self.assertIsInstance(self.window.writeback_issues_panel, FlowButtonBar)
 
-    def test_result_writeback_actions_not_stacked_toolbars(self) -> None:
-        """写回翻译 + 问题处理 share one row; recovery strip is single-row when wide enough.
-
-        Windows offscreen CI often keeps the shell narrower than the requested
-        resize, so do not hard-require page width — size the flow bar directly
-        for the wrap assertion.
-        """
+    def test_batch_page_recovery_controls_wrap_without_legacy_toolbars(self) -> None:
+        """P5 keeps batch writeback/recovery actions on its real page."""
         from gui_qt.responsive_layout import widget_layout_width
 
         self.window.resize(1600, 900)
         self.window.show()
         self.window._set_work_mode(WorkMode.BATCH_TRANSLATION, refresh_manifest_writeback=False)
-        self.window._focus_workbench_status_tab(2)
-        self.window._set_writeback_issues_expanded(True)
+        for name in (
+            "recheck_btn",
+            "check_issues_btn",
+            "retry_btn",
+            "retry_followup_btn",
+            "repair_btn",
+            "apply_failure_btn",
+            "remediation_btn",
+        ):
+            getattr(self.window, name).setVisible(True)
+        self.window._sync_batch_translation_page_controls()
         for _ in range(8):
             self._app.processEvents()
-        self.window._reflow_button_bars()
-        for _ in range(6):
-            self._app.processEvents()
 
-        page = self.window.workbench_status_tabs.widget(2)
+        page = self.window.batch_translation_page
+        self.assertTrue(self.window.writeback_primary_bar.isHidden())
+        self.assertFalse(page.writeback_bar.isHidden())
+        self.assertFalse(page.buttons["apply"].isHidden())
+        self.assertFalse(page.issues_toggle_btn.isHidden())
+        page.issues_toggle_btn.click()
+        self.assertFalse(page.issues_bar.isHidden())
 
-        # Apply + 问题处理 toggle share one horizontal band (not stacked toolbars).
-        apply_tl = self.window.apply_btn.mapTo(page, self.window.apply_btn.rect().topLeft())
-        toggle_tl = self.window.writeback_issues_toggle_btn.mapTo(
-            page, self.window.writeback_issues_toggle_btn.rect().topLeft()
-        )
-        self.assertLessEqual(
-            abs(apply_tl.y() - toggle_tl.y()),
-            12,
-            msg=f"写回翻译 / 问题处理 should share a row; y={apply_tl.y()} vs {toggle_tl.y()}",
-        )
-        self.assertGreater(toggle_tl.x(), apply_tl.x())
-
-        # Force a known-wide geometry: offscreen Windows may leave the tab page ~800px.
-        panel = self.window.writeback_issues_panel
-        visible = [b for b in panel._items if not b.isHidden()]
+        panel = page.issues_bar
+        visible = [button for button in panel._items if not button.isHidden()]
         self.assertGreaterEqual(len(visible), 2)
-        needed = sum(widget_layout_width(b) for b in visible) + 8 * max(0, len(visible) - 1) + 24
-        wide = max(1200, needed + 40)
-        panel.resize(wide, 80)
+        needed = sum(widget_layout_width(button) for button in visible) + 8 * max(0, len(visible) - 1) + 24
+        panel.resize(max(1200, needed + 40), 80)
         panel.reflow(force=True)
         for _ in range(4):
             self._app.processEvents()
-        self.assertEqual(
-            panel._root.count(),
-            1,
-            msg=f"issues panel should not wrap when forced to {wide}px",
-        )
-        ys = {b.geometry().y() for b in visible if b.isVisible() or not b.isHidden()}
+        self.assertEqual(panel._root.count(), 1)
+        ys = {button.geometry().y() for button in visible}
         self.assertEqual(len(ys), 1, msg=f"recovery buttons on multiple Y rows: {sorted(ys)}")
-
 
 class FlowButtonBarUnitTests(unittest.TestCase):
     @classmethod

--- a/tests/test_gui_p3_polish.py
+++ b/tests/test_gui_p3_polish.py
@@ -63,6 +63,31 @@ class GuiP3PolishTests(unittest.TestCase):
         self.window._update_resume_btn_enabled(running=False)
         self.assertTrue(self.window.resume_btn.isEnabled())
 
+    def test_keyword_status_query_prefers_submitted_manifest(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.KEYWORD_EXTRACTION,
+            refresh_manifest_writeback=False,
+        )
+        self.window.resume_btn.setText("查询云端状态")
+        self.window.state.get_game_root = lambda: Path("C:/game/work")  # type: ignore[method-assign]
+        self.window.state.get_latest_manifest_path_for_mode = (  # type: ignore[method-assign]
+            lambda *_a, **_k: "C:/game/work/logs/new-local/manifest.json"
+        )
+        self.window.state.get_latest_submitted_manifest_path_for_mode = (  # type: ignore[method-assign]
+            lambda *_a, **_k: "C:/game/work/logs/cloud-job/manifest.json"
+        )
+        loaded_paths: list[str] = []
+
+        def load_resume_manifest(path, **_kwargs):
+            loaded_paths.append(str(path))
+            return {"mode": "keyword_extraction", "base_dir": "C:/game/work"}
+
+        self.window.state.load_resume_manifest = load_resume_manifest  # type: ignore[method-assign]
+        self.assertEqual(self.window._resume_task_available(), (True, ""))
+        self.assertEqual(
+            loaded_paths,
+            ["C:/game/work/logs/cloud-job/manifest.json"],
+        )
     def test_doctor_empty_state_visible_before_check(self) -> None:
         self.window._doctor_check_completed = False
         self.window._sync_workbench_empty_states()

--- a/tests/test_gui_project_state.py
+++ b/tests/test_gui_project_state.py
@@ -541,6 +541,47 @@ class GuiProjectStateTests(unittest.TestCase):
             self.assertIsNotNone(latest)
             self.assertEqual(Path(latest).resolve(), manifest3.resolve())
 
+    def test_get_latest_submitted_manifest_ignores_newer_local_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = self.make_state(root)
+            logs_dir = root / "logs" / "batch_jobs"
+            remote = logs_dir / "remote" / "manifest.json"
+            local = logs_dir / "new-local" / "manifest.json"
+            remote.parent.mkdir(parents=True)
+            local.parent.mkdir(parents=True)
+            remote.write_text(
+                json.dumps(
+                    {
+                        "mode": "keyword_extraction",
+                        "base_dir": "C:/correct/project",
+                        "job_name": "batches/remote-keywords",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            local.write_text(
+                json.dumps(
+                    {
+                        "mode": "keyword_extraction",
+                        "base_dir": "C:/correct/project",
+                        "job_name": "",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (logs_dir / "latest_manifest.txt").write_text(
+                str(local), encoding="utf-8"
+            )
+            state.get_logs_dir = lambda: logs_dir
+            state._normalized_path_text = lambda p: os.path.normcase(os.path.abspath(p))
+
+            submitted = state.get_latest_submitted_manifest_path_for_mode(
+                Path("C:/correct/project"),
+                WorkMode.KEYWORD_EXTRACTION,
+            )
+
+            self.assertEqual(Path(submitted).resolve(), remote.resolve())
     def test_get_latest_manifest_path_for_mode_stops_on_unreadable_latest_manifest(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -416,6 +416,25 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(page.buttons["apply"].isEnabled())
         self.assertTrue(page.buttons["stop"].isEnabled())
 
+    def test_batch_issue_toggle_recalculates_stack_height(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+        page = self.window.batch_translation_page
+        page.set_controls(
+            {
+                "issues": (True, True, "查看问题清单"),
+                "retry": (True, True, "生成补译包"),
+                "repair": (True, True, "同步修补"),
+            }
+        )
+        page.issues_toggle_btn.click()
+
+        self.assertGreaterEqual(
+            self.window.workbench_stack.maximumHeight(),
+            page.preferred_height(self.window.workbench_stack.width()),
+        )
     def test_context_page_shows_status_cards(self) -> None:
         self.window._set_work_mode(
             WorkMode.BOOTSTRAP_RAG,

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -376,23 +376,45 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(page.writeback_btn.isEnabled())
         self.assertTrue(page.stop_btn.isEnabled())
 
-    def test_batch_page_hides_revision_apply(self) -> None:
+    def test_batch_page_owns_actions_and_running_lock(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,
             refresh_manifest_writeback=False,
         )
-        summary = WritebackSummary(
-            status="ready",
-            heading="可写回",
-            message="ok",
-            facts=[],
-            findings=[],
-            can_apply=True,
-            manifest_path="C:/batch/manifest.json",
+        page = self.window.batch_translation_page
+        self.assertIs(self.window.workbench_stack.currentWidget(), page)
+        self.assertTrue(self.window._workbench_actions_column.isHidden())
+        self.assertTrue(self.window.writeback_primary_bar.isHidden())
+
+        actions: list[str] = []
+        page.set_action_callbacks(WorkbenchPageActions(action=actions.append))
+        page.set_controls(
+            {
+                "start": (True, True, "开始翻译"),
+                "resume": (True, True, "继续翻译"),
+                "apply": (True, True, "写回翻译"),
+                "probe": (True, True, "试跑样本请求"),
+                "split": (True, True, "拆分翻译包"),
+                "issues": (True, True, "查看问题清单"),
+            }
         )
-        self.window._set_writeback_summary(summary)
-        self.assertTrue(self.window.apply_revision_btn.isHidden())
-        self.assertFalse(self.window.apply_btn.isHidden())
+        page.buttons["start"].click()
+        page.buttons["resume"].click()
+        page.buttons["apply"].click()
+        page.buttons["probe"].click()
+        page.buttons["split"].click()
+        page.issues_toggle_btn.click()
+        page.buttons["issues"].click()
+        page.set_task_running(True)
+        page.buttons["stop"].click()
+
+        self.assertEqual(
+            actions,
+            ["start", "resume", "apply", "probe", "split", "issues", "stop"],
+        )
+        self.assertFalse(page.buttons["start"].isEnabled())
+        self.assertFalse(page.buttons["apply"].isEnabled())
+        self.assertTrue(page.buttons["stop"].isEnabled())
 
     def test_context_page_shows_status_cards(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -290,6 +290,10 @@ class GuiTaskPageTests(unittest.TestCase):
         page = self.window.keywords_page
 
         self.assertEqual(page.resume_btn.text(), "查询云端状态")
+        self.window._set_task_running(False)
+        self.assertFalse(self.window.translate_btn.isEnabled())
+        self.assertFalse(page.start_btn.isEnabled())
+        self.assertTrue(page.resume_btn.isEnabled())
         self.window._set_task_running(True)
         self.assertFalse(page.mode_combo.isEnabled())
         self.assertFalse(page.start_btn.isEnabled())

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -416,8 +416,8 @@ class GuiTaskPageTests(unittest.TestCase):
             actions,
             ["start", "resume", "apply", "probe", "split", "issues", "stop"],
         )
-        self.assertFalse(page.buttons["start"].isEnabled())
-        self.assertFalse(page.buttons["apply"].isEnabled())
+        for action in ("start", "resume", "apply", "probe", "split", "issues"):
+            self.assertFalse(page.buttons[action].isEnabled())
         self.assertTrue(page.buttons["stop"].isEnabled())
 
     def test_batch_issue_toggle_recalculates_stack_height(self) -> None:
@@ -433,11 +433,14 @@ class GuiTaskPageTests(unittest.TestCase):
                 "repair": (True, True, "同步修补"),
             }
         )
+        collapsed_height = page.preferred_height(self.window.workbench_stack.width())
         page.issues_toggle_btn.click()
+        expanded_height = page.preferred_height(self.window.workbench_stack.width())
 
+        self.assertGreater(expanded_height, collapsed_height)
         self.assertGreaterEqual(
             self.window.workbench_stack.maximumHeight(),
-            page.preferred_height(self.window.workbench_stack.width()),
+            expanded_height,
         )
     def test_context_page_shows_status_cards(self) -> None:
         self.window._set_work_mode(

--- a/tests/test_gui_theme_cache.py
+++ b/tests/test_gui_theme_cache.py
@@ -11,6 +11,17 @@ class GuiThemeCacheTests(unittest.TestCase):
     def tearDown(self) -> None:
         clear_stylesheet_cache()
 
+    def test_workbench_start_buttons_use_primary_theme_rules(self):
+        template = _TEMPLATE_PATH.read_text(encoding="utf-8")
+        for selector in (
+            "QPushButton#keywords_start_btn",
+            "QPushButton#revision_start_btn",
+        ):
+            self.assertIn(f"{selector},", template)
+            self.assertIn(f"{selector}:hover,", template)
+            self.assertIn(f"{selector}:pressed,", template)
+            self.assertIn(f"{selector}:disabled,", template)
+
     def test_clear_stylesheet_cache_allows_stylesheet_reload(self):
         with tempfile.TemporaryDirectory() as tmp:
             resources = Path(tmp)


### PR DESCRIPTION
## 内容

完成 #176 的 P5：批量翻译已迁移为 `workbench_stack` 中的长期真实页面。

- 页面拥有独立的开始、继续、停止、写回、问题处理、试跑和拆分控件。
- 所有用户动作继续通过 `MainWindow` 回调进入既有 workflow、runner 与 `check → apply` 安全门控；没有复制 manifest 或 session 状态。
- 批量页显示时隐藏 legacy 共享 action/writeback widget；它们在 P6 前仅作为协调层的 readiness 来源。
- 新增页面动作、运行锁与响应式问题处理布局回归覆盖。

Part of #176 (P5).

## 验证

- `python -m unittest tests.test_gui_task_pages tests.test_gui_batch_stages tests.test_gui_batch_advanced_tools tests.test_gui_button_layout_matrix tests.test_gui_workbench_nav -q`
- `python tests/run_gui_tests.py -q`（662 tests）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Batch Translation page with controls for translation, writeback, recovery, and advanced actions.
  * Batch Translation controls now stay in sync with task status and readiness, including responsive layout updates when expanding issues/recovery.
  * Resume/“query cloud status” now prioritizes the latest submitted cloud job when determining availability.

* **Bug Fixes**
  * Fixed batch-mode navigation and layout so legacy writeback controls don’t appear alongside batch controls.
  * Improved resume behavior to ignore newer local manifests that don’t represent a submitted cloud job.
  * Tightened translate button enabling for keyword extraction while status is waiting.

* **Tests**
  * Updated and added GUI/layout and resume/manifest-selection tests for batch and keyword modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->