### PR TITLE
Reject tl_subdir escapes and enforce TL_DIR boundary

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -8336,6 +8336,8 @@ def collect_doctor_workflow_state(report):
     """Return a normal workflow state separately from actionable recommendations."""
     if report.get('layout_status') != 'ready':
         return ''
+    if report.get('mode') == 'blocked_invalid_tl_subdir':
+        return ''
     has_tl = int((report.get('counts') or {}).get('rpy_files') or 0) > 0
     if not has_tl:
         return ''
@@ -8354,6 +8356,10 @@ def collect_doctor_workflow_state(report):
 
 def collect_doctor_recommendations(report):
     recommendations = []
+
+    if report.get('mode') == 'blocked_invalid_tl_subdir':
+        # Path escape is a hard config error; surface it via warnings only.
+        return recommendations
 
     layout_status = report.get('layout_status', '')
     if layout_status == 'switch_to_work':
@@ -8762,14 +8768,46 @@ def collect_doctor_project_assets_warnings(project_assets):
 def collect_doctor_report():
     source_game_dir = legacy._guess_source_game_dir()
     template_info = legacy.get_prepare_template_command_info(source_game_dir)
-    counts = collect_tl_doctor_counts()
-    tl_exists = os.path.isdir(legacy.TL_DIR)
-    has_tl_files = counts['rpy_files'] > 0
     can_generate_template = bool(template_info.get('available'))
     original_game_dir = legacy.resolve_original_game_dir()
     work_bootstrap_allowed, work_dir, _ = legacy.work_dir_bootstrap_allowed()
 
     warnings = []
+    tl_path_invalid = False
+    try:
+        legacy.ensure_tl_dir_within_base(
+            legacy.BASE_DIR,
+            legacy.TL_DIR,
+            tl_subdir=legacy.TL_SUBDIR,
+        )
+        legacy.normalize_tl_subdir(legacy.TL_SUBDIR)
+    except Exception as exc:
+        # Catch InvalidTlSubdirError and any unexpected path errors so doctor
+        # still returns a structured report instead of crashing mid-scan.
+        tl_path_invalid = True
+        warnings.append(
+            f'Invalid tl_subdir / TL_DIR boundary: {exc}. '
+            "Fix translator_config.json tl_subdir so it is a relative path under "
+            "game_root with no '..' segments (example: 'game/tl/schinese'). "
+            'Build/apply must not proceed until this is fixed.'
+        )
+
+    # Do not walk TL_DIR when it may escape the project root.
+    if tl_path_invalid:
+        counts = {
+            'rpy_files': 0,
+            'translate_blocks': 0,
+            'string_sections': 0,
+            'old_lines': 0,
+            'new_lines': 0,
+            'commented_original_lines': 0,
+        }
+        tl_exists = False
+        has_tl_files = False
+    else:
+        counts = collect_tl_doctor_counts()
+        tl_exists = os.path.isdir(legacy.TL_DIR)
+        has_tl_files = counts['rpy_files'] > 0
 
     legacy_manifests = []
     if os.path.isdir(BATCH_JOBS_DIR):
@@ -8832,7 +8870,9 @@ def collect_doctor_report():
         else:
             warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
 
-    if has_tl_files:
+    if tl_path_invalid:
+        mode = 'blocked_invalid_tl_subdir'
+    elif has_tl_files:
         mode = 'existing_tl_only'
     elif can_generate_template:
         mode = 'can_generate_template'
@@ -8843,7 +8883,8 @@ def collect_doctor_report():
     pending_file_count = 0
     translated_task_count = 0
     total_task_count = 0
-    if has_tl_files:
+    # Avoid walking a TL tree that may sit outside the project root.
+    if has_tl_files and not tl_path_invalid:
         try:
             file_jobs = collect_pending_file_jobs(include_complete_files=True)
             progress = summarize_translation_progress(file_jobs)

--- a/gui_qt/doctor_worker.py
+++ b/gui_qt/doctor_worker.py
@@ -37,6 +37,11 @@ def run_doctor_check() -> DoctorWorkerResult:
         return DoctorWorkerResult(True, report, buffer.getvalue())
     except Exception as exc:
         return DoctorWorkerResult(False, None, "", f"环境检查失败：{exc}")
+    except SystemExit as exc:
+        # load_translator_settings raises SystemExit for hard config errors
+        # (e.g. tl_subdir escaping the project root).
+        detail = exc.code if isinstance(exc.code, str) else (str(exc) or "配置错误")
+        return DoctorWorkerResult(False, None, "", f"环境检查失败：{detail}")
 
 
 class DoctorWorker(QThread):

--- a/tests/test_gui_doctor_worker.py
+++ b/tests/test_gui_doctor_worker.py
@@ -54,6 +54,15 @@ class GuiDoctorWorkerTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertIn("boom", result.error)
 
+    def test_run_doctor_check_surfaces_systemexit_from_settings(self):
+        with mock.patch(
+            "translator_runtime.load_translator_settings",
+            side_effect=SystemExit("ERROR: Invalid tl_subdir configuration."),
+        ):
+            result = run_doctor_check()
+        self.assertFalse(result.ok)
+        self.assertIn("Invalid tl_subdir", result.error)
+
     def test_worker_delegates_to_run_doctor_check(self):
         worker = DoctorWorker()
         payload = DoctorWorkerResult(True, {"mode": "ready"}, "log")

--- a/tests/test_target_language_config.py
+++ b/tests/test_target_language_config.py
@@ -214,5 +214,157 @@ class TargetLanguageConfigTests(unittest.TestCase):
             self.assertIn('目标语言：japanese', facts)
 
 
+class TlSubdirBoundaryTests(unittest.TestCase):
+    def test_normalize_tl_subdir_accepts_posix_and_windows_relative_paths(self):
+        self.assertEqual(
+            runtime.normalize_tl_subdir('game/tl/japanese'),
+            'game/tl/japanese',
+        )
+        self.assertEqual(
+            runtime.normalize_tl_subdir(r'game\tl\korean'),
+            'game/tl/korean',
+        )
+        self.assertEqual(
+            runtime.normalize_tl_subdir('./game/tl/schinese'),
+            'game/tl/schinese',
+        )
+
+    def test_normalize_tl_subdir_rejects_parent_segments(self):
+        cases = (
+            '../outside',
+            'foo/../../outside',
+            'game/tl/../secret',
+            'game/./tl/schinese',
+            r'game\tl\..\..\outside',
+        )
+        for value in cases:
+            with self.subTest(value=value):
+                with self.assertRaises(runtime.InvalidTlSubdirError):
+                    runtime.normalize_tl_subdir(value)
+
+    def test_normalize_tl_subdir_rejects_absolute_and_drive_paths(self):
+        cases = [
+            '/tmp/game/tl/schinese',
+            r'C:\Games\Example\work\game\tl\schinese',
+            'C:/Games/Example/work/game/tl/schinese',
+            '//server/share/tl',
+            r'\\server\share\tl',
+        ]
+        # POSIX-style absolute on Windows is still absolute for isabs on some paths.
+        for value in cases:
+            with self.subTest(value=value):
+                with self.assertRaises(runtime.InvalidTlSubdirError):
+                    runtime.normalize_tl_subdir(value)
+
+    def test_ensure_tl_dir_within_base_rejects_escape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / 'work'
+            base.mkdir()
+            outside = Path(tmp) / 'outside' / 'tl'
+            outside.mkdir(parents=True)
+            with self.assertRaises(runtime.InvalidTlSubdirError):
+                runtime.ensure_tl_dir_within_base(
+                    str(base),
+                    str(outside),
+                    tl_subdir='../outside/tl',
+                )
+
+    def test_ensure_tl_dir_within_base_allows_nested_tl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / 'work'
+            tl_dir = base / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            runtime.ensure_tl_dir_within_base(
+                str(base),
+                str(tl_dir),
+                tl_subdir='game/tl/schinese',
+            )
+
+    def test_load_translator_settings_rejects_escaping_tl_subdir(self):
+        snapshot = _snapshot_runtime_path_settings()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                work_dir = workspace / 'work'
+                work_dir.mkdir()
+                config = {
+                    'game_root': str(work_dir),
+                    'tl_subdir': 'foo/../../outside',
+                }
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(json.dumps(config), encoding='utf-8')
+
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        runtime.load_translator_settings()
+                message = str(ctx.exception)
+                self.assertIn('Invalid tl_subdir', message)
+                self.assertIn('..', message)
+        finally:
+            _restore_runtime_path_settings(snapshot)
+
+    def test_load_translator_settings_accepts_valid_tl_subdir(self):
+        snapshot = _snapshot_runtime_path_settings()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                work_dir = workspace / 'work'
+                work_dir.mkdir()
+                config = {
+                    'game_root': str(work_dir),
+                    'tl_subdir': r'game\tl\japanese',
+                }
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(json.dumps(config), encoding='utf-8')
+
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    runtime.load_translator_settings()
+
+                self.assertEqual(runtime.TL_SUBDIR, 'game/tl/japanese')
+                self.assertTrue(
+                    runtime._path_contains_path(runtime.BASE_DIR, runtime.TL_DIR)
+                )
+                self.assertTrue(
+                    runtime.TL_DIR.replace('\\', '/').endswith('work/game/tl/japanese')
+                )
+        finally:
+            _restore_runtime_path_settings(snapshot)
+
+    def test_doctor_report_blocks_when_tl_dir_escapes_base(self):
+        with (
+            mock.patch.object(batch_mod.legacy, 'BASE_DIR', 'C:/Games/Example/work'),
+            mock.patch.object(batch_mod.legacy, 'TL_DIR', 'C:/Games/Other/work/game/tl/schinese'),
+            mock.patch.object(batch_mod.legacy, 'TL_SUBDIR', 'game/tl/schinese'),
+            mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+            mock.patch.object(batch_mod.legacy, '_guess_source_game_dir', return_value=''),
+            mock.patch.object(batch_mod.legacy, 'get_prepare_template_command_info', return_value={'available': False}),
+            mock.patch.object(batch_mod.legacy, 'resolve_original_game_dir', return_value=''),
+            mock.patch.object(batch_mod.legacy, 'work_dir_bootstrap_allowed', return_value=(False, '', False)),
+            mock.patch.object(batch_mod, 'collect_doctor_context_status', return_value={}),
+            mock.patch.object(batch_mod, 'collect_doctor_project_assets_status', return_value={}),
+            mock.patch.object(batch_mod, 'collect_doctor_layout_context', return_value={}),
+            mock.patch.object(batch_mod, 'assess_doctor_layout_status', return_value='ok'),
+            mock.patch.object(batch_mod, 'RAG_ENABLED', False),
+            mock.patch('os.path.isdir', return_value=False),
+            mock.patch('os.listdir', return_value=[]),
+        ):
+            report = batch_mod.collect_doctor_report()
+
+        self.assertEqual(report['mode'], 'blocked_invalid_tl_subdir')
+        self.assertTrue(any('Invalid tl_subdir' in warning for warning in report['warnings']))
+        self.assertEqual(report.get('workflow_state') or '', '')
+        self.assertEqual(report.get('recommendations') or [], [])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -295,6 +295,68 @@ def _normalize_rel_path(value):
     return value
 
 
+class InvalidTlSubdirError(ValueError):
+    """Raised when ``tl_subdir`` is not a safe project-relative path."""
+
+
+def normalize_tl_subdir(value):
+    """Normalize and validate ``translator_config.json`` ``tl_subdir``.
+
+    Accepts only relative paths that stay under the project root after join:
+    absolute paths, drive-qualified paths, UNC paths, and any ``.`` / ``..``
+    segment are rejected. Returns a forward-slash relative path.
+    """
+    if value is None:
+        raise InvalidTlSubdirError("tl_subdir is missing")
+
+    original = str(value).strip()
+    if not original:
+        raise InvalidTlSubdirError("tl_subdir is empty")
+
+    text = original.replace("\\", "/")
+
+    # Reject absolute / drive / UNC before stripping roots. On Windows,
+    # os.path.isabs('/tmp/...') can be False, so also reject a leading '/'.
+    if (
+        os.path.isabs(original)
+        or text.startswith("/")
+        or re.match(r"^[A-Za-z]:", text)
+    ):
+        raise InvalidTlSubdirError(
+            f"tl_subdir must be a relative path inside the game root, not absolute: {original!r}"
+        )
+
+    while text.startswith("./"):
+        text = text[2:]
+    if not text or text.startswith("/"):
+        raise InvalidTlSubdirError(
+            f"tl_subdir is empty or absolute after normalization: {original!r}"
+        )
+
+    parts = [part for part in text.split("/") if part]
+    if not parts:
+        raise InvalidTlSubdirError(
+            f"tl_subdir is empty after normalization: {original!r}"
+        )
+    if any(part in {".", ".."} for part in parts):
+        raise InvalidTlSubdirError(
+            "tl_subdir must not contain '.' or '..' path segments "
+            f"(got {original!r}). Use a path relative to game_root such as 'game/tl/schinese'."
+        )
+    return "/".join(parts)
+
+
+def ensure_tl_dir_within_base(base_dir, tl_dir, *, tl_subdir=None):
+    """Require the resolved TL directory to remain inside the project base dir."""
+    if _path_contains_path(base_dir, tl_dir):
+        return
+    detail = f", tl_subdir={tl_subdir!r}" if tl_subdir is not None else ""
+    raise InvalidTlSubdirError(
+        "TL_DIR must remain inside BASE_DIR"
+        f"{detail}: base_dir={base_dir!r}, tl_dir={tl_dir!r}"
+    )
+
+
 def _dedupe_keep_order(items):
     seen = set()
     result = []
@@ -844,10 +906,29 @@ def load_translator_settings():
         GLOSSARY_FILE = DEFAULT_GLOSSARY_FILE
 
     tl_subdir = config.get("tl_subdir")
-    if isinstance(tl_subdir, str) and tl_subdir.strip():
-        TL_SUBDIR = _normalize_rel_path(tl_subdir)
+    try:
+        candidate_subdir = TL_SUBDIR
+        if isinstance(tl_subdir, str) and tl_subdir.strip():
+            candidate_subdir = normalize_tl_subdir(tl_subdir)
+        else:
+            # Keep the active/default value, but re-validate so a previously
+            # accepted path still cannot escape after game_root changes.
+            candidate_subdir = normalize_tl_subdir(candidate_subdir)
+        candidate_tl_dir = _canonical_abs_path(os.path.join(BASE_DIR, candidate_subdir))
+        ensure_tl_dir_within_base(
+            BASE_DIR,
+            candidate_tl_dir,
+            tl_subdir=candidate_subdir,
+        )
+    except InvalidTlSubdirError as exc:
+        raise SystemExit(
+            "ERROR: Invalid tl_subdir configuration. "
+            "tl_subdir must be a relative path under game_root with no '..' segments "
+            f"(example: 'game/tl/schinese'). Details: {exc}"
+        ) from exc
 
-    TL_DIR = _canonical_abs_path(os.path.join(BASE_DIR, TL_SUBDIR))
+    TL_SUBDIR = candidate_subdir
+    TL_DIR = candidate_tl_dir
     WORK_GAME_DIR = _canonical_abs_path(os.path.join(BASE_DIR, WORK_GAME_SUBDIR))
 
     prepare = config.get("prepare")
@@ -1164,7 +1245,9 @@ def _apply_game_root(work_dir):
     normalized = _canonical_abs_path(work_dir)
     ENV_GAME_ROOT = normalized
     BASE_DIR = normalized
-    TL_DIR = _canonical_abs_path(os.path.join(BASE_DIR, TL_SUBDIR))
+    candidate_tl_dir = _canonical_abs_path(os.path.join(BASE_DIR, TL_SUBDIR))
+    ensure_tl_dir_within_base(BASE_DIR, candidate_tl_dir, tl_subdir=TL_SUBDIR)
+    TL_DIR = candidate_tl_dir
     WORK_GAME_DIR = _canonical_abs_path(os.path.join(BASE_DIR, WORK_GAME_SUBDIR))
 
 


### PR DESCRIPTION
## Summary
- Validate `translator_config.json` `tl_subdir` as a project-relative path: reject absolute/drive/UNC paths and any `.` / `..` segments.
- Require the resolved `TL_DIR` to remain inside `BASE_DIR` at settings load and when applying a new game root.
- Make doctor report `blocked_invalid_tl_subdir`, skip walking an escaped TL tree, and surface load-time config errors cleanly in the GUI doctor worker.

## Test plan
- [x] `python -m unittest tests.test_target_language_config -q`
- [x] `python -m unittest tests.test_gui_doctor_worker -q`
- [x] Broader runtime/doctor suite (`tests.test_translator_runtime`, layout/workflow support) passed locally
- [ ] CI green on the PR

Closes #213