### PR TITLE
Prepare v1.0.0 source release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# 变更日志
+
+本项目从 `v1.0.0` 开始记录面向使用者的发行变化。
+
+## [1.0.0] - 2026-07-16
+
+首个稳定源码发行版。
+
+### 主要能力
+
+- 提供 Gemini Batch 主工作流：`doctor -> build -> submit -> status -> download -> check -> apply`。
+- 使用 manifest / identity v2，在写回前执行 `safe / warn / block` 分级与快照校验。
+- 提供可选 PySide6 图形工作台，覆盖项目准备、批量翻译、同步翻译、关键词、订正、上下文库、设置与诊断日志。
+- 提供本地 RAG、原文索引、可选 Story Memory、关键词提取与订正流程。
+- 支持 Gemini 同步调用以及显式选择的 LiteLLM 同步后端。
+
+### 验证范围
+
+- 核心 Batch 链路已在约 11 万英文词规模的真实 Ren'Py 项目上完整跑通。
+- GUI 批量翻译主路径已在约 3,300 待译行的真实项目副本上完成烟测。
+- LiteLLM + DeepSeek 同步路径已完成小规模真实供应商烟测。
+- 自动化测试覆盖 Windows 与 Ubuntu，并单独验证不安装 GUI 依赖时的 CLI 路径。
+
+### 发行边界
+
+- 本版本以源码 ZIP 交付，需要 Python 3.11+，不是零配置安装包。
+- 不包含游戏解包、重新打包或完整游戏 QA。
+- 批量写回前必须先执行 `check`，仅在结果为 `safe` 时执行 `apply`。
+- 同步翻译会直接修改项目副本，不经过 Batch 的 `check -> apply` 闸门。
+
+[1.0.0]: https://github.com/hu-border-collie/renpy-translation-lab/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 一个面向 Ren'Py 视觉小说的翻译工作台，聚焦 Gemini Batch 作业流、上下文增强、轻量 RAG 记忆层和写回前安全校验。
 
-**当前状态：稳定版。** 核心 Batch 流程已经在约 11 万英文词规模的真实 Ren'Py 项目上完整跑通：从预建上下文、生成 Batch 包、提交和下载结果，到 `check` 安全校验、retry 合并和 `apply` 写回。CLI 仍是事实来源和高级用户主路径；仓库另提供稳定的可选图形工作台降低普通流程门槛。当前正式交付方式是从源码安装运行，暂不提供零配置安装包。
+**当前状态：稳定版（v1.0.0）。** 核心 Batch 流程已经在约 11 万英文词规模的真实 Ren'Py 项目上完整跑通：从预建上下文、生成 Batch 包、提交和下载结果，到 `check` 安全校验、retry 合并和 `apply` 写回。CLI 仍是事实来源和高级用户主路径；仓库另提供稳定的可选图形工作台降低普通流程门槛。当前正式交付方式是从源码安装运行，暂不提供零配置安装包。版本变化见 [CHANGELOG.md](CHANGELOG.md)。
 
 ## 这是什么
 
@@ -43,6 +43,8 @@ python -m gui_qt
 ## 快速开始
 
 ### 1. 安装
+
+正式发行版可从 [GitHub Releases](https://github.com/hu-border-collie/renpy-translation-lab/releases) 下载带完整 Git LFS 字体的 `source.zip` 并按随附 SHA-256 文件校验；也可以克隆对应 tag：
 
 ```bash
 git clone https://github.com/hu-border-collie/renpy-translation-lab.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 | 启用 RAG / 原文索引 / 剧情记忆 | [上下文系统](context_systems.md) · [setup.md](setup.md) 中的项目级开关 |
 | 角色关系 / 语义分析 | [关系与语义分析](relation_analysis.md) · [`relation_analyzer/README.md`](../relation_analyzer/README.md) |
 | 项目边界与安全 | [项目说明](project_notes.md) |
+| 查看版本变化 | [变更日志](../CHANGELOG.md) · [v1.0.0 发行说明](releases/v1.0.0.md) |
 | 参与开发 / AI 协作 | 根目录 [CONTRIBUTING.md](../CONTRIBUTING.md)（含 **CLI / GUI 同步**） |
 
 ## 文档分组

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,34 @@
+# Ren'Py Translation Lab v1.0.0
+
+`v1.0.0` 是项目的首个稳定源码发行版，面向熟悉 Ren'Py 项目结构、能够维护本地 Python 环境和检查翻译报告的使用者。
+
+## 下载与校验
+
+请从本 Release 下载：
+
+- `renpy-translation-lab-1.0.0-source.zip`：包含 Git LFS 字体真实内容的源码包。
+- `renpy-translation-lab-1.0.0-source.zip.sha256`：SHA-256 校验文件。
+
+Windows PowerShell 校验命令：
+
+```powershell
+Get-FileHash .\renpy-translation-lab-1.0.0-source.zip -Algorithm SHA256
+Get-Content .\renpy-translation-lab-1.0.0-source.zip.sha256
+```
+
+## 环境与启动
+
+- Python 3.11+
+- 核心依赖：`pip install -r requirements.txt`
+- 可选 GUI：`pip install -r requirements-gui.txt`
+- 可选 LiteLLM：`pip install -r requirements-litellm.txt`
+
+```powershell
+python gemini_translate_batch.py --version
+python gemini_translate_batch.py doctor
+python -m gui_qt
+```
+
+核心能力、验证记录和安全边界见 [CHANGELOG.md](../../CHANGELOG.md) 与 [README.md](../../README.md)。批量写回仍必须遵守 `check=safe -> apply`；首次使用请在项目副本上完成全流程验证。
+
+本版本不提供 `.exe`、安装器、游戏解包/重打包或零配置运行环境。

--- a/gemini_translate.py
+++ b/gemini_translate.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 import argparse
 
+from project_version import __version__
 import translator_runtime as runtime
 from translator_runtime import *  # noqa: F401,F403
 
 
 def build_arg_parser():
-    return argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         description="Synchronous translator for Ren'Py tl files using the google-genai SDK."
     )
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
+    return parser
 
 
 def main(argv=None):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -28,6 +28,7 @@ import translation_ab_experiment
 import story_memory
 import translation_core
 import translator_runtime as runtime
+from project_version import __version__
 from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
 
 try:
@@ -9082,6 +9083,7 @@ def build_arg_parser():
     parser = argparse.ArgumentParser(
         description='Batch translator for Ren\'Py tl files using Gemini Batch API.'
     )
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     subparsers = parser.add_subparsers(dest='command')
 
     subparsers.add_parser('doctor', help='Inspect prepare, SDK, and TL template compatibility without writing files.')

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -55,6 +55,7 @@ from PySide6.QtWidgets import (
     QButtonGroup,
     QToolButton,
 )
+from project_version import __version__
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
 from .responsive_layout import FlowButtonBar, ResponsiveActionPanel
@@ -9544,6 +9545,8 @@ def run_app(argv: list[str] | None = None) -> int:
         argv = sys.argv
 
     app = QApplication(argv)
+    app.setApplicationName("Ren'Py Translation Lab")
+    app.setApplicationVersion(__version__)
     resources_dir = Path(__file__).resolve().parent / "resources"
     project_state = ProjectState()
     try:

--- a/project_version.py
+++ b/project_version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for the project release version."""
+
+__version__ = "1.0.0"

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
 # Optional desktop GUI (PySide6 + custom QSS)
 # Install with: pip install -r requirements-gui.txt
 # The main CLI and core remain usable without this file.
-PySide6>=6.7
+PySide6==6.11.1

--- a/requirements-litellm.txt
+++ b/requirements-litellm.txt
@@ -1,4 +1,4 @@
 # Optional synchronous alternative backend for sync keyword/revision/repair runs.
 # Gemini Batch and the default GUI/CLI do not require this dependency.
-litellm>=1.60.0
-keyring>=25.0.0
+litellm==1.83.7
+keyring==25.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Sync + Batch translator
-google-genai
-numpy
-matplotlib
-scikit-learn
-pillow
+google-genai==1.57.0
+numpy==2.4.2
+matplotlib==3.10.8
+scikit-learn==1.8.0
+pillow==12.0.0

--- a/scripts/build_source_release.py
+++ b/scripts/build_source_release.py
@@ -1,0 +1,189 @@
+"""Build a deterministic source ZIP for a tagged release.
+
+Unlike GitHub's automatically generated source archives, this builder expands
+Git LFS pointers so the bundled GUI fonts are usable after extraction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
+VERSION_RE = re.compile(rb'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', re.MULTILINE)
+LFS_OID_RE = re.compile(rb"^oid sha256:([0-9a-f]{64})$", re.MULTILINE)
+LFS_SIZE_RE = re.compile(rb"^size ([0-9]+)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class TreeEntry:
+    mode: str
+    object_id: str
+    path: str
+
+
+def _git(*args: str, input_bytes: bytes | None = None) -> bytes:
+    completed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        input=input_bytes,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {detail}")
+    return completed.stdout
+
+
+def _tree_entries(ref: str) -> list[TreeEntry]:
+    raw = _git("ls-tree", "-r", "-z", "--full-tree", ref)
+    entries: list[TreeEntry] = []
+    for record in raw.split(b"\0"):
+        if not record:
+            continue
+        metadata, raw_path = record.split(b"\t", 1)
+        mode, object_type, object_id = metadata.decode("ascii").split()
+        if object_type != "blob":
+            continue
+        entries.append(
+            TreeEntry(
+                mode=mode,
+                object_id=object_id,
+                path=raw_path.decode("utf-8", errors="surrogateescape"),
+            )
+        )
+    return sorted(entries, key=lambda item: item.path)
+
+
+def _parse_lfs_pointer(data: bytes) -> tuple[str, int] | None:
+    if not data.startswith(LFS_POINTER_PREFIX):
+        return None
+    oid_match = LFS_OID_RE.search(data)
+    size_match = LFS_SIZE_RE.search(data)
+    if oid_match is None or size_match is None:
+        raise RuntimeError("Malformed Git LFS pointer")
+    return oid_match.group(1).decode("ascii"), int(size_match.group(1))
+
+
+def _expand_lfs(path: str, pointer: bytes) -> bytes:
+    expected = _parse_lfs_pointer(pointer)
+    if expected is None:
+        return pointer
+    expected_oid, expected_size = expected
+    data = _git("lfs", "smudge", "--", path, input_bytes=pointer)
+    actual_oid = hashlib.sha256(data).hexdigest()
+    if len(data) != expected_size or actual_oid != expected_oid:
+        raise RuntimeError(
+            f"Git LFS object verification failed for {path}: "
+            f"expected sha256={expected_oid} size={expected_size}, "
+            f"got sha256={actual_oid} size={len(data)}"
+        )
+    return data
+
+
+def _version_from_blob(data: bytes) -> str:
+    match = VERSION_RE.search(data)
+    if match is None:
+        raise RuntimeError("project_version.py does not contain __version__")
+    return match.group(1).decode("ascii")
+
+
+def _zip_datetime(epoch: int) -> tuple[int, int, int, int, int, int]:
+    # ZIP timestamps cannot represent dates earlier than 1980.
+    return time.gmtime(max(epoch, 315532800))[:6]
+
+
+def _write_entry(
+    archive: zipfile.ZipFile,
+    archive_path: str,
+    data: bytes,
+    *,
+    timestamp: tuple[int, int, int, int, int, int],
+    executable: bool = False,
+) -> None:
+    info = zipfile.ZipInfo(archive_path, date_time=timestamp)
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_DEFLATED
+    permissions = 0o100755 if executable else 0o100644
+    info.external_attr = permissions << 16
+    archive.writestr(info, data, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+
+
+def build_release(ref: str, output_dir: Path) -> tuple[Path, Path, str]:
+    commit = _git("rev-parse", f"{ref}^{{commit}}").decode("ascii").strip()
+    commit_epoch = int(_git("show", "-s", "--format=%ct", commit).decode("ascii").strip())
+    epoch = int(os.environ.get("SOURCE_DATE_EPOCH", commit_epoch))
+    timestamp = _zip_datetime(epoch)
+    entries = _tree_entries(commit)
+
+    version_entry = next((item for item in entries if item.path == "project_version.py"), None)
+    if version_entry is None:
+        raise RuntimeError("project_version.py is missing from the selected ref")
+    version = _version_from_blob(_git("cat-file", "blob", version_entry.object_id))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = f"renpy-translation-lab-{version}-source.zip"
+    archive_path = output_dir / archive_name
+    checksum_path = output_dir / f"{archive_name}.sha256"
+    archive_root = f"renpy-translation-lab-{version}"
+
+    metadata = {
+        "archive_format": 1,
+        "commit": commit,
+        "source_ref": ref,
+        "version": version,
+    }
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for entry in entries:
+            pointer_or_data = _git("cat-file", "blob", entry.object_id)
+            data = _expand_lfs(entry.path, pointer_or_data)
+            _write_entry(
+                archive,
+                f"{archive_root}/{entry.path}",
+                data,
+                timestamp=timestamp,
+                executable=entry.mode == "100755",
+            )
+        _write_entry(
+            archive,
+            f"{archive_root}/RELEASE-METADATA.json",
+            (json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+            timestamp=timestamp,
+        )
+
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    checksum_path.write_text(f"{digest}  {archive_name}\n", encoding="ascii", newline="\n")
+    return archive_path, checksum_path, digest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a source release ZIP with expanded Git LFS files.")
+    parser.add_argument("--ref", default="HEAD", help="Git ref to package (default: HEAD).")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "dist" / "release",
+        help="Directory for the ZIP and checksum.",
+    )
+    args = parser.parse_args(argv)
+    archive_path, checksum_path, digest = build_release(args.ref, args.output_dir)
+    print(f"Source archive: {archive_path}")
+    print(f"Checksum file: {checksum_path}")
+    print(f"SHA-256: {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,42 @@
+import contextlib
+import io
+import unittest
+
+import gemini_translate
+import gemini_translate_batch
+from project_version import __version__
+from scripts import build_source_release
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def test_version_is_semantic_version(self):
+        self.assertRegex(__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_sync_cli_reports_project_version(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            gemini_translate.main(["--version"])
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn(__version__, output.getvalue())
+
+    def test_batch_cli_reports_project_version(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            gemini_translate_batch.main(["--version"])
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn(__version__, output.getvalue())
+
+    def test_release_builder_parses_lfs_pointer(self):
+        pointer = (
+            b"version https://git-lfs.github.com/spec/v1\n"
+            b"oid sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"
+            b"size 123\n"
+        )
+        self.assertEqual(
+            build_source_release._parse_lfs_pointer(pointer),
+            ("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 123),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

- 新增统一版本号 `1.0.0`，并让同步 CLI、Batch CLI 与 GUI 应用元数据读取同一来源
- 新增变更日志与 `v1.0.0` 发行说明，明确源码交付范围和 `check=safe -> apply` 安全边界
- 固定本次已验证的直接依赖版本
- 新增确定性源码 ZIP 构建器：从指定 Git ref 打包、展开 Git LFS 字体、写入发行元数据并生成 SHA-256
- 在 README 和文档地图中加入 Releases/变更日志入口

## 原因

项目功能与文档已经达到稳定版边界，但此前没有版本号、tag、Release、变更日志或可校验的源码发行资产。本 PR 补齐首个源码发行版所需的最小发行工程，不引入 `.exe` 或安装器。

## 验证

- `python -B -m unittest discover -s tests -p "test_*.py" -q` — 1168 passed
- 两次独立执行 `python -B scripts/build_source_release.py --ref HEAD` 得到相同 SHA-256：`b4a4d5a42a00076ee01f48e6edf39f4cb75fa58873a253ebba44478c37f17308`
- ZIP 共 290 个条目，无路径穿越条目
- 两套 Git LFS 字体已展开为真实文件：8,261,128 bytes 与 25,770,536 bytes
- `git diff --cached --check`

合并后将从最新 `main` 创建 `v1.0.0` tag，重新从 tag 构建资产并发布 GitHub Release。