### PR TITLE
Add theme-aware Tabler action icons

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -235,6 +235,7 @@ from litellm_provider_config import (
 )
 from .project_state import ProjectState
 from .theme import apply_theme, system_prefers_dark
+from .icon_provider import set_tabler_button_icon
 from .theme_helpers import (
     DEFAULT_THEME_PREFERENCE,
     THEME_DARK,
@@ -469,6 +470,7 @@ class MainWindow(QMainWindow):
         self.tab_widget.tabBar().hide()
         self._populate_shell_nav()
         self._setup_shell_status_bar()
+        self._refresh_action_icons()
 
         self.batch_model_combo.currentTextChanged.connect(self._on_batch_model_changed)
         self.batch_thinking_combo.currentIndexChanged.connect(self._on_batch_thinking_changed)
@@ -2964,6 +2966,89 @@ class MainWindow(QMainWindow):
             resolve_effective_theme(self._theme_preference, system_is_dark=system_is_dark)
             == THEME_DARK
         )
+
+    def _refresh_action_icons(self) -> None:
+        """Apply the restrained Tabler action-icon set for the active theme."""
+        dark = self._effective_theme_is_dark()
+        resources_dir = self._resources_dir
+
+        specs: list[tuple[object, str, str]] = [
+            (getattr(self, "header_log_btn", None), "file-text", "default"),
+            (getattr(self, "global_switch_project_btn", None), "folder-open", "default"),
+            (getattr(self, "global_browse_project_btn", None), "folder-open", "default"),
+            (getattr(self, "doctor_btn", None), "stethoscope", "default"),
+            (getattr(self, "bootstrap_work_btn", None), "folder-cog", "default"),
+            (getattr(self, "translate_btn", None), "language", "on_accent"),
+            (getattr(self, "resume_btn", None), "player-play", "default"),
+            (getattr(self, "kill_btn", None), "player-stop", "danger"),
+            (getattr(self, "apply_btn", None), "file-import", "success"),
+            (getattr(self, "apply_revision_btn", None), "file-import", "success"),
+            (getattr(self, "recheck_btn", None), "refresh", "default"),
+            (getattr(self, "reload_config_btn", None), "refresh", "default"),
+            (getattr(self, "save_config_btn", None), "device-floppy", "on_accent"),
+        ]
+
+        batch_page = getattr(self, "batch_translation_page", None)
+        if batch_page is not None:
+            specs.extend(
+                (
+                    (batch_page.buttons.get("start"), "language", "on_accent"),
+                    (batch_page.buttons.get("resume"), "player-play", "default"),
+                    (batch_page.buttons.get("stop"), "player-stop", "danger"),
+                )
+            )
+
+        sync_page = getattr(self, "sync_translation_page", None)
+        if sync_page is not None:
+            specs.extend(
+                (
+                    (sync_page.start_btn, "language", "on_accent"),
+                    (sync_page.stop_btn, "player-stop", "danger"),
+                )
+            )
+
+        keywords_page = getattr(self, "keywords_page", None)
+        if keywords_page is not None:
+            specs.extend(
+                (
+                    (keywords_page.start_btn, "language", "on_accent"),
+                    (keywords_page.resume_btn, "player-play", "default"),
+                    (keywords_page.stop_btn, "player-stop", "default"),
+                    (keywords_page.merge_btn, "file-import", "default"),
+                )
+            )
+
+        revision_page = getattr(self, "revision_page", None)
+        if revision_page is not None:
+            specs.extend(
+                (
+                    (revision_page.start_btn, "file-text", "on_accent"),
+                    (revision_page.resume_btn, "player-play", "default"),
+                    (revision_page.stop_btn, "player-stop", "default"),
+                    (revision_page.writeback_btn, "file-import", "default"),
+                )
+            )
+
+        context_page = getattr(self, "context_library_page", None)
+        if context_page is not None:
+            specs.extend(
+                (
+                    (context_page.bootstrap_rag_btn, "folder-cog", "on_accent"),
+                    (context_page.bootstrap_source_index_btn, "folder-cog", "on_accent"),
+                    (context_page.open_settings_btn, "folder-cog", "default"),
+                    (context_page.stop_btn, "player-stop", "danger"),
+                )
+            )
+
+        for button, name, role in specs:
+            if isinstance(button, QPushButton):
+                set_tabler_button_icon(
+                    button,
+                    resources_dir,
+                    name,
+                    dark=dark,
+                    role=role,
+                )
 
     def _refresh_split_status_table_after_theme_change(self) -> None:
         self._configure_split_status_table_hover_palette()
@@ -9370,6 +9455,7 @@ class MainWindow(QMainWindow):
         try:
             resources_dir = getattr(self, "_resources_dir", Path(__file__).resolve().parent / "resources")
             apply_theme(qt_app, resources_dir, self._theme_preference)
+            self._refresh_action_icons()
             if hasattr(self, "_log_highlighter"):
                 self._log_highlighter.update_theme(self._effective_theme_is_dark())
             QTimer.singleShot(0, self._refresh_split_status_table_after_theme_change)

--- a/gui_qt/icon_provider.py
+++ b/gui_qt/icon_provider.py
@@ -1,0 +1,86 @@
+"""Theme-aware loading for the vendored Tabler action icons."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, QRectF, QSize, Qt
+from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap
+from PySide6.QtSvg import QSvgRenderer
+from PySide6.QtWidgets import QAbstractButton
+
+from .theme_tokens import DARK_TOKENS, LIGHT_TOKENS
+
+
+_ICON_SUBDIR = Path("icons") / "tabler"
+_ROLE_COLORS = {
+    "default": ("fg_secondary_btn", "fg_button_disabled"),
+    "on_accent": ("fg_on_accent", "fg_button_disabled"),
+    "danger": ("fg_on_accent", "fg_danger_disabled"),
+    "success": ("fg_on_accent", "fg_success_disabled"),
+}
+
+
+def _render_svg(svg: bytes, color: str, *, size: int) -> QPixmap:
+    """Render one SVG color variant at high DPI for a crisp Qt icon."""
+    colored_svg = svg.replace(b"currentColor", color.encode("ascii"))
+    renderer = QSvgRenderer(QByteArray(colored_svg))
+    if not renderer.isValid():
+        return QPixmap()
+
+    scale = 2
+    pixmap = QPixmap(size * scale, size * scale)
+    pixmap.setDevicePixelRatio(scale)
+    pixmap.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pixmap)
+    renderer.render(painter, QRectF(0, 0, size, size))
+    painter.end()
+    return pixmap
+
+
+def tabler_icon(
+    resources_dir: Path,
+    name: str,
+    *,
+    dark: bool,
+    role: str = "default",
+    size: int = 18,
+) -> QIcon:
+    """Return a theme-colored Tabler icon, or a null icon when unavailable."""
+    color_keys = _ROLE_COLORS.get(role)
+    if color_keys is None:
+        raise ValueError(f"Unknown Tabler icon role: {role}")
+
+    source_path = resources_dir / _ICON_SUBDIR / f"{name}.svg"
+    try:
+        svg = source_path.read_bytes()
+    except OSError:
+        return QIcon()
+
+    tokens = DARK_TOKENS if dark else LIGHT_TOKENS
+    normal_color, disabled_color = (tokens[key] for key in color_keys)
+    icon = QIcon()
+    normal = _render_svg(svg, QColor(normal_color).name(), size=size)
+    disabled = _render_svg(svg, QColor(disabled_color).name(), size=size)
+    if not normal.isNull():
+        icon.addPixmap(normal, QIcon.Mode.Normal, QIcon.State.Off)
+        icon.addPixmap(normal, QIcon.Mode.Active, QIcon.State.Off)
+        icon.addPixmap(normal, QIcon.Mode.Selected, QIcon.State.Off)
+        icon.addPixmap(normal, QIcon.Mode.Normal, QIcon.State.On)
+    if not disabled.isNull():
+        icon.addPixmap(disabled, QIcon.Mode.Disabled, QIcon.State.Off)
+        icon.addPixmap(disabled, QIcon.Mode.Disabled, QIcon.State.On)
+    return icon
+
+
+def set_tabler_button_icon(
+    button: QAbstractButton,
+    resources_dir: Path,
+    name: str,
+    *,
+    dark: bool,
+    role: str = "default",
+    size: int = 18,
+) -> None:
+    """Apply one consistently sized Tabler icon to a Qt button."""
+    button.setIcon(tabler_icon(resources_dir, name, dark=dark, role=role, size=size))
+    button.setIconSize(QSize(size, size))

--- a/gui_qt/resources/icons/tabler/LICENSE
+++ b/gui_qt/resources/icons/tabler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gui_qt/resources/icons/tabler/device-floppy.svg
+++ b/gui_qt/resources/icons/tabler/device-floppy.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2" />
+  <path d="M10 14a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+  <path d="M14 4l0 4l-6 0l0 -4" />
+</svg>

--- a/gui_qt/resources/icons/tabler/file-import.svg
+++ b/gui_qt/resources/icons/tabler/file-import.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M5 13v-8a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2h-5.5m-9.5 -2h7m-3 -3l3 3l-3 3" />
+</svg>

--- a/gui_qt/resources/icons/tabler/file-text.svg
+++ b/gui_qt/resources/icons/tabler/file-text.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2" />
+  <path d="M9 9l1 0" /><path d="M9 13l6 0" /><path d="M9 17l6 0" />
+</svg>

--- a/gui_qt/resources/icons/tabler/folder-cog.svg
+++ b/gui_qt/resources/icons/tabler/folder-cog.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12.5 19h-7.5a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2h4l3 3h7a2 2 0 0 1 2 2v3" />
+  <path d="M17.001 19a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+  <path d="M19.001 15.5v1.5" /><path d="M19.001 21v1.5" />
+  <path d="M22.032 17.25l-1.299 .75" /><path d="M17.27 20l-1.3 .75" />
+  <path d="M15.97 17.25l1.3 .75" /><path d="M20.733 20l1.3 .75" />
+</svg>

--- a/gui_qt/resources/icons/tabler/folder-open.svg
+++ b/gui_qt/resources/icons/tabler/folder-open.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 19l2.757 -7.351a1 1 0 0 1 .936 -.649h12.307a1 1 0 0 1 .986 1.164l-.996 5.211a2 2 0 0 1 -1.964 1.625h-14.026a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2h4l3 3h7a2 2 0 0 1 2 2v2" />
+</svg>

--- a/gui_qt/resources/icons/tabler/language.svg
+++ b/gui_qt/resources/icons/tabler/language.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 6.371c0 4.418 -2.239 6.629 -5 6.629" />
+  <path d="M4 6.371h7" /><path d="M5 9c0 2.144 2.252 3.908 6 4" />
+  <path d="M12 20l4 -9l4 9" /><path d="M19.1 18h-6.2" /><path d="M6.694 3l.793 .582" />
+</svg>

--- a/gui_qt/resources/icons/tabler/player-play.svg
+++ b/gui_qt/resources/icons/tabler/player-play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 4v16l13 -8l-13 -8" />
+</svg>

--- a/gui_qt/resources/icons/tabler/player-stop.svg
+++ b/gui_qt/resources/icons/tabler/player-stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 7a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2l0 -10" />
+</svg>

--- a/gui_qt/resources/icons/tabler/refresh.svg
+++ b/gui_qt/resources/icons/tabler/refresh.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+  <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+</svg>

--- a/gui_qt/resources/icons/tabler/stethoscope.svg
+++ b/gui_qt/resources/icons/tabler/stethoscope.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 4h-1a2 2 0 0 0 -2 2v3.5a5.5 5.5 0 0 0 11 0v-3.5a2 2 0 0 0 -2 -2h-1" />
+  <path d="M8 15a6 6 0 1 0 12 0v-3" />
+  <path d="M11 3v2" /><path d="M6 3v2" />
+  <path d="M18 10a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+</svg>

--- a/tests/test_gui_icon_provider.py
+++ b/tests/test_gui_icon_provider.py
@@ -1,0 +1,68 @@
+"""Tests for the vendored, theme-aware Tabler icon provider."""
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+try:
+    from PySide6.QtCore import QSize
+    from PySide6.QtGui import QIcon
+    from PySide6.QtWidgets import QApplication, QPushButton
+
+    from gui_qt.icon_provider import set_tabler_button_icon, tabler_icon
+except ImportError as exc:
+    QApplication = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+from tests import gui_test_support
+
+
+@gui_test_support.skip_unless_gui(QApplication is None, IMPORT_ERROR)
+class GuiIconProviderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = QApplication.instance()
+        cls._app = app or QApplication([])
+        cls._resources = Path(__file__).resolve().parents[1] / "gui_qt" / "resources"
+
+    def test_vendored_icon_renders_in_light_and_dark_themes(self) -> None:
+        light = tabler_icon(self._resources, "language", dark=False)
+        dark = tabler_icon(self._resources, "language", dark=True)
+
+        self.assertFalse(light.isNull())
+        self.assertFalse(dark.isNull())
+        self.assertFalse(light.pixmap(18, 18, QIcon.Mode.Normal).isNull())
+        self.assertFalse(dark.pixmap(18, 18, QIcon.Mode.Disabled).isNull())
+        self.assertNotEqual(
+            light.pixmap(18, 18).cacheKey(),
+            dark.pixmap(18, 18).cacheKey(),
+        )
+
+    def test_button_helper_sets_consistent_icon_size(self) -> None:
+        button = QPushButton("开始翻译")
+
+        set_tabler_button_icon(
+            button,
+            self._resources,
+            "language",
+            dark=False,
+            role="on_accent",
+        )
+
+        self.assertFalse(button.icon().isNull())
+        self.assertEqual(button.iconSize(), QSize(18, 18))
+
+    def test_missing_icon_fails_softly(self) -> None:
+        icon = tabler_icon(self._resources, "does-not-exist", dark=False)
+
+        self.assertTrue(icon.isNull())
+
+    def test_unknown_role_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            tabler_icon(self._resources, "language", dark=False, role="unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_shell_navigation.py
+++ b/tests/test_gui_shell_navigation.py
@@ -76,6 +76,11 @@ class GuiShellNavigationTests(unittest.TestCase):
             self.assertTrue(item.icon().isNull(), route)
             self.assertTrue(item.text(), route)
 
+        # Tabler icons are reserved for actions; navigation stays text-led.
+        self.assertFalse(self.window.header_log_btn.icon().isNull())
+        self.assertFalse(self.window.batch_translation_page.buttons["start"].icon().isNull())
+        self.assertFalse(self.window.save_config_btn.icon().isNull())
+
         self.window._activate_shell_route("project_prepare")
         self.assertFalse(self.window.global_project_bar.isHidden())
 


### PR DESCRIPTION
## Summary

- vendor a focused set of Tabler SVG action icons with the upstream MIT license
- add a shared Qt SVG renderer that applies light/dark theme colors and disabled-state colors
- apply icons to high-value workflow actions while keeping the primary sidebar text-only
- add provider and shell integration coverage

## Why

The GUI currently relies almost entirely on button text. A restrained action-icon layer improves scanning of frequent workflow controls without reintroducing decorative sidebar chrome or changing the information architecture.

## User impact

Core actions such as project selection, environment checks, translation start/stop, writeback, logs, reload, and save now have consistent 18 px Tabler icons. Icons automatically refresh when the GUI theme changes.

## Validation

- `python -B tests/run_gui_tests.py -q` — 748 tests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent Tabler icons to key Qt interface actions.
  * Icons now automatically adapt to light and dark themes.
  * Added contextual icon styling for actions such as success, warning, and danger states.
  * Added icons across navigation, batch, sync, keyword, revision, and context pages.

* **Bug Fixes**
  * Icons refresh automatically when the application theme changes.

* **Tests**
  * Added coverage for themed icons, button sizing, missing icons, and navigation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->