### PR TITLE
Fix post-merge writeback safety gaps

### DIFF
--- a/atomic_io.py
+++ b/atomic_io.py
@@ -204,6 +204,65 @@ def _cleanup_transaction_entries(entries: Iterable[dict[str, Any]]) -> None:
         _remove_if_present(str(entry.get("backup_path") or ""))
 
 
+def _validate_transaction_journal(
+    payload: Any,
+    journal: str,
+) -> tuple[str, list[dict[str, Any]]]:
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        raise AtomicWriteTransactionError(
+            f"Invalid writeback transaction journal: {journal}"
+        )
+
+    state = payload.get("state")
+    entries = payload.get("entries")
+    if state not in {"prepared", "committed"} or not isinstance(entries, list):
+        raise AtomicWriteTransactionError(
+            f"Invalid writeback transaction journal: {journal}"
+        )
+
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise AtomicWriteTransactionError(
+                f"Invalid entry {index} in writeback transaction journal: {journal}"
+            )
+        target = entry.get("target")
+        staged_path = entry.get("staged_path")
+        backup_path = entry.get("backup_path")
+        existed = entry.get("existed")
+        if (
+            not isinstance(target, str)
+            or not target
+            or not isinstance(staged_path, str)
+            or not staged_path
+            or not isinstance(backup_path, str)
+            or not isinstance(existed, bool)
+            or (existed and not backup_path)
+        ):
+            raise AtomicWriteTransactionError(
+                f"Invalid entry {index} in writeback transaction journal: {journal}"
+            )
+
+    return state, entries
+
+
+def _restore_backup_copy(backup_path: str, target: str) -> None:
+    directory = os.path.dirname(target) or "."
+    fd, restore_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(target)}.",
+        suffix=".txn.restore",
+        dir=directory,
+    )
+    os.close(fd)
+    try:
+        shutil.copy2(backup_path, restore_path)
+        with open(restore_path, "rb+") as handle:
+            os.fsync(handle.fileno())
+        os.replace(restore_path, target)
+    except Exception:
+        _remove_if_present(restore_path)
+        raise
+
+
 def recover_atomic_write_transaction(
     journal_path: str | os.PathLike[str],
 ) -> bool:
@@ -223,19 +282,14 @@ def recover_atomic_write_transaction(
             f"Could not read writeback transaction journal {journal}: {exc}"
         ) from exc
 
-    state = payload.get("state")
-    entries = payload.get("entries")
-    if state not in {"prepared", "committed"} or not isinstance(entries, list):
-        raise AtomicWriteTransactionError(
-            f"Invalid writeback transaction journal: {journal}"
-        )
+    state, entries = _validate_transaction_journal(payload, journal)
 
     if state == "prepared":
         for entry in reversed(entries):
-            target = str(entry.get("target") or "")
-            staged_path = str(entry.get("staged_path") or "")
-            backup_path = str(entry.get("backup_path") or "")
-            existed = bool(entry.get("existed"))
+            target = entry["target"]
+            staged_path = entry["staged_path"]
+            backup_path = entry["backup_path"]
+            existed = entry["existed"]
             # os.replace consumes the staged path. Its absence therefore means
             # this target was already committed before interruption.
             if staged_path and os.path.exists(staged_path):
@@ -245,7 +299,7 @@ def recover_atomic_write_transaction(
                     raise AtomicWriteTransactionError(
                         f"Missing rollback backup for {target}: {backup_path or '(none)'}"
                     )
-                os.replace(backup_path, target)
+                _restore_backup_copy(backup_path, target)
             else:
                 _remove_if_present(target)
 

--- a/atomic_io.py
+++ b/atomic_io.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
+import stat
 import tempfile
 from typing import Any, Callable, Iterable, TextIO
 
@@ -40,6 +42,11 @@ def atomic_write(
     target = os.fspath(path)
     directory = os.path.dirname(os.path.abspath(target)) or "."
     os.makedirs(directory, exist_ok=True)
+    target_mode = None
+    try:
+        target_mode = stat.S_IMODE(os.stat(target).st_mode)
+    except FileNotFoundError:
+        pass
     fd, tmp_path = tempfile.mkstemp(
         prefix=f".{os.path.basename(target)}.",
         suffix=".tmp",
@@ -51,6 +58,8 @@ def atomic_write(
             writer(handle)
             handle.flush()
             os.fsync(handle.fileno())
+        if target_mode is not None:
+            os.chmod(tmp_path, target_mode)
         os.replace(tmp_path, target)
         tmp_path = None
     finally:
@@ -122,6 +131,194 @@ def atomic_write_jsonl(
             handle.write(json.dumps(row, ensure_ascii=ensure_ascii) + "\n")
 
     atomic_write(path, write, encoding=encoding, newline=newline)
+
+
+class AtomicWriteTransactionError(RuntimeError):
+    """Raised when a multi-file atomic-write transaction cannot be recovered."""
+
+
+def _remove_if_present(path: str) -> None:
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+def _stage_lines(
+    path: str,
+    lines: Iterable[str],
+    *,
+    encoding: str,
+    newline: str | None,
+) -> str:
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    target_mode = None
+    try:
+        target_mode = stat.S_IMODE(os.stat(path).st_mode)
+    except FileNotFoundError:
+        pass
+    fd, staged_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".txn.tmp",
+        dir=directory,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding=encoding, newline=newline) as handle:
+            handle.writelines(lines)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if target_mode is not None:
+            os.chmod(staged_path, target_mode)
+        return staged_path
+    except Exception:
+        _remove_if_present(staged_path)
+        raise
+
+
+def _backup_file(path: str) -> str:
+    if not os.path.exists(path):
+        return ""
+    directory = os.path.dirname(path) or "."
+    fd, backup_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".txn.bak",
+        dir=directory,
+    )
+    os.close(fd)
+    try:
+        shutil.copy2(path, backup_path)
+        with open(backup_path, "rb+") as handle:
+            os.fsync(handle.fileno())
+        return backup_path
+    except Exception:
+        _remove_if_present(backup_path)
+        raise
+
+
+def _cleanup_transaction_entries(entries: Iterable[dict[str, Any]]) -> None:
+    for entry in entries:
+        _remove_if_present(str(entry.get("staged_path") or ""))
+        _remove_if_present(str(entry.get("backup_path") or ""))
+
+
+def recover_atomic_write_transaction(
+    journal_path: str | os.PathLike[str],
+) -> bool:
+    """Recover an interrupted multi-file write transaction.
+
+    Prepared transactions are rolled back. Committed transactions only need
+    leftover temporary files removed. Returns True when a journal was found.
+    """
+    journal = os.path.abspath(os.fspath(journal_path))
+    if not os.path.isfile(journal):
+        return False
+    try:
+        with open(journal, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AtomicWriteTransactionError(
+            f"Could not read writeback transaction journal {journal}: {exc}"
+        ) from exc
+
+    state = payload.get("state")
+    entries = payload.get("entries")
+    if state not in {"prepared", "committed"} or not isinstance(entries, list):
+        raise AtomicWriteTransactionError(
+            f"Invalid writeback transaction journal: {journal}"
+        )
+
+    if state == "prepared":
+        for entry in reversed(entries):
+            target = str(entry.get("target") or "")
+            staged_path = str(entry.get("staged_path") or "")
+            backup_path = str(entry.get("backup_path") or "")
+            existed = bool(entry.get("existed"))
+            # os.replace consumes the staged path. Its absence therefore means
+            # this target was already committed before interruption.
+            if staged_path and os.path.exists(staged_path):
+                continue
+            if existed:
+                if not backup_path or not os.path.isfile(backup_path):
+                    raise AtomicWriteTransactionError(
+                        f"Missing rollback backup for {target}: {backup_path or '(none)'}"
+                    )
+                os.replace(backup_path, target)
+            else:
+                _remove_if_present(target)
+
+    _cleanup_transaction_entries(entries)
+    _remove_if_present(journal)
+    return True
+
+
+def atomic_write_many_lines(
+    writes: Iterable[tuple[str | os.PathLike[str], Iterable[str]]],
+    *,
+    journal_path: str | os.PathLike[str],
+    encoding: str = "utf-8",
+    newline: str | None = "\n",
+) -> None:
+    """Replace multiple text files as one recoverable writeback transaction.
+
+    All target contents are staged and backed up before the first replacement.
+    A replacement failure rolls back every already-replaced target. A surviving
+    ``prepared`` journal is likewise rolled back on the next invocation.
+    """
+    journal = os.path.abspath(os.fspath(journal_path))
+    recover_atomic_write_transaction(journal)
+    normalized_writes = [
+        (os.path.abspath(os.fspath(path)), lines)
+        for path, lines in writes
+    ]
+    if not normalized_writes:
+        return
+
+    entries: list[dict[str, Any]] = []
+    journal_written = False
+    try:
+        for target, lines in normalized_writes:
+            existed = os.path.exists(target)
+            staged_path = _stage_lines(
+                target,
+                lines,
+                encoding=encoding,
+                newline=newline,
+            )
+            try:
+                backup_path = _backup_file(target)
+            except Exception:
+                _remove_if_present(staged_path)
+                raise
+            entries.append(
+                {
+                    "target": target,
+                    "staged_path": staged_path,
+                    "backup_path": backup_path,
+                    "existed": existed,
+                }
+            )
+
+        payload = {"version": 1, "state": "prepared", "entries": entries}
+        atomic_write_json(journal, payload, ensure_ascii=False, indent=2)
+        journal_written = True
+
+        for entry in entries:
+            os.replace(entry["staged_path"], entry["target"])
+
+        payload["state"] = "committed"
+        atomic_write_json(journal, payload, ensure_ascii=False, indent=2)
+    except Exception:
+        if journal_written:
+            recover_atomic_write_transaction(journal)
+        else:
+            _cleanup_transaction_entries(entries)
+        raise
+
+    _cleanup_transaction_entries(entries)
+    _remove_if_present(journal)
 
 
 def is_complete_jsonl(path: str | os.PathLike[str], *, encoding: str = "utf-8") -> bool:

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -20,9 +20,11 @@ if SCRIPT_DIR not in sys.path:
 from atomic_io import (
     atomic_write_json,
     atomic_write_jsonl,
+    atomic_write_many_lines,
     atomic_write_text,
     file_sha256,
     result_artifact_is_complete,
+    recover_atomic_write_transaction,
     sha256_text,
 )
 from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreLockError, hash_text, truncate_text
@@ -6254,6 +6256,12 @@ def apply_results(target=None, force=False):
     if manifest.get('applied_at') and not force:
         raise SystemExit('Manifest was already applied. Re-run apply with --force to bypass this guard; source validation still applies.')
     require_manifest_project_match(manifest, 'apply')
+
+    transaction_path = os.path.join(
+        manifest['_package_dir'],
+        '.apply_writeback_transaction.json',
+    )
+    recover_atomic_write_transaction(transaction_path)
     require_safe_check_for_apply(manifest)
 
     replacements_by_file, translated_lines_by_file, failure_entries, summary = collect_result_actions(
@@ -6325,11 +6333,29 @@ def apply_results(target=None, force=False):
         save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
         raise SystemExit(f'Apply refused because source revalidation is not safe. Report: {report_path}')
 
+    writeback_files = []
+    for file_key, replacements in revalidated_replacements_by_file.items():
+        if not replacements:
+            continue
+        writeback_files.append(
+            (
+                revalidated_file_paths[file_key],
+                legacy.render_replacement_lines(
+                    revalidated_file_lines[file_key],
+                    replacements,
+                ),
+            )
+        )
+    if writeback_files:
+        atomic_write_many_lines(
+            writeback_files,
+            journal_path=transaction_path,
+            encoding='utf-8',
+        )
+
     for file_key, replacements in revalidated_replacements_by_file.items():
         file_path = revalidated_file_paths[file_key]
         lines = revalidated_file_lines[file_key]
-        if replacements:
-            legacy.commit_replacements(file_path, lines, replacements)
         line_numbers = sorted(revalidated_line_numbers_by_file[file_key])
         update_progress(file_key, line_numbers)
         applied_files += 1
@@ -6380,6 +6406,13 @@ def apply_revisions(target=None, force=False):
     if manifest.get('revision_applied_at') and not force:
         raise SystemExit('Revision manifest was already applied. Re-run apply-revisions with --force to bypass this guard; source validation still applies.')
 
+    require_manifest_project_match(manifest, 'apply-revisions')
+    transaction_path = os.path.join(
+        manifest['_package_dir'],
+        '.revision_writeback_transaction.json',
+    )
+    recover_atomic_write_transaction(transaction_path)
+
     replacements_by_file, _revised_lines_by_file, failure_entries, summary, preview_entries = collect_revision_actions(
         manifest,
         validate_sources=True,
@@ -6390,6 +6423,8 @@ def apply_revisions(target=None, force=False):
     final_pending_files = 0
     final_pending_lines = 0
     rag_jobs = []
+    writeback_files = []
+    revision_updates = []
     for file_key, replacements in replacements_by_file.items():
         file_info = manifest['files'].get(file_key)
         if not file_info:
@@ -6413,8 +6448,20 @@ def apply_revisions(target=None, force=False):
         if not replacements and not line_numbers_set:
             continue
         if replacements:
-            legacy.commit_replacements(file_path, lines, replacements)
+            writeback_files.append(
+                (file_path, legacy.render_replacement_lines(lines, replacements))
+            )
         line_numbers = sorted(line_numbers_set)
+        revision_updates.append((file_key, line_numbers, file_path))
+
+    if writeback_files:
+        atomic_write_many_lines(
+            writeback_files,
+            journal_path=transaction_path,
+            encoding='utf-8',
+        )
+
+    for file_key, line_numbers, file_path in revision_updates:
         update_progress(file_key, line_numbers)
         applied_files += 1
         applied_lines += len(line_numbers)

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -172,8 +172,144 @@ class AtomicIoHelperTests(unittest.TestCase):
             self.assertFalse(backup.exists())
             self.assertFalse(journal.exists())
 
+    def test_recover_rejects_malformed_journal_before_rollback(self):
+        malformed_payloads = [
+            [],
+            {'version': 2, 'state': 'prepared', 'entries': []},
+            {'version': 1, 'state': 'prepared', 'entries': ['invalid']},
+            {
+                'version': 1,
+                'state': 'prepared',
+                'entries': [
+                    {
+                        'target': 'target.rpy',
+                        'staged_path': 'staged.tmp',
+                        'backup_path': 'backup.bak',
+                        'existed': 1,
+                    }
+                ],
+            },
+        ]
+
+        for payload in malformed_payloads:
+            with self.subTest(payload=payload), tempfile.TemporaryDirectory() as tmp:
+                journal = Path(tmp) / 'writeback-transaction.json'
+                journal.write_text(json.dumps(payload), encoding='utf-8')
+
+                with self.assertRaises(atomic_io.AtomicWriteTransactionError):
+                    atomic_io.recover_atomic_write_transaction(journal)
+
+                self.assertTrue(journal.exists())
+
+    def test_recover_validates_all_entries_before_mutating_targets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / 'created.rpy'
+            journal = root / 'writeback-transaction.json'
+            target.write_text('keep\n', encoding='utf-8')
+            journal.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'state': 'prepared',
+                        'entries': [
+                            {
+                                'target': 123,
+                                'staged_path': 'invalid.tmp',
+                                'backup_path': '',
+                                'existed': False,
+                            },
+                            {
+                                'target': str(target),
+                                'staged_path': str(root / 'consumed.tmp'),
+                                'backup_path': '',
+                                'existed': False,
+                            },
+                        ],
+                    }
+                ),
+                encoding='utf-8',
+            )
+
+            with self.assertRaises(atomic_io.AtomicWriteTransactionError):
+                atomic_io.recover_atomic_write_transaction(journal)
+
+            self.assertEqual(target.read_text(encoding='utf-8'), 'keep\n')
+            self.assertTrue(journal.exists())
+
+    def test_recover_prepared_transaction_is_retryable_after_partial_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / 'first.rpy'
+            second = root / 'second.rpy'
+            first_backup = root / '.first.rpy.demo.txn.bak'
+            second_backup = root / '.second.rpy.demo.txn.bak'
+            first_staged = root / '.first.rpy.demo.txn.tmp'
+            second_staged = root / '.second.rpy.demo.txn.tmp'
+            journal = root / 'writeback-transaction.json'
+            first.write_text('first new\n', encoding='utf-8')
+            second.write_text('second new\n', encoding='utf-8')
+            first_backup.write_text('first old\n', encoding='utf-8')
+            second_backup.write_text('second old\n', encoding='utf-8')
+            journal.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'state': 'prepared',
+                        'entries': [
+                            {
+                                'target': str(second),
+                                'staged_path': str(second_staged),
+                                'backup_path': str(second_backup),
+                                'existed': True,
+                            },
+                            {
+                                'target': str(first),
+                                'staged_path': str(first_staged),
+                                'backup_path': str(first_backup),
+                                'existed': True,
+                            },
+                        ],
+                    }
+                ),
+                encoding='utf-8',
+            )
+            real_replace = atomic_io.os.replace
+
+            def fail_second_restore(source, destination):
+                if os.path.abspath(os.fspath(destination)) == os.path.abspath(second):
+                    raise OSError('second restore failed')
+                return real_replace(source, destination)
+
+            with mock.patch.object(
+                atomic_io.os,
+                'replace',
+                side_effect=fail_second_restore,
+            ):
+                with self.assertRaisesRegex(OSError, 'second restore failed'):
+                    atomic_io.recover_atomic_write_transaction(journal)
+
+            self.assertEqual(first.read_text(encoding='utf-8'), 'first old\n')
+            self.assertEqual(second.read_text(encoding='utf-8'), 'second new\n')
+            self.assertTrue(first_backup.exists())
+            self.assertTrue(second_backup.exists())
+            self.assertTrue(journal.exists())
+
+            self.assertTrue(atomic_io.recover_atomic_write_transaction(journal))
+            self.assertEqual(first.read_text(encoding='utf-8'), 'first old\n')
+            self.assertEqual(second.read_text(encoding='utf-8'), 'second old\n')
+            self.assertFalse(first_backup.exists())
+            self.assertFalse(second_backup.exists())
+            self.assertFalse(journal.exists())
+
 
 class CommitReplacementsAtomicTests(unittest.TestCase):
+    def test_render_replacement_lines_skips_inverted_range(self):
+        lines = ['    "Hello"\n']
+        replacements = {0: [(11, 4, '你好', '', '"')]}
+
+        self.assertEqual(runtime.render_replacement_lines(lines, replacements), lines)
+
     def test_commit_replacements_writes_atomically(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / 'script.rpy'

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -64,6 +64,114 @@ class AtomicIoHelperTests(unittest.TestCase):
             self.assertTrue(atomic_io.result_artifact_is_complete(path, digest))
             self.assertFalse(atomic_io.result_artifact_is_complete(path, '0' * 64))
 
+    @unittest.skipIf(os.name == 'nt', 'POSIX mode bits are not available on Windows')
+    def test_atomic_write_preserves_existing_file_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'script.rpy'
+            path.write_text('old\n', encoding='utf-8')
+            path.chmod(0o644)
+
+            atomic_io.atomic_write_text(path, 'new\n')
+
+            self.assertEqual(path.stat().st_mode & 0o777, 0o644)
+
+    def test_atomic_write_many_lines_commits_all_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / 'first.rpy'
+            second = root / 'second.rpy'
+            journal = root / 'writeback-transaction.json'
+            first.write_text('first old\n', encoding='utf-8')
+            second.write_text('second old\n', encoding='utf-8')
+
+            atomic_io.atomic_write_many_lines(
+                [
+                    (first, ['first new\n']),
+                    (second, ['second new\n']),
+                ],
+                journal_path=journal,
+            )
+
+            self.assertEqual(first.read_text(encoding='utf-8'), 'first new\n')
+            self.assertEqual(second.read_text(encoding='utf-8'), 'second new\n')
+            self.assertFalse(journal.exists())
+            self.assertEqual(list(root.glob('*.txn.*')), [])
+
+    def test_atomic_write_many_lines_rolls_back_prior_replacements(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / 'first.rpy'
+            second = root / 'second.rpy'
+            journal = root / 'writeback-transaction.json'
+            first.write_text('first old\n', encoding='utf-8')
+            second.write_text('second old\n', encoding='utf-8')
+            real_replace = atomic_io.os.replace
+            failed = False
+
+            def fail_second_staged_replace(source, destination):
+                nonlocal failed
+                if (
+                    not failed
+                    and os.path.abspath(os.fspath(destination)) == os.path.abspath(second)
+                    and str(source).endswith('.txn.tmp')
+                ):
+                    failed = True
+                    raise OSError('second replace failed')
+                return real_replace(source, destination)
+
+            with mock.patch.object(
+                atomic_io.os,
+                'replace',
+                side_effect=fail_second_staged_replace,
+            ):
+                with self.assertRaisesRegex(OSError, 'second replace failed'):
+                    atomic_io.atomic_write_many_lines(
+                        [
+                            (first, ['first new\n']),
+                            (second, ['second new\n']),
+                        ],
+                        journal_path=journal,
+                    )
+
+            self.assertEqual(first.read_text(encoding='utf-8'), 'first old\n')
+            self.assertEqual(second.read_text(encoding='utf-8'), 'second old\n')
+            self.assertFalse(journal.exists())
+            self.assertEqual(list(root.glob('*.txn.*')), [])
+
+    def test_recover_prepared_transaction_rolls_back_consumed_stage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / 'script.rpy'
+            backup = root / '.script.rpy.demo.txn.bak'
+            staged = root / '.script.rpy.demo.txn.tmp'
+            journal = root / 'writeback-transaction.json'
+            target.write_text('new\n', encoding='utf-8')
+            backup.write_text('old\n', encoding='utf-8')
+            journal.write_text(
+                json.dumps(
+                    {
+                        'version': 1,
+                        'state': 'prepared',
+                        'entries': [
+                            {
+                                'target': str(target),
+                                'staged_path': str(staged),
+                                'backup_path': str(backup),
+                                'existed': True,
+                            }
+                        ],
+                    }
+                ),
+                encoding='utf-8',
+            )
+
+            recovered = atomic_io.recover_atomic_write_transaction(journal)
+
+            self.assertTrue(recovered)
+            self.assertEqual(target.read_text(encoding='utf-8'), 'old\n')
+            self.assertFalse(backup.exists())
+            self.assertFalse(journal.exists())
+
 
 class CommitReplacementsAtomicTests(unittest.TestCase):
     def test_commit_replacements_writes_atomically(self):

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -31,8 +31,37 @@ UPDATE_GOLDEN_REVISION_ENV = 'UPDATE_GOLDEN_REVISION'
 UPDATE_GOLDEN_KEYWORD_ENV = 'UPDATE_GOLDEN_KEYWORD'
 
 
-
 class BatchRepairRegressionTests(unittest.TestCase):
+    def test_apply_revisions_rejects_mismatched_active_project(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = {
+                'mode': batch_mod.MANIFEST_MODE_REVISION,
+                'base_dir': str(root / 'project-a'),
+                'tl_dir': str(root / 'project-a' / 'game' / 'tl' / 'schinese'),
+            }
+            with (
+                mock.patch.object(batch_mod, 'load_manifest', return_value=manifest),
+                mock.patch.object(
+                    batch_mod.legacy,
+                    'BASE_DIR',
+                    str(root / 'project-b'),
+                ),
+                mock.patch.object(
+                    batch_mod.legacy,
+                    'TL_DIR',
+                    str(root / 'project-b' / 'game' / 'tl' / 'schinese'),
+                ),
+                mock.patch.object(batch_mod, 'collect_revision_actions') as collect_mock,
+            ):
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    'manifest project does not match the active project',
+                ):
+                    batch_mod.apply_revisions('manifest.json')
+
+            collect_mock.assert_not_called()
+
     def test_parse_json_payload_recovers_prefixed_keyword_object(self):
         payload = batch_mod.parse_json_payload(
             'Earlier attempt: []\n'

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2716,7 +2716,7 @@ def render_replacement_lines(lines, replacements):
                 prefix = ""
             else:
                 start, end, translated, prefix, quote = repl[:5]
-            if start < 0 or end > len(line):
+            if start < 0 or end > len(line) or start > end:
                 continue
             normalized = apply_normalization(translated) if USE_TRANSLATION_MEMORY else translated
             line = line[:start] + quote_with(normalized, quote, prefix=prefix) + line[end:]

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2700,6 +2700,30 @@ def _upgrade_legacy_progress_keys(progress, file_paths):
     return progress
 
 
+def render_replacement_lines(lines, replacements):
+    """Return replacement output without modifying the caller's source lines."""
+    rendered = list(lines)
+    if not replacements:
+        return rendered
+
+    for line_idx, repls in replacements.items():
+        if line_idx >= len(rendered):
+            continue
+        line = rendered[line_idx]
+        for repl in sorted(repls, key=lambda x: x[0], reverse=True):
+            if len(repl) == 4:
+                start, end, translated, quote = repl
+                prefix = ""
+            else:
+                start, end, translated, prefix, quote = repl[:5]
+            if start < 0 or end > len(line):
+                continue
+            normalized = apply_normalization(translated) if USE_TRANSLATION_MEMORY else translated
+            line = line[:start] + quote_with(normalized, quote, prefix=prefix) + line[end:]
+        rendered[line_idx] = line
+    return rendered
+
+
 def commit_replacements(path, lines, replacements):
     """Apply replacements in memory, then atomically replace the target file.
 
@@ -2709,25 +2733,9 @@ def commit_replacements(path, lines, replacements):
     if not replacements:
         return
 
-    for line_idx, repls in replacements.items():
-        if line_idx >= len(lines):
-            continue
-        line = lines[line_idx]
-        # Sort replacements by start position descending to avoid index shifting
-        for repl in sorted(repls, key=lambda x: x[0], reverse=True):
-            if len(repl) == 4:
-                start, end, translated, quote = repl
-                prefix = ""
-            else:
-                start, end, translated, prefix, quote = repl[:5]
-            # Safety check indices
-            if start < 0 or end > len(line):
-                continue
-            normalized = apply_normalization(translated) if USE_TRANSLATION_MEMORY else translated
-            line = line[:start] + quote_with(normalized, quote, prefix=prefix) + line[end:]
-        lines[line_idx] = line
-
-    atomic_write_lines(path, lines, encoding="utf-8")
+    rendered = render_replacement_lines(lines, replacements)
+    lines[:] = rendered
+    atomic_write_lines(path, rendered, encoding="utf-8")
 
 
 def sync_rag_hash_key(text):


### PR DESCRIPTION
## Summary

- preserve existing POSIX mode bits when atomic writes replace source and artifact files
- reject `apply-revisions` when the manifest project differs from the active project
- stage and back up all source files before batch/revision writeback, using a transaction journal to roll back partial replacements or recover an interrupted prepared transaction
- share replacement rendering between single-file and transactional writeback paths

## Root cause

The post-merge review of PRs #219-#223 found three remaining gaps: `mkstemp` mode bits replaced the original file mode, the revision apply path missed the new project-identity gate, and per-file atomic replacement still allowed a multi-file apply to stop after only some targets had changed.

## Impact

Writeback now preserves existing file permissions, refuses cross-project revision apply before reading results or writing files, and keeps source files all-old or all-new when a later replacement fails. Prepared transaction journals are rolled back on recovery; committed journals only clean up leftovers.

## Validation

- `python -B -m unittest tests.test_atomic_io tests.test_translator_runtime -q` — 118 passed, 1 Windows-only POSIX test skipped
- `python -B -m unittest tests.test_batch_repair tests.test_batch_golden_corpus -q` — 46 passed
- `python -B tests/run_cli_tests.py -q` — 474 passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 749 passed
- WSL POSIX mode smoke — existing `0644` remains `0644`
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added journaled multi-file writeback with crash recovery and automatic rollback.
  * Translation and revision outputs now write via atomic batch mode to prevent partial updates.
* **Bug Fixes**
  * File permission bits are preserved when updating existing files.
  * Replacement rendering no longer mutates the original input text.
  * Added validation to reject applying revisions to a mismatched project.
* **Tests**
  * Expanded coverage for permission preservation, transaction commit/rollback, recovery cleanup/retry, malformed journal handling, and replacement range skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->