### PR TITLE
Migrate LiteLLM install to OptionalFeatureInstallController

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -246,6 +246,7 @@ from optional_feature import FeatureInstallState, FeatureStatus
 from .optional_feature_install import (
     OptionalFeatureInstallController,
     action_enabled_for_status,
+    build_litellm_controller,
     build_relation_analyzer_controller,
 )
 from .project_state import ProjectState
@@ -445,7 +446,6 @@ class MainWindow(QMainWindow):
         self._last_main_tab_index = 0
         self._handling_config_tab_leave = False
         self._task_running = False
-        self._litellm_install_active = False
         self._litellm_catalog_worker: LiteLLMModelCatalogWorker | None = None
         self._litellm_version_worker: LiteLLMVersionWorker | None = None
         self._litellm_latest_version = ""
@@ -457,6 +457,7 @@ class MainWindow(QMainWindow):
         self._litellm_catalog_models: dict[str, tuple[str, ...]] = {}
         self._updating_litellm_provider = False
         self._games_registry_panel: GamesRegistryPanel | None = None
+        self._litellm_install: OptionalFeatureInstallController | None = None
         self._relation_analyzer_install: OptionalFeatureInstallController | None = None
         self._optional_feature_last_failed: set[str] = set()
 
@@ -5357,114 +5358,63 @@ class MainWindow(QMainWindow):
             and mode in self._sync_work_modes_requiring_api_key()
         )
 
+    def _ensure_litellm_install_controller(self) -> OptionalFeatureInstallController:
+        controller = getattr(self, "_litellm_install", None)
+        if controller is not None:
+            return controller
+        controller = build_litellm_controller(self)
+        controller.output_received.connect(self._on_optional_feature_install_output)
+        controller.state_changed.connect(self._on_litellm_install_state_changed)
+        controller.finished.connect(self._on_litellm_install_finished)
+        self._litellm_install = controller
+        return controller
+
     def _litellm_install_running(self) -> bool:
-        if bool(getattr(self, "_litellm_install_active", False)):
+        controller = getattr(self, "_litellm_install", None)
+        if controller is not None and controller.is_running():
             return True
-        process = getattr(self, "_litellm_install_process", None)
-        return (
-            process is not None
-            and process.state() != QProcess.ProcessState.NotRunning
-        )
+        # Lightweight unit tests may force busy state without a QProcess.
+        return bool(getattr(self, "_litellm_install_active", False))
 
     def _on_install_litellm(self) -> None:
-        if self._litellm_install_running():
+        controller = self._ensure_litellm_install_controller()
+        if controller.is_running():
             return
-        if OptionalFeatureInstallController.any_install_running():
-            other = OptionalFeatureInstallController.active_feature_id() or "另一可选功能"
-            QMessageBox.information(
-                self,
-                "无法安装 LiteLLM",
-                f"已有可选功能正在安装（{other}），请完成后再试。",
-            )
+        started, message = controller.start_install()
+        if not started:
+            QMessageBox.information(self, "无法安装 LiteLLM", message)
             return
-        requirements_path = Path(__file__).resolve().parents[1] / "requirements-litellm.txt"
-        if not requirements_path.is_file():
-            QMessageBox.warning(self, "无法安装 LiteLLM", f"找不到依赖文件：{requirements_path}")
-            return
-
-        process = QProcess(self)
-        process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
-        environment = QProcessEnvironment.systemEnvironment()
-        environment.insert("PYTHONIOENCODING", "utf-8")
-        environment.insert("PYTHONUTF8", "1")
-        process.setProcessEnvironment(environment)
-        process.readyReadStandardOutput.connect(self._on_litellm_install_output)
-        process.finished.connect(self._on_litellm_install_finished)
-        process.errorOccurred.connect(self._on_litellm_install_error)
-        self._litellm_install_process = process
-        self._litellm_install_active = True
-        self._litellm_install_is_update = bool(installed_litellm_version())
-        # Share the optional-feature install mutex so concurrent pip installs
-        # (e.g. relation analyzer) cannot race the same environment.
-        OptionalFeatureInstallController._active_feature_id = "litellm"
-        OptionalFeatureInstallController._active_controller = None
-        OptionalFeatureInstallController._external_install_active = True
-        pip_args = ["-m", "pip", "install"]
-        if self._litellm_install_is_update:
-            pip_args.append("--upgrade")
-        pip_args.extend(["-r", str(requirements_path)])
-
-        self._show_workbench_log_drawer()
-        action = "更新" if self._litellm_install_is_update else "安装"
-        self._append_log(
-            f"=== 正在{action} LiteLLM ===\n{sys.executable} {' '.join(pip_args)}\n"
-        )
-        process.start(sys.executable, pip_args)
         self._on_sync_backend_changed(-1)
 
-    def _on_litellm_install_output(self) -> None:
-        process = getattr(self, "_litellm_install_process", None)
-        if process is None:
+    def _on_litellm_install_state_changed(
+        self,
+        _feature_id: str,
+        _status: FeatureStatus,
+    ) -> None:
+        self._on_sync_backend_changed(-1)
+
+    def _on_litellm_install_finished(
+        self,
+        feature_id: str,
+        succeeded: bool,
+        message: str,
+    ) -> None:
+        if feature_id != "litellm":
             return
-        text = bytes(process.readAllStandardOutput()).decode("utf-8", errors="replace")
-        if text:
-            self._append_log(text)
-
-    def _clear_external_optional_install_mutex(self) -> None:
-        if getattr(OptionalFeatureInstallController, "_external_install_active", False):
-            OptionalFeatureInstallController._external_install_active = False
-            if OptionalFeatureInstallController._active_feature_id == "litellm":
-                OptionalFeatureInstallController._active_feature_id = None
-                OptionalFeatureInstallController._active_controller = None
-
-    def _on_litellm_install_finished(self, exit_code: int, _exit_status: object) -> None:
-        process = getattr(self, "_litellm_install_process", None)
-        if process is not None:
-            self._on_litellm_install_output()
-        self._litellm_install_process = None
-        self._litellm_install_active = False
-        self._clear_external_optional_install_mutex()
-        importlib.invalidate_caches()
-        action = "更新" if bool(getattr(self, "_litellm_install_is_update", False)) else "安装"
-        succeeded = exit_code == 0 and bool(installed_litellm_version())
         if succeeded:
-            self._append_log(f"\n[LiteLLM {action}完成]\n")
-            self.statusBar().showMessage(f"LiteLLM {action}完成。", 5000)
+            self.statusBar().showMessage(message, 5000)
         else:
-            self._append_log(f"\n[LiteLLM {action}失败，退出码：{exit_code}]\n")
-            QMessageBox.warning(self, f"LiteLLM {action}失败", "请查看工作台日志中的 pip 输出。")
+            QMessageBox.warning(
+                self,
+                "LiteLLM 安装失败",
+                f"{message}\n请查看工作台日志中的 pip 输出。",
+            )
         self._refresh_litellm_version_label()
         self._on_sync_backend_changed(-1)
         if succeeded:
             self._on_check_litellm_version()
             if self._selected_sync_backend() == "litellm":
                 self._on_refresh_litellm_models()
-
-    def _on_litellm_install_error(self, error: object) -> None:
-        process = getattr(self, "_litellm_install_process", None)
-        message = process.errorString() if process is not None else "未知进程错误"
-        self._append_log(f"\n[LiteLLM 安装进程错误] {message}\n")
-        if error != QProcess.ProcessError.FailedToStart:
-            return
-        self._litellm_install_process = None
-        self._litellm_install_active = False
-        self._clear_external_optional_install_mutex()
-        self._on_sync_backend_changed(-1)
-        QMessageBox.warning(
-            self,
-            "LiteLLM 安装失败",
-            f"无法启动安装进程：{message}\n请查看工作台日志了解详情。",
-        )
 
     def _sync_work_modes_requiring_api_key(self) -> frozenset[WorkMode]:
         return frozenset(

--- a/gui_qt/optional_feature_install.py
+++ b/gui_qt/optional_feature_install.py
@@ -19,6 +19,7 @@ from optional_feature import (
     FeatureStatus,
     OptionalFeatureSpec,
     hash_checked_install_command,
+    litellm_feature,
     probe_feature,
     relation_analyzer_feature,
 )
@@ -36,8 +37,6 @@ class OptionalFeatureInstallController(QObject):
 
     _active_feature_id: str | None = None
     _active_controller: "OptionalFeatureInstallController | None" = None
-    # Set by non-controller install paths (e.g. LiteLLM page) sharing the mutex.
-    _external_install_active: bool = False
 
     def __init__(
         self,
@@ -60,8 +59,6 @@ class OptionalFeatureInstallController(QObject):
 
     @classmethod
     def any_install_running(cls) -> bool:
-        if cls._external_install_active:
-            return True
         controller = cls._active_controller
         if controller is None:
             return False
@@ -143,9 +140,15 @@ class OptionalFeatureInstallController(QObject):
         *,
         upgrade: bool | None,
     ) -> tuple[list[str] | None, str]:
-        lock_path = self.feature.lock_path(self.repo_root)
+        lock_relative = str(self.feature.lock_relative_path or "").strip()
+        lock_path = self.feature.lock_path(self.repo_root) if lock_relative else None
         requirements_path = self.feature.requirements_path(self.repo_root)
-        use_lock = self.prefer_hash_lock and lock_path.is_file()
+        use_lock = bool(
+            self.prefer_hash_lock
+            and lock_relative
+            and lock_path is not None
+            and lock_path.is_file()
+        )
         target = lock_path if use_lock else requirements_path
         if not target.is_file():
             return None, f"找不到依赖文件：{target}"
@@ -236,6 +239,21 @@ def build_relation_analyzer_controller(
         parent=parent,
         repo_root=repo_root,
         prefer_hash_lock=True,
+    )
+
+
+def build_litellm_controller(
+    parent: QObject | None = None,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> OptionalFeatureInstallController:
+    """LiteLLM uses the platform hash lock when available, else requirements.txt."""
+    feature = litellm_feature(repo_root)
+    return OptionalFeatureInstallController(
+        feature,
+        parent=parent,
+        repo_root=repo_root,
+        prefer_hash_lock=bool(feature.lock_relative_path),
     )
 
 

--- a/optional_feature.py
+++ b/optional_feature.py
@@ -174,14 +174,27 @@ def relation_analyzer_feature(repo_root: Path = REPO_ROOT) -> OptionalFeatureSpe
     )
 
 
+def litellm_lock_relative_path() -> str:
+    """Return the committed platform lock for the current OS, if any."""
+    if sys.platform == "win32":
+        return "requirements-lock/py311-windows-litellm.txt"
+    if sys.platform.startswith("linux"):
+        return "requirements-lock/py311-linux-litellm.txt"
+    return ""
+
+
 def litellm_feature(repo_root: Path = REPO_ROOT) -> OptionalFeatureSpec:
     requirements_path = Path(repo_root) / "requirements-litellm.txt"
     packages = _parse_pinned_requirements(requirements_path)
+    lock_relative = litellm_lock_relative_path()
+    lock_path = Path(repo_root) / lock_relative if lock_relative else None
+    if lock_path is not None and not lock_path.is_file():
+        lock_relative = ""
     return OptionalFeatureSpec(
         feature_id="litellm",
         display_name="LiteLLM",
         packages=packages,
-        lock_relative_path="",  # platform-specific; GUI currently uses unpinned requirements
+        lock_relative_path=lock_relative,
         requirements_relative_path="requirements-litellm.txt",
         purpose="可选同步翻译后端（OpenAI 兼容等 provider）。",
         components=tuple(pkg.distribution for pkg in packages),

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -2,7 +2,8 @@ import unittest
 from unittest import mock
 
 try:
-    from gui_qt.app import MainWindow, QProcess
+    from gui_qt.app import MainWindow
+    from gui_qt.optional_feature_install import OptionalFeatureInstallController
     from gui_qt.work_modes import WorkMode
 except ImportError as exc:
     MainWindow = None
@@ -49,11 +50,6 @@ class _Button:
         self.text = value
 
 
-class _Process:
-    def errorString(self):
-        return "cannot start"
-
-
 class _ProgressBar:
     def __init__(self):
         self.visible = None
@@ -73,6 +69,8 @@ class _ProgressBar:
 @unittest.skipIf(MainWindow is None, f"GUI dependencies are unavailable: {IMPORT_ERROR}")
 class GuiLiteLLMInstallTests(unittest.TestCase):
     def setUp(self):
+        OptionalFeatureInstallController._active_feature_id = None
+        OptionalFeatureInstallController._active_controller = None
         self.window = MainWindow.__new__(MainWindow)
         self.window.sync_backend_combo = _Combo("litellm")
         self.window.sync_backend_hint = _Label()
@@ -80,7 +78,13 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.window.sync_model_combo = _Combo(None)
         self.window.litellm_model_combo = _Combo(None)
         self.window.litellm_install_progress = _ProgressBar()
+        self.window._litellm_install = None
+        self.window._litellm_install_active = False
         self.window._refresh_litellm_install_action_gating = mock.Mock()
+
+    def tearDown(self):
+        OptionalFeatureInstallController._active_feature_id = None
+        OptionalFeatureInstallController._active_controller = None
 
     def test_missing_dependency_shows_enabled_install_button(self):
         with mock.patch("gui_qt.app.importlib.util.find_spec", return_value=None):
@@ -102,38 +106,64 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertFalse(self.window.install_litellm_btn.enabled)
         self.assertIn("正在后台安装", self.window.sync_backend_hint.value)
 
-    def test_failed_to_start_clears_install_state_and_restores_ui(self):
-        self.window._litellm_install_process = _Process()
-        self.window._litellm_install_active = True
-        self.window._append_log = mock.Mock()
+    def test_failed_install_restores_ui_via_controller_finished(self):
         self.window._on_sync_backend_changed = mock.Mock()
+        self.window._refresh_litellm_version_label = mock.Mock()
+        self.window._on_check_litellm_version = mock.Mock()
+        self.window._selected_sync_backend = mock.Mock(return_value="gemini")
+        self.window.statusBar = mock.Mock(return_value=mock.Mock())
         with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
-            self.window._on_litellm_install_error(
-                QProcess.ProcessError.FailedToStart
+            self.window._on_litellm_install_finished(
+                "litellm",
+                False,
+                "无法启动安装进程：cannot start",
             )
-        self.assertIsNone(self.window._litellm_install_process)
-        self.assertFalse(self.window._litellm_install_active)
         self.window._on_sync_backend_changed.assert_called_once_with(-1)
         warning.assert_called_once()
-        self.assertIn(
-            "cannot start",
-            self.window._append_log.call_args.args[0],
-        )
+        self.assertEqual(warning.call_args.args[1], "LiteLLM 安装失败")
+        self.assertIn("cannot start", warning.call_args.args[2])
 
-    def test_non_start_error_waits_for_finished_cleanup(self):
-        process = _Process()
-        self.window._litellm_install_process = process
-        self.window._litellm_install_active = True
-        self.window._append_log = mock.Mock()
+    def test_successful_install_refreshes_version_and_models(self):
         self.window._on_sync_backend_changed = mock.Mock()
+        self.window._refresh_litellm_version_label = mock.Mock()
+        self.window._on_check_litellm_version = mock.Mock()
+        self.window._on_refresh_litellm_models = mock.Mock()
+        self.window._selected_sync_backend = mock.Mock(return_value="litellm")
+        status_bar = mock.Mock()
+        self.window.statusBar = mock.Mock(return_value=status_bar)
         with mock.patch("gui_qt.app.QMessageBox.warning") as warning:
-            self.window._on_litellm_install_error(
-                QProcess.ProcessError.Crashed
+            self.window._on_litellm_install_finished(
+                "litellm",
+                True,
+                "LiteLLM 安装完成。",
             )
-        self.assertIs(self.window._litellm_install_process, process)
-        self.assertTrue(self.window._litellm_install_active)
-        self.window._on_sync_backend_changed.assert_not_called()
         warning.assert_not_called()
+        status_bar.showMessage.assert_called_once()
+        self.window._refresh_litellm_version_label.assert_called_once()
+        self.window._on_check_litellm_version.assert_called_once()
+        self.window._on_refresh_litellm_models.assert_called_once()
+        self.window._on_sync_backend_changed.assert_called_once_with(-1)
+
+    def test_install_uses_shared_optional_feature_controller(self):
+        controller = mock.Mock()
+        controller.is_running.return_value = False
+        controller.start_install.return_value = (True, "started")
+        self.window._ensure_litellm_install_controller = mock.Mock(
+            return_value=controller
+        )
+        self.window._on_sync_backend_changed = mock.Mock()
+        self.window._on_install_litellm()
+        controller.start_install.assert_called_once_with()
+        self.window._on_sync_backend_changed.assert_called_once_with(-1)
+
+    def test_install_blocks_when_controller_reports_busy(self):
+        controller = mock.Mock()
+        controller.is_running.return_value = True
+        self.window._ensure_litellm_install_controller = mock.Mock(
+            return_value=controller
+        )
+        self.window._on_install_litellm()
+        controller.start_install.assert_not_called()
 
     def test_install_blocks_all_litellm_sync_modes_but_not_batch(self):
         self.window._litellm_install_active = True
@@ -225,6 +255,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
             "当前 Python 可用最新版",
         )
         self.assertFalse(self.window.install_litellm_btn.enabled)
+
     def test_gemini_backend_hides_install_button(self):
         self.window.sync_backend_combo = _Combo("gemini")
         self.window._litellm_install_running = mock.Mock(return_value=True)

--- a/tests/test_gui_optional_feature_install.py
+++ b/tests/test_gui_optional_feature_install.py
@@ -13,9 +13,15 @@ try:
     from gui_qt.optional_feature_install import (
         OptionalFeatureInstallController,
         action_enabled_for_status,
+        build_litellm_controller,
     )
     from gui_qt.work_modes import WorkMode
-    from optional_feature import FeatureInstallState, FeatureStatus, relation_analyzer_feature
+    from optional_feature import (
+        FeatureInstallState,
+        FeatureStatus,
+        litellm_feature,
+        relation_analyzer_feature,
+    )
 except ImportError as exc:
     QApplication = None  # type: ignore[assignment,misc]
     MainWindow = None  # type: ignore[assignment,misc]
@@ -53,7 +59,6 @@ class GuiOptionalFeatureInstallTests(unittest.TestCase):
     def setUp(self) -> None:
         OptionalFeatureInstallController._active_feature_id = None
         OptionalFeatureInstallController._active_controller = None
-        OptionalFeatureInstallController._external_install_active = False
         self.window = MainWindow()
         self.window.resize(1400, 900)
         self.window.show()
@@ -66,7 +71,6 @@ class GuiOptionalFeatureInstallTests(unittest.TestCase):
     def tearDown(self) -> None:
         OptionalFeatureInstallController._active_feature_id = None
         OptionalFeatureInstallController._active_controller = None
-        OptionalFeatureInstallController._external_install_active = False
         self.window.close()
         self.window.deleteLater()
 
@@ -191,13 +195,61 @@ class GuiOptionalFeatureInstallTests(unittest.TestCase):
             action_enabled_for_status(_status(FeatureInstallState.INSTALLING))
         )
 
-    def test_controller_blocks_concurrent_external_install(self) -> None:
-        controller = OptionalFeatureInstallController(relation_analyzer_feature())
-        OptionalFeatureInstallController._external_install_active = True
-        OptionalFeatureInstallController._active_feature_id = "litellm"
-        started, message = controller.start_install()
+    def test_controller_blocks_concurrent_optional_feature_install(self) -> None:
+        analyzer = OptionalFeatureInstallController(relation_analyzer_feature())
+        litellm = build_litellm_controller()
+        analyzer._active = True
+        OptionalFeatureInstallController._active_controller = analyzer
+        OptionalFeatureInstallController._active_feature_id = "relation_analyzer"
+        started, message = litellm.start_install()
         self.assertFalse(started)
-        self.assertIn("litellm", message)
+        self.assertIn("relation_analyzer", message)
+
+    def test_litellm_builder_prefers_platform_lock_when_available(self) -> None:
+        feature = litellm_feature()
+        controller = build_litellm_controller()
+        self.assertEqual(controller.feature.feature_id, "litellm")
+        if feature.lock_relative_path:
+            self.assertTrue(controller.prefer_hash_lock)
+            self.assertTrue(feature.lock_path().is_file())
+        else:
+            self.assertFalse(controller.prefer_hash_lock)
+
+    def test_failed_to_start_emits_finished_and_releases_mutex(self) -> None:
+        controller = OptionalFeatureInstallController(relation_analyzer_feature())
+        finished = mock.Mock()
+        controller.finished.connect(finished)
+        process = mock.Mock()
+        process.errorString.return_value = "cannot start"
+        controller._process = process
+        controller._active = True
+        OptionalFeatureInstallController._active_controller = controller
+        OptionalFeatureInstallController._active_feature_id = "relation_analyzer"
+        from PySide6.QtCore import QProcess
+
+        controller._on_error(QProcess.ProcessError.FailedToStart)
+        self.assertFalse(controller.is_running())
+        self.assertIsNone(OptionalFeatureInstallController._active_controller)
+        finished.assert_called_once()
+        self.assertFalse(finished.call_args.args[1])
+        self.assertIn("cannot start", finished.call_args.args[2])
+
+    def test_non_start_error_waits_for_finished_cleanup(self) -> None:
+        controller = OptionalFeatureInstallController(relation_analyzer_feature())
+        finished = mock.Mock()
+        controller.finished.connect(finished)
+        process = mock.Mock()
+        process.errorString.return_value = "crashed"
+        controller._process = process
+        controller._active = True
+        OptionalFeatureInstallController._active_controller = controller
+        OptionalFeatureInstallController._active_feature_id = "relation_analyzer"
+        from PySide6.QtCore import QProcess
+
+        controller._on_error(QProcess.ProcessError.Crashed)
+        self.assertTrue(controller.is_running())
+        self.assertIs(OptionalFeatureInstallController._active_controller, controller)
+        finished.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Route LiteLLM GUI install/update through the shared `OptionalFeatureInstallController` used by the relation analyzer.
- Prefer the committed platform hash lock (`py311-windows-litellm` / `py311-linux-litellm`) when present; fall back to `requirements-litellm.txt`.
- Remove the duplicated LiteLLM `QProcess` path and the temporary external install mutex.

## Test plan

- [x] `python -B -m unittest tests.test_gui_litellm_install tests.test_gui_optional_feature_install tests.test_optional_feature tests.test_gui_litellm_settings_page -q`
- [ ] Install/update LiteLLM from Settings → LiteLLM while relation-analyzer install is idle
- [ ] Confirm concurrent optional-feature install is rejected with a clear message
- [ ] Confirm LiteLLM-backed sync actions stay gated only while LiteLLM install runs

Refs #234