### PR TITLE
Add credential-optional provider contract smokes

### DIFF
--- a/.github/workflows/provider-contract-smoke.yml
+++ b/.github/workflows/provider-contract-smoke.yml
@@ -1,0 +1,48 @@
+name: Provider contract smoke
+
+on:
+  schedule:
+    - cron: "41 5 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-contract-smoke
+  cancel-in-progress: false
+
+jobs:
+  provider-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GEMINI_API_KEY: ${{ secrets.PROVIDER_SMOKE_GEMINI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.PROVIDER_SMOKE_OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.PROVIDER_SMOKE_ANTHROPIC_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.PROVIDER_SMOKE_OPENROUTER_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.PROVIDER_SMOKE_DEEPSEEK_API_KEY }}
+      XAI_API_KEY: ${{ secrets.PROVIDER_SMOKE_XAI_API_KEY }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-litellm.txt
+
+      - name: Install provider adapter dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "google-genai==1.57.0" -r requirements-litellm.txt
+
+      - name: Run configured provider contracts
+        run: python -B scripts/run_provider_contract_smoke.py --provider all

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,3 +41,28 @@ xvfb-run -a python -B scripts/run_renpy_integration.py --sdk /path/to/renpy-8.5.
 ```
 
 SDK 缺失、模板没有生成、lint 失败或 testcase 失败都会返回非零退出码和明确诊断。
+
+## 外部 provider 契约 smoke
+
+`.github/workflows/provider-contract-smoke.yml` 每周定时运行，也可手动触发；它不在普通 pull request 上运行。runner 覆盖 Gemini 直连，以及生产 LiteLLM provider 目录中的 OpenAI、Anthropic、OpenRouter、DeepSeek 和 xAI。Ollama 依赖本地服务，不属于外部凭据 smoke。
+
+仓库可按需配置以下 Actions secrets：
+
+- `PROVIDER_SMOKE_GEMINI_API_KEY`
+- `PROVIDER_SMOKE_OPENAI_API_KEY`
+- `PROVIDER_SMOKE_ANTHROPIC_API_KEY`
+- `PROVIDER_SMOKE_OPENROUTER_API_KEY`
+- `PROVIDER_SMOKE_DEEPSEEK_API_KEY`
+- `PROVIDER_SMOKE_XAI_API_KEY`
+
+未配置的 provider 会打印 `SKIP` 并成功结束；至少配置一个 secret 时，对应 provider 会经过生产 adapter 发出一次请求，验证返回文本仍可解析为约定 JSON。任何配置过的 provider 失败都会打印 provider 名称和 `authentication`、`rate_limit`、`service_unavailable`、`invalid_response` 或 `provider_error` 分类，并让工作流失败。
+
+每个 provider 的硬限制为 1 次请求、64 个输出 token、30 秒客户端超时；单次保守规划成本上限为 0.01 USD，六个 provider 全部配置时每轮估算不超过 0.06 USD。实际价格以 provider 当期计费为准。smoke 不读取或写入游戏项目文件。
+
+本地可使用 provider 原生环境变量运行，例如：
+
+```powershell
+$env:OPENAI_API_KEY = "..."
+python -B scripts/run_provider_contract_smoke.py --provider openai
+Remove-Item Env:OPENAI_API_KEY
+```

--- a/scripts/run_provider_contract_smoke.py
+++ b/scripts/run_provider_contract_smoke.py
@@ -1,0 +1,245 @@
+"""Run bounded, credential-optional contract smokes through production adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from litellm_provider_config import DEFAULT_MODELS, SUPPORTED_PROVIDERS
+from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
+
+
+REQUEST_TIMEOUT_SECONDS = 30
+MAX_OUTPUT_TOKENS = 64
+MAX_REQUESTS_PER_PROVIDER = 1
+ESTIMATED_MAX_COST_USD_PER_PROVIDER = 0.01
+GEMINI_MODEL = "gemini-3.1-flash-lite"
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    name: str
+    backend: str
+    model: str
+    secret_environment: str
+
+
+_LITELLM_SECRET_ENVIRONMENTS = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "xai": "XAI_API_KEY",
+}
+
+
+def provider_specs() -> tuple[ProviderSpec, ...]:
+    specs = [
+        ProviderSpec("gemini", "gemini", GEMINI_MODEL, "GEMINI_API_KEY"),
+    ]
+    for provider, _label in SUPPORTED_PROVIDERS:
+        if provider == "ollama":
+            continue
+        secret_environment = _LITELLM_SECRET_ENVIRONMENTS.get(provider)
+        models = DEFAULT_MODELS.get(provider, ())
+        if not secret_environment or not models:
+            raise RuntimeError(
+                f"External provider {provider!r} needs a smoke secret and default model."
+            )
+        specs.append(
+            ProviderSpec(provider, "litellm", models[0], secret_environment)
+        )
+    return tuple(specs)
+
+
+PROVIDER_SPECS = provider_specs()
+PROVIDER_BY_NAME = {spec.name: spec for spec in PROVIDER_SPECS}
+
+
+class ContractSmokeError(RuntimeError):
+    """The provider response no longer satisfies the expected contract."""
+
+    category = "invalid_response"
+
+
+def api_key_for(
+    spec: ProviderSpec,
+    environment: Mapping[str, str] | None = None,
+) -> str:
+    environment = os.environ if environment is None else environment
+    value = environment.get("PROVIDER_API_KEY") or environment.get(
+        spec.secret_environment
+    )
+    return str(value or "").strip()
+
+
+def contract_request(spec: ProviderSpec) -> SyncGenerationRequest:
+    schema = {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+        "additionalProperties": False,
+    }
+    config: dict[str, Any] = {
+        "temperature": 0,
+        "max_output_tokens": MAX_OUTPUT_TOKENS,
+        "response_json_schema": schema,
+    }
+    if spec.backend == "gemini":
+        config["response_mime_type"] = "application/json"
+    else:
+        config["timeout"] = REQUEST_TIMEOUT_SECONDS
+    return SyncGenerationRequest(
+        model=spec.model,
+        contents=(
+            'Return only the compact JSON object {"ok":true}. '
+            "Do not add prose or markdown."
+        ),
+        config=config,
+    )
+
+
+def create_backend(spec: ProviderSpec, api_key: str) -> Any:
+    if spec.backend == "litellm":
+        from litellm_sync_backend import LiteLLMSyncBackend
+
+        return LiteLLMSyncBackend(api_key=api_key)
+
+    from google import genai
+    from google.genai import types
+    from gemini_translate_batch import (
+        extract_finish_reason,
+        extract_text_from_response_payload,
+        extract_usage_metadata,
+        serialize_unknown,
+        summarize_usage_metadata,
+    )
+
+    client = genai.Client(
+        api_key=api_key,
+        http_options=types.HttpOptions(timeout=REQUEST_TIMEOUT_SECONDS * 1000),
+    )
+    return GeminiSyncBackend(
+        client,
+        serialize_response=serialize_unknown,
+        extract_text=extract_text_from_response_payload,
+        extract_finish_reason=extract_finish_reason,
+        extract_usage=lambda payload: summarize_usage_metadata(
+            extract_usage_metadata(payload)
+        ),
+    )
+
+
+def validate_result(spec: ProviderSpec, result: Any) -> dict[str, Any]:
+    if result.provider != spec.backend:
+        raise ContractSmokeError(
+            f"provider mismatch: expected {spec.backend!r}, got {result.provider!r}"
+        )
+    if result.model != spec.model:
+        raise ContractSmokeError(
+            f"model mismatch: expected {spec.model!r}, got {result.model!r}"
+        )
+    text = str(result.response_text or "").strip()
+    if not text:
+        raise ContractSmokeError("response text is empty")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ContractSmokeError("response text is not valid JSON") from exc
+    if not isinstance(parsed, dict) or parsed.get("ok") is not True:
+        raise ContractSmokeError("response JSON does not satisfy the smoke schema")
+    return parsed
+
+
+def classify_error(exc: Exception) -> str:
+    category = str(getattr(exc, "category", "") or "").strip()
+    if category:
+        return category
+    status = getattr(exc, "status_code", None)
+    if status in {401, 403}:
+        return "authentication"
+    if status == 429:
+        return "rate_limit"
+    if status in {408, 502, 503, 504} or isinstance(exc, TimeoutError):
+        return "service_unavailable"
+    return "provider_error"
+
+
+def run_provider(spec: ProviderSpec, api_key: str, backend: Any = None) -> None:
+    backend = backend or create_backend(spec, api_key)
+    result = backend.generate(contract_request(spec))
+    validate_result(spec, result)
+    usage = dict(result.usage_metadata or {})
+    print(
+        "PASS "
+        f"provider={spec.name} backend={spec.backend} model={spec.model} "
+        f"requests={MAX_REQUESTS_PER_PROVIDER} "
+        f"max_output_tokens={MAX_OUTPUT_TOKENS} usage={json.dumps(usage, sort_keys=True)}"
+    )
+
+
+def run_selected(
+    selected: list[ProviderSpec],
+    environment: Mapping[str, str] | None = None,
+) -> int:
+    passed = 0
+    skipped = 0
+    failed = 0
+    for spec in selected:
+        api_key = api_key_for(spec, environment)
+        if not api_key:
+            skipped += 1
+            print(
+                f"SKIP provider={spec.name} missing_secret={spec.secret_environment}"
+            )
+            continue
+        try:
+            run_provider(spec, api_key)
+            passed += 1
+        except Exception as exc:
+            failed += 1
+            print(
+                f"FAIL provider={spec.name} category={classify_error(exc)}: {exc}",
+                file=sys.stderr,
+            )
+    print(
+        f"SUMMARY passed={passed} skipped={skipped} failed={failed} "
+        f"requests_max={len(selected) * MAX_REQUESTS_PER_PROVIDER} "
+        "estimated_cost_max_usd="
+        f"{len(selected) * ESTIMATED_MAX_COST_USD_PER_PROVIDER:.2f}"
+    )
+    return 1 if failed else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provider",
+        choices=("all", *PROVIDER_BY_NAME),
+        default="all",
+        help="provider contract to run; missing credentials are successful skips",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    selected = (
+        list(PROVIDER_SPECS)
+        if args.provider == "all"
+        else [PROVIDER_BY_NAME[args.provider]]
+    )
+    return run_selected(selected)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provider_contract_smoke.py
+++ b/tests/test_provider_contract_smoke.py
@@ -1,0 +1,107 @@
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from scripts import run_provider_contract_smoke as smoke
+
+
+class ProviderContractSmokeTests(unittest.TestCase):
+    def test_catalog_covers_all_external_production_providers(self):
+        expected = {"gemini", "openai", "anthropic", "openrouter", "deepseek", "xai"}
+        self.assertEqual(set(smoke.PROVIDER_BY_NAME), expected)
+        self.assertNotIn("ollama", smoke.PROVIDER_BY_NAME)
+
+    def test_missing_credentials_skip_without_creating_backend(self):
+        output = io.StringIO()
+        with (
+            mock.patch.object(smoke, "create_backend") as create_backend,
+            redirect_stdout(output),
+        ):
+            code = smoke.run_selected(list(smoke.PROVIDER_SPECS), {})
+
+        self.assertEqual(code, 0)
+        create_backend.assert_not_called()
+        self.assertIn("SUMMARY passed=0 skipped=6 failed=0", output.getvalue())
+
+    def test_configured_provider_uses_one_bounded_production_request(self):
+        spec = smoke.PROVIDER_BY_NAME["openai"]
+        result = SimpleNamespace(
+            provider="litellm",
+            model=spec.model,
+            response_text='{"ok":true}',
+            usage_metadata={"total_tokens": 9},
+        )
+        backend = mock.Mock()
+        backend.generate.return_value = result
+
+        smoke.run_provider(spec, "secret", backend=backend)
+
+        request = backend.generate.call_args.args[0]
+        self.assertEqual(request.model, spec.model)
+        self.assertEqual(
+            request.config["max_output_tokens"],
+            smoke.MAX_OUTPUT_TOKENS,
+        )
+        self.assertEqual(
+            request.config["timeout"],
+            smoke.REQUEST_TIMEOUT_SECONDS,
+        )
+
+    def test_invalid_response_fails_with_provider_name_and_category(self):
+        spec = smoke.PROVIDER_BY_NAME["openai"]
+        backend = mock.Mock()
+        backend.generate.return_value = SimpleNamespace(
+            provider="litellm",
+            model=spec.model,
+            response_text="not-json",
+            usage_metadata={},
+        )
+        error = io.StringIO()
+        with (
+            mock.patch.object(smoke, "create_backend", return_value=backend),
+            redirect_stderr(error),
+            redirect_stdout(io.StringIO()),
+        ):
+            code = smoke.run_selected([spec], {"OPENAI_API_KEY": "secret"})
+
+        self.assertEqual(code, 1)
+        self.assertIn("provider=openai", error.getvalue())
+        self.assertIn("category=invalid_response", error.getvalue())
+
+    def test_error_classification_covers_auth_rate_limit_and_outage(self):
+        for status, expected in (
+            (401, "authentication"),
+            (429, "rate_limit"),
+            (503, "service_unavailable"),
+        ):
+            error = RuntimeError("provider failed")
+            error.status_code = status
+            self.assertEqual(smoke.classify_error(error), expected)
+
+    def test_workflow_is_scheduled_manual_and_not_a_pr_gate(self):
+        workflow = (
+            Path(smoke.__file__).resolve().parents[1]
+            / ".github"
+            / "workflows"
+            / "provider-contract-smoke.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("schedule:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertIn("timeout-minutes: 10", workflow)
+        for secret in (
+            "PROVIDER_SMOKE_GEMINI_API_KEY",
+            "PROVIDER_SMOKE_OPENAI_API_KEY",
+            "PROVIDER_SMOKE_ANTHROPIC_API_KEY",
+            "PROVIDER_SMOKE_OPENROUTER_API_KEY",
+            "PROVIDER_SMOKE_DEEPSEEK_API_KEY",
+            "PROVIDER_SMOKE_XAI_API_KEY",
+        ):
+            self.assertIn(secret, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a credential-optional contract smoke runner for Gemini and the five external LiteLLM providers exposed by the production catalog
- add a weekly/manual workflow that skips missing secrets successfully and never runs as a pull-request gate
- bound each configured provider to one request, 64 output tokens, and a 30-second client timeout
- validate JSON response parsing and report provider-specific error categories without touching project files
- document secret names, limits, estimated cost, and local reproduction

## Provider scope

- Gemini
- OpenAI
- Anthropic
- OpenRouter
- DeepSeek
- xAI
- Ollama is intentionally excluded because it is a local service rather than an external credentialed provider

## Validation

- python -B -m unittest tests.test_provider_contract_smoke tests.test_litellm_sync_backend tests.test_litellm_error_classification tests.test_litellm_sync_integration tests.test_sync_model_backend -v (20 passed)
- python -B scripts/run_provider_contract_smoke.py --provider all (6 explicit skips, zero requests, exit 0 without credentials)
- python -B tests/run_cli_tests.py -q (510 passed, 1 skipped)
- python -B tests/run_gui_tests.py -q (750 passed)
- git diff --check

Closes #228
Refs #215