### PR TITLE
Add synchronous model backend foundation

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -28,6 +28,7 @@ import translation_ab_experiment
 import story_memory
 import translation_core
 import translator_runtime as runtime
+from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
 
 try:
     from google import genai
@@ -6053,15 +6054,21 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
         usage_metadata = {}
         response_text = ''
         try:
-            response = client.models.generate_content(
+            backend = GeminiSyncBackend(
+                client,
+                serialize_response=serialize_unknown,
+                extract_text=extract_text_from_response_payload,
+                extract_finish_reason=extract_finish_reason,
+                extract_usage=lambda payload: summarize_usage_metadata(extract_usage_metadata(payload)),
+            )
+            result = backend.generate(SyncGenerationRequest(
                 model=manifest.get('batch_model') or BATCH_MODEL,
                 contents=request_payload.get('contents') or [],
                 config=config,
-            )
-            response_payload = serialize_unknown(response)
-            finish_reason = extract_finish_reason(response_payload)
-            usage_metadata = summarize_usage_metadata(extract_usage_metadata(response_payload))
-            response_text = extract_text_from_response_payload(response_payload)
+            ))
+            finish_reason = result.finish_reason
+            usage_metadata = dict(result.usage_metadata)
+            response_text = result.response_text
         except Exception as exc:
             summary['request_errors'] += 1
             parse_error = str(exc)
@@ -7448,17 +7455,26 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
             safety_settings = request_payload.get('safety_settings')
             if safety_settings:
                 config['safety_settings'] = safety_settings
-            response = client.models.generate_content(
+            backend = GeminiSyncBackend(
+                client,
+                serialize_response=serialize_unknown,
+                extract_text=extract_text_from_response_payload,
+                extract_finish_reason=extract_finish_reason,
+                extract_usage=lambda payload: summarize_usage_metadata(extract_usage_metadata(payload)),
+            )
+            result = backend.generate(SyncGenerationRequest(
                 model=model_name,
                 contents=request_payload.get('contents') or [],
                 config=config,
-            )
-            response_payload = serialize_unknown(response)
+            ))
             return {
-                'response_payload': response_payload,
-                'response_text': extract_text_from_response_payload(response_payload),
-                'finish_reason': extract_finish_reason(response_payload),
-                'usage_metadata': summarize_usage_metadata(extract_usage_metadata(response_payload)),
+                'response_payload': result.response_payload,
+                'response_text': result.response_text,
+                'finish_reason': result.finish_reason,
+                'usage_metadata': dict(result.usage_metadata),
+                'provider': result.provider,
+                'model': result.model,
+                'execution_mode': result.execution_mode,
             }
         except Exception as exc:
             last_error = exc

--- a/sync_model_backend.py
+++ b/sync_model_backend.py
@@ -1,0 +1,61 @@
+"""Minimal backend boundary for synchronous model generation.
+
+Gemini Batch intentionally does not use this module. It remains the default
+translation path; this boundary is for explicitly selected synchronous calls.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, Optional, Protocol, runtime_checkable
+
+SYNC_EXECUTION_MODE = "sync"
+
+@dataclass(frozen=True)
+class SyncGenerationRequest:
+    model: str
+    contents: Any
+    config: Mapping[str, Any] = field(default_factory=dict)
+
+@dataclass(frozen=True)
+class SyncGenerationResult:
+    provider: str
+    model: str
+    execution_mode: str
+    response_payload: Any
+    response_text: str = ""
+    parsed: Any = None
+    finish_reason: str = ""
+    usage_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+@runtime_checkable
+class SyncModelBackend(Protocol):
+    provider: str
+    def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult: ...
+
+class GeminiSyncBackend:
+    """Adapter for the existing google-genai synchronous client."""
+    provider = "gemini"
+
+    def __init__(self, client: Any, *, serialize_response: Callable[[Any], Any],
+                 extract_text: Callable[[Any], str],
+                 extract_finish_reason: Callable[[Any], str],
+                 extract_usage: Optional[Callable[[Any], Mapping[str, Any]]] = None) -> None:
+        self._client = client
+        self._serialize_response = serialize_response
+        self._extract_text = extract_text
+        self._extract_finish_reason = extract_finish_reason
+        self._extract_usage = extract_usage
+
+    def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult:
+        response = self._client.models.generate_content(
+            model=request.model, contents=request.contents, config=dict(request.config))
+        payload = self._serialize_response(response)
+        usage: Dict[str, Any] = {}
+        if self._extract_usage is not None:
+            usage = dict(self._extract_usage(payload) or {})
+        return SyncGenerationResult(
+            provider=self.provider, model=request.model,
+            execution_mode=SYNC_EXECUTION_MODE, response_payload=payload,
+            response_text=self._extract_text(payload) or "",
+            parsed=getattr(response, "parsed", None),
+            finish_reason=self._extract_finish_reason(payload) or "",
+            usage_metadata=usage)

--- a/tests/test_sync_model_backend.py
+++ b/tests/test_sync_model_backend.py
@@ -1,0 +1,67 @@
+import unittest
+
+from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest, SyncModelBackend
+
+
+class _Models:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def generate_content(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+class _Client:
+    def __init__(self, response):
+        self.models = _Models(response)
+
+
+class _Response:
+    parsed = [{"id": "a", "translation": "你好"}]
+
+
+class SyncModelBackendTests(unittest.TestCase):
+    def test_gemini_adapter_standardizes_metadata_and_payload(self):
+        client = _Client(_Response())
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=lambda response: {
+                "text": "[]", "finish_reason": "STOP", "usage": {"total_tokens": 12},
+            },
+            extract_text=lambda payload: payload["text"],
+            extract_finish_reason=lambda payload: payload["finish_reason"],
+            extract_usage=lambda payload: payload["usage"],
+        )
+        self.assertIsInstance(backend, SyncModelBackend)
+        result = backend.generate(SyncGenerationRequest(
+            model="gemini-test", contents="prompt", config={"temperature": 0.2},
+        ))
+        self.assertEqual(client.models.calls, [{
+            "model": "gemini-test", "contents": "prompt", "config": {"temperature": 0.2},
+        }])
+        self.assertEqual(result.provider, "gemini")
+        self.assertEqual(result.model, "gemini-test")
+        self.assertEqual(result.execution_mode, "sync")
+        self.assertEqual(result.response_text, "[]")
+        self.assertEqual(result.finish_reason, "STOP")
+        self.assertEqual(result.usage_metadata, {"total_tokens": 12})
+        self.assertEqual(result.parsed, _Response.parsed)
+
+    def test_request_config_is_copied_before_sdk_call(self):
+        config = {"nested": {"enabled": True}}
+        client = _Client(_Response())
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=lambda response: {},
+            extract_text=lambda payload: "",
+            extract_finish_reason=lambda payload: "",
+        )
+        backend.generate(SyncGenerationRequest("gemini-test", [], config))
+        self.assertIsNot(client.models.calls[0]["config"], config)
+        self.assertEqual(client.models.calls[0]["config"], config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -31,6 +31,7 @@ from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
 import translation_core
+from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -3043,13 +3044,19 @@ def call_gemini_sdk(prompt, items):
             "response_json_schema": build_response_json_schema(items),
         }
 
-        response = client.models.generate_content(
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=serialize_unknown,
+            extract_text=extract_text_from_response_payload,
+            extract_finish_reason=extract_finish_reason,
+        )
+        result = backend.generate(SyncGenerationRequest(
             model=model_name,
             contents=prompt,
             config=generation_config,
-        )
+        ))
 
-        parsed = get_nested(response, "parsed")
+        parsed = result.parsed
         if parsed is not None:
             return normalize_result_items(serialize_unknown(parsed))
 
@@ -3059,7 +3066,7 @@ def call_gemini_sdk(prompt, items):
             return normalize_result_items(parse_json_payload(response_text))
 
         prompt_feedback = extract_prompt_feedback(response_payload)
-        finish_reason = extract_finish_reason(response_payload)
+        finish_reason = result.finish_reason
         diagnostics = []
         if prompt_feedback:
             diagnostics.append(f"Prompt feedback: {prompt_feedback}")


### PR DESCRIPTION
## What changed

- add a minimal synchronous model backend protocol and standardized result type
- adapt the existing Gemini synchronous translation, repair, revision, keyword, and probe calls
- record provider, model, execution mode, finish reason, and usage metadata at the backend boundary
- add an offline fake-client test for the Gemini adapter

## Why

This is the first implementation stage of #178. It creates the narrow extension point needed for optional providers while keeping Gemini native Batch as the default and unchanged path.

LiteLLM is intentionally not included in this PR; it will be added as a separate optional backend after this foundation is reviewed.

## Validation

- python -m unittest -q tests.test_sync_model_backend tests.test_translator_runtime tests.test_batch_repair (144 tests passed)
- git diff --check

The repository-wide quiet runners were stopped after producing no output for more than two minutes; the scoped regression suite above completes successfully.