### PR TITLE
Replace bundled LFS fonts with optional official downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-gui_qt/resources/fonts/*.ttf filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -113,7 +112,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ downloads/
 *.tmp
 *.bak
 *.orig
+/gui_qt/resources/fonts/*.ttf
 
 # RAG / memory
 rag_store/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python -m gui_qt
 
 ### 1. 安装
 
-正式发行版可从 [GitHub Releases](https://github.com/hu-border-collie/renpy-translation-lab/releases) 下载带完整 Git LFS 字体的 `source.zip` 并按随附 SHA-256 文件校验；也可以克隆对应 tag：
+正式发行版可从 [GitHub Releases](https://github.com/hu-border-collie/renpy-translation-lab/releases) 下载 `source.zip` 并按随附 SHA-256 文件校验；也可以克隆对应 tag。GUI 推荐字体改为从发布者官方来源按需下载，详见 [GUI 工作台文档](docs/gui_workbench.md#可选字体)。
 
 ```bash
 git clone https://github.com/hu-border-collie/renpy-translation-lab.git

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -30,30 +30,22 @@ python -m gui_qt
 
 如果未安装 PySide6，`python -m gui_qt` 会打印安装提示并退出；这不会影响 CLI。
 
-### 字体（Git LFS）
+### 可选字体
 
-GUI 字体位于 `gui_qt/resources/fonts/`，通过 **Git LFS** 存储（约 32 MB）：
+GUI 推荐使用以下字体，但字体文件不随仓库分发，也不再使用 Git LFS：
 
 - 界面正文：`HarmonyOS Sans SC`（见 `HarmonyOS_Sans_LICENSE.txt`）
 - 等宽区域（项目路径、诊断日志、CLI 命令、任务记录、API Key 列表）：`LXGW WenKai Mono GB`（见 `LXGW_WenKai_OFL.txt`）
 
-克隆仓库后请先安装并拉取 LFS 对象：
+程序未安装字体也能正常启动，并自动回退到系统 `Segoe UI` 与 `Cascadia Mono` / `Consolas`。如需获得一致的中文显示效果，可在 GUI 的「设置 → 外观 → 推荐字体」点击「下载推荐字体」。界面会先说明官方来源与预计流量，再在后台下载、校验并提示重启。
+
+也可以显式运行：
 
 ```powershell
-git lfs install
-git clone <repo-url>
-cd renpy-translation-lab
-git lfs pull
+python scripts/download_gui_fonts.py
 ```
 
-若已克隆过普通 git 仓库，补拉字体：
-
-```powershell
-git lfs install
-git lfs pull
-```
-
-启动 GUI 时自动加载字体；若 LFS 对象缺失或加载失败，会回退到系统 `Segoe UI` 与 `Consolas`。
+下载工具只访问[华为 HarmonyOS 设计资源](https://developer.huawei.com/consumer/cn/design/resource/)和[霞鹜文楷 GB 官方 Release](https://github.com/lxgw/LxgwWenkaiGB/releases)，使用固定版本与 SHA-256 校验后写入当前用户缓存目录。解压华为官方 RAR 包需要系统提供 `tar` 或 `bsdtar`；缺少时工具会明确报错。它不会在首次启动时静默联网；下载完成后重启 GUI 即可加载字体。许可证文本仍保留在 `gui_qt/resources/fonts/`。
 
 ## 主流程
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -189,6 +189,9 @@ from .doctor_report import (
     summarize_doctor_report,
 )
 from .doctor_worker import DoctorWorker, DoctorWorkerResult
+from .font_helpers import optional_fonts_installed, user_fonts_dir
+from .font_worker import FontInstallResult, FontInstallWorker
+
 from .games_registry_actions import handle_post_apply_registry_update
 from .games_registry_panel import GamesRegistryPanel
 from .games_registry_doctor_compare import compare_registry_with_doctor_report
@@ -434,6 +437,7 @@ class MainWindow(QMainWindow):
         self._litellm_latest_requires_python = ""
         self._litellm_catalog_source = ""
         self._litellm_connection_worker: LiteLLMConnectionTestWorker | None = None
+        self._font_install_worker: FontInstallWorker | None = None
         self._litellm_catalog_models: dict[str, tuple[str, ...]] = {}
         self._updating_litellm_provider = False
         self._games_registry_panel: GamesRegistryPanel | None = None
@@ -2379,6 +2383,37 @@ class MainWindow(QMainWindow):
         hint.setObjectName("config_hint_label")
         appearance_layout.addRow("", hint)
         layout.addWidget(appearance_box)
+
+        fonts_box = QGroupBox("推荐字体")
+        fonts_layout = self._settings_form(fonts_box)
+        self.font_install_status_label = QLabel()
+        self.font_install_status_label.setWordWrap(True)
+        self.font_install_status_label.setObjectName("config_hint_label")
+        fonts_layout.addRow("安装状态：", self.font_install_status_label)
+
+        font_actions = QWidget()
+        font_actions_layout = QHBoxLayout(font_actions)
+        font_actions_layout.setContentsMargins(0, 0, 0, 0)
+        font_actions_layout.setSpacing(8)
+        self.download_fonts_btn = QPushButton("下载推荐字体")
+        self.download_fonts_btn.setObjectName("secondary_btn")
+        self.download_fonts_btn.setToolTip(
+            "从华为和霞鹜文楷官方来源下载固定版本字体，并执行 SHA-256 校验。"
+        )
+        self.download_fonts_btn.clicked.connect(self._on_download_recommended_fonts)
+        font_actions_layout.addWidget(self.download_fonts_btn)
+        font_actions_layout.addStretch(1)
+        fonts_layout.addRow("", font_actions)
+
+        self.font_install_progress = QProgressBar()
+        self.font_install_progress.setObjectName("font_install_progress")
+        self.font_install_progress.setRange(0, 0)
+        self.font_install_progress.setFormat("正在后台下载并校验推荐字体…")
+        self.font_install_progress.setVisible(False)
+        fonts_layout.addRow(self.font_install_progress)
+        layout.addWidget(fonts_box)
+        self._refresh_font_install_status()
+
         layout.addStretch(1)
         return page
 
@@ -6648,6 +6683,86 @@ class MainWindow(QMainWindow):
             except TypeError:
                 return str(value)
         return str(value or "")
+
+
+    def _refresh_font_install_status(self) -> None:
+        label = getattr(self, "font_install_status_label", None)
+        button = getattr(self, "download_fonts_btn", None)
+        if label is None:
+            return
+        installed = optional_fonts_installed()
+        if installed:
+            label.setText(
+                f"已安装到 {user_fonts_dir()}。GUI 将使用 HarmonyOS Sans SC 和 "
+                "LXGW WenKai Mono GB。"
+            )
+        else:
+            label.setText(
+                "尚未完整安装推荐字体；当前使用系统字体回退，不影响 GUI 功能。"
+            )
+        if button is not None and getattr(self, "_font_install_worker", None) is None:
+            button.setEnabled(True)
+            button.setText("重新下载推荐字体" if installed else "下载推荐字体")
+
+    def _on_download_recommended_fonts(self) -> None:
+        if getattr(self, "_font_install_worker", None) is not None:
+            return
+        reply = QMessageBox.question(
+            self,
+            "下载推荐字体",
+            (
+                "将从华为官方资源下载 HarmonyOS Sans，并从霞鹜文楷官方 Release "
+                "下载 LXGW WenKai Mono GB。\n\n"
+                "预计下载约 80 MB；下载后会校验 SHA-256，并保存到当前用户缓存目录。"
+                "是否继续？"
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        button = getattr(self, "download_fonts_btn", None)
+        if button is not None:
+            button.setEnabled(False)
+            button.setText("正在下载…")
+        label = getattr(self, "font_install_status_label", None)
+        if label is not None:
+            label.setText("正在从字体发布者的官方来源下载并校验，请稍候…")
+        progress = getattr(self, "font_install_progress", None)
+        if progress is not None:
+            progress.setVisible(True)
+
+        worker = FontInstallWorker(self)
+        worker.completed.connect(self._on_recommended_fonts_downloaded)
+        self._font_install_worker = worker
+        worker.start()
+
+    def _on_recommended_fonts_downloaded(self, result: FontInstallResult) -> None:
+        worker = getattr(self, "_font_install_worker", None)
+        self._font_install_worker = None
+        if worker is not None:
+            worker.deleteLater()
+        progress = getattr(self, "font_install_progress", None)
+        if progress is not None:
+            progress.setVisible(False)
+        self._refresh_font_install_status()
+        if result.ok:
+            self._show_settings_status("推荐字体下载完成；重启 GUI 后生效。", 8000)
+            QMessageBox.information(
+                self,
+                "字体安装完成",
+                "HarmonyOS Sans SC 和 LXGW WenKai Mono GB 已安装。\n"
+                "请重启 GUI 以加载推荐字体。",
+            )
+            return
+        label = getattr(self, "font_install_status_label", None)
+        if label is not None:
+            label.setText(
+                "字体下载失败，GUI 将继续使用系统字体回退。\n"
+                f"错误：{result.error}"
+            )
+        self._show_settings_status("推荐字体下载失败；已继续使用系统字体。", 8000)
 
     def _show_advanced_setting_errors(self, errors: dict[str, str]) -> None:
         labels = getattr(self, "_advanced_setting_error_labels", {})

--- a/gui_qt/font_helpers.py
+++ b/gui_qt/font_helpers.py
@@ -1,8 +1,10 @@
-"""Bundled GUI font loading."""
+"""Optional GUI font loading with system-font fallback."""
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
+import sys
 
 MONO_FONT_SELECTORS = (
     "QListWidget#api_key_list",
@@ -35,6 +37,39 @@ def bundled_fonts_dir(resources_dir: Path) -> Path:
     return resources_dir / "fonts"
 
 
+def user_fonts_dir() -> Path:
+    """Return the per-user directory used by ``download_gui_fonts.py``."""
+    override = os.environ.get("RENPY_TRANSLATION_LAB_FONT_DIR")
+    if override:
+        return Path(override).expanduser()
+    if sys.platform == "win32":
+        cache_root = Path(
+            os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")
+        )
+    elif sys.platform == "darwin":
+        cache_root = Path.home() / "Library" / "Caches"
+    else:
+        cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_root / "renpy-translation-lab" / "fonts"
+
+
+def optional_font_files() -> tuple[Path, Path]:
+    fonts_dir = user_fonts_dir()
+    return fonts_dir / UI_FONT_FILENAME, fonts_dir / MONO_FONT_FILENAME
+
+
+def optional_fonts_installed() -> bool:
+    return all(path.is_file() for path in optional_font_files())
+
+
+def _font_path(resources_dir: Path, filename: str) -> Path:
+    for fonts_dir in (user_fonts_dir(), bundled_fonts_dir(resources_dir)):
+        candidate = fonts_dir / filename
+        if candidate.is_file():
+            return candidate
+    return user_fonts_dir() / filename
+
+
 def _qss_family_name(family: str) -> str:
     escaped = family.replace('"', '\\"')
     return f'"{escaped}"'
@@ -55,9 +90,8 @@ def _load_font_family(font_path: Path) -> str:
 
 
 def load_gui_fonts(resources_dir: Path) -> GuiFontFamilies:
-    fonts_dir = bundled_fonts_dir(resources_dir)
-    ui_family = _load_font_family(fonts_dir / UI_FONT_FILENAME)
-    mono_family = _load_font_family(fonts_dir / MONO_FONT_FILENAME)
+    ui_family = _load_font_family(_font_path(resources_dir, UI_FONT_FILENAME))
+    mono_family = _load_font_family(_font_path(resources_dir, MONO_FONT_FILENAME))
     return GuiFontFamilies(ui_family=ui_family, mono_family=mono_family)
 
 

--- a/gui_qt/font_helpers.py
+++ b/gui_qt/font_helpers.py
@@ -44,12 +44,12 @@ def user_fonts_dir() -> Path:
         return Path(override).expanduser()
     if sys.platform == "win32":
         cache_root = Path(
-            os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")
+            os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local"
         )
     elif sys.platform == "darwin":
         cache_root = Path.home() / "Library" / "Caches"
     else:
-        cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+        cache_root = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
     return cache_root / "renpy-translation-lab" / "fonts"
 
 

--- a/gui_qt/font_worker.py
+++ b/gui_qt/font_worker.py
@@ -1,0 +1,38 @@
+"""Background worker for downloading optional GUI fonts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+
+from scripts.download_gui_fonts import install_fonts
+
+
+@dataclass(frozen=True)
+class FontInstallResult:
+    ok: bool
+    installed: tuple[Path, ...] = ()
+    error: str = ""
+
+
+def run_font_install(destination: Path | None = None) -> FontInstallResult:
+    try:
+        installed = install_fonts(destination) if destination is not None else install_fonts_default()
+        return FontInstallResult(True, tuple(installed))
+    except Exception as exc:
+        return FontInstallResult(False, error=str(exc))
+
+
+def install_fonts_default() -> list[Path]:
+    from gui_qt.font_helpers import user_fonts_dir
+
+    return install_fonts(user_fonts_dir())
+
+
+class FontInstallWorker(QThread):
+    completed = Signal(object)
+
+    def run(self) -> None:
+        self.completed.emit(run_font_install())

--- a/gui_qt/resources/fonts/HarmonyOS_Sans_SC_Regular.ttf
+++ b/gui_qt/resources/fonts/HarmonyOS_Sans_SC_Regular.ttf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:297b088424be212207df2ce8b98e335468b782aa6b96832af0b8b773d711e2b1
-size 8261128

--- a/gui_qt/resources/fonts/LXGWWenKaiMonoGB-Regular.ttf
+++ b/gui_qt/resources/fonts/LXGWWenKaiMonoGB-Regular.ttf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41660b309e42757ea3e757cf358be926c3685e3e2f3f536ffef299002aa1e105
-size 25770536

--- a/scripts/build_source_release.py
+++ b/scripts/build_source_release.py
@@ -1,7 +1,6 @@
 """Build a deterministic source ZIP for a tagged release.
 
-Unlike GitHub's automatically generated source archives, this builder expands
-Git LFS pointers so the bundled GUI fonts are usable after extraction.
+Historical refs may contain Git LFS pointers; those are expanded when present.
 """
 
 from __future__ import annotations
@@ -169,7 +168,7 @@ def build_release(ref: str, output_dir: Path) -> tuple[Path, Path, str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build a source release ZIP with expanded Git LFS files.")
+    parser = argparse.ArgumentParser(description="Build a deterministic source release ZIP.")
     parser.add_argument("--ref", default="HEAD", help="Git ref to package (default: HEAD).")
     parser.add_argument(
         "--output-dir",

--- a/scripts/download_gui_fonts.py
+++ b/scripts/download_gui_fonts.py
@@ -1,0 +1,153 @@
+"""Download optional GUI fonts from their upstream publishers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from gui_qt.font_helpers import (  # noqa: E402
+    MONO_FONT_FILENAME,
+    UI_FONT_FILENAME,
+    user_fonts_dir,
+)
+
+
+HARMONYOS_URL = (
+    "https://developer.huawei.com/Enexport/sites/default/images/download/next/"
+    "HarmonyOS-Sans.rar"
+)
+HARMONYOS_ARCHIVE_SHA256 = "510274fbc12e80abe641d7b0d9bd4d2bb4fec111b7b710122364a7723fe12bd7"
+HARMONYOS_MEMBER = "HarmonyOS-Sans/HarmonyOS_SansSC/HarmonyOS_SansSC_Regular.ttf"
+HARMONYOS_FONT_SHA256 = "984cf609545acee8ef060780fb70fc3099b058c0553416331b6e863fdf7c26fa"
+
+LXGW_VERSION = "v1.522"
+LXGW_URL = (
+    f"https://github.com/lxgw/LxgwWenkaiGB/releases/download/{LXGW_VERSION}/"
+    "LXGWWenKaiMonoGB-Regular.ttf"
+)
+LXGW_FONT_SHA256 = "fb82a0d6b9c0a1a3c83ad303eab1cc998e6a52c1028027fc3527455bdadb4ecb"
+
+
+class FontInstallError(RuntimeError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify(path: Path, expected: str, label: str) -> None:
+    actual = _sha256(path)
+    if actual != expected:
+        raise FontInstallError(
+            f"{label} SHA-256 校验失败：期望 {expected}，实际 {actual}"
+        )
+
+
+def _download(url: str, destination: Path) -> None:
+    request = Request(url, headers={"User-Agent": "renpy-translation-lab/font-installer"})
+    try:
+        with urlopen(request, timeout=120) as response, destination.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    except Exception as exc:
+        raise FontInstallError(f"下载失败：{url}\n{exc}") from exc
+
+
+def _archive_tool() -> str:
+    for name in ("bsdtar", "tar"):
+        executable = shutil.which(name)
+        if executable:
+            return executable
+    raise FontInstallError("找不到 tar 或 bsdtar，无法解压华为官方 RAR 字体包。")
+
+
+def _extract_member(archive: Path, member: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = destination.with_suffix(destination.suffix + ".tmp")
+    try:
+        with temp_path.open("wb") as output:
+            completed = subprocess.run(
+                [_archive_tool(), "-xOf", str(archive), member],
+                stdout=output,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        if completed.returncode != 0:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise FontInstallError(f"无法从华为字体包解压 {member}：{detail}")
+        _verify(temp_path, HARMONYOS_FONT_SHA256, "HarmonyOS Sans SC 字体")
+        os.replace(temp_path, destination)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def install_fonts(destination: Path) -> list[Path]:
+    destination.mkdir(parents=True, exist_ok=True)
+    installed: list[Path] = []
+    with tempfile.TemporaryDirectory(prefix="renpy-fonts-") as temp_dir:
+        temp_root = Path(temp_dir)
+
+        harmony_archive = temp_root / "HarmonyOS-Sans.rar"
+        print("正在从华为官方来源下载 HarmonyOS Sans...")
+        _download(HARMONYOS_URL, harmony_archive)
+        _verify(harmony_archive, HARMONYOS_ARCHIVE_SHA256, "HarmonyOS Sans 官方包")
+        harmony_target = destination / UI_FONT_FILENAME
+        _extract_member(harmony_archive, HARMONYOS_MEMBER, harmony_target)
+        installed.append(harmony_target)
+
+        lxgw_temp = temp_root / MONO_FONT_FILENAME
+        print(f"正在从霞鹜文楷官方 Release 下载 {LXGW_VERSION}...")
+        _download(LXGW_URL, lxgw_temp)
+        _verify(lxgw_temp, LXGW_FONT_SHA256, "LXGW WenKai Mono GB 字体")
+        lxgw_target = destination / MONO_FONT_FILENAME
+        lxgw_stage = lxgw_target.with_suffix(lxgw_target.suffix + ".tmp")
+        try:
+            shutil.copyfile(lxgw_temp, lxgw_stage)
+            _verify(lxgw_stage, LXGW_FONT_SHA256, "LXGW WenKai Mono GB 字体")
+            os.replace(lxgw_stage, lxgw_target)
+        finally:
+            lxgw_stage.unlink(missing_ok=True)
+        installed.append(lxgw_target)
+    return installed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="从字体发布者的官方来源下载并校验可选 GUI 字体。"
+    )
+    parser.add_argument(
+        "--destination",
+        type=Path,
+        default=user_fonts_dir(),
+        help="字体安装目录（默认：当前用户缓存目录）。",
+    )
+    args = parser.parse_args(argv)
+    try:
+        installed = install_fonts(args.destination.expanduser().resolve())
+    except FontInstallError as exc:
+        print(f"字体安装失败：{exc}", file=sys.stderr)
+        return 1
+    print("字体安装完成：")
+    for path in installed:
+        print(f"- {path}")
+    print("请重启 GUI 以加载字体。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_download_gui_fonts.py
+++ b/tests/test_download_gui_fonts.py
@@ -1,0 +1,32 @@
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import download_gui_fonts
+
+
+class DownloadGuiFontsTests(unittest.TestCase):
+    def test_verify_accepts_matching_digest(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "font.ttf"
+            path.write_bytes(b"font data")
+            expected = hashlib.sha256(b"font data").hexdigest()
+            download_gui_fonts._verify(path, expected, "test font")
+
+    def test_verify_rejects_mismatched_digest(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "font.ttf"
+            path.write_bytes(b"font data")
+            with self.assertRaises(download_gui_fonts.FontInstallError):
+                download_gui_fonts._verify(path, "0" * 64, "test font")
+
+    def test_archive_tool_requires_supported_extractor(self):
+        with mock.patch("scripts.download_gui_fonts.shutil.which", return_value=None):
+            with self.assertRaises(download_gui_fonts.FontInstallError):
+                download_gui_fonts._archive_tool()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -1400,6 +1400,110 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(error_label.text, "")
         self.assertEqual(status_bar.messages[-1][0], "已恢复推荐值，保存后生效。")
 
+    def test_download_recommended_fonts_starts_background_worker(self):
+        class FakeWidget:
+            def __init__(self):
+                self.enabled = True
+                self.text = ""
+                self.visible = False
+
+            def setEnabled(self, value):
+                self.enabled = value
+
+            def setText(self, value):
+                self.text = value
+
+            def setVisible(self, value):
+                self.visible = value
+
+        class FakeSignal:
+            def __init__(self):
+                self.callback = None
+
+            def connect(self, callback):
+                self.callback = callback
+
+        class FakeWorker:
+            def __init__(self, parent):
+                self.parent = parent
+                self.completed = FakeSignal()
+                self.started = False
+
+            def start(self):
+                self.started = True
+
+        button = FakeWidget()
+        label = FakeWidget()
+        progress = FakeWidget()
+        self.window._font_install_worker = None
+        self.window.download_fonts_btn = button
+        self.window.font_install_status_label = label
+        self.window.font_install_progress = progress
+
+        from gui_qt.app import QMessageBox
+
+        with (
+            mock.patch(
+                "gui_qt.app.QMessageBox.question",
+                return_value=QMessageBox.StandardButton.Yes,
+            ),
+            mock.patch("gui_qt.app.FontInstallWorker", FakeWorker),
+        ):
+            self.window._on_download_recommended_fonts()
+
+        worker = self.window._font_install_worker
+        self.assertIsInstance(worker, FakeWorker)
+        self.assertTrue(worker.started)
+        self.assertEqual(worker.completed.callback, self.window._on_recommended_fonts_downloaded)
+        self.assertFalse(button.enabled)
+        self.assertEqual(button.text, "正在下载…")
+        self.assertTrue(progress.visible)
+        self.assertIn("正在从字体发布者", label.text)
+
+    def test_recommended_fonts_download_failure_keeps_system_fallback(self):
+        class FakeWidget:
+            def __init__(self):
+                self.text = ""
+                self.visible = True
+
+            def setText(self, value):
+                self.text = value
+
+            def setVisible(self, value):
+                self.visible = value
+
+        class FakeWorker:
+            def __init__(self):
+                self.deleted = False
+
+            def deleteLater(self):
+                self.deleted = True
+
+        worker = FakeWorker()
+        label = FakeWidget()
+        progress = FakeWidget()
+        messages = []
+        self.window._font_install_worker = worker
+        self.window.font_install_status_label = label
+        self.window.font_install_progress = progress
+        self.window._refresh_font_install_status = lambda: None
+        self.window._show_settings_status = lambda message, timeout: messages.append(
+            (message, timeout)
+        )
+
+        from gui_qt.font_worker import FontInstallResult
+
+        self.window._on_recommended_fonts_downloaded(
+            FontInstallResult(False, error="network down")
+        )
+
+        self.assertIsNone(self.window._font_install_worker)
+        self.assertTrue(worker.deleted)
+        self.assertFalse(progress.visible)
+        self.assertIn("系统字体回退", label.text)
+        self.assertIn("network down", label.text)
+        self.assertIn("下载失败", messages[-1][0])
+
     def test_theme_change_previews_without_persisting(self):
         class FakeCombo:
             def currentData(self):

--- a/tests/test_gui_font_helpers.py
+++ b/tests/test_gui_font_helpers.py
@@ -1,13 +1,13 @@
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from gui_qt.font_helpers import (
     GuiFontFamilies,
-    MONO_FONT_FILENAME,
-    UI_FONT_FILENAME,
     build_font_stylesheet,
     bundled_fonts_dir,
     load_gui_fonts,
+    user_fonts_dir,
 )
 
 
@@ -18,12 +18,16 @@ class GuiFontHelpersTests(unittest.TestCase):
     def test_bundled_fonts_dir_points_under_resources(self):
         self.assertEqual(bundled_fonts_dir(self.resources_dir), self.resources_dir / "fonts")
 
-    def test_bundled_font_files_exist(self):
+    def test_font_license_files_exist(self):
         fonts_dir = bundled_fonts_dir(self.resources_dir)
-        self.assertTrue((fonts_dir / UI_FONT_FILENAME).is_file())
-        self.assertTrue((fonts_dir / MONO_FONT_FILENAME).is_file())
         self.assertTrue((fonts_dir / "HarmonyOS_Sans_LICENSE.txt").is_file())
         self.assertTrue((fonts_dir / "LXGW_WenKai_OFL.txt").is_file())
+
+    def test_user_fonts_dir_honors_override(self):
+        with mock.patch.dict(
+            "os.environ", {"RENPY_TRANSLATION_LAB_FONT_DIR": "custom-fonts"}
+        ):
+            self.assertEqual(user_fonts_dir(), Path("custom-fonts"))
 
     def test_build_font_stylesheet_empty_when_no_families(self):
         self.assertEqual(build_font_stylesheet(GuiFontFamilies()), "")
@@ -41,19 +45,11 @@ class GuiFontHelpersTests(unittest.TestCase):
         self.assertNotIn("QTextEdit#workbench_log_view", stylesheet)
         self.assertIn("QLineEdit#global_project_path_edit", stylesheet)
 
-    def test_load_gui_fonts_reads_bundled_files(self):
-        try:
-            from PySide6.QtWidgets import QApplication
-        except ImportError:
-            self.skipTest("PySide6 is not installed")
-
-        app = QApplication.instance()
-        if app is None:
-            app = QApplication([])
-
-        families = load_gui_fonts(self.resources_dir)
-        self.assertEqual(families.ui_family, "HarmonyOS Sans SC")
-        self.assertEqual(families.mono_family, "LXGW WenKai Mono GB")
+    def test_load_gui_fonts_falls_back_cleanly_when_optional_fonts_are_missing(self):
+        with mock.patch("gui_qt.font_helpers._load_font_family", return_value="") as load:
+            families = load_gui_fonts(self.resources_dir)
+        self.assertEqual(families, GuiFontFamilies())
+        self.assertEqual(load.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_font_helpers.py
+++ b/tests/test_gui_font_helpers.py
@@ -29,6 +29,26 @@ class GuiFontHelpersTests(unittest.TestCase):
         ):
             self.assertEqual(user_fonts_dir(), Path("custom-fonts"))
 
+    def test_user_fonts_dir_treats_empty_cache_environment_as_unset(self):
+        cases = (
+            ("win32", "LOCALAPPDATA", Path("home/AppData/Local")),
+            ("linux", "XDG_CACHE_HOME", Path("home/.cache")),
+        )
+        for platform, environment_key, expected_root in cases:
+            with self.subTest(platform=platform), mock.patch.dict(
+                "os.environ",
+                {
+                    "RENPY_TRANSLATION_LAB_FONT_DIR": "",
+                    environment_key: "",
+                },
+            ), mock.patch("gui_qt.font_helpers.sys.platform", platform), mock.patch(
+                "gui_qt.font_helpers.Path.home", return_value=Path("home")
+            ):
+                self.assertEqual(
+                    user_fonts_dir(),
+                    expected_root / "renpy-translation-lab" / "fonts",
+                )
+
     def test_build_font_stylesheet_empty_when_no_families(self):
         self.assertEqual(build_font_stylesheet(GuiFontFamilies()), "")
 

--- a/tests/test_gui_font_worker.py
+++ b/tests/test_gui_font_worker.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gui_qt.font_worker import FontInstallResult, run_font_install
+
+
+class FontWorkerTests(unittest.TestCase):
+    def test_run_font_install_returns_installed_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir)
+            installed = [destination / "ui.ttf", destination / "mono.ttf"]
+            with mock.patch(
+                "gui_qt.font_worker.install_fonts", return_value=installed
+            ) as install:
+                result = run_font_install(destination)
+
+        self.assertEqual(result, FontInstallResult(True, tuple(installed)))
+        install.assert_called_once_with(destination)
+
+    def test_run_font_install_reports_error(self):
+        with mock.patch(
+            "gui_qt.font_worker.install_fonts", side_effect=RuntimeError("network down")
+        ):
+            result = run_font_install(Path("fonts"))
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error, "network down")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_font_worker.py
+++ b/tests/test_gui_font_worker.py
@@ -3,9 +3,16 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from gui_qt.font_worker import FontInstallResult, run_font_install
+try:
+    from gui_qt.font_worker import FontInstallResult, run_font_install
+except ImportError as exc:
+    FontInstallResult = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
 
 
+@unittest.skipIf(FontInstallResult is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
 class FontWorkerTests(unittest.TestCase):
     def test_run_font_install_returns_installed_paths(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- remove the bundled HarmonyOS Sans SC and LXGW WenKai Mono GB Git LFS objects
- stop GitHub Actions from downloading LFS fonts on every GUI/unittest job
- load optional fonts from a per-user cache with safe system-font fallback
- add a Settings > Appearance button that downloads both fonts from their official publishers in a background worker
- pin upstream versions and verify the HarmonyOS archive, extracted font, and LXGW font with SHA-256
- update source-release wording, README, GUI docs, and regression coverage

## Why

The two bundled font objects were downloaded multiple times per workflow run and consumed most of the repository owner's monthly Git LFS bandwidth. Both fonts are optional presentation assets: the GUI already works with system-font fallback.

## User impact

Existing v1.0.0 release assets are unchanged and still contain the bundled fonts. Future source checkouts and releases use system fonts until the user clicks **下载推荐字体** under **设置 → 外观 → 推荐字体** or runs `python scripts/download_gui_fonts.py`. Download failures do not block the GUI.

## Validation

- `python -B tests/run_gui_tests.py -q` — 743 tests OK
- `python -B -m unittest discover -s tests -q` — 1176 tests OK
- real downloads from both official upstreams, SHA-256 verification, extraction, and Qt font-family loading verified
- `git diff --check`
- confirmed both font paths have no Git LFS attributes after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an in-app option to download recommended GUI fonts, with progress and success or failure feedback.
  - Added a command-line font downloader with integrity verification and clear error reporting.
  - GUI fonts now support optional per-user installation with automatic system-font fallback.

- **Documentation**
  - Updated installation and GUI guidance to explain optional font downloads, supported sources, verification, and restart requirements.

- **Chores**
  - Fonts are no longer distributed through Git LFS and are excluded from source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->