### PR TITLE
Add pinned Ren'Py fixture integration

### DIFF
--- a/.github/workflows/renpy-integration.yml
+++ b/.github/workflows/renpy-integration.yml
@@ -1,0 +1,50 @@
+name: Ren'Py integration
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renpy-integration
+  cancel-in-progress: false
+
+jobs:
+  fixture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      RENPY_VERSION: "8.5.2"
+      RENPY_ARCHIVE_SHA256: "cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install virtual display dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends xvfb xauth libgl1-mesa-dri libglu1-mesa
+
+      - name: Download and verify pinned Ren'Py SDK
+        shell: bash
+        run: |
+          archive="$RUNNER_TEMP/renpy-${RENPY_VERSION}-sdk.tar.bz2"
+          curl --fail --location --retry 3 --output "$archive" \
+            "https://www.renpy.org/dl/${RENPY_VERSION}/renpy-${RENPY_VERSION}-sdk.tar.bz2"
+          echo "${RENPY_ARCHIVE_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+
+      - name: Run real SDK fixture integration
+        env:
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          SDL_AUDIODRIVER: dummy
+        run: |
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
+            python -B scripts/run_renpy_integration.py \
+              --sdk "$RUNNER_TEMP/renpy-${RENPY_VERSION}-sdk"

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@
 | 项目边界与安全 | [项目说明](project_notes.md) |
 | 查看版本变化 | [变更日志](../CHANGELOG.md) · [v1.0.0 发行说明](releases/v1.0.0.md) |
 | 参与开发 / AI 协作 | 根目录 [CONTRIBUTING.md](../CONTRIBUTING.md)（含 **CLI / GUI 同步**） |
+| 理解 PR 门禁与定时集成 | [CI 与定时集成检查](ci.md) |
 
 ## 文档分组
 
@@ -38,6 +39,7 @@
 ### 现行：分析与项目状态
 
 - [关系与语义分析](relation_analysis.md)
+- [CI 与定时集成检查](ci.md)
 - [项目说明](project_notes.md)
 - [story_graph.example.json](story_graph.example.json) · [story_graph.schema.json](story_graph.schema.json)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,43 @@
+# CI 与定时集成检查
+
+## Pull request 门禁
+
+`.github/workflows/tests.yml` 在 pull request 和 `main` push 上运行：
+
+- Windows / Linux unittest；
+- 不安装 PySide6 的 CLI-only 测试；
+- Linux offscreen GUI 测试。
+
+这些检查不访问供应商 API，也不下载 Ren'Py SDK，必须保持确定、快速并作为合并门禁。
+
+## Ren'Py 真实 SDK 集成
+
+`.github/workflows/renpy-integration.yml` 每周定时运行，也可从 Actions 手动触发。它不会在普通 pull request 上运行，因为官方 SDK 约 146 MiB，并且 Ren'Py 8.5 的自动测试会经过真实 GUI / OpenGL 渲染路径。
+
+工作流固定使用 Ren'Py 8.5.2：
+
+- 下载：`https://www.renpy.org/dl/8.5.2/renpy-8.5.2-sdk.tar.bz2`
+- SHA-256：`cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4`
+- 官方校验来源：`https://www.renpy.org/dl/8.5.2/checksums.txt`
+
+集成 runner 会把 `tests/fixtures/renpy_smoke/` 复制到临时目录，然后依次：
+
+1. 生成 `schinese` 翻译模板并验证产物；
+2. 用 `lint --error-code` 检查脚本；
+3. 运行 `test smoke --report-detailed`，真实启动引擎并走完最小翻译 fixture。
+
+所有生成的 `.rpyc`、`game/tl/`、save 和日志都留在临时目录，不修改仓库 fixture。
+
+本地已有 SDK 时可复现：
+
+```powershell
+python -B scripts/run_renpy_integration.py --sdk C:\RenPy_Workspace\renpy-8.5.2-sdk
+```
+
+Linux 无桌面环境时，在 Xvfb 下执行同一 runner：
+
+```bash
+xvfb-run -a python -B scripts/run_renpy_integration.py --sdk /path/to/renpy-8.5.2-sdk
+```
+
+SDK 缺失、模板没有生成、lint 失败或 testcase 失败都会返回非零退出码和明确诊断。

--- a/scripts/run_renpy_integration.py
+++ b/scripts/run_renpy_integration.py
@@ -143,8 +143,8 @@ def run_integration(
 
         def invoke(command: str, *arguments: str) -> None:
             command_runner(
-                launcher
-                + [
+                [
+                    *launcher,
                     "--savedir",
                     str(savedir),
                     str(project_dir),

--- a/scripts/run_renpy_integration.py
+++ b/scripts/run_renpy_integration.py
@@ -1,0 +1,203 @@
+"""Run the repository's minimal fixture through a real Ren'Py SDK."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURE = REPO_ROOT / "tests" / "fixtures" / "renpy_smoke"
+REQUIRED_FIXTURE_FILES = (
+    "game/options.rpy",
+    "game/screens.rpy",
+    "game/script.rpy",
+    "game/testcases.rpy",
+)
+
+
+class RenPyIntegrationError(RuntimeError):
+    """Raised when the SDK fixture integration cannot complete safely."""
+
+
+def resolve_launcher(sdk_dir: Path, platform_name: str | None = None) -> list[str]:
+    sdk_dir = sdk_dir.resolve()
+    platform_name = platform_name or sys.platform
+    if platform_name.startswith("win"):
+        python_exe = sdk_dir / "lib" / "py3-windows-x86_64" / "python.exe"
+        renpy_py = sdk_dir / "renpy.py"
+        missing = [path for path in (python_exe, renpy_py) if not path.is_file()]
+        if missing:
+            raise RenPyIntegrationError(
+                "Ren'Py SDK is missing the Windows launcher files: "
+                + ", ".join(str(path) for path in missing)
+            )
+        return [str(python_exe), str(renpy_py)]
+
+    renpy_sh = sdk_dir / "renpy.sh"
+    if not renpy_sh.is_file():
+        raise RenPyIntegrationError(
+            f"Ren'Py SDK is missing the POSIX launcher: {renpy_sh}"
+        )
+    return [str(renpy_sh)]
+
+
+def validate_fixture(fixture_dir: Path) -> None:
+    missing = [
+        relative
+        for relative in REQUIRED_FIXTURE_FILES
+        if not (fixture_dir / relative).is_file()
+    ]
+    if missing:
+        raise RenPyIntegrationError(
+            "Ren'Py integration fixture is incomplete; missing: " + ", ".join(missing)
+        )
+
+
+def validate_generated_template(project_dir: Path, language: str) -> Path:
+    language_dir = project_dir / "game" / "tl" / language
+    candidates = sorted(language_dir.rglob("*.rpy")) if language_dir.is_dir() else []
+    if not candidates:
+        raise RenPyIntegrationError(
+            f"Ren'Py did not generate any translation scripts under {language_dir}."
+        )
+
+    combined = "\n".join(path.read_text(encoding="utf-8-sig") for path in candidates)
+    if f"translate {language}" not in combined:
+        raise RenPyIntegrationError(
+            f"Generated scripts do not contain a translate {language} block."
+        )
+    if "Hello from the integration fixture." not in combined:
+        raise RenPyIntegrationError(
+            "Generated scripts do not contain the fixture dialogue source text."
+        )
+    return language_dir
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    print("Running:", subprocess.list2cmdline(command))
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+    if completed.stdout:
+        print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
+    if completed.returncode:
+        raise RenPyIntegrationError(
+            f"Ren'Py command failed with exit code {completed.returncode}: "
+            + subprocess.list2cmdline(command)
+        )
+    return completed
+
+
+def run_integration(
+    sdk_dir: Path,
+    fixture_dir: Path = DEFAULT_FIXTURE,
+    *,
+    language: str = "schinese",
+    testcase: str = "smoke",
+    command_timeout: int = 180,
+    temp_parent: Path | None = None,
+    platform_name: str | None = None,
+    command_runner=run_command,
+) -> None:
+    sdk_dir = sdk_dir.resolve()
+    fixture_dir = fixture_dir.resolve()
+    launcher = resolve_launcher(sdk_dir, platform_name)
+    validate_fixture(fixture_dir)
+
+    if temp_parent is not None:
+        temp_parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix="rtl-renpy-integration-",
+        dir=temp_parent,
+    ) as temporary:
+        temporary_dir = Path(temporary)
+        project_dir = temporary_dir / "project"
+        savedir = temporary_dir / "saves"
+        shutil.copytree(fixture_dir, project_dir)
+        savedir.mkdir()
+
+        env = os.environ.copy()
+        env.setdefault("SDL_AUDIODRIVER", "dummy")
+
+        def invoke(command: str, *arguments: str) -> None:
+            command_runner(
+                launcher
+                + [
+                    "--savedir",
+                    str(savedir),
+                    str(project_dir),
+                    command,
+                    *arguments,
+                ],
+                cwd=sdk_dir,
+                env=env,
+                timeout=command_timeout,
+            )
+
+        invoke("translate", language)
+        language_dir = validate_generated_template(project_dir, language)
+        print(f"Generated translation template: {language_dir}")
+
+        invoke("lint", "--error-code")
+        invoke("test", testcase, "--report-detailed")
+
+    print("Ren'Py fixture integration completed successfully.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sdk", required=True, type=Path, help="Ren'Py SDK directory")
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help="fixture project directory",
+    )
+    parser.add_argument("--language", default="schinese")
+    parser.add_argument("--testcase", default="smoke")
+    parser.add_argument("--command-timeout", type=int, default=180)
+    parser.add_argument("--temp-parent", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        run_integration(
+            args.sdk,
+            args.fixture,
+            language=args.language,
+            testcase=args.testcase,
+            command_timeout=args.command_timeout,
+            temp_parent=args.temp_parent,
+        )
+    except (OSError, subprocess.TimeoutExpired, RenPyIntegrationError) as exc:
+        print(f"Ren'Py integration failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/renpy_smoke/game/options.rpy
+++ b/tests/fixtures/renpy_smoke/game/options.rpy
@@ -1,0 +1,4 @@
+define config.name = "Translation Lab CI Fixture"
+define config.version = "1.0"
+define build.name = "translation_lab_ci_fixture"
+define config.save_directory = "translation-lab-ci-fixture"

--- a/tests/fixtures/renpy_smoke/game/screens.rpy
+++ b/tests/fixtures/renpy_smoke/game/screens.rpy
@@ -1,0 +1,8 @@
+screen say(who, what):
+    window:
+        id "window"
+
+        vbox:
+            if who:
+                text who id "who"
+            text what id "what"

--- a/tests/fixtures/renpy_smoke/game/script.rpy
+++ b/tests/fixtures/renpy_smoke/game/script.rpy
@@ -1,0 +1,7 @@
+define e = Character("Eileen")
+
+
+label start:
+    e "Hello from the integration fixture."
+    e "Translation fixture complete."
+    return

--- a/tests/fixtures/renpy_smoke/game/testcases.rpy
+++ b/tests/fixtures/renpy_smoke/game/testcases.rpy
@@ -1,0 +1,10 @@
+testsuite global:
+    teardown:
+        exit
+
+testcase smoke:
+    $ _test.timeout = 5.0
+    $ _test.transition_timeout = 0.05
+    run Jump("start")
+    advance until "Translation fixture complete." raw
+    advance

--- a/tests/test_renpy_integration_runner.py
+++ b/tests/test_renpy_integration_runner.py
@@ -1,0 +1,106 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_renpy_integration as integration
+
+
+class RenPyIntegrationRunnerTests(unittest.TestCase):
+    def test_missing_sdk_launcher_fails_clearly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sdk = Path(tmp) / "sdk"
+            sdk.mkdir()
+
+            with self.assertRaisesRegex(
+                integration.RenPyIntegrationError,
+                "missing the POSIX launcher",
+            ):
+                integration.resolve_launcher(sdk, "linux")
+
+    def test_runner_generates_template_then_lints_and_tests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sdk = root / "sdk"
+            sdk.mkdir()
+            (sdk / "renpy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            actions = []
+
+            def fake_runner(command, **kwargs):
+                project_dir = Path(command[3])
+                action = command[4]
+                actions.append((action, command[5:]))
+                if action == "translate":
+                    target = project_dir / "game" / "tl" / "schinese" / "script.rpy"
+                    target.parent.mkdir(parents=True)
+                    target.write_text(
+                        "translate schinese start_fixture:\n"
+                        "    # Eileen \"Hello from the integration fixture.\"\n"
+                        "    Eileen \"\"\n",
+                        encoding="utf-8",
+                    )
+                return subprocess.CompletedProcess(command, 0, "ok")
+
+            integration.run_integration(
+                sdk,
+                platform_name="linux",
+                command_runner=fake_runner,
+                temp_parent=root / "temp",
+            )
+
+            self.assertEqual(
+                actions,
+                [
+                    ("translate", ["schinese"]),
+                    ("lint", ["--error-code"]),
+                    ("test", ["smoke", "--report-detailed"]),
+                ],
+            )
+
+    def test_runner_stops_when_template_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sdk = root / "sdk"
+            sdk.mkdir()
+            (sdk / "renpy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            actions = []
+
+            def fake_runner(command, **kwargs):
+                actions.append(command[4])
+                return subprocess.CompletedProcess(command, 0, "ok")
+
+            with self.assertRaisesRegex(
+                integration.RenPyIntegrationError,
+                "did not generate any translation scripts",
+            ):
+                integration.run_integration(
+                    sdk,
+                    platform_name="linux",
+                    command_runner=fake_runner,
+                    temp_parent=root / "temp",
+                )
+
+            self.assertEqual(actions, ["translate"])
+
+    def test_scheduled_workflow_pins_official_sdk_and_checksum(self):
+        workflow = (
+            integration.REPO_ROOT / ".github" / "workflows" / "renpy-integration.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('RENPY_VERSION: "8.5.2"', workflow)
+        version_reference = chr(36) + "{RENPY_VERSION}"
+        self.assertIn(
+            f"https://www.renpy.org/dl/{version_reference}/"
+            f"renpy-{version_reference}-sdk.tar.bz2",
+            workflow,
+        )
+        self.assertIn(
+            "cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4",
+            workflow,
+        )
+        self.assertIn("schedule:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a minimal Ren'Py project fixture and a cross-platform real-SDK integration runner
- add a scheduled/manual GitHub Actions job pinned to Ren'Py 8.5.2 with SHA-256 verification
- document the split between fast PR gates and heavyweight scheduled SDK integration

## Validation

- python -B -m unittest tests.test_renpy_integration_runner -v
- python -B tests/run_cli_tests.py -q (504 passed, 1 skipped)
- python -B tests/run_gui_tests.py -q (750 passed)
- python -u -B scripts/run_renpy_integration.py --sdk C:\RenPy_Workspace\renpy-8.5.2-sdk --temp-parent C:\tmp --command-timeout 60
  - generated the schinese template
  - lint passed with --error-code
  - global::smoke passed through the real Ren'Py test runner

Closes #227
Refs #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated weekly and manually triggered Ren’Py integration checks using a pinned SDK.
  - Added smoke-test coverage for translation generation, linting, and runtime behavior.
  - Added a reusable Ren’Py fixture project with dialogue, UI, metadata, and test scenarios.

- **Documentation**
  - Added CI strategy documentation and linked it from the documentation index.

- **Tests**
  - Added coverage for launcher validation, integration sequencing, generated translations, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->