### PR TITLE
Scope RuntimeConfig through GUI doctor and registry jobs

### DIFF
--- a/games_registry.py
+++ b/games_registry.py
@@ -503,15 +503,33 @@ def scan_project_auto(
 
 @contextmanager
 def _temporary_game_root(work_dir: str) -> Iterator[None]:
+    """Point runtime paths at ``work_dir`` for the block, then fully restore.
+
+    Snapshots the full :class:`~translator_runtime.RuntimeConfig` so temporary
+    path overrides cannot leak into the caller's process globals
+    (issue #216 phase 2).
+    """
     import translator_runtime as runtime
 
     with runtime.locked_runtime_state():
-        previous = runtime.BASE_DIR
-        runtime._apply_game_root(work_dir)
+        previous = runtime.snapshot_runtime_config()
+        # Derive a job-scoped config with the temporary work root while keeping
+        # the caller's language/tl_subdir and other project knobs.
+        job = previous.copy()
+        normalized = runtime._canonical_abs_path(work_dir)
+        job.env_game_root = normalized
+        job.base_dir = normalized
+        job.tl_dir = runtime._canonical_abs_path(
+            os.path.join(normalized, job.tl_subdir or runtime.DEFAULT_TL_SUBDIR)
+        )
+        job.work_game_dir = runtime._canonical_abs_path(
+            os.path.join(normalized, runtime.WORK_GAME_SUBDIR)
+        )
         try:
+            runtime.apply_runtime_config(job)
             yield
         finally:
-            runtime._apply_game_root(previous)
+            runtime.apply_runtime_config(previous)
 
 
 def _doctor_layout_snapshot(game_root: str, has_tl: bool) -> tuple[str, str]:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -7172,6 +7172,27 @@ class MainWindow(QMainWindow):
     def _is_doctor_running(self) -> bool:
         return self._doctor_worker is not None and self._doctor_worker.isRunning()
 
+    def _snapshot_runtime_config_for_job(self):
+        """Build a frozen RuntimeConfig for an in-process background job.
+
+        Reloads translator settings under the runtime lock so the snapshot
+        matches the current project on disk, then returns an independent copy.
+        Returns None if runtime cannot be imported (worker will reload itself).
+        """
+        try:
+            import translator_runtime as legacy
+        except Exception:
+            return None
+        try:
+            with legacy.locked_runtime_state():
+                legacy.load_translator_settings()
+                return legacy.snapshot_runtime_config()
+        except SystemExit:
+            # Hard config errors surface again inside the worker with user-facing text.
+            return None
+        except Exception:
+            return None
+
     def _on_run_doctor(self):
         if not self._confirm_unsaved_config_before_workflow():
             return
@@ -7196,7 +7217,11 @@ class MainWindow(QMainWindow):
         self._append_log("=== 正在运行环境检查（collect_doctor_report）===\n")
         self._set_task_running(True)
 
-        self._doctor_worker = DoctorWorker(parent=self)
+        # Snapshot current process runtime for this job so a later project switch
+        # (or disk reload) cannot mutate globals mid-doctor. The worker restores
+        # prior globals after the check (issue #216 phase 2).
+        doctor_config = self._snapshot_runtime_config_for_job()
+        self._doctor_worker = DoctorWorker(config=doctor_config, parent=self)
         self._doctor_worker.completed.connect(self._on_doctor_completed)
         self._doctor_worker.start()
 

--- a/gui_qt/doctor_worker.py
+++ b/gui_qt/doctor_worker.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 import io
 from contextlib import redirect_stdout
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from PySide6.QtCore import QThread, Signal
+
+if TYPE_CHECKING:
+    from translator_runtime import RuntimeConfig
 
 
 @dataclass(frozen=True)
@@ -17,8 +20,14 @@ class DoctorWorkerResult:
     error: str = ""
 
 
-def run_doctor_check() -> DoctorWorkerResult:
-    """Collect and format a doctor report for the current translator settings."""
+def run_doctor_check(config: RuntimeConfig | None = None) -> DoctorWorkerResult:
+    """Collect and format a doctor report for a frozen project configuration.
+
+    When ``config`` is provided it is applied for the duration of the check and
+    the previous process-global runtime state is restored afterwards. When
+    omitted, translator settings are reloaded from disk under the same scoped
+    restore semantics (issue #216 phase 2).
+    """
     try:
         import gemini_translate_batch as batch_mod
         import translator_runtime as legacy
@@ -26,8 +35,10 @@ def run_doctor_check() -> DoctorWorkerResult:
         return DoctorWorkerResult(False, None, "", f"无法加载 doctor 模块：{exc}")
 
     try:
-        with legacy.locked_runtime_state():
-            legacy.load_translator_settings()
+        with legacy.runtime_config_scope(
+            config,
+            reload_translator_settings=config is None,
+        ):
             legacy.load_glossary()
             batch_mod.load_batch_settings()
             report = batch_mod.collect_doctor_report()
@@ -35,19 +46,28 @@ def run_doctor_check() -> DoctorWorkerResult:
             with redirect_stdout(buffer):
                 batch_mod.print_doctor_report(report)
         return DoctorWorkerResult(True, report, buffer.getvalue())
-    except Exception as exc:
-        return DoctorWorkerResult(False, None, "", f"环境检查失败：{exc}")
     except SystemExit as exc:
-        # load_translator_settings raises SystemExit for hard config errors
-        # (e.g. tl_subdir escaping the project root).
+        # load_translator_settings / invalid config raise SystemExit for hard
+        # config errors (e.g. tl_subdir escaping the project root).
         detail = exc.code if isinstance(exc.code, str) else (str(exc) or "配置错误")
         return DoctorWorkerResult(False, None, "", f"环境检查失败：{detail}")
+    except Exception as exc:
+        return DoctorWorkerResult(False, None, "", f"环境检查失败：{exc}")
 
 
 class DoctorWorker(QThread):
-    """Run collect_doctor_report() off the UI thread."""
+    """Run collect_doctor_report() off the UI thread against a config snapshot."""
 
     completed = Signal(object)
 
+    def __init__(
+        self,
+        config: RuntimeConfig | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        # Freeze whatever the UI/host passed; do not re-read UI state in run().
+        self._config = config
+
     def run(self) -> None:
-        self.completed.emit(run_doctor_check())
+        self.completed.emit(run_doctor_check(self._config))

--- a/tests/test_gui_doctor_worker.py
+++ b/tests/test_gui_doctor_worker.py
@@ -63,15 +63,78 @@ class GuiDoctorWorkerTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertIn("Invalid tl_subdir", result.error)
 
-    def test_worker_delegates_to_run_doctor_check(self):
-        worker = DoctorWorker()
+    def test_run_doctor_check_applies_explicit_config_without_disk_reload(self):
+        import translator_runtime as runtime
+
+        report = {"mode": "ready"}
+        cfg = runtime.default_runtime_config()
+        cfg.prep_language = "korean"
+        cfg.tl_subdir = "game/tl/korean"
+        cfg.base_dir = "C:/games/Example/work"
+        cfg.tl_dir = "C:/games/Example/work/game/tl/korean"
+        cfg.work_game_dir = "C:/games/Example/work/game"
+
+        with mock.patch(
+            "gemini_translate_batch.collect_doctor_report",
+            return_value=report,
+        ), mock.patch(
+            "gemini_translate_batch.load_batch_settings",
+        ), mock.patch(
+            "gemini_translate_batch.print_doctor_report",
+        ), mock.patch(
+            "translator_runtime.load_translator_settings",
+        ) as load_settings, mock.patch(
+            "translator_runtime.load_glossary",
+        ):
+            result = run_doctor_check(cfg)
+
+        self.assertTrue(result.ok)
+        load_settings.assert_not_called()
+
+    def test_run_doctor_check_restores_previous_globals(self):
+        import translator_runtime as runtime
+
+        previous_lang = runtime.PREP_LANGUAGE
+        previous_subdir = runtime.TL_SUBDIR
+        report = {"mode": "ready"}
+        cfg = runtime.default_runtime_config()
+        cfg.prep_language = "japanese"
+        cfg.tl_subdir = "game/tl/japanese"
+        cfg.base_dir = runtime.BASE_DIR
+        cfg.tl_dir = runtime.TL_DIR
+        cfg.work_game_dir = runtime.WORK_GAME_DIR
+
+        try:
+            with mock.patch(
+                "gemini_translate_batch.collect_doctor_report",
+                return_value=report,
+            ), mock.patch(
+                "gemini_translate_batch.load_batch_settings",
+            ), mock.patch(
+                "gemini_translate_batch.print_doctor_report",
+            ), mock.patch(
+                "translator_runtime.load_glossary",
+            ):
+                result = run_doctor_check(cfg)
+            self.assertTrue(result.ok)
+            self.assertEqual(runtime.PREP_LANGUAGE, previous_lang)
+            self.assertEqual(runtime.TL_SUBDIR, previous_subdir)
+        finally:
+            runtime.PREP_LANGUAGE = previous_lang
+            runtime.TL_SUBDIR = previous_subdir
+
+    def test_worker_passes_config_to_run_doctor_check(self):
+        import translator_runtime as runtime
+
+        cfg = runtime.default_runtime_config()
+        worker = DoctorWorker(config=cfg)
         payload = DoctorWorkerResult(True, {"mode": "ready"}, "log")
         with mock.patch(
             "gui_qt.doctor_worker.run_doctor_check",
             return_value=payload,
         ) as run_mock:
             worker.run()
-        run_mock.assert_called_once()
+        run_mock.assert_called_once_with(cfg)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -312,5 +312,72 @@ class DefaultsFirstReloadTests(unittest.TestCase):
             _restore_sensitive_runtime(snapshot)
 
 
+class RuntimeConfigScopeTests(unittest.TestCase):
+    def test_scope_applies_config_and_restores_previous(self):
+        snapshot = _snapshot_sensitive_runtime()
+        try:
+            before = runtime.snapshot_runtime_config()
+            job = before.copy()
+            job.prep_language = "korean"
+            job.api_keys = ["scope-key"]
+            seen = {}
+            with runtime.runtime_config_scope(job) as active:
+                seen["lang"] = runtime.PREP_LANGUAGE
+                seen["keys"] = list(runtime.API_KEYS)
+                seen["active_lang"] = active.prep_language
+            self.assertEqual(seen["lang"], "korean")
+            self.assertEqual(seen["keys"], ["scope-key"])
+            self.assertEqual(seen["active_lang"], "korean")
+            self.assertEqual(runtime.PREP_LANGUAGE, before.prep_language)
+            self.assertEqual(runtime.API_KEYS, before.api_keys)
+        finally:
+            _restore_sensitive_runtime(snapshot)
+
+    def test_scope_restores_after_exception(self):
+        snapshot = _snapshot_sensitive_runtime()
+        try:
+            before_lang = runtime.PREP_LANGUAGE
+            job = runtime.snapshot_runtime_config().copy()
+            job.prep_language = "japanese"
+            with self.assertRaises(RuntimeError):
+                with runtime.runtime_config_scope(job):
+                    self.assertEqual(runtime.PREP_LANGUAGE, "japanese")
+                    raise RuntimeError("job failed")
+            self.assertEqual(runtime.PREP_LANGUAGE, before_lang)
+        finally:
+            _restore_sensitive_runtime(snapshot)
+
+    def test_scope_reload_translator_settings_is_restored(self):
+        snapshot = _snapshot_sensitive_runtime()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                workspace = Path(tmp)
+                work = workspace / "work"
+                work.mkdir()
+                config_path = workspace / "translator_config.json"
+                config_path.write_text(
+                    json.dumps(
+                        {
+                            "game_root": str(work),
+                            "tl_subdir": "game/tl/japanese",
+                            "prepare": {"language": "japanese"},
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                before_lang = runtime.PREP_LANGUAGE
+                with (
+                    mock.patch.object(runtime, "TRANSLATOR_CONFIG", str(config_path)),
+                    mock.patch.object(runtime, "ROOT_DIR", str(workspace / "tool")),
+                    mock.patch.object(runtime, "TOOL_DIR", str(workspace / "tool")),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    with runtime.runtime_config_scope(reload_translator_settings=True):
+                        self.assertEqual(runtime.PREP_LANGUAGE, "japanese")
+                    self.assertEqual(runtime.PREP_LANGUAGE, before_lang)
+        finally:
+            _restore_sensitive_runtime(snapshot)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -20,13 +20,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
-_runtime_state_lock = threading.Lock()
+# RLock so apply_runtime_config can nest inside locked_runtime_state /
+# runtime_config_scope without deadlocking (GUI workers hold the outer lock).
+_runtime_state_lock = threading.RLock()
 _active_runtime_config: Optional["RuntimeConfig"] = None
 
 
 @contextmanager
 def locked_runtime_state():
-    """Serialize temporary BASE_DIR overrides across worker threads."""
+    """Serialize temporary BASE_DIR / runtime-config overrides across workers."""
     with _runtime_state_lock:
         yield
 
@@ -1212,6 +1214,48 @@ def get_runtime_config() -> RuntimeConfig:
     if _active_runtime_config is not None:
         return _active_runtime_config.copy()
     return snapshot_runtime_config()
+
+
+@contextmanager
+def runtime_config_scope(
+    config: Optional["RuntimeConfig"] = None,
+    *,
+    reload_translator_settings: bool = False,
+    reload_runtime_config: bool = False,
+    require_api_key: bool = False,
+):
+    """Temporarily publish a job-scoped RuntimeConfig, then restore the previous one.
+
+    Long-lived hosts (GUI workers, registry scans) should use this so a job runs
+    against a frozen configuration snapshot without permanently mutating process
+    globals for other concurrent or subsequent work.
+
+    Args:
+        config: Explicit config to apply for the duration of the ``with`` block.
+            When provided, disk loaders are not run unless a reload flag is also set.
+        reload_translator_settings: When ``config`` is omitted, reload project
+            settings from ``translator_config.json`` (and leave API keys as-is).
+        reload_runtime_config: When ``config`` is omitted, call
+            :func:`load_runtime_config` for a full defaults-first rebuild.
+        require_api_key: Forwarded to :func:`load_runtime_config` when reloading.
+    """
+    if reload_translator_settings and reload_runtime_config:
+        raise ValueError(
+            "reload_translator_settings and reload_runtime_config are mutually exclusive"
+        )
+
+    with locked_runtime_state():
+        previous = snapshot_runtime_config()
+        try:
+            if config is not None:
+                apply_runtime_config(config)
+            elif reload_runtime_config:
+                load_runtime_config(require_api_key=require_api_key)
+            elif reload_translator_settings:
+                load_translator_settings()
+            yield snapshot_runtime_config()
+        finally:
+            apply_runtime_config(previous)
 
 
 def _read_json_object(path: str, *, label: str) -> dict:


### PR DESCRIPTION
## Summary
- Add `runtime_config_scope()` (and re-entrant runtime lock) so long-lived hosts can run a job against a frozen `RuntimeConfig` and always restore the previous process globals.
- `DoctorWorker` / `run_doctor_check(config=...)` accept an explicit snapshot; MainWindow freezes current settings when starting doctor.
- `games_registry._temporary_game_root` restores a full config snapshot instead of only `BASE_DIR`.

This is phase 2 of #216: per-job isolation for the in-process GUI paths that still share module globals. Full call-graph threading of `RuntimeConfig` through batch/sync remains future work.

## Test plan
- [x] `python -m unittest tests.test_runtime_config tests.test_gui_doctor_worker -v`
- [x] `python -m unittest tests.test_translator_runtime tests.test_target_language_config tests.test_prepare_command_trust tests.test_runtime_config tests.test_gui_doctor_worker`
- [ ] CI green on this PR

Refs #216