### PR TITLE
Add independent LiteLLM settings page

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -207,6 +207,11 @@ from .work_bootstrap_report import (
     with_game_root_persist_warning,
     work_bootstrap_to_doctor_summary,
 )
+from .litellm_settings import (
+    provider_credential_status,
+    read_sync_backend_models,
+    write_sync_backend_models,
+)
 from .project_state import ProjectState
 from .theme import apply_theme, system_prefers_dark
 from .theme_helpers import (
@@ -1437,6 +1442,7 @@ class MainWindow(QMainWindow):
             ("project", "项目", self._build_settings_project_page()),
             ("api_keys", "密钥", self._build_settings_api_keys_page()),
             ("models", "模型", self._build_settings_models_page()),
+            ("litellm", "LiteLLM", self._build_settings_litellm_page()),
             ("context", "上下文", self._build_settings_context_page()),
             ("appearance", "外观", self._build_settings_appearance_page()),
             ("advanced", "高级", self._build_settings_advanced_page()),
@@ -1531,10 +1537,10 @@ class MainWindow(QMainWindow):
 
     def _build_settings_api_keys_page(self) -> QWidget:
         page, layout = self._settings_page("settings_api_keys")
-        api_box, api_layout = self._settings_group("API Key")
+        api_box, api_layout = self._settings_group("Gemini API Key")
 
         api_hint = QLabel(
-            "翻译任务需要 Gemini API 密钥。密钥保存在本地配置文件中，"
+            "此页面只管理 Gemini API 密钥。密钥保存在本地配置文件中，"
             "不会上传或代理。也可通过环境变量配置。"
         )
         api_hint.setWordWrap(True)
@@ -1658,16 +1664,10 @@ class MainWindow(QMainWindow):
         config_row = QHBoxLayout()
         config_row.setSpacing(16)
 
-        sync_box = QGroupBox("同步翻译")
+        sync_box = QGroupBox("Gemini 同步翻译")
         sync_layout = QFormLayout(sync_box)
         sync_layout.setSpacing(8)
         sync_layout.setContentsMargins(12, 16, 12, 12)
-
-        self.sync_backend_combo = NoWheelComboBox()
-        self.sync_backend_combo.addItem("Gemini 同步（推荐）", "gemini")
-        self.sync_backend_combo.addItem("LiteLLM 同步替代", "litellm")
-        self.sync_backend_combo.currentIndexChanged.connect(self._on_sync_backend_changed)
-        sync_layout.addRow("执行后端：", self.sync_backend_combo)
 
         self.sync_model_combo = NoWheelComboBox()
         self.sync_model_combo.setEditable(True)
@@ -1689,23 +1689,10 @@ class MainWindow(QMainWindow):
         ])
         sync_layout.addRow("RAG 向量模型：", self.sync_embedding_combo)
 
-        self.sync_backend_hint = QLabel()
-        self.sync_backend_hint.setWordWrap(True)
-        self.sync_backend_hint.setObjectName("config_hint_label")
-        sync_layout.addRow(self.sync_backend_hint)
-
-        self.install_litellm_btn = QPushButton("安装 LiteLLM")
-        self.install_litellm_btn.setObjectName("secondary_btn")
-        self.install_litellm_btn.clicked.connect(self._on_install_litellm)
-        self.install_litellm_btn.setVisible(False)
-        sync_layout.addRow(self.install_litellm_btn)
-        self.litellm_install_progress = QProgressBar()
-        self.litellm_install_progress.setObjectName("litellm_install_progress")
-        self.litellm_install_progress.setTextVisible(True)
-        self.litellm_install_progress.setFormat("正在后台安装 LiteLLM…")
-        self.litellm_install_progress.setVisible(False)
-        sync_layout.addRow(self.litellm_install_progress)
-
+        sync_hint = QLabel("此处只配置 Gemini 同步模型；LiteLLM 已移至左侧独立页面。")
+        sync_hint.setWordWrap(True)
+        sync_hint.setObjectName("config_hint_label")
+        sync_layout.addRow(sync_hint)
         config_row.addWidget(sync_box, 1)
 
         batch_box = QGroupBox("批量离线翻译")
@@ -1742,6 +1729,70 @@ class MainWindow(QMainWindow):
 
         config_row.addWidget(batch_box, 1)
         layout.addLayout(config_row)
+        layout.addStretch(1)
+        return page
+
+    def _build_settings_litellm_page(self) -> QWidget:
+        page, layout = self._settings_page("settings_litellm")
+
+        backend_box = QGroupBox("LiteLLM 同步替代后端")
+        backend_layout = QFormLayout(backend_box)
+        backend_layout.setSpacing(8)
+        backend_layout.setContentsMargins(12, 16, 12, 12)
+
+        self.sync_backend_combo = NoWheelComboBox()
+        self.sync_backend_combo.addItem("Gemini 同步（推荐）", "gemini")
+        self.sync_backend_combo.addItem("启用 LiteLLM 同步替代", "litellm")
+        self.sync_backend_combo.currentIndexChanged.connect(self._on_sync_backend_changed)
+        backend_layout.addRow("同步执行后端：", self.sync_backend_combo)
+
+        self.litellm_model_combo = NoWheelComboBox()
+        self.litellm_model_combo.setEditable(True)
+        self.litellm_model_combo.addItems([
+            "openai/gpt-5",
+            "anthropic/claude-sonnet-4-5-20250929",
+            "openrouter/openai/gpt-5",
+            "xai/grok-2-latest",
+            "ollama/llama3",
+        ])
+        self.litellm_model_combo.currentTextChanged.connect(self._on_litellm_model_changed)
+        backend_layout.addRow("LiteLLM 模型：", self.litellm_model_combo)
+
+        self.sync_backend_hint = QLabel()
+        self.sync_backend_hint.setWordWrap(True)
+        self.sync_backend_hint.setObjectName("config_hint_label")
+        backend_layout.addRow(self.sync_backend_hint)
+
+        self.install_litellm_btn = QPushButton("安装 LiteLLM")
+        self.install_litellm_btn.setObjectName("secondary_btn")
+        self.install_litellm_btn.clicked.connect(self._on_install_litellm)
+        self.install_litellm_btn.setVisible(False)
+        backend_layout.addRow(self.install_litellm_btn)
+
+        self.litellm_install_progress = QProgressBar()
+        self.litellm_install_progress.setObjectName("litellm_install_progress")
+        self.litellm_install_progress.setTextVisible(True)
+        self.litellm_install_progress.setFormat("正在后台安装 LiteLLM…")
+        self.litellm_install_progress.setVisible(False)
+        backend_layout.addRow(self.litellm_install_progress)
+        layout.addWidget(backend_box)
+
+        credentials_box, credentials_layout = self._settings_group("Provider 凭据状态")
+        credentials_hint = QLabel(
+            "LiteLLM 凭据与 Gemini API Key 完全分离。应用只检测当前进程的环境变量，"
+            "不会读取、显示或写入 provider 密钥。修改环境变量后请重启 GUI。"
+        )
+        credentials_hint.setWordWrap(True)
+        credentials_hint.setObjectName("config_hint_label")
+        credentials_layout.addWidget(credentials_hint)
+        self.litellm_provider_label = QLabel()
+        self.litellm_provider_label.setObjectName("litellm_provider_label")
+        credentials_layout.addWidget(self.litellm_provider_label)
+        self.litellm_credential_status_label = QLabel()
+        self.litellm_credential_status_label.setWordWrap(True)
+        self.litellm_credential_status_label.setObjectName("api_status_label")
+        credentials_layout.addWidget(self.litellm_credential_status_label)
+        layout.addWidget(credentials_box)
         layout.addStretch(1)
         return page
 
@@ -4054,6 +4105,24 @@ class MainWindow(QMainWindow):
         value = combo.currentData()
         return value if value in {"gemini", "litellm"} else "gemini"
 
+    def _litellm_model_text(self) -> str:
+        combo = getattr(self, "litellm_model_combo", None)
+        return combo.currentText().strip() if combo is not None else ""
+
+    def _refresh_litellm_credential_status(self) -> None:
+        provider_label = getattr(self, "litellm_provider_label", None)
+        status_label = getattr(self, "litellm_credential_status_label", None)
+        if provider_label is None or status_label is None:
+            return
+        status = provider_credential_status(self._litellm_model_text(), os.environ)
+        provider_label.setText(
+            f"当前 provider：{status.provider}" if status.provider else "当前 provider：尚未识别"
+        )
+        status_label.setText(status.message)
+
+    def _on_litellm_model_changed(self, _text: str) -> None:
+        self._refresh_litellm_credential_status()
+
     def _saved_sync_backend(self) -> str:
         try:
             config = self.state.load_translator_config()
@@ -4086,7 +4155,7 @@ class MainWindow(QMainWindow):
                 install_btn.setText("正在安装…" if installing else "安装 LiteLLM")
         else:
             hint.setText(
-                "推荐路径。同步任务使用 Gemini API Key；批量离线翻译仍始终使用 Gemini Batch。"
+                "推荐路径仍为 Gemini；同步配置位于「模型」与「密钥」页，批量离线翻译仍使用 Gemini Batch。"
             )
             if install_btn is not None:
                 install_btn.setVisible(False)
@@ -4098,11 +4167,12 @@ class MainWindow(QMainWindow):
                 install_progress.setRange(0, 0)
                 install_progress.setFormat("正在后台安装 LiteLLM…")
 
-        model_combo = getattr(self, "sync_model_combo", None)
+        model_combo = getattr(self, "litellm_model_combo", None)
         if model_combo is not None:
-            model_combo.setEnabled(not (backend == "litellm" and installing))
+            model_combo.setEnabled(backend == "litellm" and not installing)
         if hasattr(self, "translate_btn"):
             self._set_task_running(bool(getattr(self, "_task_running", False)))
+        self._refresh_litellm_credential_status()
         self._refresh_litellm_install_action_gating()
 
     def _refresh_litellm_install_action_gating(self) -> None:
@@ -5765,6 +5835,7 @@ class MainWindow(QMainWindow):
             "context_storage_location": "game" if self.context_storage_game_cb.isChecked() else "tool",
             "sync_backend": self._selected_sync_backend(),
             "sync_model": self.sync_model_combo.currentText().strip(),
+            "litellm_model": self._litellm_model_text(),
             "batch_model": self.batch_model_combo.currentText().strip(),
             "sync_embedding_model": self.sync_embedding_combo.currentText().strip(),
             "batch_embedding_model": self.batch_embedding_combo.currentText().strip(),
@@ -5940,6 +6011,9 @@ class MainWindow(QMainWindow):
         if backend_combo is not None:
             backend_combo.setCurrentIndex(backend_idx)
         self._set_combo_value(self.sync_model_combo, values["sync_model"])
+        litellm_combo = getattr(self, "litellm_model_combo", None)
+        if litellm_combo is not None:
+            self._set_combo_value(litellm_combo, "")
         self._on_sync_backend_changed(backend_idx)
         self._set_combo_value(self.batch_model_combo, values["batch_model"])
         self._set_combo_value(self.sync_embedding_combo, values["sync_embedding_model"])
@@ -8378,20 +8452,15 @@ class MainWindow(QMainWindow):
             if backend_combo is not None:
                 backend_combo.setCurrentIndex(backend_idx)
 
-            sync_models = sync_config.get("models")
-            sync_val = ""
-            if isinstance(sync_models, list):
-                for model in sync_models:
-                    sync_val = self._config_string(model)
-                    if sync_val:
-                        break
-            elif isinstance(sync_models, str):
-                sync_val = self._config_string(sync_models)
-            if not sync_val:
-                sync_val = self._config_string(sync_config.get("model", ""))
-            if not sync_val:
-                sync_val = str(BASIC_RECOMMENDED_VALUES["sync_model"])
-            self._set_combo_value(self.sync_model_combo, sync_val)
+            backend_models = read_sync_backend_models(
+                sync_config,
+                sync_backend,
+                str(BASIC_RECOMMENDED_VALUES["sync_model"]),
+            )
+            self._set_combo_value(self.sync_model_combo, backend_models.gemini_model)
+            litellm_combo = getattr(self, "litellm_model_combo", None)
+            if litellm_combo is not None:
+                self._set_combo_value(litellm_combo, backend_models.litellm_model)
             self._on_sync_backend_changed(backend_idx)
 
             batch_val = self._config_string(batch_config.get("model", "")) or str(
@@ -8480,9 +8549,22 @@ class MainWindow(QMainWindow):
                 "bootstrap_on_build": self.bootstrap_on_build_cb.isChecked(),
             }
 
-            sync_config["backend"] = self._selected_sync_backend()
-            sync_model = self.sync_model_combo.currentText().strip()
-            sync_config["model"] = sync_model
+            sync_backend = self._selected_sync_backend()
+            litellm_model = self._litellm_model_text()
+            if sync_backend == "litellm" and not litellm_model:
+                self._focus_settings_section("litellm")
+                QMessageBox.information(
+                    self,
+                    "请配置 LiteLLM 模型",
+                    "启用 LiteLLM 前，请填写带 provider 前缀的模型名称。",
+                )
+                return False
+            sync_model = write_sync_backend_models(
+                sync_config,
+                sync_backend,
+                self.sync_model_combo.currentText(),
+                litellm_model,
+            )
             if "models" in sync_config:
                 sync_models = self._sync_models_for_save(sync_config.get("models"), sync_model)
                 if sync_models:

--- a/gui_qt/litellm_settings.py
+++ b/gui_qt/litellm_settings.py
@@ -112,9 +112,10 @@ def provider_credential_status(
             configured=True,
             message="Ollama 通常不需要 API Key；请确保本地服务可访问。",
         )
+    available_environment_names = frozenset(environment)
     if provider == "vertex_ai":
         names = ("VERTEXAI_PROJECT", "VERTEXAI_LOCATION")
-        configured = all(str(environment.get(name, "")).strip() for name in names)
+        configured = all(name in available_environment_names for name in names)
         state = "已检测到" if configured else "未完整检测到"
         return ProviderCredentialStatus(
             provider=provider,
@@ -130,7 +131,7 @@ def provider_credential_status(
             configured=None,
             message="未内置该 provider 的凭据检测；请按 LiteLLM 与供应商文档配置环境变量。",
         )
-    configured = all(str(environment.get(name, "")).strip() for name in names)
+    configured = all(name in available_environment_names for name in names)
     state = "已检测到" if configured else "未检测到完整"
     return ProviderCredentialStatus(
         provider=provider,

--- a/gui_qt/litellm_settings.py
+++ b/gui_qt/litellm_settings.py
@@ -1,0 +1,140 @@
+"""Pure helpers for the GUI's provider-aware LiteLLM settings page."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderCredentialStatus:
+    provider: str
+    environment_names: tuple[str, ...]
+    configured: bool | None
+    message: str
+
+
+@dataclass(frozen=True)
+class SyncBackendModels:
+    gemini_model: str
+    litellm_model: str
+
+
+def _clean(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def read_sync_backend_models(
+    sync_config: Mapping[str, object],
+    backend: str,
+    recommended_gemini_model: str,
+) -> SyncBackendModels:
+    active_model = ""
+    configured_models = sync_config.get("models")
+    if isinstance(configured_models, list):
+        for model in configured_models:
+            active_model = _clean(model)
+            if active_model:
+                break
+    elif isinstance(configured_models, str):
+        active_model = _clean(configured_models)
+    if not active_model:
+        active_model = _clean(sync_config.get("model"))
+
+    gemini_model = _clean(sync_config.get("gemini_model"))
+    if not gemini_model and backend == "gemini":
+        gemini_model = active_model
+    if not gemini_model:
+        gemini_model = recommended_gemini_model
+
+    litellm_model = _clean(sync_config.get("litellm_model"))
+    if not litellm_model and backend == "litellm":
+        litellm_model = active_model
+    return SyncBackendModels(gemini_model, litellm_model)
+
+
+def write_sync_backend_models(
+    sync_config: dict[str, object],
+    backend: str,
+    gemini_model: str,
+    litellm_model: str,
+) -> str:
+    gemini_model = gemini_model.strip()
+    litellm_model = litellm_model.strip()
+    sync_config["gemini_model"] = gemini_model
+    if litellm_model:
+        sync_config["litellm_model"] = litellm_model
+    else:
+        sync_config.pop("litellm_model", None)
+    active_model = litellm_model if backend == "litellm" else gemini_model
+    sync_config["backend"] = backend
+    sync_config["model"] = active_model
+    return active_model
+
+
+_PROVIDER_ENVIRONMENT: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "azure": ("AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "huggingface": ("HUGGINGFACE_API_KEY",),
+    "novita": ("NOVITA_API_KEY",),
+    "nvidia_nim": ("NVIDIA_NIM_API_KEY", "NVIDIA_NIM_API_BASE"),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "vercel_ai_gateway": ("VERCEL_AI_GATEWAY_API_KEY",),
+    "xai": ("XAI_API_KEY",),
+}
+
+
+def provider_from_model(model: str) -> str:
+    text = str(model or "").strip()
+    if "/" not in text:
+        return ""
+    return text.split("/", 1)[0].strip().lower()
+
+
+def provider_credential_status(
+    model: str,
+    environment: Mapping[str, str],
+) -> ProviderCredentialStatus:
+    provider = provider_from_model(model)
+    if not provider:
+        return ProviderCredentialStatus(
+            provider="",
+            environment_names=(),
+            configured=None,
+            message="请先填写带 provider 前缀的模型，例如 openai/gpt-5。",
+        )
+    if provider == "ollama":
+        return ProviderCredentialStatus(
+            provider=provider,
+            environment_names=(),
+            configured=True,
+            message="Ollama 通常不需要 API Key；请确保本地服务可访问。",
+        )
+    if provider == "vertex_ai":
+        names = ("VERTEXAI_PROJECT", "VERTEXAI_LOCATION")
+        configured = all(str(environment.get(name, "")).strip() for name in names)
+        state = "已检测到" if configured else "未完整检测到"
+        return ProviderCredentialStatus(
+            provider=provider,
+            environment_names=names,
+            configured=configured,
+            message=f"{state} Vertex AI 项目环境变量；身份凭据仍由 Google ADC 管理。",
+        )
+    names = _PROVIDER_ENVIRONMENT.get(provider, ())
+    if not names:
+        return ProviderCredentialStatus(
+            provider=provider,
+            environment_names=(),
+            configured=None,
+            message="未内置该 provider 的凭据检测；请按 LiteLLM 与供应商文档配置环境变量。",
+        )
+    configured = all(str(environment.get(name, "")).strip() for name in names)
+    state = "已检测到" if configured else "未检测到完整"
+    return ProviderCredentialStatus(
+        provider=provider,
+        environment_names=names,
+        configured=configured,
+        message=f"{state}环境变量：{', '.join(names)}。",
+    )

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -75,6 +75,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.window.sync_backend_hint = _Label()
         self.window.install_litellm_btn = _Button()
         self.window.sync_model_combo = _Combo(None)
+        self.window.litellm_model_combo = _Combo(None)
         self.window.litellm_install_progress = _ProgressBar()
         self.window._refresh_litellm_install_action_gating = mock.Mock()
 
@@ -85,7 +86,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertTrue(self.window.install_litellm_btn.enabled)
         self.assertEqual(self.window.install_litellm_btn.text, "安装 LiteLLM")
         self.assertFalse(self.window.litellm_install_progress.visible)
-        self.assertTrue(self.window.sync_model_combo.enabled)
+        self.assertTrue(self.window.litellm_model_combo.enabled)
 
     def test_installing_shows_busy_progress_and_disables_litellm_model(self):
         self.window._litellm_install_running = mock.Mock(return_value=True)
@@ -94,7 +95,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertTrue(self.window.litellm_install_progress.visible)
         self.assertEqual(self.window.litellm_install_progress.range_values, (0, 0))
         self.assertIn("后台安装", self.window.litellm_install_progress.format)
-        self.assertFalse(self.window.sync_model_combo.enabled)
+        self.assertFalse(self.window.litellm_model_combo.enabled)
         self.assertFalse(self.window.install_litellm_btn.enabled)
         self.assertIn("正在后台安装", self.window.sync_backend_hint.value)
 
@@ -203,7 +204,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.window._on_sync_backend_changed(0)
         self.assertFalse(self.window.install_litellm_btn.visible)
         self.assertTrue(self.window.litellm_install_progress.visible)
-        self.assertTrue(self.window.sync_model_combo.enabled)
+        self.assertFalse(self.window.litellm_model_combo.enabled)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_litellm_settings.py
+++ b/tests/test_gui_litellm_settings.py
@@ -1,0 +1,65 @@
+import unittest
+
+from gui_qt.litellm_settings import (
+    provider_credential_status,
+    provider_from_model,
+    read_sync_backend_models,
+    write_sync_backend_models,
+)
+
+
+class GuiLiteLLMSettingsTests(unittest.TestCase):
+    def test_provider_is_model_prefix(self):
+        self.assertEqual(provider_from_model("openrouter/openai/gpt-5"), "openrouter")
+
+    def test_openai_key_status_never_exposes_value(self):
+        status = provider_credential_status(
+            "openai/gpt-5",
+            {"OPENAI_API_KEY": "secret-value"},
+        )
+        self.assertTrue(status.configured)
+        self.assertIn("OPENAI_API_KEY", status.message)
+        self.assertNotIn("secret-value", status.message)
+
+    def test_missing_provider_key_is_reported(self):
+        status = provider_credential_status("anthropic/claude", {})
+        self.assertFalse(status.configured)
+        self.assertIn("ANTHROPIC_API_KEY", status.message)
+
+    def test_ollama_does_not_require_key(self):
+        status = provider_credential_status("ollama/llama3", {})
+        self.assertTrue(status.configured)
+        self.assertEqual(status.environment_names, ())
+
+    def test_unknown_provider_defers_to_provider_docs(self):
+        status = provider_credential_status("custom/model", {})
+        self.assertIsNone(status.configured)
+        self.assertIn("未内置", status.message)
+
+    def test_legacy_litellm_model_loads_without_overwriting_gemini_default(self):
+        models = read_sync_backend_models(
+            {"backend": "litellm", "model": "openai/gpt-5"},
+            "litellm",
+            "gemini-default",
+        )
+        self.assertEqual(models.gemini_model, "gemini-default")
+        self.assertEqual(models.litellm_model, "openai/gpt-5")
+
+    def test_backend_models_roundtrip_through_existing_runtime_fields(self):
+        config = {"unknown": "preserved"}
+        active = write_sync_backend_models(
+            config,
+            "litellm",
+            "gemini-model",
+            "anthropic/claude",
+        )
+        self.assertEqual(active, "anthropic/claude")
+        self.assertEqual(config["backend"], "litellm")
+        self.assertEqual(config["model"], "anthropic/claude")
+        self.assertEqual(config["gemini_model"], "gemini-model")
+        self.assertEqual(config["litellm_model"], "anthropic/claude")
+        self.assertEqual(config["unknown"], "preserved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_litellm_settings.py
+++ b/tests/test_gui_litellm_settings.py
@@ -8,6 +8,11 @@ from gui_qt.litellm_settings import (
 )
 
 
+class _PresenceOnlyEnvironment(dict[str, str]):
+    def get(self, key, default=None):
+        raise AssertionError("credential values must not be read")
+
+
 class GuiLiteLLMSettingsTests(unittest.TestCase):
     def test_provider_is_model_prefix(self):
         self.assertEqual(provider_from_model("openrouter/openai/gpt-5"), "openrouter")
@@ -25,6 +30,22 @@ class GuiLiteLLMSettingsTests(unittest.TestCase):
         status = provider_credential_status("anthropic/claude", {})
         self.assertFalse(status.configured)
         self.assertIn("ANTHROPIC_API_KEY", status.message)
+
+    def test_credential_presence_check_never_reads_values(self):
+        cases = (
+            ("openai/gpt-5", {"OPENAI_API_KEY": "secret-value"}),
+            (
+                "vertex_ai/gemini",
+                {"VERTEXAI_PROJECT": "secret-project", "VERTEXAI_LOCATION": "region"},
+            ),
+        )
+        for model, values in cases:
+            with self.subTest(model=model):
+                status = provider_credential_status(
+                    model,
+                    _PresenceOnlyEnvironment(values),
+                )
+                self.assertTrue(status.configured)
 
     def test_ollama_does_not_require_key(self):
         status = provider_credential_status("ollama/llama3", {})

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -21,13 +21,13 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
+        cls.window = MainWindow()
 
-    def setUp(self):
-        self.window = MainWindow()
-
-    def tearDown(self):
-        self.window.close()
-        self.window.deleteLater()
+    @classmethod
+    def tearDownClass(cls):
+        cls.window.close()
+        cls.window.deleteLater()
+        cls._app.processEvents()
 
     def test_litellm_has_independent_settings_page(self):
         self.assertIn("litellm", self.window._settings_nav_rows)
@@ -49,20 +49,27 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         )
 
     def test_empty_litellm_model_cannot_be_saved(self):
-        self.window.state = mock.Mock()
-        self.window.state.get_game_root.return_value = Path("C:/Game/work")
-        self.window.state.load_translator_config.return_value = {
-            "sync": {},
-            "batch": {},
-        }
         self.window.sync_backend_combo.setCurrentIndex(
             self.window.sync_backend_combo.findData("litellm")
         )
         self.window.litellm_model_combo.setEditText("")
-        with mock.patch("gui_qt.app.QMessageBox.information") as information:
+        with (
+            mock.patch.object(
+                self.window.state,
+                "get_game_root",
+                return_value=Path("C:/Game/work"),
+            ),
+            mock.patch.object(
+                self.window.state,
+                "load_translator_config",
+                return_value={"sync": {}, "batch": {}},
+            ),
+            mock.patch.object(self.window.state, "save_translator_config") as save_config,
+            mock.patch("gui_qt.app.QMessageBox.information") as information,
+        ):
             saved = self.window._on_save_config()
         self.assertFalse(saved)
-        self.window.state.save_translator_config.assert_not_called()
+        save_config.assert_not_called()
         information.assert_called_once()
 
     def test_models_page_is_gemini_only(self):

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -1,0 +1,78 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from PySide6.QtWidgets import QApplication, QGroupBox
+
+    from gui_qt.app import MainWindow
+except ImportError as exc:
+    MainWindow = None
+    QApplication = None
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+from tests import gui_test_support
+
+
+@gui_test_support.skip_unless_gui(MainWindow is None, IMPORT_ERROR)
+class GuiLiteLLMSettingsPageTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication.instance() or QApplication([])
+
+    def setUp(self):
+        self.window = MainWindow()
+
+    def tearDown(self):
+        self.window.close()
+        self.window.deleteLater()
+
+    def test_litellm_has_independent_settings_page(self):
+        self.assertIn("litellm", self.window._settings_nav_rows)
+        row = self.window._settings_nav_rows["litellm"]
+        page = self.window.settings_stack.widget(row)
+        self.assertEqual(page.objectName(), "settings_litellm_scroll")
+        titles = {group.title() for group in page.findChildren(QGroupBox)}
+        self.assertIn("LiteLLM 同步替代后端", titles)
+        self.assertIn("Provider 凭据状态", titles)
+
+    def test_gemini_key_page_does_not_contain_litellm_controls(self):
+        row = self.window._settings_nav_rows["api_keys"]
+        page = self.window.settings_stack.widget(row)
+        titles = {group.title() for group in page.findChildren(QGroupBox)}
+        self.assertEqual(titles, {"Gemini API Key"})
+        self.assertNotIn(
+            self.window.install_litellm_btn,
+            page.findChildren(type(self.window.install_litellm_btn)),
+        )
+
+    def test_empty_litellm_model_cannot_be_saved(self):
+        self.window.state = mock.Mock()
+        self.window.state.get_game_root.return_value = Path("C:/Game/work")
+        self.window.state.load_translator_config.return_value = {
+            "sync": {},
+            "batch": {},
+        }
+        self.window.sync_backend_combo.setCurrentIndex(
+            self.window.sync_backend_combo.findData("litellm")
+        )
+        self.window.litellm_model_combo.setEditText("")
+        with mock.patch("gui_qt.app.QMessageBox.information") as information:
+            saved = self.window._on_save_config()
+        self.assertFalse(saved)
+        self.window.state.save_translator_config.assert_not_called()
+        information.assert_called_once()
+
+    def test_models_page_is_gemini_only(self):
+        row = self.window._settings_nav_rows["models"]
+        page = self.window.settings_stack.widget(row)
+        titles = {group.title() for group in page.findChildren(QGroupBox)}
+        self.assertIn("Gemini 同步翻译", titles)
+        self.assertIn("批量离线翻译", titles)
+        self.assertNotIn("LiteLLM 同步替代后端", titles)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a dedicated LiteLLM settings page for backend activation, model selection, dependency installation, progress, and provider status
- keep the existing Models and API Key pages Gemini-only
- detect provider credential environment-variable presence without reading, displaying, or persisting secret values
- remember Gemini and LiteLLM model choices separately while continuing to write the active backend/model to the existing sync.backend and sync.model runtime fields
- preserve unknown sync configuration fields and reject an enabled LiteLLM backend with an empty model

## Why

LiteLLM configuration and provider credentials should not be mixed with the existing Gemini model and API Key controls. This implements the next GUI stage of #178 without changing the Gemini Batch default path.

## Validation

- python tests/run_gui_tests.py -q (692 tests passed)
- python tests/run_cli_tests.py -q (410 tests passed)
- focused LiteLLM/settings tests (93 tests passed)
- python -m py_compile gui_qt/app.py gui_qt/litellm_settings.py tests/test_gui_litellm_settings.py tests/test_gui_litellm_settings_page.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated LiteLLM settings page in the Qt application.
  * Configure the sync backend and select a LiteLLM model independently from Gemini settings.
  * Display provider and credential status based on the selected model.
  * Automatically load and preserve Gemini and LiteLLM model selections.

* **Bug Fixes**
  * Prevented saving when LiteLLM is selected without a configured model.
  * Improved model enablement and status updates when switching sync backends.
  * Restoring recommended defaults now clears LiteLLM selections appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->