### PR TITLE
Atomic writeback for source files and batch artifacts

### DIFF
--- a/atomic_io.py
+++ b/atomic_io.py
@@ -1,0 +1,166 @@
+"""Atomic file writes for translation writeback and batch artifacts.
+
+Pattern matches the RAG store: write to a same-directory temporary file,
+flush + fsync, then ``os.replace`` so readers never observe a truncated file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from typing import Any, Callable, Iterable, TextIO
+
+
+def file_sha256(path: str | os.PathLike[str], *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_text(text: str, *, encoding: str = "utf-8") -> str:
+    return hashlib.sha256(text.encode(encoding)).hexdigest()
+
+
+def atomic_write(
+    path: str | os.PathLike[str],
+    writer: Callable[[TextIO], None],
+    *,
+    encoding: str = "utf-8",
+    newline: str | None = "\n",
+) -> None:
+    """Write text via *writer* and replace *path* atomically.
+
+    Default ``newline='\\n'`` keeps JSON/JSONL bytes stable across platforms so
+    checksums match the in-memory content used when hashing downloads.
+    """
+    target = os.fspath(path)
+    directory = os.path.dirname(os.path.abspath(target)) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(target)}.",
+        suffix=".tmp",
+        dir=directory,
+    )
+    try:
+        # Close via context manager before os.replace (required on Windows).
+        with os.fdopen(fd, "w", encoding=encoding, newline=newline) as handle:
+            writer(handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def atomic_write_text(
+    path: str | os.PathLike[str],
+    text: str,
+    *,
+    encoding: str = "utf-8",
+    newline: str | None = "\n",
+) -> None:
+    def write(handle: TextIO) -> None:
+        handle.write(text)
+
+    atomic_write(path, write, encoding=encoding, newline=newline)
+
+
+def atomic_write_lines(
+    path: str | os.PathLike[str],
+    lines: Iterable[str],
+    *,
+    encoding: str = "utf-8",
+    newline: str | None = "\n",
+) -> None:
+    def write(handle: TextIO) -> None:
+        handle.writelines(lines)
+
+    atomic_write(path, write, encoding=encoding, newline=newline)
+
+
+def atomic_write_json(
+    path: str | os.PathLike[str],
+    payload: Any,
+    *,
+    encoding: str = "utf-8",
+    ensure_ascii: bool = False,
+    indent: int | None = 2,
+    newline: str | None = "\n",
+    **dump_kwargs: Any,
+) -> None:
+    def write(handle: TextIO) -> None:
+        json.dump(
+            payload,
+            handle,
+            ensure_ascii=ensure_ascii,
+            indent=indent,
+            **dump_kwargs,
+        )
+
+    atomic_write(path, write, encoding=encoding, newline=newline)
+
+
+def atomic_write_jsonl(
+    path: str | os.PathLike[str],
+    rows: Iterable[Any],
+    *,
+    encoding: str = "utf-8",
+    ensure_ascii: bool = False,
+    newline: str | None = "\n",
+) -> None:
+    def write(handle: TextIO) -> None:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=ensure_ascii) + "\n")
+
+    atomic_write(path, write, encoding=encoding, newline=newline)
+
+
+def is_complete_jsonl(path: str | os.PathLike[str], *, encoding: str = "utf-8") -> bool:
+    """Return True when *path* is a non-empty JSONL file with parseable lines."""
+    target = os.fspath(path)
+    if not os.path.isfile(target) or os.path.getsize(target) <= 0:
+        return False
+    try:
+        with open(target, "r", encoding=encoding) as handle:
+            saw_line = False
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                saw_line = True
+                json.loads(line)
+            return saw_line
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+
+
+def result_artifact_is_complete(
+    path: str | os.PathLike[str],
+    expected_sha256: str | None = None,
+    *,
+    encoding: str = "utf-8",
+) -> bool:
+    """Validate a downloaded results.jsonl artifact.
+
+    When *expected_sha256* is known (from a previous successful download), require
+    an exact content match. Otherwise require non-empty, parseable JSONL so a
+    truncated mid-write file is not treated as already downloaded.
+    """
+    target = os.fspath(path)
+    if not os.path.isfile(target) or os.path.getsize(target) <= 0:
+        return False
+    if expected_sha256:
+        try:
+            return file_sha256(target) == str(expected_sha256).strip().lower()
+        except OSError:
+            return False
+    return is_complete_jsonl(target, encoding=encoding)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -17,6 +17,14 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
+from atomic_io import (
+    atomic_write_json,
+    atomic_write_jsonl,
+    atomic_write_text,
+    file_sha256,
+    result_artifact_is_complete,
+    sha256_text,
+)
 from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreLockError, hash_text, truncate_text
 import batch_cost_estimate
 import batch_non_chinese_rules
@@ -520,8 +528,7 @@ def load_progress():
 
 def save_progress(progress):
     ensure_batch_dirs()
-    with open(PROGRESS_LOG, 'w', encoding='utf-8') as handle:
-        json.dump(progress, handle, ensure_ascii=False, indent=2)
+    atomic_write_json(PROGRESS_LOG, progress, ensure_ascii=False, indent=2)
 
 
 def update_progress(file_key, translated_lines):
@@ -1542,8 +1549,7 @@ def manifest_path_for_target(target):
 
 def remember_latest_manifest(manifest_path):
     ensure_batch_dirs()
-    with open(LATEST_MANIFEST_FILE, 'w', encoding='utf-8') as handle:
-        handle.write(manifest_path)
+    atomic_write_text(LATEST_MANIFEST_FILE, str(manifest_path))
 
 
 def load_manifest(target=None):
@@ -1644,8 +1650,7 @@ def save_manifest(manifest, update_latest=True):
     data = dict(manifest)
     data.pop('_manifest_path', None)
     data.pop('_package_dir', None)
-    with open(manifest_path, 'w', encoding='utf-8') as handle:
-        json.dump(data, handle, ensure_ascii=False, indent=2)
+    atomic_write_json(manifest_path, data, ensure_ascii=False, indent=2)
     if update_latest:
         remember_latest_manifest(manifest_path)
 
@@ -2020,20 +2025,11 @@ def annotate_failure_entries(entries):
 
 
 def write_json_report(path, payload):
-    directory = os.path.dirname(path)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    with open(path, 'w', encoding='utf-8') as handle:
-        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    atomic_write_json(path, payload, ensure_ascii=False, indent=2)
 
 
 def write_jsonl_report(path, entries):
-    directory = os.path.dirname(path)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    with open(path, 'w', encoding='utf-8') as handle:
-        for entry in entries:
-            handle.write(json.dumps(entry, ensure_ascii=False) + '\n')
+    atomic_write_jsonl(path, entries, ensure_ascii=False)
 
 
 def write_check_failure_report(manifest, failure_entries):
@@ -2287,8 +2283,7 @@ def write_status_snapshot(manifest, batch_job):
         'batch_stats': extract_batch_stats(batch_job),
         'job': serialize_unknown(batch_job),
     }
-    with open(snapshot_path, 'w', encoding='utf-8') as handle:
-        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    atomic_write_json(snapshot_path, payload, ensure_ascii=False, indent=2)
     manifest['last_status_snapshot_path'] = snapshot_path
 
 def collect_files_to_process():
@@ -4385,9 +4380,14 @@ def download_results(target=None, force=False):
         raise SystemExit(f'Batch job is not succeeded yet: {state}')
 
     result_path = resolve_manifest_result_path(manifest)
+    expected_sha = manifest.get('result_jsonl_sha256')
     if os.path.isfile(result_path) and not force:
-        print(f'Result file already exists: {result_path}')
-        return result_path
+        if result_artifact_is_complete(result_path, expected_sha):
+            print(f'Result file already exists: {result_path}')
+            return result_path
+        print(
+            f'Result file looks incomplete or corrupt (will re-download): {result_path}'
+        )
 
     result_file_name = manifest.get('result_file_name')
     if not result_file_name:
@@ -4397,11 +4397,17 @@ def download_results(target=None, force=False):
     print(f'Downloading result file: {result_file_name}')
     downloaded = client.files.download(file=result_file_name)
     text = decode_downloaded_content(downloaded)
+    if not isinstance(text, str):
+        text = str(text)
+    content_sha = sha256_text(text)
 
-    with open(result_path, 'w', encoding='utf-8') as handle:
-        handle.write(text)
+    # Atomic replace so a crash cannot leave a truncated results.jsonl that
+    # later download runs would skip without --force.
+    atomic_write_text(result_path, text)
+    atomic_write_text(f'{result_path}.sha256', content_sha + '\n')
 
     manifest['result_jsonl_path'] = result_path
+    manifest['result_jsonl_sha256'] = content_sha
     manifest['downloaded_at'] = datetime.now().isoformat(timespec='seconds')
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
 
@@ -7627,15 +7633,12 @@ def select_chunk_window(chunks, limit=0, offset=0):
 
 
 def write_request_rows(path, request_rows):
-    with open(path, 'w', encoding='utf-8') as handle:
-        for row in request_rows:
-            handle.write(json.dumps(row, ensure_ascii=False) + '\n')
+    atomic_write_jsonl(path, request_rows, ensure_ascii=False)
 
 
 def write_manifest_file(package_dir, manifest, update_latest=True):
     manifest_path = os.path.join(package_dir, 'manifest.json')
-    with open(manifest_path, 'w', encoding='utf-8') as handle:
-        json.dump(manifest, handle, ensure_ascii=False, indent=2)
+    atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
     if update_latest:
         remember_latest_manifest(manifest_path)
     return manifest_path
@@ -7652,43 +7655,47 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
         'missing_text_count': 0,
         'reason_counts': {},
     }
-    os.makedirs(os.path.dirname(result_path), exist_ok=True)
-    with open(result_path, 'w', encoding='utf-8') as handle:
-        for index, row in enumerate(request_rows, start=1):
-            key = row.get('key', f'sync-{index}')
-            print(f'[{index}/{len(request_rows)}] {key}')
-            result_row = {'key': key}
-            try:
-                result = run_sync_request(
-                    row.get('request') or {},
-                    manifest.get('batch_model') or BATCH_MODEL,
-                    api_key_index=api_key_index,
-                )
-                result_row['response'] = result.get('response_payload') or {}
-                result_row['finish_reason'] = result.get('finish_reason', '')
-                result_row['usage_metadata'] = result.get('usage_metadata') or {}
-                result_row['provider'] = result.get('provider') or SYNC_BACKEND
-                result_row['model'] = result.get('model') or SYNC_MODEL or BATCH_MODEL
-                result_row['execution_mode'] = result.get('execution_mode') or 'sync'
-                summary['successful_request_count'] += 1
-                if result.get('finish_reason') == 'MAX_TOKENS':
-                    summary['max_tokens_count'] += 1
-                    bump_counter(summary['reason_counts'], 'max_tokens')
-                if not result.get('response_text'):
-                    summary['missing_text_count'] += 1
-                    bump_counter(summary['reason_counts'], 'missing_response_text')
-                print(f"  finish_reason: {result.get('finish_reason') or '(none)'}")
-            except Exception as exc:
-                summary['failed_request_count'] += 1
-                bump_counter(summary['reason_counts'], 'request_error')
-                result_row['error'] = str(exc)
-                print(f'  error: {str(exc)[:160]}')
-            handle.write(json.dumps(result_row, ensure_ascii=False) + '\n')
+    result_rows = []
+    for index, row in enumerate(request_rows, start=1):
+        key = row.get('key', f'sync-{index}')
+        print(f'[{index}/{len(request_rows)}] {key}')
+        result_row = {'key': key}
+        try:
+            result = run_sync_request(
+                row.get('request') or {},
+                manifest.get('batch_model') or BATCH_MODEL,
+                api_key_index=api_key_index,
+            )
+            result_row['response'] = result.get('response_payload') or {}
+            result_row['finish_reason'] = result.get('finish_reason', '')
+            result_row['usage_metadata'] = result.get('usage_metadata') or {}
+            result_row['provider'] = result.get('provider') or SYNC_BACKEND
+            result_row['model'] = result.get('model') or SYNC_MODEL or BATCH_MODEL
+            result_row['execution_mode'] = result.get('execution_mode') or 'sync'
+            summary['successful_request_count'] += 1
+            if result.get('finish_reason') == 'MAX_TOKENS':
+                summary['max_tokens_count'] += 1
+                bump_counter(summary['reason_counts'], 'max_tokens')
+            if not result.get('response_text'):
+                summary['missing_text_count'] += 1
+                bump_counter(summary['reason_counts'], 'missing_response_text')
+            print(f"  finish_reason: {result.get('finish_reason') or '(none)'}")
+        except Exception as exc:
+            summary['failed_request_count'] += 1
+            bump_counter(summary['reason_counts'], 'request_error')
+            result_row['error'] = str(exc)
+            print(f'  error: {str(exc)[:160]}')
+        result_rows.append(result_row)
+
+    atomic_write_jsonl(result_path, result_rows, ensure_ascii=False)
+    content_sha = file_sha256(result_path)
+    atomic_write_text(f'{result_path}.sha256', content_sha + '\n')
 
     manifest['sync_completed_at'] = datetime.now().isoformat(timespec='seconds')
     manifest['job_state'] = 'SYNC_COMPLETED' if summary['failed_request_count'] == 0 else 'SYNC_PARTIAL'
     manifest['sync_summary'] = summary
     manifest['result_jsonl_path'] = result_path
+    manifest['result_jsonl_sha256'] = content_sha
     save_manifest(manifest, update_latest=False)
     return manifest
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,181 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import atomic_io
+import gemini_translate_batch as batch_mod
+import translator_runtime as runtime
+
+
+class AtomicIoHelperTests(unittest.TestCase):
+    def test_atomic_write_text_replaces_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'note.txt'
+            path.write_text('old\n', encoding='utf-8')
+            atomic_io.atomic_write_text(path, 'new\n')
+            self.assertEqual(path.read_text(encoding='utf-8'), 'new\n')
+            self.assertEqual(list(Path(tmp).glob('*.tmp')), [])
+
+    def test_atomic_write_preserves_original_when_replace_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'data.json'
+            path.write_text('{"ok": true}\n', encoding='utf-8')
+            with mock.patch.object(atomic_io.os, 'replace', side_effect=OSError('replace failed')):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    atomic_io.atomic_write_json(path, {'ok': False})
+            self.assertEqual(path.read_text(encoding='utf-8'), '{"ok": true}\n')
+            self.assertEqual(list(Path(tmp).glob('*.tmp')), [])
+
+    def test_atomic_write_preserves_original_when_writer_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'script.rpy'
+            path.write_text('old line\n', encoding='utf-8')
+
+            def boom(_handle):
+                raise RuntimeError('disk full')
+
+            with self.assertRaisesRegex(RuntimeError, 'disk full'):
+                atomic_io.atomic_write(path, boom)
+            self.assertEqual(path.read_text(encoding='utf-8'), 'old line\n')
+            self.assertEqual(list(Path(tmp).glob('*.tmp')), [])
+
+    def test_result_artifact_is_complete_requires_valid_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'results.jsonl'
+            path.write_text('', encoding='utf-8')
+            self.assertFalse(atomic_io.result_artifact_is_complete(path))
+
+            path.write_text('{"key": "a"}\nnot-json\n', encoding='utf-8')
+            self.assertFalse(atomic_io.result_artifact_is_complete(path))
+
+            path.write_text('{"key": "a"}\n{"key": "b"}\n', encoding='utf-8')
+            self.assertTrue(atomic_io.result_artifact_is_complete(path))
+
+    def test_result_artifact_is_complete_checks_expected_sha(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'results.jsonl'
+            content = '{"key": "a"}\n'
+            atomic_io.atomic_write_text(path, content)
+            digest = atomic_io.sha256_text(content)
+            self.assertEqual(atomic_io.file_sha256(path), digest)
+            self.assertTrue(atomic_io.result_artifact_is_complete(path, digest))
+            self.assertFalse(atomic_io.result_artifact_is_complete(path, '0' * 64))
+
+
+class CommitReplacementsAtomicTests(unittest.TestCase):
+    def test_commit_replacements_writes_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'script.rpy'
+            original = '    "Hello"\n'
+            path.write_text(original, encoding='utf-8')
+            lines = [original]
+            replacements = {0: [(4, 11, '你好', '', '"')]}
+
+            with mock.patch.object(atomic_io.os, 'replace', side_effect=OSError('replace failed')):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    runtime.commit_replacements(str(path), list(lines), replacements)
+
+            self.assertEqual(path.read_text(encoding='utf-8'), original)
+
+    def test_commit_replacements_updates_file_on_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'script.rpy'
+            lines = ['    "Hello"\n']
+            path.write_text(lines[0], encoding='utf-8')
+            replacements = {0: [(4, 11, '你好', '', '"')]}
+            runtime.commit_replacements(str(path), lines, replacements)
+            self.assertEqual(path.read_text(encoding='utf-8'), '    "你好"\n')
+
+
+class BatchArtifactAtomicTests(unittest.TestCase):
+    def test_save_manifest_preserves_original_on_replace_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            manifest_path = package / 'manifest.json'
+            manifest_path.write_text('{"version": 1}\n', encoding='utf-8')
+            manifest = {
+                '_manifest_path': str(manifest_path),
+                '_package_dir': str(package),
+                'version': 2,
+                'display_name': 'demo',
+            }
+            with mock.patch.object(atomic_io.os, 'replace', side_effect=OSError('replace failed')):
+                with self.assertRaisesRegex(OSError, 'replace failed'):
+                    batch_mod.save_manifest(manifest, update_latest=False)
+            self.assertEqual(manifest_path.read_text(encoding='utf-8'), '{"version": 1}\n')
+
+    def test_download_results_redownloads_incomplete_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            result_path = package / 'results.jsonl'
+            result_path.write_text('{"truncated": true\n', encoding='utf-8')  # invalid JSONL
+            manifest_path = package / 'manifest.json'
+            manifest = {
+                '_manifest_path': str(manifest_path),
+                '_package_dir': str(package),
+                'job_state': 'JOB_STATE_SUCCEEDED',
+                'result_file_name': 'files/demo-result',
+                'result_jsonl_path': str(result_path),
+                'execution': 'sync',
+            }
+            atomic_io.atomic_write_json(manifest_path, {
+                'job_state': 'JOB_STATE_SUCCEEDED',
+                'result_file_name': 'files/demo-result',
+                'result_jsonl_path': str(result_path),
+                'execution': 'sync',
+            })
+
+            class FakeFiles:
+                def download(self, file):
+                    return b'{"key": "ok"}\n'
+
+            class FakeClient:
+                files = FakeFiles()
+
+            with (
+                mock.patch.object(batch_mod, 'load_manifest', return_value=manifest),
+                mock.patch.object(batch_mod, 'refresh_manifest_status', side_effect=lambda m: m),
+                mock.patch.object(batch_mod, 'resolve_manifest_result_path', return_value=str(result_path)),
+                mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()),
+                mock.patch.object(batch_mod, 'save_manifest') as save_mock,
+            ):
+                returned = batch_mod.download_results(force=False)
+
+            self.assertEqual(returned, str(result_path))
+            self.assertEqual(result_path.read_text(encoding='utf-8'), '{"key": "ok"}\n')
+            self.assertTrue((package / 'results.jsonl.sha256').is_file())
+            self.assertEqual(manifest.get('result_jsonl_sha256'), atomic_io.file_sha256(result_path))
+            save_mock.assert_called_once()
+
+    def test_download_results_skips_complete_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            result_path = package / 'results.jsonl'
+            content = '{"key": "ok"}\n'
+            atomic_io.atomic_write_text(result_path, content)
+            digest = atomic_io.sha256_text(content)
+            manifest = {
+                '_manifest_path': str(package / 'manifest.json'),
+                '_package_dir': str(package),
+                'job_state': 'JOB_STATE_SUCCEEDED',
+                'result_file_name': 'files/demo-result',
+                'result_jsonl_sha256': digest,
+            }
+
+            with (
+                mock.patch.object(batch_mod, 'load_manifest', return_value=manifest),
+                mock.patch.object(batch_mod, 'refresh_manifest_status', side_effect=lambda m: m),
+                mock.patch.object(batch_mod, 'resolve_manifest_result_path', return_value=str(result_path)),
+                mock.patch.object(batch_mod, 'create_batch_client') as client_mock,
+            ):
+                returned = batch_mod.download_results(force=False)
+
+            self.assertEqual(returned, str(result_path))
+            client_mock.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -27,6 +27,7 @@ def locked_runtime_state():
     with _runtime_state_lock:
         yield
 
+from atomic_io import atomic_write_json, atomic_write_lines
 from rag_memory import JsonRagStore, hash_text, truncate_text
 import prompt_context
 import story_memory
@@ -2516,8 +2517,7 @@ def load_progress():
 
 def save_progress(progress):
     try:
-        with open(PROGRESS_LOG, "w", encoding="utf-8-sig") as handle:
-            json.dump(progress, handle, ensure_ascii=False, indent=2)
+        atomic_write_json(PROGRESS_LOG, progress, encoding="utf-8-sig", ensure_ascii=False, indent=2)
     except Exception as e:
         print(f"Warning: Could not save progress: {e}")
 
@@ -2612,7 +2612,11 @@ def _upgrade_legacy_progress_keys(progress, file_paths):
 
 
 def commit_replacements(path, lines, replacements):
-    """Writes the replacements to the file."""
+    """Apply replacements in memory, then atomically replace the target file.
+
+    Writes to a same-directory temp file, fsyncs, and uses ``os.replace`` so a
+    crash or I/O error cannot leave a truncated ``.rpy`` behind.
+    """
     if not replacements:
         return
 
@@ -2634,8 +2638,7 @@ def commit_replacements(path, lines, replacements):
             line = line[:start] + quote_with(normalized, quote, prefix=prefix) + line[end:]
         lines[line_idx] = line
 
-    with open(path, "w", encoding="utf-8") as handle:
-        handle.writelines(lines)
+    atomic_write_lines(path, lines, encoding="utf-8")
 
 
 def sync_rag_hash_key(text):


### PR DESCRIPTION
## Summary
- Add shared `atomic_io` helpers: same-directory temp file, flush/fsync, `os.replace`, stable LF newlines for checksum-friendly artifacts.
- **#211**: `commit_replacements` no longer truncates `.rpy` files in place; failed replace leaves the original intact (sync + batch apply).
- **#212**: Atomic writes for `save_manifest`, progress logs, latest-manifest pointer, JSON/JSONL reports, status snapshots, request rows, and downloaded/sync `results.jsonl`.
- Download path records `result_jsonl_sha256` (+ `.sha256` sidecar) and re-downloads incomplete/corrupt artifacts without forcing the user to pass `--force`.

## Test plan
- [x] `python -m unittest tests.test_atomic_io -q`
- [x] `python -m unittest tests.test_batch_repair tests.test_batch_golden_corpus -q`
- [ ] CI green on the PR

Closes #211
Closes #212