### PR TITLE
Bound RPA decompression and extraction resources

### DIFF
--- a/relation_analyzer/common.py
+++ b/relation_analyzer/common.py
@@ -10,8 +10,14 @@ import re
 import sys
 import time
 import tokenize
-import zlib
 from pathlib import Path
+
+from rpa_safety import (
+    DEFAULT_RPA_LIMITS,
+    decode_and_validate_index,
+    read_bounded_compressed_index,
+    read_member_bytes,
+)
 
 # ====== 路径 ======
 MODULE_DIR = Path(__file__).resolve().parent
@@ -288,75 +294,66 @@ class _RestrictedUnpickler(pickle.Unpickler):
 def load_pickle_blob(blob):
     return _RestrictedUnpickler(io.BytesIO(blob)).load()
 
-def read_rpa_index(archive_path):
+def read_rpa_index(archive_path, limits=DEFAULT_RPA_LIMITS):
     archive_path = str(archive_path)
-    cached = _ARCHIVE_INDEX_CACHE.get(archive_path)
+    stat = os.stat(archive_path)
+    cache_key = (archive_path, stat.st_size, stat.st_mtime_ns, limits)
+    cached = _ARCHIVE_INDEX_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
     with open(archive_path, 'rb') as infile:
+        archive_size = os.fstat(infile.fileno()).st_size
         header = infile.read(40)
 
         if header.startswith(b'RPA-3.0 '):
             offset = int(header[8:24], 16)
             key = int(header[25:33], 16)
-            infile.seek(offset)
-            raw_index = load_pickle_blob(zlib.decompress(infile.read()))
-            index = {}
-            for name, chunks in raw_index.items():
-                decoded_chunks = []
-                for chunk in chunks:
-                    if len(chunk) == 2:
-                        start = b''
-                        chunk_offset, chunk_len = chunk
-                    else:
-                        chunk_offset, chunk_len, start = chunk
-                        if start is None:
-                            start = b''
-                        elif not isinstance(start, bytes):
-                            start = str(start).encode('latin-1', errors='ignore')
-                    decoded_chunks.append((int(chunk_offset) ^ key, int(chunk_len) ^ key, start))
-                index[str(name)] = decoded_chunks
-            _ARCHIVE_INDEX_CACHE[archive_path] = index
+            payload = read_bounded_compressed_index(
+                infile,
+                offset,
+                archive_size,
+                limits,
+            )
+            index = decode_and_validate_index(
+                load_pickle_blob(payload),
+                archive_size,
+                key=key,
+                stringify_names=True,
+                limits=limits,
+            )
+            _ARCHIVE_INDEX_CACHE[cache_key] = index
             return index
 
         if header.startswith(b'RPA-2.0 '):
             infile.seek(0)
             line = infile.read(24)
             offset = int(line[8:], 16)
-            infile.seek(offset)
-            raw_index = load_pickle_blob(zlib.decompress(infile.read()))
-            index = {}
-            for name, chunks in raw_index.items():
-                decoded_chunks = []
-                for chunk in chunks:
-                    chunk_offset, chunk_len = chunk[:2]
-                    start = b''
-                    if len(chunk) >= 3:
-                        start = chunk[2] or b''
-                        if not isinstance(start, bytes):
-                            start = str(start).encode('latin-1', errors='ignore')
-                    decoded_chunks.append((int(chunk_offset), int(chunk_len), start))
-                index[str(name)] = decoded_chunks
-            _ARCHIVE_INDEX_CACHE[archive_path] = index
+            payload = read_bounded_compressed_index(
+                infile,
+                offset,
+                archive_size,
+                limits,
+            )
+            index = decode_and_validate_index(
+                load_pickle_blob(payload),
+                archive_size,
+                stringify_names=True,
+                limits=limits,
+            )
+            _ARCHIVE_INDEX_CACHE[cache_key] = index
             return index
 
     raise RuntimeError('Unsupported RPA format (expecting RPA-3.0 or RPA-2.0).')
 
-def read_rpa_member(archive_path, member_name):
-    index = read_rpa_index(archive_path)
+def read_rpa_member(archive_path, member_name, limits=DEFAULT_RPA_LIMITS):
+    index = read_rpa_index(archive_path, limits=limits)
     chunks = index.get(member_name)
     if not chunks:
         return None
 
-    data = bytearray()
     with open(archive_path, 'rb') as source:
-        for chunk_offset, chunk_len, start in chunks:
-            if start:
-                data.extend(start)
-            source.seek(chunk_offset)
-            data.extend(source.read(chunk_len))
-    return bytes(data)
+        return read_member_bytes(source, chunks, limits)
 
 def find_archive_for_input(input_path):
     path = Path(input_path)

--- a/rpa_safety.py
+++ b/rpa_safety.py
@@ -1,0 +1,206 @@
+"""Shared resource limits and validation helpers for local Ren'Py RPA archives."""
+
+from dataclasses import dataclass
+import zlib
+
+
+@dataclass(frozen=True)
+class RpaLimits:
+    max_compressed_index_bytes: int = 64 * 1024 * 1024
+    max_decompressed_index_bytes: int = 256 * 1024 * 1024
+    max_entries: int = 200_000
+    max_chunks_per_member: int = 65_536
+    max_total_chunks: int = 1_000_000
+    max_member_output_bytes: int = 512 * 1024 * 1024
+    max_total_extraction_bytes: int = 2 * 1024 * 1024 * 1024
+    copy_chunk_bytes: int = 1024 * 1024
+
+
+DEFAULT_RPA_LIMITS = RpaLimits()
+
+
+class RpaResourceLimitError(RuntimeError):
+    pass
+
+
+@dataclass
+class RpaExtractionBudget:
+    maximum: int
+    used: int = 0
+
+    def reserve(self, amount):
+        next_used = self.used + amount
+        if next_used > self.maximum:
+            _raise_limit("total extraction output", next_used, self.maximum)
+        self.used = next_used
+
+
+def _raise_limit(label, actual, maximum):
+    raise RpaResourceLimitError(
+        f"RPA resource limit exceeded: {label} is {actual}; maximum is {maximum}."
+    )
+
+
+def read_bounded_compressed_index(infile, offset, archive_size, limits=DEFAULT_RPA_LIMITS):
+    if not isinstance(offset, int) or offset < 0 or offset >= archive_size:
+        raise RuntimeError(
+            f"Invalid RPA index offset {offset!r} for archive size {archive_size}."
+        )
+
+    compressed_size = archive_size - offset
+    if compressed_size > limits.max_compressed_index_bytes:
+        _raise_limit(
+            "compressed index",
+            compressed_size,
+            limits.max_compressed_index_bytes,
+        )
+
+    infile.seek(offset)
+    compressed = infile.read(compressed_size)
+    if len(compressed) != compressed_size:
+        raise RuntimeError("Invalid RPA archive: compressed index is truncated.")
+
+    decompressor = zlib.decompressobj()
+    try:
+        payload = decompressor.decompress(
+            compressed,
+            limits.max_decompressed_index_bytes + 1,
+        )
+        if (
+            len(payload) > limits.max_decompressed_index_bytes
+            or decompressor.unconsumed_tail
+        ):
+            _raise_limit(
+                "decompressed index",
+                limits.max_decompressed_index_bytes + 1,
+                limits.max_decompressed_index_bytes,
+            )
+        tail = decompressor.flush(
+            max(1, limits.max_decompressed_index_bytes - len(payload) + 1)
+        )
+    except zlib.error as exc:
+        raise RuntimeError(f"Invalid RPA compressed index: {exc}") from exc
+
+    if len(payload) + len(tail) > limits.max_decompressed_index_bytes:
+        _raise_limit(
+            "decompressed index",
+            len(payload) + len(tail),
+            limits.max_decompressed_index_bytes,
+        )
+    if not decompressor.eof:
+        raise RuntimeError("Invalid RPA compressed index: incomplete zlib stream.")
+    return payload + tail
+
+
+def _coerce_start_bytes(start):
+    if start is None:
+        return b""
+    if isinstance(start, bytes):
+        return start
+    return str(start).encode("latin-1", errors="ignore")
+
+
+def decode_and_validate_index(
+    raw_index,
+    archive_size,
+    *,
+    key=None,
+    stringify_names=False,
+    limits=DEFAULT_RPA_LIMITS,
+):
+    if not isinstance(raw_index, dict):
+        raise RuntimeError("Invalid RPA index: expected a dictionary.")
+    if len(raw_index) > limits.max_entries:
+        _raise_limit("index entries", len(raw_index), limits.max_entries)
+
+    index = {}
+    total_chunks = 0
+    for raw_name, raw_chunks in raw_index.items():
+        if not isinstance(raw_chunks, (list, tuple)):
+            raise RuntimeError("Invalid RPA index: member chunks must be a list or tuple.")
+        if len(raw_chunks) > limits.max_chunks_per_member:
+            _raise_limit(
+                "chunks for one member",
+                len(raw_chunks),
+                limits.max_chunks_per_member,
+            )
+        total_chunks += len(raw_chunks)
+        if total_chunks > limits.max_total_chunks:
+            _raise_limit("total chunks", total_chunks, limits.max_total_chunks)
+
+        decoded_chunks = []
+        member_size = 0
+        for raw_chunk in raw_chunks:
+            if not isinstance(raw_chunk, (list, tuple)) or len(raw_chunk) not in (2, 3):
+                raise RuntimeError("Invalid RPA index: each chunk must have two or three fields.")
+
+            chunk_offset = int(raw_chunk[0])
+            chunk_len = int(raw_chunk[1])
+            if key is not None:
+                chunk_offset ^= key
+                chunk_len ^= key
+            start = _coerce_start_bytes(raw_chunk[2] if len(raw_chunk) == 3 else b"")
+
+            if chunk_offset < 0 or chunk_len < 0:
+                raise RuntimeError(
+                    f"Invalid RPA chunk: negative offset or length for {raw_name!r}."
+                )
+            if chunk_offset > archive_size or chunk_len > archive_size - chunk_offset:
+                raise RuntimeError(
+                    f"Invalid RPA chunk: data for {raw_name!r} falls outside archive."
+                )
+
+            member_size += len(start) + chunk_len
+            if member_size > limits.max_member_output_bytes:
+                _raise_limit(
+                    f"member output for {raw_name!r}",
+                    member_size,
+                    limits.max_member_output_bytes,
+                )
+            decoded_chunks.append((chunk_offset, chunk_len, start))
+
+        name = str(raw_name) if stringify_names else raw_name
+        index[name] = decoded_chunks
+
+    return index
+
+
+def member_output_size(chunks):
+    return sum(len(start) + chunk_len for chunk_offset, chunk_len, start in chunks)
+
+
+def read_member_bytes(source, chunks, limits=DEFAULT_RPA_LIMITS):
+    expected_size = member_output_size(chunks)
+    if expected_size > limits.max_member_output_bytes:
+        _raise_limit(
+            "member output",
+            expected_size,
+            limits.max_member_output_bytes,
+        )
+
+    data = bytearray()
+    for chunk_offset, chunk_len, start in chunks:
+        data.extend(start)
+        source.seek(chunk_offset)
+        remaining = chunk_len
+        while remaining:
+            block = source.read(min(remaining, limits.copy_chunk_bytes))
+            if not block:
+                raise RuntimeError("Invalid RPA archive: member data is truncated.")
+            data.extend(block)
+            remaining -= len(block)
+    return bytes(data)
+
+
+def copy_member(source, target, chunks, limits=DEFAULT_RPA_LIMITS):
+    for chunk_offset, chunk_len, start in chunks:
+        if start:
+            target.write(start)
+        source.seek(chunk_offset)
+        remaining = chunk_len
+        while remaining:
+            block = source.read(min(remaining, limits.copy_chunk_bytes))
+            if not block:
+                raise RuntimeError("Invalid RPA archive: member data is truncated.")
+            target.write(block)
+            remaining -= len(block)

--- a/tests/test_rpa_safety.py
+++ b/tests/test_rpa_safety.py
@@ -1,0 +1,226 @@
+import pickle
+import tempfile
+import unittest
+import zlib
+from dataclasses import replace
+from pathlib import Path
+
+import translator_runtime as runtime
+from relation_analyzer import common
+from rpa_safety import (
+    DEFAULT_RPA_LIMITS,
+    RpaExtractionBudget,
+    RpaResourceLimitError,
+)
+
+
+class RpaSafetyTests(unittest.TestCase):
+    def _write_rpa3(self, root, raw_index, data=b"", name="archive.rpa"):
+        archive = root / name
+        offset = 34 + len(data)
+        header = b"RPA-3.0 %016x %08x\n" % (offset, 0)
+        archive.write_bytes(header + data + zlib.compress(pickle.dumps(raw_index, protocol=4)))
+        return archive
+
+    def _write_rpa2(self, root, raw_index, data=b""):
+        archive = root / "archive-v2.rpa"
+        offset = 25 + len(data)
+        header = b"RPA-2.0 %016x\n" % offset
+        archive.write_bytes(header + data + zlib.compress(pickle.dumps(raw_index, protocol=4)))
+        return archive
+
+    def test_runtime_rejects_compressed_index_over_limit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(root, {"game/script.rpy": [(0, 0, b"")]})
+            limits = replace(DEFAULT_RPA_LIMITS, max_compressed_index_bytes=1)
+
+            with self.assertRaisesRegex(RpaResourceLimitError, "compressed index"):
+                runtime._read_rpa_index(str(archive), limits=limits)
+
+    def test_runtime_rejects_decompressed_index_over_limit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(
+                root,
+                {"game/script.rpy": [(0, 0, b"A" * 1024)]},
+            )
+            limits = replace(DEFAULT_RPA_LIMITS, max_decompressed_index_bytes=128)
+
+            with self.assertRaisesRegex(RpaResourceLimitError, "decompressed index"):
+                runtime._read_rpa_index(str(archive), limits=limits)
+
+    def test_analyzer_rejects_decompressed_index_over_limit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(
+                root,
+                {"portrait.png": [(0, 0, b"A" * 1024)]},
+            )
+            limits = replace(DEFAULT_RPA_LIMITS, max_decompressed_index_bytes=128)
+
+            with self.assertRaisesRegex(RpaResourceLimitError, "decompressed index"):
+                common.read_rpa_index(str(archive), limits=limits)
+
+    def test_both_parsers_reject_chunk_outside_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(root, {"game/script.rpy": [(10_000_000, 5, b"")]})
+
+            with self.assertRaisesRegex(RuntimeError, "outside archive"):
+                runtime._read_rpa_index(str(archive))
+            with self.assertRaisesRegex(RuntimeError, "outside archive"):
+                common.read_rpa_index(str(archive))
+
+    def test_runtime_rejects_negative_chunk_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            samples = ((-1, 0, b""), (0, -1, b""))
+            for index, chunk in enumerate(samples):
+                archive = self._write_rpa3(
+                    root,
+                    {"game/script.rpy": [chunk]},
+                    name=f"negative-{index}.rpa",
+                )
+                with self.subTest(chunk=chunk):
+                    with self.assertRaisesRegex(RuntimeError, "negative offset or length"):
+                        runtime._read_rpa_index(str(archive))
+
+    def test_runtime_rejects_index_cardinality_limits(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entries_archive = self._write_rpa3(
+                root,
+                {"a.rpy": [], "b.rpy": []},
+                name="entries.rpa",
+            )
+            chunks_archive = self._write_rpa3(
+                root,
+                {"a.rpy": [(0, 0), (0, 0)]},
+                name="chunks.rpa",
+            )
+            total_chunks_archive = self._write_rpa3(
+                root,
+                {"a.rpy": [(0, 0)], "b.rpy": [(0, 0)]},
+                name="total-chunks.rpa",
+            )
+
+            with self.assertRaisesRegex(RpaResourceLimitError, "index entries"):
+                runtime._read_rpa_index(
+                    str(entries_archive),
+                    limits=replace(DEFAULT_RPA_LIMITS, max_entries=1),
+                )
+            with self.assertRaisesRegex(RpaResourceLimitError, "chunks for one member"):
+                runtime._read_rpa_index(
+                    str(chunks_archive),
+                    limits=replace(DEFAULT_RPA_LIMITS, max_chunks_per_member=1),
+                )
+            with self.assertRaisesRegex(RpaResourceLimitError, "total chunks"):
+                runtime._read_rpa_index(
+                    str(total_chunks_archive),
+                    limits=replace(DEFAULT_RPA_LIMITS, max_total_chunks=1),
+                )
+
+    def test_analyzer_rejects_member_output_over_limit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(root, {"portrait.png": [(0, 0, b"A" * 16)]})
+            limits = replace(DEFAULT_RPA_LIMITS, max_member_output_bytes=8)
+
+            self.assertIn("portrait.png", common.read_rpa_index(str(archive)))
+            with self.assertRaisesRegex(RpaResourceLimitError, "member output"):
+                common.read_rpa_index(str(archive), limits=limits)
+
+    def test_runtime_rejects_total_extraction_over_limit_before_writing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = self._write_rpa3(
+                root,
+                {
+                    "game/a.rpy": [(0, 0, b"A" * 8)],
+                    "game/b.rpy": [(0, 0, b"B" * 8)],
+                },
+            )
+            target = root / "target"
+            limits = replace(DEFAULT_RPA_LIMITS, max_total_extraction_bytes=12)
+
+            with self.assertRaisesRegex(RpaResourceLimitError, "total extraction"):
+                runtime._extract_rpa_scripts(str(archive), str(target), limits=limits)
+
+            self.assertFalse((target / "game" / "a.rpy").exists())
+            self.assertFalse((target / "game" / "b.rpy").exists())
+
+    def test_runtime_shares_total_extraction_budget_across_archives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = self._write_rpa3(
+                root,
+                {"game/a.rpy": [(0, 0, b"A" * 8)]},
+                name="first.rpa",
+            )
+            second = self._write_rpa3(
+                root,
+                {"game/b.rpy": [(0, 0, b"B" * 8)]},
+                name="second.rpa",
+            )
+            target = root / "target"
+            budget = RpaExtractionBudget(12)
+
+            self.assertEqual(
+                runtime._extract_rpa_scripts(
+                    str(first),
+                    str(target),
+                    extraction_budget=budget,
+                ),
+                1,
+            )
+            with self.assertRaisesRegex(RpaResourceLimitError, "total extraction"):
+                runtime._extract_rpa_scripts(
+                    str(second),
+                    str(target),
+                    extraction_budget=budget,
+                )
+
+            self.assertEqual((target / "game" / "a.rpy").read_bytes(), b"A" * 8)
+            self.assertFalse((target / "game" / "b.rpy").exists())
+
+    def test_valid_member_remains_readable_by_both_entry_points(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = b"hello"
+            archive = self._write_rpa3(
+                root,
+                {"portrait.png": [(34, len(data), b"prefix-")]},
+                data=data,
+            )
+
+            runtime_index = runtime._read_rpa_index(str(archive))
+            analyzer_index = common.read_rpa_index(str(archive))
+
+            self.assertEqual(runtime_index["portrait.png"], [(34, 5, b"prefix-")])
+            self.assertEqual(analyzer_index["portrait.png"], [(34, 5, b"prefix-")])
+            self.assertEqual(common.read_rpa_member(str(archive), "portrait.png"), b"prefix-hello")
+
+    def test_valid_rpa2_member_remains_readable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = b"hello-v2"
+            archive = self._write_rpa2(
+                root,
+                {"portrait.png": [(25, len(data), b"prefix-")]},
+                data=data,
+            )
+
+            runtime_index = runtime._read_rpa_index(str(archive))
+            analyzer_index = common.read_rpa_index(str(archive))
+
+            self.assertEqual(runtime_index["portrait.png"], [(25, 8, b"prefix-")])
+            self.assertEqual(analyzer_index["portrait.png"], [(25, 8, b"prefix-")])
+            self.assertEqual(
+                common.read_rpa_member(str(archive), "portrait.png"),
+                b"prefix-hello-v2",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -586,10 +586,11 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
     def test_rpa_index_loads_primitive_pickle_index(self):
         with tempfile.TemporaryDirectory() as tmp:
             archive_path = Path(tmp) / 'archive.rpa'
-            raw_index = {'game/script.rpy': [(123, 4, b'')]}
+            data = b'test'
+            raw_index = {'game/script.rpy': [(34, len(data), b'')]}
             payload = zlib.compress(pickle.dumps(raw_index, protocol=4))
-            header = b'RPA-3.0 %016x %08x\n' % (34, 0)
-            archive_path.write_bytes(header + payload)
+            header = b'RPA-3.0 %016x %08x\n' % (34 + len(data), 0)
+            archive_path.write_bytes(header + data + payload)
 
             index = runtime._read_rpa_index(str(archive_path))
 
@@ -1031,9 +1032,15 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 runtime.run_prepare_steps()
 
             self.assertTrue((base / 'game' / 'tl' / 'schinese' / 'script.rpy').is_file())
-            extract_mock.assert_called_once_with(
-                runtime.canonical_abs_path(archive),
-                work_game_dir,
+            extract_mock.assert_called_once()
+            args, kwargs = extract_mock.call_args
+            self.assertEqual(
+                args,
+                (runtime.canonical_abs_path(archive), work_game_dir),
+            )
+            self.assertIsInstance(
+                kwargs["extraction_budget"],
+                runtime.RpaExtractionBudget,
             )
 
     def test_prepare_missing_tl_without_launcher_errors(self):

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -12,7 +12,6 @@ import glob
 import pickle
 import shutil
 import subprocess
-import zlib
 import threading
 from collections import Counter
 from contextlib import contextmanager
@@ -30,6 +29,14 @@ def locked_runtime_state():
 
 from atomic_io import atomic_write_json, atomic_write_lines, file_sha256
 from rag_memory import JsonRagStore, hash_text, truncate_text
+from rpa_safety import (
+    DEFAULT_RPA_LIMITS,
+    RpaExtractionBudget,
+    copy_member,
+    decode_and_validate_index,
+    member_output_size,
+    read_bounded_compressed_index,
+)
 import prompt_context
 import story_memory
 import sync_translation_preview
@@ -1531,96 +1538,94 @@ def _load_pickle_blob(blob):
     return _RestrictedRpaUnpickler(io.BytesIO(blob), encoding="bytes").load()
 
 
-def _validate_rpa_index(raw_index):
-    if not isinstance(raw_index, dict):
-        raise RuntimeError("Invalid RPA index: expected a dictionary.")
-    return raw_index
-
-
-def _read_rpa_index(archive_path):
+def _read_rpa_index(archive_path, limits=DEFAULT_RPA_LIMITS):
     with open(archive_path, "rb") as infile:
+        archive_size = os.fstat(infile.fileno()).st_size
         header = infile.read(40)
 
         if header.startswith(b"RPA-3.0 "):
             offset = int(header[8:24], 16)
             key = int(header[25:33], 16)
-            infile.seek(offset)
-            raw_index = _validate_rpa_index(_load_pickle_blob(zlib.decompress(infile.read())))
-
-            index = {}
-            for name, chunks in raw_index.items():
-                decoded_chunks = []
-                for chunk in chunks:
-                    if len(chunk) == 2:
-                        start = b""
-                        chunk_offset, chunk_len = chunk
-                    else:
-                        chunk_offset, chunk_len, start = chunk
-                        if start is None:
-                            start = b""
-                        elif not isinstance(start, bytes):
-                            start = str(start).encode("latin-1", errors="ignore")
-
-                    decoded_chunks.append((int(chunk_offset) ^ key, int(chunk_len) ^ key, start))
-                index[name] = decoded_chunks
-
-            return index
+            payload = read_bounded_compressed_index(
+                infile,
+                offset,
+                archive_size,
+                limits,
+            )
+            return decode_and_validate_index(
+                _load_pickle_blob(payload),
+                archive_size,
+                key=key,
+                limits=limits,
+            )
 
         if header.startswith(b"RPA-2.0 "):
             infile.seek(0)
             line = infile.read(24)
             offset = int(line[8:], 16)
-            infile.seek(offset)
-            raw_index = _validate_rpa_index(_load_pickle_blob(zlib.decompress(infile.read())))
-
-            index = {}
-            for name, chunks in raw_index.items():
-                decoded_chunks = []
-                for chunk in chunks:
-                    chunk_offset, chunk_len = chunk[:2]
-                    start = b""
-                    if len(chunk) >= 3:
-                        start = chunk[2] or b""
-                        if not isinstance(start, bytes):
-                            start = str(start).encode("latin-1", errors="ignore")
-                    decoded_chunks.append((int(chunk_offset), int(chunk_len), start))
-                index[name] = decoded_chunks
-
-            return index
+            payload = read_bounded_compressed_index(
+                infile,
+                offset,
+                archive_size,
+                limits,
+            )
+            return decode_and_validate_index(
+                _load_pickle_blob(payload),
+                archive_size,
+                limits=limits,
+            )
 
     raise RuntimeError("Unsupported RPA format (expecting RPA-3.0 or RPA-2.0).")
 
 
-def _extract_rpa_scripts(archive_path, target_game_dir):
-    index = _read_rpa_index(archive_path)
+def _extract_rpa_scripts(
+    archive_path,
+    target_game_dir,
+    limits=DEFAULT_RPA_LIMITS,
+    extraction_budget=None,
+):
+    index = _read_rpa_index(archive_path, limits=limits)
     target_root = os.path.abspath(target_game_dir)
     extracted = 0
+    planned = []
+    total_output = 0
+
+    for raw_name, chunks in index.items():
+        rel = _safe_archive_relpath(raw_name)
+        if not rel:
+            continue
+        if os.path.splitext(rel)[1].lower() not in SCRIPT_FILE_EXTENSIONS:
+            continue
+
+        out_path = os.path.abspath(os.path.join(target_root, rel))
+        try:
+            if os.path.commonpath([target_root, out_path]) != target_root:
+                continue
+        except ValueError:
+            continue
+
+        if os.path.exists(out_path):
+            continue
+
+        total_output += member_output_size(chunks)
+        planned.append((out_path, chunks))
+
+    if extraction_budget is None:
+        extraction_budget = RpaExtractionBudget(limits.max_total_extraction_bytes)
+    extraction_budget.reserve(total_output)
 
     with open(archive_path, "rb") as source:
-        for raw_name, chunks in index.items():
-            rel = _safe_archive_relpath(raw_name)
-            if not rel:
-                continue
-            if os.path.splitext(rel)[1].lower() not in SCRIPT_FILE_EXTENSIONS:
-                continue
-
-            out_path = os.path.abspath(os.path.join(target_root, rel))
-            try:
-                if os.path.commonpath([target_root, out_path]) != target_root:
-                    continue
-            except ValueError:
-                continue
-
-            if os.path.exists(out_path):
-                continue
-
+        for out_path, chunks in planned:
             os.makedirs(os.path.dirname(out_path), exist_ok=True)
-            with open(out_path, "wb") as target:
-                for chunk_offset, chunk_len, start in chunks:
-                    if start:
-                        target.write(start)
-                    source.seek(chunk_offset)
-                    target.write(source.read(chunk_len))
+            try:
+                with open(out_path, "wb") as target:
+                    copy_member(source, target, chunks, limits)
+            except Exception:
+                try:
+                    os.remove(out_path)
+                except FileNotFoundError:
+                    pass
+                raise
             extracted += 1
 
     return extracted
@@ -1957,9 +1962,16 @@ def run_prepare_steps():
                 _run_unpack_command(PREP_UNPACK_COMMAND, archives, source_game_dir)
             else:
                 total_extracted = 0
+                extraction_budget = RpaExtractionBudget(
+                    DEFAULT_RPA_LIMITS.max_total_extraction_bytes
+                )
                 for archive in archives:
                     try:
-                        extracted = _extract_rpa_scripts(archive, WORK_GAME_DIR)
+                        extracted = _extract_rpa_scripts(
+                            archive,
+                            WORK_GAME_DIR,
+                            extraction_budget=extraction_budget,
+                        )
                         total_extracted += extracted
                         print(f"[Prepare] Extracted {extracted} script files from {os.path.basename(archive)}.")
                     except Exception as e:


### PR DESCRIPTION
## Summary
- add shared, explicit limits for compressed/decompressed RPA indexes, entry and chunk counts, per-member output, and total extraction output
- validate decoded offsets and lengths against the archive before any member read or script write
- use bounded member reads/copies and share one extraction budget across all archives in a prepare run
- apply the same index boundary to the runtime unpacker and relation-analyzer reader, with cache keys scoped by file version and limits
- preserve valid RPA-2.0 and RPA-3.0 behavior with focused compatibility tests

## Security boundary
Untrusted local RPA index data can no longer cause unbounded index decompression, unchecked member reads, or unbounded script extraction. Invalid or over-budget archives fail with explicit diagnostics before writeback begins.

## Validation
- `python -B -m unittest tests.test_rpa_safety tests.test_translator_runtime tests.test_relation_analyzer -q` — 151 passed
- `python -B tests/run_cli_tests.py -q` — 500 passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 750 passed
- `git diff --cached --check` — passed before commit

Closes #217