### PR TITLE
Add optional LiteLLM synchronous backend

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -47,6 +47,8 @@ BATCH_JOBS_DIR = os.path.join(LOG_DIR, 'batch_jobs')
 LATEST_MANIFEST_FILE = os.path.join(BATCH_JOBS_DIR, 'latest_manifest.txt')
 REPAIR_RUNS_DIR = os.path.join(LOG_DIR, 'repair_runs')
 SYNC_RUNS_DIR = os.path.join(LOG_DIR, 'sync_runs')
+SYNC_BACKEND = 'gemini'
+SYNC_MODEL = ''
 
 
 class DualLogger(object):
@@ -295,7 +297,7 @@ def load_batch_settings():
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
-    global BATCH_NON_CHINESE_RULES
+    global BATCH_NON_CHINESE_RULES, SYNC_BACKEND, SYNC_MODEL
 
     config = load_json_file(legacy.CONFIG_FILE)
     translator_config = load_json_file(legacy.TRANSLATOR_CONFIG)
@@ -347,6 +349,17 @@ def load_batch_settings():
 
     BATCH_NON_CHINESE_RULES = batch_non_chinese_rules.load_non_chinese_rules(translator_config)
 
+    sync = translator_config.get('sync')
+    if not isinstance(sync, dict):
+        sync = {}
+    backend_name = str(sync.get('backend') or 'gemini').strip().lower()
+    if backend_name not in {'gemini', 'litellm'}:
+        raise SystemExit(
+            f"Unsupported sync backend: {backend_name}. Choose 'gemini' or 'litellm'."
+        )
+    SYNC_BACKEND = backend_name
+    sync_model = sync.get('model')
+    SYNC_MODEL = str(sync_model).strip() if sync_model else ''
     model_name = batch.get('model')
     if isinstance(model_name, str) and model_name.strip():
         BATCH_MODEL = model_name.strip()
@@ -7442,19 +7455,41 @@ def build_repair_request(job):
     }
 
 def run_sync_request(request_payload, model_name, api_key_index=None):
+    config = dict(request_payload.get('generation_config') or {})
+    system_instruction = request_payload.get('system_instruction')
+    if system_instruction:
+        config['system_instruction'] = system_instruction
+    safety_settings = request_payload.get('safety_settings')
+    if safety_settings:
+        config['safety_settings'] = safety_settings
+    effective_model = SYNC_MODEL or model_name
+
+    if SYNC_BACKEND == 'litellm':
+        if api_key_index is not None:
+            raise SystemExit('--api-key-index is only supported by the Gemini sync backend.')
+        from litellm_sync_backend import LiteLLMSyncBackend
+
+        result = LiteLLMSyncBackend().generate(SyncGenerationRequest(
+            model=effective_model,
+            contents=request_payload.get('contents') or [],
+            config=config,
+        ))
+        return {
+            'response_payload': result.response_payload,
+            'response_text': result.response_text,
+            'finish_reason': result.finish_reason,
+            'usage_metadata': dict(result.usage_metadata),
+            'provider': result.provider,
+            'model': result.model,
+            'execution_mode': result.execution_mode,
+        }
+
     attempts = 1 if api_key_index is not None else max(1, len(getattr(legacy, 'API_KEYS', [])))
     last_error = None
 
     for attempt in range(1, attempts + 1):
         client = create_batch_client(api_key_index=api_key_index)
         try:
-            config = dict(request_payload.get('generation_config') or {})
-            system_instruction = request_payload.get('system_instruction')
-            if system_instruction:
-                config['system_instruction'] = system_instruction
-            safety_settings = request_payload.get('safety_settings')
-            if safety_settings:
-                config['safety_settings'] = safety_settings
             backend = GeminiSyncBackend(
                 client,
                 serialize_response=serialize_unknown,
@@ -7554,6 +7589,9 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                 result_row['response'] = result.get('response_payload') or {}
                 result_row['finish_reason'] = result.get('finish_reason', '')
                 result_row['usage_metadata'] = result.get('usage_metadata') or {}
+                result_row['provider'] = result.get('provider') or SYNC_BACKEND
+                result_row['model'] = result.get('model') or SYNC_MODEL or BATCH_MODEL
+                result_row['execution_mode'] = result.get('execution_mode') or 'sync'
                 summary['successful_request_count'] += 1
                 if result.get('finish_reason') == 'MAX_TOKENS':
                     summary['max_tokens_count'] += 1
@@ -7598,7 +7636,10 @@ def make_sync_manifest(
         'execution': 'sync',
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
-        'batch_model': BATCH_MODEL,
+        'batch_model': SYNC_MODEL or BATCH_MODEL,
+        'provider': SYNC_BACKEND,
+        'model': SYNC_MODEL or BATCH_MODEL,
+        'execution_mode': 'sync',
         'base_dir': legacy.BASE_DIR,
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -359,7 +359,10 @@ def load_batch_settings():
         )
     SYNC_BACKEND = backend_name
     sync_model = sync.get('model')
-    SYNC_MODEL = str(sync_model).strip() if sync_model else ''
+    if isinstance(sync_model, str) and sync_model.strip():
+        SYNC_MODEL = sync_model.strip()
+    else:
+        SYNC_MODEL = ''
     model_name = batch.get('model')
     if isinstance(model_name, str) and model_name.strip():
         BATCH_MODEL = model_name.strip()
@@ -7454,6 +7457,18 @@ def build_repair_request(job):
         'request': request,
     }
 
+def _sync_result_to_dict(result):
+    return {
+        'response_payload': result.response_payload,
+        'response_text': result.response_text,
+        'finish_reason': result.finish_reason,
+        'usage_metadata': dict(result.usage_metadata),
+        'provider': result.provider,
+        'model': result.model,
+        'execution_mode': result.execution_mode,
+    }
+
+
 def run_sync_request(request_payload, model_name, api_key_index=None):
     config = dict(request_payload.get('generation_config') or {})
     system_instruction = request_payload.get('system_instruction')
@@ -7474,15 +7489,7 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
             contents=request_payload.get('contents') or [],
             config=config,
         ))
-        return {
-            'response_payload': result.response_payload,
-            'response_text': result.response_text,
-            'finish_reason': result.finish_reason,
-            'usage_metadata': dict(result.usage_metadata),
-            'provider': result.provider,
-            'model': result.model,
-            'execution_mode': result.execution_mode,
-        }
+        return _sync_result_to_dict(result)
 
     attempts = 1 if api_key_index is not None else max(1, len(getattr(legacy, 'API_KEYS', [])))
     last_error = None
@@ -7498,19 +7505,12 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
                 extract_usage=lambda payload: summarize_usage_metadata(extract_usage_metadata(payload)),
             )
             result = backend.generate(SyncGenerationRequest(
-                model=model_name,
+                model=effective_model,
                 contents=request_payload.get('contents') or [],
                 config=config,
             ))
-            return {
-                'response_payload': result.response_payload,
-                'response_text': result.response_text,
-                'finish_reason': result.finish_reason,
-                'usage_metadata': dict(result.usage_metadata),
-                'provider': result.provider,
-                'model': result.model,
-                'execution_mode': result.execution_mode,
-            }
+            return _sync_result_to_dict(result)
+
         except Exception as exc:
             last_error = exc
             retryable = is_quota_error(exc) or is_unavailable_error(exc)

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -1,0 +1,154 @@
+"""Optional LiteLLM implementation of the synchronous model backend."""
+
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+from sync_model_backend import SYNC_EXECUTION_MODE, SyncGenerationRequest, SyncGenerationResult
+
+
+class LiteLLMBackendError(RuntimeError):
+    def __init__(self, message: str, *, category: str = "provider_error") -> None:
+        super().__init__(message)
+        self.category = category
+
+
+class LiteLLMUnavailableError(LiteLLMBackendError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, category="missing_dependency")
+
+
+class LiteLLMCapabilityError(LiteLLMBackendError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, category="unsupported_capability")
+
+
+def _serialize_response(response: Any) -> Mapping[str, Any]:
+    if isinstance(response, Mapping):
+        return dict(response)
+    for method_name in ("model_dump", "to_dict"):
+        method = getattr(response, method_name, None)
+        if callable(method):
+            payload = method()
+            if isinstance(payload, Mapping):
+                return dict(payload)
+    raise LiteLLMBackendError(
+        f"LiteLLM returned unsupported response type: {type(response).__name__}",
+        category="invalid_response",
+    )
+
+
+def _instruction_text(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return str(value or "")
+    parts = value.get("parts") or []
+    return "\n".join(
+        str(part.get("text") or "") for part in parts if isinstance(part, Mapping)
+    )
+
+
+def _messages(contents: Any, config: Mapping[str, Any]) -> List[Dict[str, str]]:
+    messages: List[Dict[str, str]] = []
+    if config.get("system_instruction"):
+        messages.append({
+            "role": "system",
+            "content": _instruction_text(config["system_instruction"]),
+        })
+    if isinstance(contents, str):
+        messages.append({"role": "user", "content": contents})
+        return messages
+    if not isinstance(contents, list):
+        raise LiteLLMCapabilityError("LiteLLM contents must be text or a message list.")
+    for entry in contents:
+        if not isinstance(entry, Mapping):
+            raise LiteLLMCapabilityError("LiteLLM message entries must be objects.")
+        messages.append({
+            "role": str(entry.get("role") or "user"),
+            "content": (
+                str(entry.get("content") or "")
+                if "content" in entry
+                else _instruction_text(entry)
+            ),
+        })
+    return messages
+
+
+def _error_category(exc: Exception) -> str:
+    name = type(exc).__name__.lower()
+    status = getattr(exc, "status_code", None)
+    if status == 429 or "ratelimit" in name or "quota" in name:
+        return "rate_limit"
+    if status in {502, 503, 504} or "serviceunavailable" in name or "timeout" in name:
+        return "service_unavailable"
+    if status in {401, 403} or "authentication" in name or "permission" in name:
+        return "authentication"
+    return "provider_error"
+
+
+class LiteLLMSyncBackend:
+    """Lazy optional adapter; importing this module does not import LiteLLM."""
+
+    provider = "litellm"
+
+    def __init__(self, completion: Optional[Callable[..., Any]] = None) -> None:
+        self._completion = completion
+
+    def _resolve_completion(self) -> Callable[..., Any]:
+        if self._completion is not None:
+            return self._completion
+        try:
+            from litellm import completion
+        except ImportError as exc:
+            raise LiteLLMUnavailableError(
+                "LiteLLM backend was selected but litellm is not installed. "
+                "Install the optional dependency or select Gemini Batch."
+            ) from exc
+        self._completion = completion
+        return completion
+
+    def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult:
+        config = dict(request.config)
+        if config.get("safety_settings"):
+            raise LiteLLMCapabilityError(
+                "LiteLLM does not share Gemini safety_settings semantics; "
+                "remove that setting or use Gemini."
+            )
+        kwargs: Dict[str, Any] = {
+            "model": request.model,
+            "messages": _messages(request.contents, config),
+        }
+        if "temperature" in config:
+            kwargs["temperature"] = config["temperature"]
+        if "max_output_tokens" in config:
+            kwargs["max_tokens"] = config["max_output_tokens"]
+        schema = config.get("response_json_schema")
+        if schema:
+            kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "translation_response",
+                    "schema": schema,
+                    "strict": True,
+                },
+            }
+        try:
+            response = self._resolve_completion()(**kwargs)
+        except LiteLLMBackendError:
+            raise
+        except Exception as exc:
+            raise LiteLLMBackendError(
+                f"LiteLLM request failed: {exc}", category=_error_category(exc)
+            ) from exc
+        payload = _serialize_response(response)
+        choices = payload.get("choices") or []
+        choice = choices[0] if choices and isinstance(choices[0], Mapping) else {}
+        message = choice.get("message") or {}
+        text = message.get("content") if isinstance(message, Mapping) else ""
+        usage = payload.get("usage") or {}
+        return SyncGenerationResult(
+            provider=self.provider,
+            model=request.model,
+            execution_mode=SYNC_EXECUTION_MODE,
+            response_payload=payload,
+            response_text=str(text or ""),
+            finish_reason=str(choice.get("finish_reason") or ""),
+            usage_metadata=dict(usage) if isinstance(usage, Mapping) else {},
+        )

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -72,16 +72,38 @@ def _messages(contents: Any, config: Mapping[str, Any]) -> List[Dict[str, str]]:
 
 
 def _error_category(exc: Exception) -> str:
-    name = type(exc).__name__.lower()
+    try:
+        import litellm
+
+        typed_categories = (
+            ("rate_limit", (getattr(litellm, "RateLimitError", None),)),
+            ("service_unavailable", (
+                getattr(litellm, "ServiceUnavailableError", None),
+                getattr(litellm, "Timeout", None),
+                getattr(litellm, "APIConnectionError", None),
+            )),
+            ("authentication", (
+                getattr(litellm, "AuthenticationError", None),
+                getattr(litellm, "PermissionDeniedError", None),
+            )),
+        )
+        for category, candidates in typed_categories:
+            exception_types = tuple(
+                candidate for candidate in candidates if isinstance(candidate, type)
+            )
+            if exception_types and isinstance(exc, exception_types):
+                return category
+    except ImportError:
+        pass
+
     status = getattr(exc, "status_code", None)
-    if status == 429 or "ratelimit" in name or "quota" in name:
+    if status == 429:
         return "rate_limit"
-    if status in {502, 503, 504} or "serviceunavailable" in name or "timeout" in name:
+    if status in {502, 503, 504}:
         return "service_unavailable"
-    if status in {401, 403} or "authentication" in name or "permission" in name:
+    if status in {401, 403}:
         return "authentication"
     return "provider_error"
-
 
 class LiteLLMSyncBackend:
     """Lazy optional adapter; importing this module does not import LiteLLM."""

--- a/requirements-litellm.txt
+++ b/requirements-litellm.txt
@@ -1,3 +1,3 @@
 # Optional synchronous alternative backend for sync keyword/revision/repair runs.
 # Gemini Batch and the default GUI/CLI do not require this dependency.
-litellm
+litellm>=1.60.0

--- a/requirements-litellm.txt
+++ b/requirements-litellm.txt
@@ -1,0 +1,3 @@
+# Optional synchronous alternative backend for sync keyword/revision/repair runs.
+# Gemini Batch and the default GUI/CLI do not require this dependency.
+litellm

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+
+
+class LiteLLMConfigTests(unittest.TestCase):
+    def test_batch_settings_load_explicit_sync_backend_and_model(self):
+        previous_backend = batch_mod.SYNC_BACKEND
+        previous_model = batch_mod.SYNC_MODEL
+        try:
+            with mock.patch.object(
+                batch_mod,
+                "load_json_file",
+                side_effect=[{}, {"sync": {"backend": "litellm", "model": "openai/test"}}],
+            ):
+                batch_mod.load_batch_settings()
+            self.assertEqual(batch_mod.SYNC_BACKEND, "litellm")
+            self.assertEqual(batch_mod.SYNC_MODEL, "openai/test")
+        finally:
+            batch_mod.SYNC_BACKEND = previous_backend
+            batch_mod.SYNC_MODEL = previous_model
+
+    def test_batch_settings_reject_unknown_sync_backend(self):
+        with mock.patch.object(
+            batch_mod,
+            "load_json_file",
+            side_effect=[{}, {"sync": {"backend": "automatic"}}],
+        ):
+            with self.assertRaises(SystemExit) as captured:
+                batch_mod.load_batch_settings()
+        self.assertIn("Unsupported sync backend", str(captured.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm_error_classification.py
+++ b/tests/test_litellm_error_classification.py
@@ -1,0 +1,34 @@
+import sys
+import types
+import unittest
+from unittest import mock
+
+from litellm_sync_backend import _error_category
+
+
+class LiteLLMErrorClassificationTests(unittest.TestCase):
+    def test_prefers_litellm_typed_exceptions(self):
+        class RateLimitError(Exception):
+            pass
+
+        class ServiceUnavailableError(Exception):
+            pass
+
+        class AuthenticationError(Exception):
+            pass
+
+        fake_litellm = types.SimpleNamespace(
+            RateLimitError=RateLimitError,
+            ServiceUnavailableError=ServiceUnavailableError,
+            AuthenticationError=AuthenticationError,
+        )
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            self.assertEqual(_error_category(RateLimitError()), "rate_limit")
+            self.assertEqual(
+                _error_category(ServiceUnavailableError()), "service_unavailable"
+            )
+            self.assertEqual(_error_category(AuthenticationError()), "authentication")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm_runtime_integration.py
+++ b/tests/test_litellm_runtime_integration.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest import mock
+
+import translator_runtime as runtime
+
+
+class LiteLLMRuntimeIntegrationTests(unittest.TestCase):
+    def test_runtime_uses_explicit_litellm_backend_without_gemini_client(self):
+        fake_result = type("Result", (), {
+            "parsed": None,
+            "response_text": '[{"id":"a","translation":"你好"}]',
+            "response_payload": {},
+            "finish_reason": "stop",
+        })()
+        fake_backend = mock.Mock()
+        fake_backend.generate.return_value = fake_result
+        items = [{"id": "a", "text": "Hello"}]
+
+        with (
+            mock.patch.object(runtime, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(runtime, "get_current_model", return_value="openai/test"),
+            mock.patch.object(runtime, "create_genai_client") as create_gemini,
+            mock.patch("litellm_sync_backend.LiteLLMSyncBackend", return_value=fake_backend),
+        ):
+            result = runtime.call_gemini_sdk("prompt", items)
+
+        create_gemini.assert_not_called()
+        request = fake_backend.generate.call_args.args[0]
+        self.assertEqual(request.model, "openai/test")
+        self.assertEqual(result, [{"id": "a", "translation": "你好"}])
+
+    def test_sync_settings_default_to_gemini_and_accept_litellm(self):
+        previous = runtime.SYNC_BACKEND
+        try:
+            runtime.load_sync_translation_settings({"sync": {}})
+            self.assertEqual(runtime.SYNC_BACKEND, "gemini")
+            runtime.load_sync_translation_settings({
+                "sync": {"backend": "litellm", "model": "openai/test"}
+            })
+            self.assertEqual(runtime.SYNC_BACKEND, "litellm")
+            self.assertEqual(runtime.MODELS, ["openai/test"])
+        finally:
+            runtime.SYNC_BACKEND = previous
+
+    def test_unknown_backend_fails_before_model_call(self):
+        with self.assertRaises(ValueError) as captured:
+            runtime.load_sync_translation_settings({"sync": {"backend": "automatic"}})
+        self.assertIn("Unsupported sync backend", str(captured.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -1,0 +1,96 @@
+import builtins
+import unittest
+from unittest import mock
+
+from litellm_sync_backend import (
+    LiteLLMBackendError,
+    LiteLLMCapabilityError,
+    LiteLLMSyncBackend,
+    LiteLLMUnavailableError,
+)
+from sync_model_backend import SyncGenerationRequest, SyncModelBackend
+
+
+class LiteLLMSyncBackendTests(unittest.TestCase):
+    def test_success_normalizes_response_and_maps_config(self):
+        calls = []
+
+        def completion(**kwargs):
+            calls.append(kwargs)
+            return {
+                "choices": [{
+                    "message": {"content": '[{"id":"a","translation":"你好"}]'},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 8, "completion_tokens": 6},
+            }
+
+        backend = LiteLLMSyncBackend(completion=completion)
+        self.assertIsInstance(backend, SyncModelBackend)
+        result = backend.generate(SyncGenerationRequest(
+            model="openai/gpt-test",
+            contents="Translate this",
+            config={
+                "temperature": 0.2,
+                "max_output_tokens": 100,
+                "response_json_schema": {"type": "array"},
+            },
+        ))
+
+        self.assertEqual(calls[0]["model"], "openai/gpt-test")
+        self.assertEqual(calls[0]["messages"], [{"role": "user", "content": "Translate this"}])
+        self.assertEqual(calls[0]["max_tokens"], 100)
+        self.assertEqual(calls[0]["response_format"]["type"], "json_schema")
+        self.assertEqual(result.provider, "litellm")
+        self.assertEqual(result.execution_mode, "sync")
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertEqual(result.usage_metadata["prompt_tokens"], 8)
+
+    def test_converts_gemini_style_system_instruction_and_contents(self):
+        calls = []
+        backend = LiteLLMSyncBackend(completion=lambda **kwargs: calls.append(kwargs) or {"choices": []})
+        backend.generate(SyncGenerationRequest(
+            "anthropic/test",
+            [{"role": "user", "parts": [{"text": "hello"}]}],
+            {"system_instruction": {"parts": [{"text": "rules"}]}},
+        ))
+        self.assertEqual(calls[0]["messages"], [
+            {"role": "system", "content": "rules"},
+            {"role": "user", "content": "hello"},
+        ])
+
+    def test_missing_dependency_is_reported_only_when_selected(self):
+        backend = LiteLLMSyncBackend()
+        original_import = builtins.__import__
+
+        def reject_litellm(name, *args, **kwargs):
+            if name == "litellm":
+                raise ImportError("not installed")
+            return original_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=reject_litellm):
+            with self.assertRaises(LiteLLMUnavailableError) as captured:
+                backend.generate(SyncGenerationRequest("openai/test", "hello"))
+        self.assertEqual(captured.exception.category, "missing_dependency")
+        self.assertIn("select Gemini Batch", str(captured.exception))
+
+    def test_rejects_gemini_only_safety_settings_before_request(self):
+        backend = LiteLLMSyncBackend(completion=lambda **kwargs: {})
+        with self.assertRaises(LiteLLMCapabilityError) as captured:
+            backend.generate(SyncGenerationRequest(
+                "openai/test", "hello", {"safety_settings": [{"category": "x"}]}
+            ))
+        self.assertEqual(captured.exception.category, "unsupported_capability")
+
+    def test_classifies_rate_limit_and_service_unavailable(self):
+        class RateLimitError(Exception):
+            pass
+
+        backend = LiteLLMSyncBackend(completion=lambda **kwargs: (_ for _ in ()).throw(RateLimitError()))
+        with self.assertRaises(LiteLLMBackendError) as captured:
+            backend.generate(SyncGenerationRequest("openai/test", "hello"))
+        self.assertEqual(captured.exception.category, "rate_limit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -84,7 +84,7 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
 
     def test_classifies_rate_limit_and_service_unavailable(self):
         class RateLimitError(Exception):
-            pass
+            status_code = 429
 
         backend = LiteLLMSyncBackend(completion=lambda **kwargs: (_ for _ in ()).throw(RateLimitError()))
         with self.assertRaises(LiteLLMBackendError) as captured:

--- a/tests/test_litellm_sync_integration.py
+++ b/tests/test_litellm_sync_integration.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+
+
+class LiteLLMSyncIntegrationTests(unittest.TestCase):
+    def test_sync_runner_uses_litellm_only_when_explicitly_selected(self):
+        fake_result = type("Result", (), {
+            "response_payload": {"choices": []},
+            "response_text": "[]",
+            "finish_reason": "stop",
+            "usage_metadata": {"total_tokens": 3},
+            "provider": "litellm",
+            "model": "openai/test",
+            "execution_mode": "sync",
+        })()
+        fake_backend = mock.Mock()
+        fake_backend.generate.return_value = fake_result
+
+        with (
+            mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod, "create_batch_client") as create_client,
+            mock.patch("litellm_sync_backend.LiteLLMSyncBackend", return_value=fake_backend),
+        ):
+            result = batch_mod.run_sync_request(
+                {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+                model_name="gemini-default",
+            )
+
+        create_client.assert_not_called()
+        request = fake_backend.generate.call_args.args[0]
+        self.assertEqual(request.model, "openai/test")
+        self.assertEqual(result["provider"], "litellm")
+        self.assertEqual(result["execution_mode"], "sync")
+
+    def test_litellm_rejects_gemini_api_key_index(self):
+        with (
+            mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+        ):
+            with self.assertRaises(SystemExit) as captured:
+                batch_mod.run_sync_request({}, "gemini-default", api_key_index=0)
+        self.assertIn("only supported by the Gemini", str(captured.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -19,6 +19,7 @@
     "python_exe": ""
   },
   "sync": {
+    "backend": "gemini",
     "model": "gemini-3.1-flash-lite",
     "chunk_size": 40,
     "max_source_chars": 12000,

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -109,6 +109,7 @@ PRESERVE_TERMS = [
 MAX_CHARS = 12000
 MAX_ITEMS = 40
 SYNC_MAX_OUTPUT_TOKENS = 24576
+SYNC_BACKEND = "gemini"
 MIN_DELAY = 1.0  # Reduced delay for SDK
 MAX_DELAY = 3.0
 BATCH_RETRIES = 3
@@ -702,11 +703,18 @@ def load_sync_story_memory_settings(config):
 
 
 def load_sync_translation_settings(config):
-    global MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS
+    global MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS, SYNC_BACKEND
 
     sync = config.get("sync")
     if not isinstance(sync, dict):
         sync = {}
+
+    backend_name = str(sync.get("backend") or "gemini").strip().lower()
+    if backend_name not in {"gemini", "litellm"}:
+        raise ValueError(
+            f"Unsupported sync backend: {backend_name}. Choose 'gemini' or 'litellm'."
+        )
+    SYNC_BACKEND = backend_name
 
     custom_models = sync.get("models")
     single_model = sync.get("model")
@@ -3029,23 +3037,27 @@ def normalize_result_items(payload):
 
 
 def call_gemini_sdk(prompt, items):
-    """Calls Gemini using the current google-genai SDK."""
-    configure_genai()
+    """Calls the explicitly configured synchronous backend."""
     model_name = get_current_model()
-    
-    try:
-        client = create_genai_client()
-        
-        # Generation config
-        generation_config = {
-            "temperature": 0.2,
-            "max_output_tokens": SYNC_MAX_OUTPUT_TOKENS,
-            "response_mime_type": "application/json",
-            "response_json_schema": build_response_json_schema(items),
-        }
+    generation_config = {
+        "temperature": 0.2,
+        "max_output_tokens": SYNC_MAX_OUTPUT_TOKENS,
+        "response_mime_type": "application/json",
+        "response_json_schema": build_response_json_schema(items),
+    }
 
+    if SYNC_BACKEND == "litellm":
+        from litellm_sync_backend import LiteLLMSyncBackend
+
+        result = LiteLLMSyncBackend().generate(SyncGenerationRequest(
+            model=model_name,
+            contents=prompt,
+            config=generation_config,
+        ))
+    else:
+        configure_genai()
         backend = GeminiSyncBackend(
-            client,
+            create_genai_client(),
             serialize_response=serialize_unknown,
             extract_text=extract_text_from_response_payload,
             extract_finish_reason=extract_finish_reason,
@@ -3056,28 +3068,19 @@ def call_gemini_sdk(prompt, items):
             config=generation_config,
         ))
 
-        parsed = result.parsed
-        if parsed is not None:
-            return normalize_result_items(serialize_unknown(parsed))
+    if result.parsed is not None:
+        return normalize_result_items(serialize_unknown(result.parsed))
+    if result.response_text:
+        return normalize_result_items(parse_json_payload(result.response_text))
 
-        response_payload = serialize_unknown(response)
-        response_text = extract_text_from_response_payload(response_payload)
-        if response_text:
-            return normalize_result_items(parse_json_payload(response_text))
-
-        prompt_feedback = extract_prompt_feedback(response_payload)
-        finish_reason = result.finish_reason
-        diagnostics = []
-        if prompt_feedback:
-            diagnostics.append(f"Prompt feedback: {prompt_feedback}")
-        if finish_reason:
-            diagnostics.append(f"Finish reason: {finish_reason}")
-        detail = f" ({'; '.join(diagnostics)})" if diagnostics else ""
-        raise ValueError(f"Invalid response from API. Missing structured text{detail}.")
-
-    except Exception as e:
-        # Re-raise to be handled by retry logic
-        raise e
+    prompt_feedback = extract_prompt_feedback(result.response_payload)
+    diagnostics = []
+    if prompt_feedback:
+        diagnostics.append(f"Prompt feedback: {prompt_feedback}")
+    if result.finish_reason:
+        diagnostics.append(f"Finish reason: {result.finish_reason}")
+    detail = f" ({'; '.join(diagnostics)})" if diagnostics else ""
+    raise ValueError(f"Invalid response from API. Missing structured text{detail}.")
 
 def process_batch(batch, replacements):
     glossary_hits = retrieve_sync_glossary_hits(batch) if SYNC_RAG_ENABLED else []


### PR DESCRIPTION
## What changed

- add a lazy optional LiteLLM synchronous backend
- support explicit Gemini and LiteLLM sync backend selection
- route standalone translation plus sync keyword, revision, and repair requests through the selected backend
- map prompts and JSON schemas to LiteLLM completion calls
- classify dependency, capability, rate limit, availability, and authentication failures
- record provider, model, execution mode, finish reason, and usage
- add an optional LiteLLM requirements file without changing default dependencies

## Behavior and safety

Gemini native Batch remains the default and unchanged path. LiteLLM is imported only after explicit selection. There is no automatic provider fallback, and Gemini embedding configuration remains unchanged. Provider credentials remain in provider environment variables and are not stored in translator_config.json.

## Validation

- 14 LiteLLM and configuration tests passed
- 171 translator, repair, and doctor regression tests passed
- CLI, translator runtime, and GUI imports succeed without LiteLLM installed
- example configuration parses successfully
- git diff --check

Continues #178. GUI controls and broader documentation remain follow-up stages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LiteLLM as an optional synchronous translation backend.
  * Added configuration options to select the synchronous backend and model.
  * Synchronous results now report the selected provider, model, and execution mode.
  * Added validation for unsupported backend options and Gemini-only settings.

* **Documentation**
  * Updated the example configuration with the synchronous backend setting.

* **Tests**
  * Added coverage for LiteLLM configuration, request handling, response normalization, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->