### PR TITLE
Fix LiteLLM sync API key gate

### DIFF
--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from litellm_provider_config import provider_from_model
 from sync_model_backend import SYNC_EXECUTION_MODE, SyncGenerationRequest, SyncGenerationResult
 
 
@@ -145,10 +146,7 @@ class LiteLLMSyncBackend:
         api_key = self._api_key
         if not api_key:
             try:
-                from litellm_provider_config import (
-                    load_provider_api_key,
-                    provider_from_model,
-                )
+                from litellm_provider_config import load_provider_api_key
 
                 api_key = load_provider_api_key(provider_from_model(request.model))
             except Exception:
@@ -164,14 +162,20 @@ class LiteLLMSyncBackend:
             kwargs["max_tokens"] = config["max_output_tokens"]
         schema = config.get("response_json_schema")
         if schema:
-            kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "translation_response",
-                    "schema": schema,
-                    "strict": True,
-                },
-            }
+            provider = provider_from_model(request.model)
+            # DeepSeek rejects json_schema even though it supports JSON mode.
+            # Other providers still benefit from downstream schema validation.
+            if provider in {"openai", "azure"}:
+                kwargs["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "translation_response",
+                        "schema": schema,
+                        "strict": True,
+                    },
+                }
+            else:
+                kwargs["response_format"] = {"type": "json_object"}
         try:
             response = self._resolve_completion()(**kwargs)
         except LiteLLMBackendError:

--- a/tests/test_litellm_runtime_integration.py
+++ b/tests/test_litellm_runtime_integration.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 from unittest import mock
 
@@ -5,6 +6,61 @@ import translator_runtime as runtime
 
 
 class LiteLLMRuntimeIntegrationTests(unittest.TestCase):
+    def test_sync_runner_does_not_require_gemini_key_for_litellm(self):
+        previous_backend = runtime.SYNC_BACKEND
+        previous_keys = runtime.API_KEYS
+
+        def select_litellm():
+            runtime.SYNC_BACKEND = "litellm"
+
+        try:
+            runtime.API_KEYS = []
+            with (
+                mock.patch.object(runtime, "load_config") as load_config,
+                mock.patch.object(
+                    runtime,
+                    "load_translator_settings",
+                    side_effect=select_litellm,
+                ),
+                mock.patch.object(runtime, "load_glossary"),
+                mock.patch.object(runtime, "run_prepare_steps"),
+                mock.patch.object(runtime.os, "walk", return_value=[]),
+                mock.patch.object(runtime, "load_progress", return_value={}),
+                mock.patch("sys.stdout", output := io.StringIO()),
+            ):
+                runtime.run_translation()
+
+            load_config.assert_called_once_with(require_api_key=False)
+            self.assertIn("Sync backend: litellm", output.getvalue())
+            self.assertIn("not required for LiteLLM", output.getvalue())
+        finally:
+            runtime.SYNC_BACKEND = previous_backend
+            runtime.API_KEYS = previous_keys
+
+    def test_sync_runner_still_requires_gemini_key_for_gemini(self):
+        previous_backend = runtime.SYNC_BACKEND
+        previous_keys = runtime.API_KEYS
+
+        def select_gemini():
+            runtime.SYNC_BACKEND = "gemini"
+
+        try:
+            runtime.API_KEYS = []
+            with (
+                mock.patch.object(runtime, "load_config"),
+                mock.patch.object(
+                    runtime,
+                    "load_translator_settings",
+                    side_effect=select_gemini,
+                ),
+                mock.patch("sys.stdout"),
+            ):
+                with self.assertRaisesRegex(SystemExit, "No API keys available"):
+                    runtime.run_translation()
+        finally:
+            runtime.SYNC_BACKEND = previous_backend
+            runtime.API_KEYS = previous_keys
+
     def test_runtime_uses_explicit_litellm_backend_without_gemini_client(self):
         fake_result = type("Result", (), {
             "parsed": None,

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -48,6 +48,31 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "stop")
         self.assertEqual(result.usage_metadata["prompt_tokens"], 8)
 
+    def test_uses_json_object_for_deepseek(self):
+        calls = []
+
+        def completion(**kwargs):
+            calls.append(kwargs)
+            return {
+                "choices": [{
+                    "message": {"content": '[{"id":"a","translation":"你好"}]'},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 8, "completion_tokens": 6},
+            }
+
+        backend = LiteLLMSyncBackend(completion=completion)
+        backend.generate(SyncGenerationRequest(
+            model="deepseek/deepseek-v4-flash",
+            contents="Translate this",
+            config={
+                "response_json_schema": {"type": "array"},
+            },
+        ))
+
+        self.assertEqual(calls[0]["model"], "deepseek/deepseek-v4-flash")
+        self.assertEqual(calls[0]["response_format"], {"type": "json_object"})
+
     def test_converts_gemini_style_system_instruction_and_contents(self):
         calls = []
         backend = LiteLLMSyncBackend(completion=lambda **kwargs: calls.append(kwargs) or {"choices": []})

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -901,7 +901,17 @@ def load_translator_settings():
     load_sync_story_memory_settings(config)
 
 
-def load_config():
+def _require_gemini_api_key():
+    if API_KEYS:
+        return
+    print("="*60)
+    print("ERROR: No valid API keys found!")
+    print("Please check api_keys.json or set GEMINI_API_KEY env vars.")
+    print("="*60)
+    raise SystemExit("No API keys available")
+
+
+def load_config(*, require_api_key=True):
     """Loads API keys and settings from api_keys.json or environment."""
     global API_KEYS, MODELS, MAX_CHARS, MAX_ITEMS, SYNC_MAX_OUTPUT_TOKENS
     global INCLUDE_FILES, INCLUDE_PREFIXES
@@ -986,12 +996,8 @@ def load_config():
         ]
         API_KEYS = [k for k in env_keys if k]
 
-    if not API_KEYS:
-        print("="*60)
-        print("ERROR: No valid API keys found!")
-        print("Please check api_keys.json or set GEMINI_API_KEY env vars.")
-        print("="*60)
-        raise SystemExit("No API keys available")
+    if require_api_key:
+        _require_gemini_api_key()
 
 
 SCRIPT_FILE_EXTENSIONS = {".rpy", ".rpym", ".rpyc", ".rpymc"}
@@ -3712,13 +3718,19 @@ def collect_tasks(lines, skip_translated=True):
     return tasks
 
 def run_translation():
-    load_config()
+    load_config(require_api_key=False)
     load_translator_settings()
+    if SYNC_BACKEND == "gemini":
+        _require_gemini_api_key()
     load_glossary()
     print("="*60)
-    print("Gemini Translator (Ren'Py)")
+    print("Synchronous Translator (Ren'Py)")
+    print(f"Sync backend: {SYNC_BACKEND}")
     print(f"Models: {MODELS}")
-    print(f"API Keys Loaded: {len(API_KEYS)}")
+    if SYNC_BACKEND == "gemini":
+        print(f"Gemini API Keys Loaded: {len(API_KEYS)}")
+    else:
+        print("Gemini API Key: not required for LiteLLM")
     print(f"Base dir: {BASE_DIR}")
     print(f"TL subdir: {TL_SUBDIR}")
     print(f"TL dir: {TL_DIR} (exists: {os.path.isdir(TL_DIR)})")


### PR DESCRIPTION
## 修复内容

- 同步翻译启动时先加载通用配置，但把 Gemini API Key 校验延后到后端选择完成之后
- LiteLLM 同步后端不再错误要求 api_keys.json 或 GEMINI_API_KEY
- Gemini 同步后端继续保持原有 API Key 强制校验
- 运行日志明确显示当前同步后端，并说明 LiteLLM 不需要 Gemini Key

## 根因

run_translation() 在加载 translator_config.json 的 sync.backend 之前调用 load_config()，旧校验因此无条件按 Gemini 路径退出。

## 验证

- 完整 LiteLLM 测试组：28 项通过
- 相关同步后端测试：15 项通过
- translator_runtime 配置回归：4 项通过
- 隔离 Ren'Py 项目 fake-backend 全流程：5/5 条翻译成功，backend=litellm、Gemini Key=0
- git diff --check


## DeepSeek 真实烟测

- `deepseek/deepseek-v4-flash` 连接及同步翻译成功
- DeepSeek 使用其支持的 `json_object` 模式，避免不支持的严格 `json_schema`
- 隔离 Ren'Py 项目完成 5/5 条翻译，占位符与颜色标签保持不变


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JSON responses across more LiteLLM providers, including compatible handling for schema-based requests.
  * LiteLLM translation runs no longer require Gemini API keys.
  * Gemini translation runs continue to require valid Gemini API keys.
  * Startup messaging now reflects API-key requirements for the selected backend.

* **Tests**
  * Added coverage for provider-specific JSON response handling and backend API-key requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->