### PR TITLE
Fix resume actions after task completion

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -7213,6 +7213,11 @@ class MainWindow(QMainWindow):
     def _set_task_running(self, running: bool):
         was_running = bool(getattr(self, "_task_running", False))
         self._task_running = running
+        # Update the stop action before recomputing resume availability. The
+        # availability check treats an enabled stop action as an active task;
+        # leaving the old running state here would keep resume/status disabled
+        # until another UI refresh (or an application restart).
+        self.kill_btn.setEnabled(running)
         spec = work_mode_spec(self._current_work_mode())
         project_switch_enabled = not running
         if hasattr(self, "select_btn"):
@@ -7265,7 +7270,6 @@ class MainWindow(QMainWindow):
         self._update_compare_variants_btn_enabled(running=running)
         self._update_keyword_merge_btn_enabled(running=running)
         self._update_split_btn_enabled(running=running)
-        self.kill_btn.setEnabled(running)
         self._sync_sync_translation_page_controls(running=running)
         self._sync_batch_translation_page_controls(running=running)
         self._sync_keywords_page_controls(running=running)

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -420,6 +420,29 @@ class GuiTaskPageTests(unittest.TestCase):
             self.assertFalse(page.buttons[action].isEnabled())
         self.assertTrue(page.buttons["stop"].isEnabled())
 
+    def test_batch_resume_reenables_immediately_when_task_stops(self) -> None:
+        self.window._set_work_mode(
+            WorkMode.BATCH_TRANSLATION,
+            refresh_manifest_writeback=False,
+        )
+
+        class WaitingWorkflow:
+            manifest_path = ""
+
+            @staticmethod
+            def current_step():
+                return object()
+
+        self.window._workflow = WaitingWorkflow()
+        self.window._set_task_running(True)
+        self.assertFalse(self.window.batch_translation_page.buttons["resume"].isEnabled())
+
+        self.window._set_task_running(False)
+
+        self.assertFalse(self.window.kill_btn.isEnabled())
+        self.assertTrue(self.window.resume_btn.isEnabled())
+        self.assertTrue(self.window.batch_translation_page.buttons["resume"].isEnabled())
+
     def test_batch_issue_toggle_recalculates_stack_height(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,


### PR DESCRIPTION
## 修改内容

- 在重新计算“继续/查询云端状态”可用性之前，先同步停止按钮的运行状态
- 防止任务结束后仍被误判为运行中，导致继续操作必须重启应用才恢复
- 增加批量翻译页面从运行中切换到空闲状态的回归测试

## 根因

`_set_task_running(False)` 原先会先调用继续操作的可用性检查，再禁用停止按钮。可用性检查把仍启用的停止按钮视为任务尚在运行，因此“查询云端状态”或“继续翻译”会被错误禁用，直到后续刷新或重启。

## 用户影响

提交云端任务后可立即查询状态；云端任务完成后可立即继续下载和校验，无需重启 GUI。共享状态修复同样覆盖批量关键词和批量订正页面。

## 验证

- `python -m unittest tests.test_gui_task_pages -q`（26 项通过）
- `python -m unittest tests.test_gui_batch_stages tests.test_gui_translation_workflow tests.test_gui_app_config -q`（89 项通过）
- `python tests/run_gui_tests.py -q`（667 项通过）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resume and status actions now update immediately when a batch task stops.
  * Prevented resume controls from remaining disabled until a later interface refresh.

* **Tests**
  * Added coverage to verify resume buttons are correctly disabled while a task runs and re-enabled immediately afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->