### PR TITLE
Add LiteLLM install action to GUI

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -16,7 +16,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import QEvent, Qt, QTimer
+from PySide6.QtCore import QEvent, QProcess, QProcessEnvironment, Qt, QTimer
 from PySide6.QtGui import QBrush, QColor, QGuiApplication, QKeySequence, QPalette, QShortcut
 from PySide6.QtWidgets import (
     QApplication,
@@ -1692,6 +1692,13 @@ class MainWindow(QMainWindow):
         self.sync_backend_hint.setWordWrap(True)
         self.sync_backend_hint.setObjectName("config_hint_label")
         sync_layout.addRow(self.sync_backend_hint)
+
+        self.install_litellm_btn = QPushButton("安装 LiteLLM")
+        self.install_litellm_btn.setObjectName("secondary_btn")
+        self.install_litellm_btn.clicked.connect(self._on_install_litellm)
+        self.install_litellm_btn.setVisible(False)
+        sync_layout.addRow(self.install_litellm_btn)
+
         config_row.addWidget(sync_box, 1)
 
         batch_box = QGroupBox("批量离线翻译")
@@ -4056,17 +4063,85 @@ class MainWindow(QMainWindow):
         hint = getattr(self, "sync_backend_hint", None)
         if hint is None:
             return
+        install_btn = getattr(self, "install_litellm_btn", None)
         if backend == "litellm":
             installed = importlib.util.find_spec("litellm") is not None
-            state = "已安装" if installed else "尚未安装（pip install -r requirements-litellm.txt）"
+            state = "已安装" if installed else "尚未安装"
             hint.setText(
                 "同步替代模式；不使用 Gemini API Key，也没有远程 Batch 恢复。"
                 f"LiteLLM：{state}。凭据从对应供应商环境变量读取。"
             )
+            if install_btn is not None:
+                installing = self._litellm_install_running()
+                install_btn.setVisible(not installed)
+                install_btn.setEnabled(not installing)
+                install_btn.setText("正在安装…" if installing else "安装 LiteLLM")
         else:
             hint.setText(
                 "推荐路径。同步任务使用 Gemini API Key；批量离线翻译仍始终使用 Gemini Batch。"
             )
+            if install_btn is not None:
+                install_btn.setVisible(False)
+
+    def _litellm_install_running(self) -> bool:
+        process = getattr(self, "_litellm_install_process", None)
+        return process is not None and process.state() == QProcess.ProcessState.Running
+
+    def _on_install_litellm(self) -> None:
+        if self._litellm_install_running():
+            return
+        requirements_path = Path(__file__).resolve().parents[1] / "requirements-litellm.txt"
+        if not requirements_path.is_file():
+            QMessageBox.warning(self, "无法安装 LiteLLM", f"找不到依赖文件：{requirements_path}")
+            return
+
+        process = QProcess(self)
+        process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        environment = QProcessEnvironment.systemEnvironment()
+        environment.insert("PYTHONIOENCODING", "utf-8")
+        environment.insert("PYTHONUTF8", "1")
+        process.setProcessEnvironment(environment)
+        process.readyReadStandardOutput.connect(self._on_litellm_install_output)
+        process.finished.connect(self._on_litellm_install_finished)
+        process.errorOccurred.connect(self._on_litellm_install_error)
+        self._litellm_install_process = process
+
+        self._show_workbench_log_drawer()
+        self._append_log(
+            f"=== 正在安装 LiteLLM ===\n{sys.executable} -m pip install -r {requirements_path}\n"
+        )
+        self._on_sync_backend_changed(-1)
+        process.start(
+            sys.executable,
+            ["-m", "pip", "install", "-r", str(requirements_path)],
+        )
+
+    def _on_litellm_install_output(self) -> None:
+        process = getattr(self, "_litellm_install_process", None)
+        if process is None:
+            return
+        text = bytes(process.readAllStandardOutput()).decode("utf-8", errors="replace")
+        if text:
+            self._append_log(text)
+
+    def _on_litellm_install_finished(self, exit_code: int, _exit_status: object) -> None:
+        process = getattr(self, "_litellm_install_process", None)
+        if process is not None:
+            self._on_litellm_install_output()
+        self._litellm_install_process = None
+        importlib.invalidate_caches()
+        if exit_code == 0 and importlib.util.find_spec("litellm") is not None:
+            self._append_log("\n[LiteLLM 安装完成]\n")
+            self.statusBar().showMessage("LiteLLM 安装完成。", 5000)
+        else:
+            self._append_log(f"\n[LiteLLM 安装失败，退出码：{exit_code}]\n")
+            QMessageBox.warning(self, "LiteLLM 安装失败", "请查看工作台日志中的 pip 输出。")
+        self._on_sync_backend_changed(-1)
+
+    def _on_litellm_install_error(self, _error: object) -> None:
+        process = getattr(self, "_litellm_install_process", None)
+        message = process.errorString() if process is not None else "未知进程错误"
+        self._append_log(f"\n[LiteLLM 安装进程错误] {message}\n")
 
     def _sync_work_modes_requiring_api_key(self) -> frozenset[WorkMode]:
         return frozenset(

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1698,6 +1698,12 @@ class MainWindow(QMainWindow):
         self.install_litellm_btn.clicked.connect(self._on_install_litellm)
         self.install_litellm_btn.setVisible(False)
         sync_layout.addRow(self.install_litellm_btn)
+        self.litellm_install_progress = QProgressBar()
+        self.litellm_install_progress.setObjectName("litellm_install_progress")
+        self.litellm_install_progress.setTextVisible(True)
+        self.litellm_install_progress.setFormat("正在后台安装 LiteLLM…")
+        self.litellm_install_progress.setVisible(False)
+        sync_layout.addRow(self.litellm_install_progress)
 
         config_row.addWidget(sync_box, 1)
 
@@ -4064,15 +4070,16 @@ class MainWindow(QMainWindow):
         if hint is None:
             return
         install_btn = getattr(self, "install_litellm_btn", None)
+        install_progress = getattr(self, "litellm_install_progress", None)
+        installing = self._litellm_install_running()
         if backend == "litellm":
             installed = importlib.util.find_spec("litellm") is not None
-            state = "已安装" if installed else "尚未安装"
+            state = "正在后台安装" if installing else ("已安装" if installed else "尚未安装")
             hint.setText(
                 "同步替代模式；不使用 Gemini API Key，也没有远程 Batch 恢复。"
                 f"LiteLLM：{state}。凭据从对应供应商环境变量读取。"
             )
             if install_btn is not None:
-                installing = self._litellm_install_running()
                 install_btn.setVisible(not installed)
                 install_btn.setEnabled(not installing)
                 install_btn.setText("正在安装…" if installing else "安装 LiteLLM")
@@ -4082,10 +4089,44 @@ class MainWindow(QMainWindow):
             )
             if install_btn is not None:
                 install_btn.setVisible(False)
+        if install_progress is not None:
+            install_progress.setVisible(installing)
+            if installing:
+                # pip does not expose a trustworthy total; busy mode gives honest
+                # visual feedback without inventing a completion percentage.
+                install_progress.setRange(0, 0)
+                install_progress.setFormat("正在后台安装 LiteLLM…")
+
+        model_combo = getattr(self, "sync_model_combo", None)
+        if model_combo is not None:
+            model_combo.setEnabled(not (backend == "litellm" and installing))
+        if hasattr(self, "translate_btn"):
+            self._set_task_running(bool(getattr(self, "_task_running", False)))
+        self._refresh_litellm_install_action_gating()
+
+    def _refresh_litellm_install_action_gating(self) -> None:
+        """Disable only LiteLLM-backed task actions while installation is active."""
+        translate_btn = getattr(self, "translate_btn", None)
+        if translate_btn is None:
+            return
+        mode = self._current_work_mode()
+        installing_litellm = (
+            self._litellm_install_running()
+            and self._selected_sync_backend() == "litellm"
+            and mode in self._sync_work_modes_requiring_api_key()
+        )
+        if installing_litellm:
+            translate_btn.setEnabled(False)
+            self._sync_sync_translation_page_controls()
+            self._sync_keywords_page_controls()
+            self._sync_revision_page_controls()
 
     def _litellm_install_running(self) -> bool:
         process = getattr(self, "_litellm_install_process", None)
-        return process is not None and process.state() == QProcess.ProcessState.Running
+        return (
+            process is not None
+            and process.state() != QProcess.ProcessState.NotRunning
+        )
 
     def _on_install_litellm(self) -> None:
         if self._litellm_install_running():
@@ -4110,11 +4151,11 @@ class MainWindow(QMainWindow):
         self._append_log(
             f"=== 正在安装 LiteLLM ===\n{sys.executable} -m pip install -r {requirements_path}\n"
         )
-        self._on_sync_backend_changed(-1)
         process.start(
             sys.executable,
             ["-m", "pip", "install", "-r", str(requirements_path)],
         )
+        self._on_sync_backend_changed(-1)
 
     def _on_litellm_install_output(self) -> None:
         process = getattr(self, "_litellm_install_process", None)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -4179,10 +4179,19 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "LiteLLM 安装失败", "请查看工作台日志中的 pip 输出。")
         self._on_sync_backend_changed(-1)
 
-    def _on_litellm_install_error(self, _error: object) -> None:
+    def _on_litellm_install_error(self, error: object) -> None:
         process = getattr(self, "_litellm_install_process", None)
         message = process.errorString() if process is not None else "未知进程错误"
         self._append_log(f"\n[LiteLLM 安装进程错误] {message}\n")
+        if error != QProcess.ProcessError.FailedToStart:
+            return
+        self._litellm_install_process = None
+        self._on_sync_backend_changed(-1)
+        QMessageBox.warning(
+            self,
+            "LiteLLM 安装失败",
+            f"无法启动安装进程：{message}\n请查看工作台日志了解详情。",
+        )
 
     def _sync_work_modes_requiring_api_key(self) -> frozenset[WorkMode]:
         return frozenset(

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import mock
+
+try:
+    from gui_qt.app import MainWindow
+except ImportError as exc:
+    MainWindow = None
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+class _Combo:
+    def __init__(self, data):
+        self.data = data
+
+    def currentData(self):
+        return self.data
+
+
+class _Label:
+    def __init__(self):
+        self.value = ""
+
+    def setText(self, value):
+        self.value = value
+
+
+class _Button:
+    def __init__(self):
+        self.visible = None
+        self.enabled = None
+        self.text = ""
+
+    def setVisible(self, value):
+        self.visible = value
+
+    def setEnabled(self, value):
+        self.enabled = value
+
+    def setText(self, value):
+        self.text = value
+
+
+@unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
+class GuiLiteLLMInstallTests(unittest.TestCase):
+    def setUp(self):
+        self.window = MainWindow.__new__(MainWindow)
+        self.window.sync_backend_combo = _Combo("litellm")
+        self.window.sync_backend_hint = _Label()
+        self.window.install_litellm_btn = _Button()
+
+    def test_missing_dependency_shows_enabled_install_button(self):
+        with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=None):
+            self.window._on_sync_backend_changed(0)
+        self.assertTrue(self.window.install_litellm_btn.visible)
+        self.assertTrue(self.window.install_litellm_btn.enabled)
+        self.assertEqual(self.window.install_litellm_btn.text, "安装 LiteLLM")
+
+    def test_installed_dependency_hides_install_button(self):
+        with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=object()):
+            self.window._on_sync_backend_changed(0)
+        self.assertFalse(self.window.install_litellm_btn.visible)
+        self.assertIn("已安装", self.window.sync_backend_hint.value)
+
+    def test_gemini_backend_hides_install_button(self):
+        self.window.sync_backend_combo = _Combo("gemini")
+        self.window._on_sync_backend_changed(0)
+        self.assertFalse(self.window.install_litellm_btn.visible)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 try:
-    from gui_qt.app import MainWindow
+    from gui_qt.app import MainWindow, QProcess
 except ImportError as exc:
     MainWindow = None
     IMPORT_ERROR = exc
@@ -43,6 +43,11 @@ class _Button:
 
     def setText(self, value):
         self.text = value
+
+
+class _Process:
+    def errorString(self):
+        return "cannot start"
 
 
 class _ProgressBar:
@@ -91,6 +96,35 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertFalse(self.window.sync_model_combo.enabled)
         self.assertFalse(self.window.install_litellm_btn.enabled)
         self.assertIn("正在后台安装", self.window.sync_backend_hint.value)
+
+    def test_failed_to_start_clears_install_state_and_restores_ui(self):
+        self.window._litellm_install_process = _Process()
+        self.window._append_log = mock.Mock()
+        self.window._on_sync_backend_changed = mock.Mock()
+        with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
+            self.window._on_litellm_install_error(
+                QProcess.ProcessError.FailedToStart
+            )
+        self.assertIsNone(self.window._litellm_install_process)
+        self.window._on_sync_backend_changed.assert_called_once_with(-1)
+        warning.assert_called_once()
+        self.assertIn(
+            "cannot start",
+            self.window._append_log.call_args.args[0],
+        )
+
+    def test_non_start_error_waits_for_finished_cleanup(self):
+        process = _Process()
+        self.window._litellm_install_process = process
+        self.window._append_log = mock.Mock()
+        self.window._on_sync_backend_changed = mock.Mock()
+        with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
+            self.window._on_litellm_install_error(
+                QProcess.ProcessError.Crashed
+            )
+        self.assertIs(self.window._litellm_install_process, process)
+        self.window._on_sync_backend_changed.assert_not_called()
+        warning.assert_not_called()
 
     def test_installed_dependency_hides_install_button(self):
         with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=object()):

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -17,6 +17,9 @@ class _Combo:
     def currentData(self):
         return self.data
 
+    def setEnabled(self, value):
+        self.enabled = value
+
 
 class _Label:
     def __init__(self):
@@ -42,6 +45,22 @@ class _Button:
         self.text = value
 
 
+class _ProgressBar:
+    def __init__(self):
+        self.visible = None
+        self.range_values = None
+        self.format = ""
+
+    def setVisible(self, value):
+        self.visible = value
+
+    def setRange(self, minimum, maximum):
+        self.range_values = (minimum, maximum)
+
+    def setFormat(self, value):
+        self.format = value
+
+
 @unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
 class GuiLiteLLMInstallTests(unittest.TestCase):
     def setUp(self):
@@ -49,6 +68,9 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.window.sync_backend_combo = _Combo("litellm")
         self.window.sync_backend_hint = _Label()
         self.window.install_litellm_btn = _Button()
+        self.window.sync_model_combo = _Combo(None)
+        self.window.litellm_install_progress = _ProgressBar()
+        self.window._refresh_litellm_install_action_gating = mock.Mock()
 
     def test_missing_dependency_shows_enabled_install_button(self):
         with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=None):
@@ -56,6 +78,19 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertTrue(self.window.install_litellm_btn.visible)
         self.assertTrue(self.window.install_litellm_btn.enabled)
         self.assertEqual(self.window.install_litellm_btn.text, "安装 LiteLLM")
+        self.assertFalse(self.window.litellm_install_progress.visible)
+        self.assertTrue(self.window.sync_model_combo.enabled)
+
+    def test_installing_shows_busy_progress_and_disables_litellm_model(self):
+        self.window._litellm_install_running = mock.Mock(return_value=True)
+        with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=None):
+            self.window._on_sync_backend_changed(0)
+        self.assertTrue(self.window.litellm_install_progress.visible)
+        self.assertEqual(self.window.litellm_install_progress.range_values, (0, 0))
+        self.assertIn("后台安装", self.window.litellm_install_progress.format)
+        self.assertFalse(self.window.sync_model_combo.enabled)
+        self.assertFalse(self.window.install_litellm_btn.enabled)
+        self.assertIn("正在后台安装", self.window.sync_backend_hint.value)
 
     def test_installed_dependency_hides_install_button(self):
         with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=object()):
@@ -65,8 +100,11 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
 
     def test_gemini_backend_hides_install_button(self):
         self.window.sync_backend_combo = _Combo("gemini")
+        self.window._litellm_install_running = mock.Mock(return_value=True)
         self.window._on_sync_backend_changed(0)
         self.assertFalse(self.window.install_litellm_btn.visible)
+        self.assertTrue(self.window.litellm_install_progress.visible)
+        self.assertTrue(self.window.sync_model_combo.enabled)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- show an Install LiteLLM button when the LiteLLM backend is selected but unavailable
- install through the GUI Python environment using pip and requirements-litellm.txt
- stream installation output into the workbench log
- disable the action and show an installing state while pip is running
- refresh dependency status automatically after completion
- keep the button hidden for Gemini or an already installed LiteLLM dependency

## Safety and behavior

The action uses QProcess argument lists without a shell. Installation only starts after the user clicks the button. Failures keep LiteLLM unavailable and direct the user to the captured pip log.

## Validation

- 74 GUI backend, install-state, and settings tests passed
- 20 runner and workflow tests passed
- Python syntax compilation passed
- git diff --check

Continues #178.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “安装 LiteLLM” button in Settings → Models when the LiteLLM backend is selected.
  * Added in-app LiteLLM installation with live progress output and completion or failure status.
  * The interface now indicates whether LiteLLM is installed and automatically refreshes backend availability.

* **Bug Fixes**
  * The installation option is hidden for other backends and after LiteLLM is installed.

* **Tests**
  * Added coverage for LiteLLM installation button visibility, enabled state, and status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->