### PR TITLE
Keep LiteLLM sync actions disabled during install

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -387,6 +387,7 @@ class MainWindow(QMainWindow):
         self._last_main_tab_index = 0
         self._handling_config_tab_leave = False
         self._task_running = False
+        self._litellm_install_active = False
         self._games_registry_panel: GamesRegistryPanel | None = None
 
         central = QWidget()
@@ -4110,18 +4111,22 @@ class MainWindow(QMainWindow):
         if translate_btn is None:
             return
         mode = self._current_work_mode()
-        installing_litellm = (
-            self._litellm_install_running()
-            and self._selected_sync_backend() == "litellm"
-            and mode in self._sync_work_modes_requiring_api_key()
-        )
-        if installing_litellm:
+        if self._litellm_install_blocks_mode(mode):
             translate_btn.setEnabled(False)
             self._sync_sync_translation_page_controls()
             self._sync_keywords_page_controls()
             self._sync_revision_page_controls()
 
+    def _litellm_install_blocks_mode(self, mode: WorkMode) -> bool:
+        return (
+            self._litellm_install_running()
+            and self._selected_sync_backend() == "litellm"
+            and mode in self._sync_work_modes_requiring_api_key()
+        )
+
     def _litellm_install_running(self) -> bool:
+        if bool(getattr(self, "_litellm_install_active", False)):
+            return True
         process = getattr(self, "_litellm_install_process", None)
         return (
             process is not None
@@ -4146,6 +4151,7 @@ class MainWindow(QMainWindow):
         process.finished.connect(self._on_litellm_install_finished)
         process.errorOccurred.connect(self._on_litellm_install_error)
         self._litellm_install_process = process
+        self._litellm_install_active = True
 
         self._show_workbench_log_drawer()
         self._append_log(
@@ -4170,6 +4176,7 @@ class MainWindow(QMainWindow):
         if process is not None:
             self._on_litellm_install_output()
         self._litellm_install_process = None
+        self._litellm_install_active = False
         importlib.invalidate_caches()
         if exit_code == 0 and importlib.util.find_spec("litellm") is not None:
             self._append_log("\n[LiteLLM 安装完成]\n")
@@ -4186,6 +4193,7 @@ class MainWindow(QMainWindow):
         if error != QProcess.ProcessError.FailedToStart:
             return
         self._litellm_install_process = None
+        self._litellm_install_active = False
         self._on_sync_backend_changed(-1)
         QMessageBox.warning(
             self,
@@ -4655,6 +4663,8 @@ class MainWindow(QMainWindow):
         bootstrap_ready: bool,
         running: bool,
     ) -> bool:
+        if self._litellm_install_blocks_mode(spec.mode):
+            return False
         if running or not spec.implemented or not bootstrap_ready:
             return False
         if (
@@ -6276,6 +6286,13 @@ class MainWindow(QMainWindow):
 
     def _on_start_translation(self):
         spec = work_mode_spec(self._current_work_mode())
+        if self._litellm_install_blocks_mode(spec.mode):
+            QMessageBox.information(
+                self,
+                "LiteLLM 正在安装",
+                "请等待 LiteLLM 后台安装完成后再启动同步任务。其他功能仍可继续使用。",
+            )
+            return
         if not spec.implemented:
             QMessageBox.information(self, "功能开发中", spec.not_implemented_message)
             return

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -4120,7 +4120,7 @@ class MainWindow(QMainWindow):
     def _litellm_install_blocks_mode(self, mode: WorkMode) -> bool:
         return (
             self._litellm_install_running()
-            and self._selected_sync_backend() == "litellm"
+            and self._saved_sync_backend() == "litellm"
             and mode in self._sync_work_modes_requiring_api_key()
         )
 
@@ -6286,13 +6286,6 @@ class MainWindow(QMainWindow):
 
     def _on_start_translation(self):
         spec = work_mode_spec(self._current_work_mode())
-        if self._litellm_install_blocks_mode(spec.mode):
-            QMessageBox.information(
-                self,
-                "LiteLLM 正在安装",
-                "请等待 LiteLLM 后台安装完成后再启动同步任务。其他功能仍可继续使用。",
-            )
-            return
         if not spec.implemented:
             QMessageBox.information(self, "功能开发中", spec.not_implemented_message)
             return
@@ -6321,6 +6314,14 @@ class MainWindow(QMainWindow):
             return
 
         if not self._confirm_unsaved_config_before_workflow():
+            return
+
+        if self._litellm_install_blocks_mode(spec.mode):
+            QMessageBox.information(
+                self,
+                "LiteLLM 正在安装",
+                "请等待 LiteLLM 后台安装完成后再启动同步任务。其他功能仍可继续使用。",
+            )
             return
 
         if spec.mode in self._sync_work_modes_requiring_api_key():

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -133,6 +133,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
 
     def test_install_blocks_all_litellm_sync_modes_but_not_batch(self):
         self.window._litellm_install_active = True
+        self.window._saved_sync_backend = mock.Mock(return_value="litellm")
         for mode in (
             WorkMode.SYNC_TRANSLATION,
             WorkMode.SYNC_KEYWORD_EXTRACTION,
@@ -142,6 +143,22 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
                 self.assertTrue(self.window._litellm_install_blocks_mode(mode))
         self.assertFalse(
             self.window._litellm_install_blocks_mode(WorkMode.BATCH_TRANSLATION)
+        )
+
+    def test_install_guard_uses_saved_litellm_when_ui_selects_gemini(self):
+        self.window._litellm_install_active = True
+        self.window.sync_backend_combo = _Combo("gemini")
+        self.window._saved_sync_backend = mock.Mock(return_value="litellm")
+        self.assertTrue(
+            self.window._litellm_install_blocks_mode(WorkMode.SYNC_TRANSLATION)
+        )
+
+    def test_install_guard_allows_saved_gemini_when_ui_selects_litellm(self):
+        self.window._litellm_install_active = True
+        self.window.sync_backend_combo = _Combo("litellm")
+        self.window._saved_sync_backend = mock.Mock(return_value="gemini")
+        self.assertFalse(
+            self.window._litellm_install_blocks_mode(WorkMode.SYNC_TRANSLATION)
         )
 
     def test_translate_availability_stays_disabled_after_ui_refresh(self):
@@ -155,13 +172,22 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
             )
         )
 
-    def test_start_action_rejects_litellm_task_during_install(self):
+    def test_start_action_checks_install_after_unsaved_config_resolution(self):
         self.window._current_work_mode = mock.Mock(
-            return_value=WorkMode.SYNC_TRANSLATION
+            return_value=WorkMode.SYNC_KEYWORD_EXTRACTION
+        )
+        self.window.state = mock.Mock()
+        self.window.state.get_game_root.return_value = "C:/Game/work"
+        self.window._confirm_unsaved_config_before_workflow = mock.Mock(
+            return_value=True
         )
         self.window._litellm_install_blocks_mode = mock.Mock(return_value=True)
         with mock.patch("gui_qt.app.QMessageBox.information") as information:
             self.window._on_start_translation()
+        self.window._confirm_unsaved_config_before_workflow.assert_called_once()
+        self.window._litellm_install_blocks_mode.assert_called_once_with(
+            WorkMode.SYNC_KEYWORD_EXTRACTION
+        )
         information.assert_called_once()
         self.assertIn("正在安装", information.call_args.args[1])
 

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 try:
     from gui_qt.app import MainWindow, QProcess
+    from gui_qt.work_modes import WorkMode
 except ImportError as exc:
     MainWindow = None
     IMPORT_ERROR = exc
@@ -99,6 +100,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
 
     def test_failed_to_start_clears_install_state_and_restores_ui(self):
         self.window._litellm_install_process = _Process()
+        self.window._litellm_install_active = True
         self.window._append_log = mock.Mock()
         self.window._on_sync_backend_changed = mock.Mock()
         with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
@@ -106,6 +108,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
                 QProcess.ProcessError.FailedToStart
             )
         self.assertIsNone(self.window._litellm_install_process)
+        self.assertFalse(self.window._litellm_install_active)
         self.window._on_sync_backend_changed.assert_called_once_with(-1)
         warning.assert_called_once()
         self.assertIn(
@@ -116,6 +119,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
     def test_non_start_error_waits_for_finished_cleanup(self):
         process = _Process()
         self.window._litellm_install_process = process
+        self.window._litellm_install_active = True
         self.window._append_log = mock.Mock()
         self.window._on_sync_backend_changed = mock.Mock()
         with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
@@ -123,8 +127,43 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
                 QProcess.ProcessError.Crashed
             )
         self.assertIs(self.window._litellm_install_process, process)
+        self.assertTrue(self.window._litellm_install_active)
         self.window._on_sync_backend_changed.assert_not_called()
         warning.assert_not_called()
+
+    def test_install_blocks_all_litellm_sync_modes_but_not_batch(self):
+        self.window._litellm_install_active = True
+        for mode in (
+            WorkMode.SYNC_TRANSLATION,
+            WorkMode.SYNC_KEYWORD_EXTRACTION,
+            WorkMode.SYNC_REVISION,
+        ):
+            with self.subTest(mode=mode):
+                self.assertTrue(self.window._litellm_install_blocks_mode(mode))
+        self.assertFalse(
+            self.window._litellm_install_blocks_mode(WorkMode.BATCH_TRANSLATION)
+        )
+
+    def test_translate_availability_stays_disabled_after_ui_refresh(self):
+        self.window._litellm_install_blocks_mode = mock.Mock(return_value=True)
+        spec = mock.Mock(mode=WorkMode.SYNC_TRANSLATION, implemented=True)
+        self.assertFalse(
+            self.window._translate_button_enabled(
+                spec=spec,
+                bootstrap_ready=True,
+                running=False,
+            )
+        )
+
+    def test_start_action_rejects_litellm_task_during_install(self):
+        self.window._current_work_mode = mock.Mock(
+            return_value=WorkMode.SYNC_TRANSLATION
+        )
+        self.window._litellm_install_blocks_mode = mock.Mock(return_value=True)
+        with mock.patch("gui_qt.app.QMessageBox.information") as information:
+            self.window._on_start_translation()
+        information.assert_called_once()
+        self.assertIn("正在安装", information.call_args.args[1])
 
     def test_installed_dependency_hides_install_button(self):
         with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=object()):


### PR DESCRIPTION
## What changed

- keep LiteLLM installation state active independently of transient QProcess states
- gate sync translation, sync keyword extraction, and sync revision through the shared action-availability calculation
- reject stale shortcut/action launches while LiteLLM is installing
- preserve Gemini Batch and unrelated GUI functionality during background installation

## Why

PR #196 disabled the current button once, but later work-mode or doctor refreshes could re-enable page-level sync actions while installation was still running.

## Validation

- python -m unittest tests.test_gui_litellm_install tests.test_gui_sync_backend tests.test_gui_settings_schema tests.test_gui_settings_context_primary tests.test_gui_app_config tests.test_gui_task_pages tests.test_test_runners -q
- 122 tests passed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation and start controls are now consistently disabled while LiteLLM installation is in progress.
  * Prevented blocked translation modes from starting during installation and added an informational warning.
  * Improved handling of installation failures and completion states so controls are restored correctly.
* **Tests**
  * Expanded coverage for installation state tracking, mode restrictions, UI refresh behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->