### PR TITLE
Treat prepare commands as a trusted execution boundary

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -81,6 +81,8 @@ Game_Example/
 
 不要用 Ren'Py 的 `--empty` 生成空模板。本工具的初译流程需要目标行保留原文，之后再把目标行或 `new` 行替换成中文。
 
+**信任边界：** `translator_config.json` 是**可执行的本地配置**，不只是数据文件。`prepare.unpack_command` / `prepare.template_command` 会在准备阶段在本机运行。推荐使用 **argv 列表**；shell 字符串命令默认拒绝，只有显式设置 `prepare.allow_shell_commands: true` 后才允许（doctor / GUI 会标高风险）。不要加载来源不明的项目配置。
+
 可以通过 `translator_config.json` 或环境变量 `RENPY_SDK_DIR` 指定 SDK 位置；如果没有配置，脚本会尝试在 `game_root` 附近和工具工作区里自动查找 `renpy-*-sdk`：
 
 ```json
@@ -92,7 +94,15 @@ Game_Example/
     "generate_template": true,
     "refresh_existing_template": true,
     "language": "schinese",
-    "renpy_sdk_dir": "C:/RenPy/renpy-8.5.2-sdk"
+    "renpy_sdk_dir": "C:/RenPy/renpy-8.5.2-sdk",
+    "template_command": [
+      "{python_exe}",
+      "{launcher_py}",
+      "{base_dir}",
+      "translate",
+      "{language}"
+    ],
+    "allow_shell_commands": false
   }
 }
 ```

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -8185,11 +8185,7 @@ DOCTOR_STRING_BLOCK_RE = re.compile(r'^translate\s+\S+\s+strings\s*:')
 
 
 def _stringify_command(command):
-    if command is None:
-        return ''
-    if isinstance(command, list):
-        return ' '.join(str(part) for part in command)
-    return str(command)
+    return legacy.describe_prepare_command(command)
 
 
 def collect_tl_doctor_counts():
@@ -8877,6 +8873,27 @@ def collect_doctor_report():
         else:
             warnings.append('Ren\'Py SDK/game launcher not found; existing TL files can still be processed.')
 
+    # Custom prepare commands are a trusted local execution boundary.
+    allow_shell = bool(getattr(legacy, 'PREP_ALLOW_SHELL_COMMANDS', False))
+    shell_command_fields = []
+    if legacy.prepare_command_uses_shell(getattr(legacy, 'PREP_UNPACK_COMMAND', None)):
+        shell_command_fields.append('prepare.unpack_command')
+    if legacy.prepare_command_uses_shell(getattr(legacy, 'PREP_TEMPLATE_COMMAND', None)):
+        shell_command_fields.append('prepare.template_command')
+    if allow_shell:
+        warnings.append(
+            'HIGH RISK: prepare.allow_shell_commands is enabled. '
+            'translator_config.json is executable local configuration and shell-string '
+            'prepare commands can run arbitrary system commands during prepare. '
+            'Prefer argv lists and disable shell mode unless you fully trust this config.'
+        )
+    if shell_command_fields:
+        warnings.append(
+            'HIGH RISK: shell-string prepare command(s) configured: '
+            + ', '.join(shell_command_fields)
+            + '. Resolved commands run under game_root with shell=True.'
+        )
+
     if tl_path_invalid:
         mode = 'blocked_invalid_tl_subdir'
     elif has_tl_files:
@@ -8931,9 +8948,13 @@ def collect_doctor_report():
         'can_generate_template': can_generate_template,
         'template_command_kind': template_info.get('kind', ''),
         'template_command': _stringify_command(template_info.get('command')),
+        'template_command_cwd': template_info.get('cwd', ''),
+        'template_command_shell': bool(template_info.get('shell')),
         'template_reason': template_info.get('reason', ''),
         'python_exe': template_info.get('python_exe', ''),
         'launcher_py': template_info.get('launcher_py', ''),
+        'allow_shell_commands': allow_shell,
+        'shell_prepare_command_fields': list(shell_command_fields),
         'mode': mode,
         'counts': counts,
         'pending_task_count': pending_task_count,
@@ -8988,8 +9009,14 @@ def print_doctor_report(report):
     if report['can_generate_template']:
         print(f"- Template generation: available ({report['template_command_kind']})")
         print(f"- Template command: {report['template_command']}")
+        if report.get('template_command_cwd'):
+            print(f"- Template cwd: {report['template_command_cwd']}")
+        if report.get('template_command_shell'):
+            print('- Template shell: True (HIGH RISK)')
     else:
         print(f"- Template generation: unavailable ({report['template_reason'] or 'no command resolved'})")
+    if report.get('allow_shell_commands'):
+        print('- Allow shell prepare commands: True (HIGH RISK; trusted local config only)')
     print(f"- Mode: {report['mode']}")
     print(f"- Is work root: {report.get('is_work_root', False)}")
     print(

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -650,7 +650,8 @@ FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
         "prepare_unpack_command",
         ("prepare", "unpack_command"),
         "自定义解包命令",
-        "可填命令字符串，或 JSON 数组。留空使用内置解包流程。",
+        "推荐 JSON 数组 argv，例如 [\"python\", \"unpack.py\", \"{archive}\"]。"
+        "字符串形式会走 shell，需同时开启「允许 shell 字符串命令」。留空使用内置解包。",
         "json",
         "",
         "准备流程",
@@ -660,11 +661,22 @@ FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
         "prepare_template_command",
         ("prepare", "template_command"),
         "自定义模板命令",
-        "可填命令字符串，或 JSON 数组。留空使用内置模板流程。",
+        "推荐 JSON 数组 argv，例如 [\"python\", \"{launcher_py}\", \"{base_dir}\", \"translate\", \"{language}\"]。"
+        "字符串形式会走 shell，需同时开启「允许 shell 字符串命令」。留空使用内置模板流程。",
         "json",
         "",
         "准备流程",
         allow_empty=True,
+    ),
+    SettingField(
+        "prepare_allow_shell_commands",
+        ("prepare", "allow_shell_commands"),
+        "允许 shell 字符串命令（高风险）",
+        "开启后，自定义准备命令才可用 shell 字符串执行。"
+        "translator_config.json 视为可执行本地配置；仅在完全信任该配置时启用。默认关闭。",
+        "bool",
+        False,
+        "准备流程",
     ),
     SettingField(
         "batch_retry_chunk_size",

--- a/tests/test_prepare_command_trust.py
+++ b/tests/test_prepare_command_trust.py
@@ -1,0 +1,213 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch_mod
+import translator_runtime as runtime
+
+
+def _snapshot_prepare_settings():
+    return {
+        'PREP_ALLOW_SHELL_COMMANDS': runtime.PREP_ALLOW_SHELL_COMMANDS,
+        'PREP_UNPACK_COMMAND': runtime.PREP_UNPACK_COMMAND,
+        'PREP_TEMPLATE_COMMAND': runtime.PREP_TEMPLATE_COMMAND,
+        'TL_SUBDIR': runtime.TL_SUBDIR,
+        'TL_DIR': runtime.TL_DIR,
+        'BASE_DIR': runtime.BASE_DIR,
+        'WORK_GAME_DIR': runtime.WORK_GAME_DIR,
+        'PREP_LANGUAGE': runtime.PREP_LANGUAGE,
+    }
+
+
+def _restore_prepare_settings(snapshot):
+    for key, value in snapshot.items():
+        setattr(runtime, key, value)
+
+
+class CoercePrepareCommandTests(unittest.TestCase):
+    def test_argv_list_is_preferred_and_accepted(self):
+        cmd = runtime._coerce_command(
+            ['python', 'unpack.py', '{archive}'],
+            field_name='prepare.unpack_command',
+            allow_shell=False,
+        )
+        self.assertEqual(cmd, ['python', 'unpack.py', '{archive}'])
+
+    def test_string_command_rejected_without_shell_opt_in(self):
+        with self.assertRaises(runtime.InvalidPrepareCommandError) as ctx:
+            runtime._coerce_command(
+                'python unpack.py {archive}',
+                field_name='prepare.unpack_command',
+                allow_shell=False,
+            )
+        self.assertIn('allow_shell_commands', str(ctx.exception))
+
+    def test_string_command_allowed_with_shell_opt_in(self):
+        cmd = runtime._coerce_command(
+            'python unpack.py {archive}',
+            field_name='prepare.unpack_command',
+            allow_shell=True,
+        )
+        self.assertEqual(cmd, 'python unpack.py {archive}')
+
+    def test_malformed_command_type_rejected(self):
+        with self.assertRaises(runtime.InvalidPrepareCommandError):
+            runtime._coerce_command(
+                {'bin': 'python'},
+                field_name='prepare.template_command',
+                allow_shell=True,
+            )
+
+    def test_empty_string_is_treated_as_unset(self):
+        self.assertIsNone(
+            runtime._coerce_command('   ', field_name='prepare.unpack_command', allow_shell=False)
+        )
+
+
+class LoadPrepareCommandSettingsTests(unittest.TestCase):
+    def test_load_accepts_argv_commands(self):
+        snapshot = _snapshot_prepare_settings()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                work_dir = workspace / 'work'
+                work_dir.mkdir()
+                config = {
+                    'game_root': str(work_dir),
+                    'prepare': {
+                        'unpack_command': ['python', 'unpack.py', '{archive}'],
+                        'template_command': ['{python_exe}', '{launcher_py}', '{base_dir}', 'translate', '{language}'],
+                        'allow_shell_commands': False,
+                    },
+                }
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(json.dumps(config), encoding='utf-8')
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    runtime.load_translator_settings()
+                self.assertFalse(runtime.PREP_ALLOW_SHELL_COMMANDS)
+                self.assertEqual(runtime.PREP_UNPACK_COMMAND[0], 'python')
+                self.assertIsInstance(runtime.PREP_TEMPLATE_COMMAND, list)
+        finally:
+            _restore_prepare_settings(snapshot)
+
+    def test_load_rejects_shell_string_without_opt_in(self):
+        snapshot = _snapshot_prepare_settings()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                work_dir = workspace / 'work'
+                work_dir.mkdir()
+                config = {
+                    'game_root': str(work_dir),
+                    'prepare': {
+                        'unpack_command': 'python unpack.py',
+                        'allow_shell_commands': False,
+                    },
+                }
+                config_path = workspace / 'translator_config.json'
+                config_path.write_text(json.dumps(config), encoding='utf-8')
+                with (
+                    mock.patch.object(runtime, 'TRANSLATOR_CONFIG', str(config_path)),
+                    mock.patch.object(runtime, 'ROOT_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.object(runtime, 'TOOL_DIR', str(workspace / 'renpy-translation-lab')),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        runtime.load_translator_settings()
+                self.assertIn('Invalid prepare command', str(ctx.exception))
+                self.assertIn('allow_shell_commands', str(ctx.exception))
+        finally:
+            _restore_prepare_settings(snapshot)
+
+
+class RunPrepareCommandTests(unittest.TestCase):
+    def test_run_prints_cwd_and_uses_argv_without_shell(self):
+        completed = mock.Mock(returncode=0)
+        with (
+            mock.patch.object(runtime, 'PREP_ALLOW_SHELL_COMMANDS', False),
+            mock.patch.object(runtime.subprocess, 'run', return_value=completed) as run_mock,
+            mock.patch('builtins.print') as print_mock,
+        ):
+            ok = runtime._run_prepare_command(
+                ['python', 'tool.py'],
+                cwd='/tmp/work',
+                step_name='Custom RPA unpack',
+            )
+        self.assertTrue(ok)
+        run_mock.assert_called_once()
+        args, kwargs = run_mock.call_args
+        self.assertEqual(args[0], ['python', 'tool.py'])
+        self.assertEqual(kwargs['cwd'], '/tmp/work')
+        self.assertFalse(kwargs['shell'])
+        printed = ' '.join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn('cwd: /tmp/work', printed)
+        self.assertIn('shell: False', printed)
+
+    def test_run_refuses_shell_string_without_opt_in(self):
+        with (
+            mock.patch.object(runtime, 'PREP_ALLOW_SHELL_COMMANDS', False),
+            mock.patch.object(runtime.subprocess, 'run') as run_mock,
+            mock.patch('builtins.print'),
+        ):
+            ok = runtime._run_prepare_command('echo hi', cwd='/tmp/work', step_name='Custom')
+        self.assertFalse(ok)
+        run_mock.assert_not_called()
+
+    def test_run_allows_shell_string_with_opt_in(self):
+        completed = mock.Mock(returncode=0)
+        with (
+            mock.patch.object(runtime, 'PREP_ALLOW_SHELL_COMMANDS', True),
+            mock.patch.object(runtime.subprocess, 'run', return_value=completed) as run_mock,
+            mock.patch('builtins.print'),
+        ):
+            ok = runtime._run_prepare_command('echo hi', cwd='/tmp/work', step_name='Custom')
+        self.assertTrue(ok)
+        _args, kwargs = run_mock.call_args
+        self.assertTrue(kwargs['shell'])
+
+
+class DoctorPrepareShellWarningTests(unittest.TestCase):
+    def test_doctor_warns_when_shell_mode_enabled(self):
+        with (
+            mock.patch.object(batch_mod.legacy, 'BASE_DIR', 'C:/Games/Example/work'),
+            mock.patch.object(batch_mod.legacy, 'TL_DIR', 'C:/Games/Example/work/game/tl/schinese'),
+            mock.patch.object(batch_mod.legacy, 'TL_SUBDIR', 'game/tl/schinese'),
+            mock.patch.object(batch_mod.legacy, 'PREP_LANGUAGE', 'schinese'),
+            mock.patch.object(batch_mod.legacy, 'PREP_ALLOW_SHELL_COMMANDS', True),
+            mock.patch.object(batch_mod.legacy, 'PREP_UNPACK_COMMAND', 'python unpack.py'),
+            mock.patch.object(batch_mod.legacy, 'PREP_TEMPLATE_COMMAND', None),
+            mock.patch.object(batch_mod.legacy, '_guess_source_game_dir', return_value=''),
+            mock.patch.object(
+                batch_mod.legacy,
+                'get_prepare_template_command_info',
+                return_value={'available': False, 'kind': 'auto', 'reason': 'missing', 'command': None, 'cwd': ''},
+            ),
+            mock.patch.object(batch_mod.legacy, 'resolve_original_game_dir', return_value=''),
+            mock.patch.object(batch_mod.legacy, 'work_dir_bootstrap_allowed', return_value=(False, '', False)),
+            mock.patch.object(batch_mod, 'collect_doctor_context_status', return_value={}),
+            mock.patch.object(batch_mod, 'collect_doctor_project_assets_status', return_value={}),
+            mock.patch.object(batch_mod, 'collect_doctor_layout_context', return_value={}),
+            mock.patch.object(batch_mod, 'assess_doctor_layout_status', return_value='ok'),
+            mock.patch.object(batch_mod, 'RAG_ENABLED', False),
+            mock.patch('os.path.isdir', return_value=False),
+            mock.patch('os.listdir', return_value=[]),
+        ):
+            report = batch_mod.collect_doctor_report()
+
+        joined = ' '.join(report['warnings'])
+        self.assertTrue(report['allow_shell_commands'])
+        self.assertIn('prepare.unpack_command', report['shell_prepare_command_fields'])
+        self.assertIn('HIGH RISK', joined)
+        self.assertIn('allow_shell_commands', joined)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -16,7 +16,8 @@
     "refresh_existing_template": true,
     "language": "schinese",
     "renpy_sdk_dir": "",
-    "python_exe": ""
+    "python_exe": "",
+    "allow_shell_commands": false
   },
   "sync": {
     "backend": "gemini",

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -68,6 +68,8 @@ PREP_LAUNCHER_PY = ""
 PREP_PYTHON_EXE = ""
 PREP_UNPACK_COMMAND = None
 PREP_TEMPLATE_COMMAND = None
+# String prepare commands run with shell=True only when this opt-in is set.
+PREP_ALLOW_SHELL_COMMANDS = False
 LOG_DIR = os.path.join(ROOT_DIR, "logs")
 FAILED_LOG = os.path.join(LOG_DIR, "translation_failures_v2.jsonl")
 PROGRESS_LOG = os.path.join(LOG_DIR, "translation_progress_v2.json")
@@ -605,22 +607,67 @@ def resolve_story_memory_graph_path(value):
     return _resolve_preferred_path_from_bases(value, (ROOT_DIR, BASE_DIR, TOOL_DIR))
 
 
-def _coerce_command(value):
+class InvalidPrepareCommandError(ValueError):
+    """Raised when a prepare command is malformed or shell mode is not allowed."""
+
+
+def _coerce_command(value, *, field_name="command", allow_shell=False):
+    """Normalize a prepare command to an argv list or (opt-in) shell string.
+
+    Preferred form is a JSON/argv list such as ``["python", "unpack.py"]``.
+    Plain strings are executed with ``shell=True`` only when *allow_shell* is
+    true (``prepare.allow_shell_commands``).
+    """
     if value is None:
         return None
     if isinstance(value, str):
         text = value.strip()
-        return text if text else None
+        if not text:
+            return None
+        if not allow_shell:
+            raise InvalidPrepareCommandError(
+                f"{field_name} is a shell string, but prepare.allow_shell_commands "
+                "is not enabled. Prefer an argv list "
+                '(example: ["python", "script.py", "{base_dir}"]) or set '
+                "prepare.allow_shell_commands to true for trusted local configs only."
+            )
+        return text
     if isinstance(value, list):
         cmd = []
         for item in value:
             if item is None:
                 continue
+            if not isinstance(item, (str, int, float)):
+                raise InvalidPrepareCommandError(
+                    f"{field_name} argv entries must be strings "
+                    f"(got {type(item).__name__})."
+                )
             token = str(item).strip()
             if token:
                 cmd.append(token)
         return cmd or None
-    return None
+    raise InvalidPrepareCommandError(
+        f"{field_name} must be an argv list or (with allow_shell_commands) a string; "
+        f"got {type(value).__name__}."
+    )
+
+
+def describe_prepare_command(command):
+    """Return a single-line display string for logs and doctor reports."""
+    if command is None:
+        return ""
+    if isinstance(command, str):
+        return command
+    if isinstance(command, (list, tuple)):
+        try:
+            return subprocess.list2cmdline([str(part) for part in command])
+        except Exception:
+            return " ".join(str(part) for part in command)
+    return str(command)
+
+
+def prepare_command_uses_shell(command):
+    return isinstance(command, str)
 
 
 def refresh_derived_terms():
@@ -862,6 +909,7 @@ def load_translator_settings():
     global BASE_DIR, TL_DIR, TL_SUBDIR, ENV_GAME_ROOT, WORK_GAME_DIR, SOURCE_GAME_DIR, GLOSSARY_FILE
     global PREP_ENABLED, PREP_UNPACK_RPA, PREP_GENERATE_TEMPLATE, PREP_REFRESH_EXISTING_TEMPLATE, PREP_LANGUAGE
     global PREP_RENPY_SDK_DIR, PREP_LAUNCHER_PY, PREP_PYTHON_EXE, PREP_UNPACK_COMMAND, PREP_TEMPLATE_COMMAND
+    global PREP_ALLOW_SHELL_COMMANDS
 
     config = {}
     if os.path.exists(TRANSLATOR_CONFIG):
@@ -975,8 +1023,25 @@ def load_translator_settings():
     else:
         PREP_PYTHON_EXE = ""
 
-    PREP_UNPACK_COMMAND = _coerce_command(prepare.get("unpack_command"))
-    PREP_TEMPLATE_COMMAND = _coerce_command(prepare.get("template_command"))
+    PREP_ALLOW_SHELL_COMMANDS = _coerce_bool(prepare.get("allow_shell_commands"), False)
+    try:
+        PREP_UNPACK_COMMAND = _coerce_command(
+            prepare.get("unpack_command"),
+            field_name="prepare.unpack_command",
+            allow_shell=PREP_ALLOW_SHELL_COMMANDS,
+        )
+        PREP_TEMPLATE_COMMAND = _coerce_command(
+            prepare.get("template_command"),
+            field_name="prepare.template_command",
+            allow_shell=PREP_ALLOW_SHELL_COMMANDS,
+        )
+    except InvalidPrepareCommandError as exc:
+        raise SystemExit(
+            "ERROR: Invalid prepare command configuration. "
+            "translator_config.json is executable local configuration: custom prepare "
+            "commands can run arbitrary processes. Prefer argv lists and enable "
+            f"prepare.allow_shell_commands only for trusted shell strings. Details: {exc}"
+        ) from exc
     load_include_filters_from_config(config)
     load_sync_translation_settings(config)
     load_sync_rag_settings(config)
@@ -1670,14 +1735,30 @@ def _render_prepare_command(command, variables):
             rendered.append(_fmt(token))
         return rendered, False
 
-    rendered = _fmt(command)
-    return rendered, True
+    if isinstance(command, str):
+        if not PREP_ALLOW_SHELL_COMMANDS:
+            raise RuntimeError(
+                "Shell string prepare commands require prepare.allow_shell_commands=true"
+            )
+        return _fmt(command), True
+
+    raise RuntimeError(f"Unsupported prepare command type: {type(command).__name__}")
 
 
 def _run_prepare_command(command, cwd, step_name):
-    use_shell = isinstance(command, str)
-    shown = command if use_shell else " ".join(command)
-    print(f"[Prepare] {step_name}: {shown}")
+    use_shell = prepare_command_uses_shell(command)
+    if use_shell and not PREP_ALLOW_SHELL_COMMANDS:
+        print(
+            f"[Prepare] {step_name} refused: shell string commands require "
+            "prepare.allow_shell_commands=true (trusted local config only)."
+        )
+        return False
+
+    shown = describe_prepare_command(command)
+    print(f"[Prepare] {step_name}")
+    print(f"[Prepare]   cwd: {cwd}")
+    print(f"[Prepare]   shell: {use_shell}")
+    print(f"[Prepare]   command: {shown}")
 
     try:
         result = subprocess.run(command, cwd=cwd, shell=use_shell, check=False)
@@ -1710,7 +1791,7 @@ def get_prepare_template_command_info(source_game_dir=""):
 
     if PREP_TEMPLATE_COMMAND:
         try:
-            rendered, _ = _render_prepare_command(PREP_TEMPLATE_COMMAND, variables)
+            rendered, use_shell = _render_prepare_command(PREP_TEMPLATE_COMMAND, variables)
         except Exception as e:
             return {
                 "available": False,
@@ -1720,6 +1801,8 @@ def get_prepare_template_command_info(source_game_dir=""):
                 "cwd": BASE_DIR,
                 "python_exe": python_exe,
                 "launcher_py": launcher_py,
+                "shell": False,
+                "allow_shell_commands": PREP_ALLOW_SHELL_COMMANDS,
             }
         return {
             "available": True,
@@ -1729,6 +1812,8 @@ def get_prepare_template_command_info(source_game_dir=""):
             "cwd": BASE_DIR,
             "python_exe": python_exe,
             "launcher_py": launcher_py,
+            "shell": use_shell,
+            "allow_shell_commands": PREP_ALLOW_SHELL_COMMANDS,
         }
 
     if not launcher_py:
@@ -1740,6 +1825,8 @@ def get_prepare_template_command_info(source_game_dir=""):
             "cwd": BASE_DIR,
             "python_exe": python_exe,
             "launcher_py": "",
+            "shell": False,
+            "allow_shell_commands": PREP_ALLOW_SHELL_COMMANDS,
         }
 
     if _is_sdk_launcher(launcher_py):
@@ -1766,6 +1853,8 @@ def get_prepare_template_command_info(source_game_dir=""):
         "cwd": cwd,
         "python_exe": python_exe,
         "launcher_py": launcher_py,
+        "shell": False,
+        "allow_shell_commands": PREP_ALLOW_SHELL_COMMANDS,
     }
 
 


### PR DESCRIPTION
## Summary
- Prefer argv-list custom prepare commands (`unpack_command` / `template_command`).
- Reject shell-string commands unless `prepare.allow_shell_commands` is explicitly enabled.
- Before execution, print resolved command, `cwd`, and whether `shell=True`.
- Doctor and GUI call out the high-risk shell boundary; docs state that `translator_config.json` is executable local configuration.

## Test plan
- [x] `python -m unittest tests.test_prepare_command_trust -q`
- [x] `python -m unittest tests.test_gui_settings_schema tests.test_gui_app_config -q`
- [x] Doctor custom-template error regression still passes
- [ ] CI green on the PR

Closes #214