### PR TITLE
feat: Project Analysis 阶段 1 产物合同与只读状态 (#256)

### DIFF
--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -2,13 +2,14 @@
 
 文档地图：[docs/README.md](README.md)
 
-本文档说明 Batch / sync 可选上下文层：RAG history store、Batch source-only index 和 Structured Story Memory。
+本文档说明 Batch / sync 可选上下文层：RAG history store、Batch source-only index、Structured Story Memory，以及 **Project Analysis（项目分析）** 的产物合同。
 
 ## 如何选择上下文层
 
 - RAG history store：使用“已有原文 + 已有译文”保持术语、称呼和风格一致。
 - Batch source-only index：只使用全文原文，为新项目或译文很少的项目提供远距离剧情上下文。
 - Structured Story Memory：人工维护的结构化角色、关系、术语和场景图谱。
+- Project Analysis：从带 evidence 的 chunk / label / route 摘要聚合为可审核的项目理解（路线感知 brief）；**只有已发布且 fingerprint 未陈旧的产物**才允许注入后续翻译/审校（生成与发布见后续阶段）。
 
 这些上下文层会进入不同 prompt 分区，避免把“以前的译法参考”和“相关剧情原文”混在一起。
 
@@ -24,6 +25,7 @@
 ```text
 logs/rag_store/<project_slug>/
 logs/source_index_store/<project_slug>/
+logs/project_analysis/<project_slug>/
 logs/story_memory/story_graph.json
 ```
 
@@ -43,10 +45,76 @@ logs/story_memory/story_graph.json
 ```text
 <GameProject>/translation_context/rag_store/
 <GameProject>/translation_context/source_index_store/
+<GameProject>/translation_context/project_analysis/
 <GameProject>/translation_context/story_memory/story_graph.json
 ```
 
 `batch.rag.store_dir`、`batch.source_index.store_dir`、`sync.rag.store_dir` 和 `story_memory.graph_file` 仍然可以显式指定；一旦填了具体路径，就优先使用该路径，不再跟随 `context_storage.location`。
+
+## Project Analysis（项目分析）
+
+> 阶段 1（#256）只交付**产物合同、状态与只读检查**，不调用模型，也不把分析正文注入翻译 prompt。路线感知生成（#254）与最终审校 campaign（#255）将复用同一套 schema / fingerprint / 发布状态。
+
+### 产物目录
+
+默认与其它上下文库一样，跟随 `context_storage`：
+
+```text
+.../project_analysis/
+  manifest.json
+  chunk_summaries.jsonl
+  scene_summaries.jsonl
+  label_summaries.jsonl
+  route_summaries.json
+  project_brief.draft.md
+  project_brief.published.md
+```
+
+核心模块：`project_analysis.py`（schema、原子写入、lineage fingerprint、失效规划、状态汇总）。
+
+### 状态
+
+| 状态 | 含义 |
+|------|------|
+| `missing` | 尚无产物 |
+| `draft` | 已生成，未发布 |
+| `review_required` | 需要人工审核 |
+| `published` | 已发布 |
+| `stale` | 上游源/依赖 fingerprint 已变，或显式失效 |
+| `failed` | 读取/校验失败 |
+
+**只有 `published` 且 fingerprint 仍匹配时**，下游才可将该产物视为可注入的正式上下文。stale published **不得**静默继续注入。
+
+### 证据与 lineage
+
+每条可发布摘要至少包含稳定 `id` / `kind`、源文件、适用时的 label/scene/route 标识、`evidence_item_ids`、行跨度 / `source_checksum`、上游产物 id，以及 lineage：
+
+- `schema_version`
+- `source_fingerprint`
+- `prompt_schema_version`
+- `provider` / `model` / `thinking_level`（生成阶段可为空）
+- `upstream_dependency_digest`
+- `generated_at` / `reviewed_at` / `published_at`
+
+### 局部失效
+
+- 单个源 item 变化 → 失效引用它的 chunk / scene / label、依赖它们的 route，以及 global brief
+- 无关 route 保持有效
+- prompt / schema / provider / model 变化按 dependency digest 判定（调用方把受影响 artifact id 传入失效规划器）
+
+### 只读 CLI / GUI
+
+```bash
+python gemini_translate_batch.py project-analysis-status
+python gemini_translate_batch.py project-analysis-status --json
+python gemini_translate_batch.py project-analysis-status --store-dir <path> --source-fingerprint <digest>
+```
+
+- `doctor` 报告中的 `Project analysis:` 行汇总 overall / 计数 / brief 状态。
+- GUI「上下文库」展示只读「项目分析」状态行；状态判断在 `project_analysis` 模块内完成，GUI 不重复实现失效逻辑。
+- 本阶段**不**提供生成、发布或写回按钮。
+
+设计对照与取舍见 [plans/wenyi_reference_and_batch_roadmap.md](plans/wenyi_reference_and_batch_roadmap.md)。
 
 ## Batch RAG 预建
 

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -332,7 +332,9 @@ build-keywords -> submit -> status -> download -> export-keywords
 
 若项目已有一部分译文，或希望在 build 时检索相关剧情原文，可在设置页启用批量上下文并预建本地库。
 
-设置页「上下文」里的「上下文库保存到游戏目录」会把默认 RAG / 原文索引 / 剧情图谱路径切到当前 `work` 同级的 `translation_context/`；关闭时仍使用工具项目内的 `logs/`。高级分区可显式覆盖 store 路径；Batch manifest、检查失败报告、补译包等运行记录仍保存在工具日志目录。
+设置页「上下文」里的「上下文库保存到游戏目录」会把默认 RAG / 原文索引 / 项目分析 / 剧情图谱路径切到当前 `work` 同级的 `translation_context/`；关闭时仍使用工具项目内的 `logs/`。高级分区可显式覆盖 store 路径；Batch manifest、检查失败报告、补译包等运行记录仍保存在工具日志目录。
+
+上下文库页中的 **项目分析** 行为只读状态（`project-analysis-status`）；阶段 1 不提供生成或发布按钮。详见 [上下文系统 · Project Analysis](context_systems.md#project-analysis项目分析)。
 
 预建流程：
 
@@ -348,9 +350,10 @@ build-keywords -> submit -> status -> download -> export-keywords
 ```text
 bootstrap-rag --skip-prepare
 bootstrap-source-index
+project-analysis-status
 ```
 
-预建结果以普通语言摘要显示；失败细节可在「诊断与运行日志」的原始输出查看。任务运行中状态卡上的预建按钮会禁用，避免叠跑。
+预建结果以普通语言摘要显示；失败细节可在「诊断与运行日志」的原始输出查看。任务运行中状态卡上的预建按钮会禁用，避免叠跑。项目分析在阶段 1 仅支持状态查看。
 
 若开启了 build 时自动补建，后续 `build` 仍可能自动补建；图形预建入口适合在首次翻译前手动确认 store 状态。
 

--- a/docs/plans/wenyi_reference_and_batch_roadmap.md
+++ b/docs/plans/wenyi_reference_and_batch_roadmap.md
@@ -34,7 +34,7 @@
 | 翻译对象 | 长篇小说电子书 | Ren'Py `game/tl/<lang>/` |
 | 主路径 | **同步在线** LLM 调用（进程内长跑） | **Batch 异步**（`build → submit → download → check → apply`） |
 | 「batch」含义 | 切段大小（字符预算） | 远端 Batch 作业 + package/manifest |
-| 全书理解 | `pipeline.book_understanding`：预扫 → 章梗概 + 全书概览，直接注入翻译 prompt | 规划中：**Project Analysis**（#253/#256–#254），draft → 人工 publish 后才注入 |
+| 全书理解 | `pipeline.book_understanding`：预扫 → 章梗概 + 全书概览，直接注入翻译 prompt | **#256 已交付**产物/状态合同与只读检查；**#254** 路线感知生成与人工 publish 后才注入（仍待做） |
 | 质量手段 | 多阶段 LLM（分析/梗概/译/润/审）+ 段数对齐 | glossary / macro / RAG / Story Memory + **规则闸门** + 订正/关键词 |
 | 最终审校 | 独立 `review` 命令；可 `--force` / 可选 `autofix_severe`；默认关闭 | 规划中：#255 report-only campaign → 现有 revision preview/apply |
 | 用量 | `state/.../usage.json`：provider-neutral，按 tier/stage 归因，跨续跑增量合并 | 规划中：#252 项目级账本；现有估算 + 分散在 results 的 raw usage |

--- a/docs/plans/wenyi_reference_and_batch_roadmap.md
+++ b/docs/plans/wenyi_reference_and_batch_roadmap.md
@@ -1,8 +1,8 @@
 # 文译（Wenyi）参考对照与 Batch 主路径增强计划
 
-> **状态：草案 / 规划中**（2026-07）  
-> **性质：设计与取舍记录，不是用户手册。**  
-> 实现落地后，应把「用户可见行为」写进现行文档（如 `batch_workflows.md`、`context_systems.md`），本文可迁入 `docs/archive/`。
+> **状态：进行中**（2026-07-22 对照刷新；#256 起落地 Project Analysis 合同）
+> **性质：设计与取舍记录，不是用户手册。**
+> 用户可见行为写入现行文档（如 `batch_workflows.md`、`context_systems.md`）；实现落地后本计划可迁入 `docs/archive/`。
 
 ## 1. 背景
 
@@ -10,28 +10,53 @@
 
 - 路径：`C:\RenPy_Workspace\_ref\wenyi`（仓库外，不随 lab 提交）
 - 上游：`https://github.com/BigDawnGhost/wenyi`（文译 / Wenyi，`trans-novel`）
+- 本轮对照基线：本地 `main@b796e45`（已与 origin 对齐），发行标签至 **v0.3.4**
 
-文译是**多语言小说 → 中文**的 CLI 工具：EPUB/FB2/TXT/HTML/PDF 等，强调全书预扫、滚动上下文、动态术语、可选润色与审校。  
+文译是**多语言小说 → 中文**的 CLI 工具：EPUB/FB2/TXT/Markdown/HTML/PDF 等，强调全书预扫、滚动上下文、动态术语、可选润色与可独立续跑的最终审校。
 本仓库（Ren'Py Translation Lab）是**游戏 `tl/*.rpy` 翻译工作台**，稳定版主路径是 **Gemini Batch 作业流** + check/apply 写回闸门；同步 CLI/GUI 为辅。
+
+**代码复用立场（默认）：**
+
+- **默认不复制**文译源码；对照其阶段划分、可续跑状态与用量归因等**产品意图**，在 lab 内独立实现。
+- 文译为 MIT；若将来复制 substantial portions，须保留 `Copyright (c) 2026 BigDawnGhost` 与 MIT 文本。仅 issue 致谢不构成许可证合规。
+- 不把文译作为 submodule 或运行时依赖。
 
 本文回答：
 
 1. 文译哪些做法值得学、哪些不该搬；
-2. 与 lab 已有能力（尤其**订正**）如何区分；
-3. 在 **Batch 为主** 的前提下，若要增强，应拆成哪些方向（非实现规格）。
+2. 与 lab 已有能力（尤其**订正**、Batch 闸门、上下文层）如何区分；
+3. 在 **Batch 为主** 的前提下，增强方向如何映射到已拆 GitHub issues。
 
 ## 2. 架构对照（决定取舍）
 
-| 维度 | 文译 | Lab（本仓库） |
-|------|------|----------------|
+| 维度 | 文译（当前） | Lab（本仓库） |
+|------|--------------|----------------|
 | 翻译对象 | 长篇小说电子书 | Ren'Py `game/tl/<lang>/` |
 | 主路径 | **同步在线** LLM 调用（进程内长跑） | **Batch 异步**（`build → submit → download → check → apply`） |
 | 「batch」含义 | 切段大小（字符预算） | 远端 Batch 作业 + package/manifest |
-| 质量手段 | 多阶段 LLM（分析/梗概/译/润/审） | glossary / macro / RAG / Story Memory + **规则闸门** + 订正/关键词 |
+| 全书理解 | `pipeline.book_understanding`：预扫 → 章梗概 + 全书概览，直接注入翻译 prompt | 规划中：**Project Analysis**（#253/#256–#254），draft → 人工 publish 后才注入 |
+| 质量手段 | 多阶段 LLM（分析/梗概/译/润/审）+ 段数对齐 | glossary / macro / RAG / Story Memory + **规则闸门** + 订正/关键词 |
+| 最终审校 | 独立 `review` 命令；可 `--force` / 可选 `autofix_severe`；默认关闭 | 规划中：#255 report-only campaign → 现有 revision preview/apply |
+| 用量 | `state/.../usage.json`：provider-neutral，按 tier/stage 归因，跨续跑增量合并 | 规划中：#252 项目级账本；现有估算 + 分散在 results 的 raw usage |
 | 写回 | 组装 EPUB 等到 `output/` | 写回 `.rpy`，强调 identity、快照、safe check |
-| 代码自称 | multi-agent | 无 Agent 层；CLI + 可选 GUI |
+| 状态目录 | `state/<book-slug>/`（manifest、chapters、context、glossary.db、usage…） | `logs/batch_jobs` manifest + 可选 `translation_context/` 上下文库 |
+| 代码自称 | multi-agent（实为 role-specialized LLM stage） | 无 Agent 层；可复用模块 + CLI + 可选 GUI |
 
-文译代码里的 `Agent` 实质是 **role-specialized LLM stage**（固定 prompt + 档位 + orchestrator 调度），**不是**自治多智能体。命名可参考为「阶段/角色」，不宜引入 lab 的 Agent 抽象层。
+文译 `Agent` 实质是 **固定 prompt + 档位 + orchestrator 调度**，不是自治多智能体。命名可参考为「阶段/角色」，不宜引入 lab 的 Agent 抽象层。
+
+### 2.1 文译近期能力（对照时注意）
+
+相对 2026-07-21 初版对照，上游已更明显的部分：
+
+| 能力 | 位置 / 说明 | Lab 映射 |
+|------|-------------|----------|
+| `prepare` 仅预扫分析 | 先生成风格指南与初始术语，再 `translate` | 对应「准备阶段」思路；lab 用 `bootstrap-*` / 未来 analysis 子命令，不塞进 translation submit |
+| 独立 `review` 续跑 | `review` / `--force` / `--fix`；`REVIEW_*` 状态 | #255 最终审校 campaign；**默认无 autofix 写 `.rpy`** |
+| 全书理解 map-reduce | `agents/synopsis.py` 分组归并章梗概 | #254 路线感知层级摘要；模型改为 Ren'Py route，非线性章 |
+| 用量账本 | `llm/usage.py` + RunStore `usage.json` | #252；采集 Batch results + 同步 backend，项目隔离 |
+| 模型分档 | `llm.tiers`: strong / cheap / fast | 后续阶段级路由；**先有 #252 真实数据** |
+| 断点续跑 | 章/批状态写盘，再跑跳过已完成 | lab 已有 Batch package/manifest；审校另建 digest 模型（#255） |
+| 术语作用域 | `glossary_scope: chapter` | 可在 build 时按 chunk 裁剪 glossary（P1a，与 epic 可并行） |
 
 ## 3. 明确不学 / 不搬
 
@@ -39,6 +64,9 @@
 |----|------|
 | 整包 multi-agent 类结构 | 增加抽象、不提升 Batch 闸门安全性 |
 | 默认全量「润色 pass」嵌进主译 | 成本高；对含标签/变量的 TL 风险大；与 Batch 物化请求模型不契合 |
+| 线性「章节」作为唯一结构 | Ren'Py 是分支剧本，至少区分 file / label / scene / route / global |
+| 自动把模型输出写入正式术语库 / 知识图 | lab 要求 draft → 人工确认 → published；不自动写 `glossary.json` / `story_graph.json` |
+| `autofix_severe` 式审校直接改文 | 任何正文修改继续走 revision preview/apply + 源快照校验 |
 | EPUB assemble / MinerU PDF 等 | 领域无关 |
 | 以同步长跑替换 Batch 主路径 | 违背 lab 已定稳定范围与交付形态 |
 | 回译抽检作为主质检 | 游戏短句 + code 混排更适合规则 check + 可选订正 |
@@ -53,67 +81,80 @@
 | 工程闸门 | 段数对齐失败则退回原文 | 预览报告 + 写回前旧译文快照校验 |
 | 输出可解释性 | 弱 | `reason` + revision preview 表 |
 
-**结论：** lab 的订正已经覆盖「改已有译文」的主需求，且更贴 Ren'Py。  
+**结论：** lab 的订正已经覆盖「改已有译文」的主需求，且更贴 Ren'Py。
 **不要**再平行引入一个默认全量 polish 阶段去替代订正。若未来要「风格抛光」，应作为**可选、显式、可预览**的订正策略或独立 package 模式，而不是翻译 submit 的隐式附带步骤。
 
 ## 5. 值得学的方向（按 Batch 主路径改写）
 
-下列意图来自文译，但实现必须落在 **build 时注入 / 多轮 package / 配置开关**，而不是「边译边改」的在线流水线。
+下列意图来自文译，但实现必须落在 **build 时注入 / 多轮 package / 配置开关 / 独立子命令**，而不是「边译边改」的在线流水线。
 
-### 5.1 开翻前「项目理解」强化（P1 候选）
+### 5.1 开翻前「项目理解」强化 → Epic #253
 
-**文译：** 预扫源文 → 分章梗概 + 全书概览，再注入翻译 prompt。  
-**Lab 现状：** macro setting、Story Memory、source index、RAG 已有；缺的是「一键从 TL/原文生成可审 brief」的标准化步骤。  
-**Batch 落点：**
+**文译：** 预扫源文 → 分章梗概 + 全书概览，再注入翻译 prompt。
+**Lab 落点（已拆 issue）：**
 
-- 独立准备阶段或 doctor/bootstrap 增强（**不**塞进同一次 translation submit）
-- 产物写入 work 目录或 store，供后续 `build` 读入 system/user 固定前缀
-- 可开关、可人工编辑后再 build
+| 阶段 | Issue | 要点 |
+|------|-------|------|
+| 产物与依赖合同 | **#256**（当前实现） | schema / evidence / fingerprint / draft·published / 失效语义；不调模型 |
+| 路线感知生成与发布 | #254 | chunk → label/scene → route → global brief；仅 published 注入 |
+| 最终审校 campaign | #255 | 稳定上下文快照；report-only → revision candidates |
 
-### 5.2 术语：先抽后译 / 多轮，而非译中实时（P1 候选）
+**与文译差异：**
 
-**文译：** 译完一批立刻抽术语，下一批在线用上。  
-**Lab 现状：** glossary + `build-keywords` / 关键词合并；Batch **无法**在同一次作业内让后 chunk 看到前 chunk 新术语。  
+- 不按线性章节建模；未解析动态跳转标 `unresolved`，不虚构单一路线
+- 每项摘要保留 evidence item IDs / 行号 / checksum
+- draft 不得静默进入 prompt；stale published 不得静默继续注入
+- 产物集中在项目 `translation_context/project_analysis/`（或 tool 模式等价路径），不散落到 Batch package
+
+### 5.2 术语：先抽后译 / 多轮，而非译中实时
+
+**文译：** 译完一批立刻抽术语，下一批在线用上。
+**Lab 现状：** glossary + `build-keywords` / 关键词合并；Batch **无法**在同一次作业内让后 chunk 看到前 chunk 新术语。
 **Batch 落点：**
 
 - 推荐节奏：`关键词/术语 pass` → 人工或半自动合并 glossary → 再 `build` 翻译
 - 可选：大项目「译完 → 抽术语 → 订正统一术语」第二轮 package
 - 可参考文译「本章作用域只注入相关词条」——在 **build 时**按 chunk 裁剪 glossary，省 token
 
-### 5.3 模型分档 strong / cheap / fast（P2 候选）
+### 5.3 模型分档 strong / cheap / fast
 
-**文译：** 分析/润色用强档，梗概/审校用便宜档。  
-**Lab 落点：** 主译 Batch、关键词、订正、probe 等可配置不同模型或 tier；配置进 `translator_config` + GUI 设置同步（见 CONTRIBUTING）。
+**文译：** 分析/润色用强档，梗概/审校用便宜档。
+**Lab 落点：** 主译 Batch、关键词、订正、后续 analysis/review 可配置不同模型；**阶段级自动路由应基于 #252 真实用量**，不要在无数据时硬编码。
 
-### 5.4 阶段开关与成本可见（P2 候选）
+### 5.4 阶段开关与成本可见 → #252
 
-**文译：** `pipeline.polish/review/...` 可关。  
-**Lab 落点：** 已有多子命令；可加强「推荐流水线说明 + 成本估算」一致性（`batch_cost_estimate` 等），避免暗示用户必须开满上下文层。
+**文译：** `pipeline.polish/review/...` 可关；`usage.json` 累计实际 token。
+**Lab 落点：** 已有多子命令 + `batch_cost_estimate`；#252 建立 provider-neutral 实际用量账本（Batch results + 同步路径，可去重、可按 project/task/stage 聚合）。
 
-### 5.5 状态与续跑清晰度（P3 对照，非必须重写）
+### 5.5 状态与续跑清晰度
 
-**文译：** `state/` + 再跑 `translate` 跳过已完成。  
-**Lab：** `logs/batch_jobs` manifest 已是作业状态中枢。以对照改进文档与 doctor 提示为主，避免为「更像文译」重做 store。
+**文译：** `state/` + 再跑 `translate`/`review` 跳过已完成 digest。
+**Lab：** Batch 作业以 package/manifest 为中枢；Project Analysis 与最终审校各自用 fingerprint / input digest（#256/#255），**不**为「更像文译」重做翻译主路径 store。
 
-## 6. 建议优先级（草案）
+## 6. 建议优先级（与 issue 对齐）
 
-| 优先级 | 主题 | 依赖 | 备注 |
-|--------|------|------|------|
-| P0 | 本文档定稿 + 是否拆 GitHub issues | — | 无代码 |
-| P1a | 术语：build 时按 chunk 裁剪注入 + 文档化「先 keyword 后翻译」 | 现有 keyword/glossary | 低风险、贴 Batch |
-| P1b | 开翻前 brief/预扫产物（可选 bootstrap） | source index / story 可选 | 需防幻觉，产物可编辑 |
-| P2 | 任务类型模型分档 | 配置与 GUI 同步 | 跨 CLI/GUI |
-| P2/P3 | 可选「风格向」订正策略（显式，非默认 polish） | 现有 revision | 仅当用户反馈机翻腔严重 |
-| 不做 | Agent 框架、默认同进程润色链、换主路径为同步 | — | 见 §3 |
+| 优先级 | 主题 | Issue / 依赖 | 备注 |
+|--------|------|--------------|------|
+| P0 | 对照文档刷新 + issue 拆分 | 本文 + #252–#256 | 本轮完成对照刷新 |
+| **P1** | Project Analysis 阶段 1 合同 | **#256** | 地基；不调模型 |
+| P1 | 实际模型用量账本 | #252 | 可与 #256 并行，勿混 PR |
+| P1 | 路线感知生成与发布 | #254 ← #256 | 仅 published 注入 |
+| P1 | 最终审校 campaign | #255 ← #256 | report-only → revision |
+| P1a | 术语：build 时按 chunk 裁剪 + 文档化「先 keyword 后翻译」 | 现有 keyword/glossary | 低风险、贴 Batch；可并行 |
+| P2 | 任务类型模型分档 / 路由 | 配置 + GUI；宜参考 #252 | 跨 CLI/GUI |
+| P2/P3 | 可选「风格向」订正策略 | 现有 revision | 显式，非默认 polish |
+| 低 | Story Graph 试点 | #147 | 不被 #253 吞并 |
+| 不做 | Agent 框架、默认同进程润色链、换主路径为同步、审校 autofix 写 rpy | — | 见 §3 |
 
 ## 7. 与现行文档/代码的衔接
 
 | 主题 | 现行入口 |
 |------|----------|
 | Batch / 订正 / 关键词 | `docs/batch_workflows.md`，`gemini_translate_batch.py`，`translation_core.py` |
-| RAG / 索引 / Story Memory | `docs/context_systems.md` |
-| CLI/GUI 同步 | `CONTRIBUTING.md` |
+| RAG / 索引 / Story Memory / Project Analysis | `docs/context_systems.md` |
+| CLI/GUI 同步 | `CONTRIBUTING.md`、`Agents.md` |
 | 项目边界 | `docs/project_notes.md` |
+| 原子写 / 指纹 | `atomic_io.py`；Batch check fingerprint 在 `gemini_translate_batch.py` |
 
 落地功能时：
 
@@ -123,18 +164,25 @@
 
 ## 8. 参考阅读（仓库外）
 
-- 文译流水线说明：`_ref/wenyi/docs/zh/pipeline.md`
-- 文译配置：`_ref/wenyi/config.yaml`（`pipeline.*`、`llm.tiers`）
-- 润色实现：`_ref/wenyi/trans_novel/agents/polisher.py`（对照 lab `build_revision_*`）
+对照时以本地 `_ref/wenyi` 为准（实现前 `git pull`）：
+
+- 流水线：`docs/zh/pipeline.md` / `docs/pipeline.md`
+- 配置：`config.yaml`（`pipeline.*`、`llm.tiers`、`glossary_scope`）
+- 全书理解：`trans_novel/agents/synopsis.py`
+- 审校：`trans_novel/agents/reviewer.py` + orchestrator 中 review 阶段
+- 状态与用量：`trans_novel/pipeline/runstore.py`、`trans_novel/llm/usage.py`
+- 润色（仅对照边界）：`trans_novel/agents/polisher.py` ↔ lab `build_revision_*`
 
 ## 9. 开放问题
 
-1. P1b brief 的权威来源优先 TL 注释、解包原文，还是 source index？
+1. Project Analysis brief 的权威来源优先 TL 注释、解包原文，还是 source index / keyword chunk summaries？（#254 实现时定稿）
 2. 术语「本章/本 chunk 裁剪」是否与 preserve_terms / identity 锁定词冲突，如何测？
 3. 是否需要在 doctor 中提示「大批量前建议先 keywords → 合并 glossary」？
+4. #252 账本与 #256 analysis fingerprint 是否共享 digest 工具函数（宜小公共模块，避免互相 import 重量级 batch 入口）？
 
 ## 10. 变更记录
 
 | 日期 | 说明 |
 |------|------|
 | 2026-07-21 | 初版：对照文译、Batch 主路径取舍、润色 vs 订正、候选优先级 |
+| 2026-07-22 | 刷新本地 wenyi 至 `b796e45` / v0.3.4；补 prepare/review/usage/tiers；对齐 #252–#256；明确默认不复制源码 |

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -8613,9 +8613,22 @@ def collect_doctor_context_status():
             )
             source_index_status['error'] = combined_error
 
+    try:
+        from project_analysis import collect_project_analysis_status
+
+        project_analysis_status = collect_project_analysis_status()
+    except Exception as exc:
+        project_analysis_status = {
+            'store_dir': '',
+            'store_exists': False,
+            'overall_status': 'failed',
+            'error': str(exc),
+        }
+
     return {
         'rag': rag_status,
         'source_index': source_index_status,
+        'project_analysis': project_analysis_status,
     }
 
 def _read_translator_config_object():
@@ -9053,6 +9066,7 @@ def print_doctor_report(report):
     context_status = report.get('context_status') or {}
     rag_context = context_status.get('rag') or {}
     source_index_context = context_status.get('source_index') or {}
+    project_analysis_context = context_status.get('project_analysis') or {}
     print('Doctor report:')
     print(f"- Base dir: {report['base_dir']}")
     print(f"- TL dir: {report['tl_dir']} (exists: {report['tl_exists']})")
@@ -9134,6 +9148,19 @@ def print_doctor_report(report):
         f"schema_version={source_index_context.get('schema_version') or ''}, "
         f"updated_at={source_index_context.get('updated_at') or ''}, "
         f"error={source_index_context.get('error') or ''}"
+    )
+    print(
+        '- Project analysis: '
+        f"overall={project_analysis_context.get('overall_status') or 'missing'}, "
+        f"store_dir={project_analysis_context.get('store_dir') or ''}, "
+        f"store_exists={project_analysis_context.get('store_exists', False)}, "
+        f"injectable={project_analysis_context.get('injectable', False)}, "
+        f"chunks={project_analysis_context.get('chunk_count', 0)}, "
+        f"labels={project_analysis_context.get('label_count', 0)}, "
+        f"routes={project_analysis_context.get('route_count', 0)}, "
+        f"brief={project_analysis_context.get('brief_status') or 'missing'}, "
+        f"updated_at={project_analysis_context.get('updated_at') or ''}, "
+        f"error={project_analysis_context.get('error') or ''}"
     )
     project_assets = report.get('project_assets') or {}
     print(
@@ -9397,6 +9424,32 @@ def build_arg_parser():
         '--no-prune',
         action='store_true',
         help='Do not prune stale segments from the index store after indexing.',
+    )
+
+    project_analysis_status_parser = subparsers.add_parser(
+        'project-analysis-status',
+        help=(
+            'Inspect Project Analysis store status (missing/draft/published/stale) '
+            'without generating or injecting analysis context.'
+        ),
+    )
+    project_analysis_status_parser.add_argument(
+        '--store-dir',
+        default='',
+        help='Override project analysis store directory. Defaults to context_storage path.',
+    )
+    project_analysis_status_parser.add_argument(
+        '--source-fingerprint',
+        default='',
+        help=(
+            'Optional expected source fingerprint. When set, published artifacts with a '
+            'mismatched lineage fingerprint are reported as stale.'
+        ),
+    )
+    project_analysis_status_parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Print machine-readable JSON status instead of the human-readable report.',
     )
 
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
@@ -9799,6 +9852,38 @@ def main(argv=None):
         load_batch_settings()
         print_banner()
         run_generate_template()
+        return
+
+    if command == 'project-analysis-status':
+        # Readonly inspect: load settings for default store path, skip batch logging.
+        from project_analysis import collect_project_analysis_status, print_status
+
+        store_dir = getattr(args, 'store_dir', None) or None
+        as_json = bool(getattr(args, 'json', False))
+        if store_dir:
+            # Explicit store needs no config chatter.
+            pass
+        elif as_json:
+            # Keep machine-readable stdout clean while resolving context_storage defaults.
+            import contextlib
+            import io
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                legacy.load_translator_settings()
+                load_batch_settings()
+        else:
+            legacy.load_translator_settings()
+            load_batch_settings()
+
+        status = collect_project_analysis_status(
+            store_dir=store_dir,
+            expected_source_fingerprint=getattr(args, 'source_fingerprint', '') or '',
+        )
+        if as_json:
+            print(json.dumps(status, ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            print_banner()
+            print_status(status)
         return
 
     initialize_batch_logging()

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -9856,32 +9856,32 @@ def main(argv=None):
 
     if command == 'project-analysis-status':
         # Readonly inspect: load settings for default store path, skip batch logging.
+        import contextlib
+        import io
+
         from project_analysis import collect_project_analysis_status, print_status
 
         store_dir = getattr(args, 'store_dir', None) or None
         as_json = bool(getattr(args, 'json', False))
-        if store_dir:
-            # Explicit store needs no config chatter.
-            pass
-        elif as_json:
-            # Keep machine-readable stdout clean while resolving context_storage defaults.
-            import contextlib
-            import io
+        source_fp = getattr(args, 'source_fingerprint', '') or ''
 
-            with contextlib.redirect_stdout(io.StringIO()):
+        def _load_settings_and_status():
+            if not store_dir:
                 legacy.load_translator_settings()
                 load_batch_settings()
-        else:
-            legacy.load_translator_settings()
-            load_batch_settings()
+            return collect_project_analysis_status(
+                store_dir=store_dir,
+                expected_source_fingerprint=source_fp,
+            )
 
-        status = collect_project_analysis_status(
-            store_dir=store_dir,
-            expected_source_fingerprint=getattr(args, 'source_fingerprint', '') or '',
-        )
         if as_json:
+            # Keep machine-readable stdout clean: settings load and path resolution
+            # may emit warnings via print (e.g. game_root unset under game storage).
+            with contextlib.redirect_stdout(io.StringIO()):
+                status = _load_settings_and_status()
             print(json.dumps(status, ensure_ascii=False, indent=2, sort_keys=True))
         else:
+            status = _load_settings_and_status()
             print_banner()
             print_status(status)
         return

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -9867,7 +9867,9 @@ def main(argv=None):
 
         def _load_settings_and_status():
             if not store_dir:
-                legacy.load_translator_settings()
+                # Readonly command: never rewrite translator_config.json when the
+                # configured game_root is normalized to an effective work root.
+                legacy.load_translator_settings(persist_corrected_game_root=False)
                 load_batch_settings()
             return collect_project_analysis_status(
                 store_dir=store_dir,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -1647,6 +1647,7 @@ class MainWindow(QMainWindow):
                 self.context_library_panel = page
                 self.context_rag_status_label = page.rag_status_label
                 self.context_source_index_status_label = page.source_index_status_label
+                self.context_project_analysis_status_label = page.project_analysis_status_label
                 self.context_bootstrap_rag_btn = page.bootstrap_rag_btn
                 self.context_bootstrap_source_index_btn = page.bootstrap_source_index_btn
                 self.context_open_settings_btn = page.open_settings_btn
@@ -2270,10 +2271,24 @@ class MainWindow(QMainWindow):
             game_root = self.state.get_game_root() if hasattr(self, "state") else None
             if running is None:
                 running = self._task_page_running_chrome()
+            analysis_status = None
+            analysis_label = "未检测"
+            try:
+                from project_analysis import (
+                    collect_project_analysis_status,
+                    format_status_label,
+                )
+
+                analysis_status = collect_project_analysis_status()
+                analysis_label = format_status_label(analysis_status)
+            except Exception as exc:
+                analysis_label = f"读取失败 · {exc}"
             page.set_context_status(
                 rag_enabled=rag_on,
                 source_index_enabled=idx_on,
                 game_root=str(game_root or ""),
+                project_analysis_status=analysis_status,
+                project_analysis_label=analysis_label,
             )
             page.set_task_running(running)
             return

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2279,7 +2279,9 @@ class MainWindow(QMainWindow):
                     format_status_label,
                 )
 
-                analysis_status = collect_project_analysis_status()
+                analysis_status = collect_project_analysis_status(
+                    base_dir=str(game_root) if game_root else None,
+                )
                 analysis_label = format_status_label(analysis_status)
             except Exception as exc:
                 analysis_label = f"读取失败 · {exc}"

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -210,6 +210,14 @@ def build_cli_commands(
             label="项目检查",
             command=format_cli_command(python_exe, batch_script_path, ["doctor"]),
         ),
+        DiagnosticsCommand(
+            label="项目分析状态",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["project-analysis-status"],
+            ),
+        ),
     ]
 
     mode = manifest.get("mode")

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -1,8 +1,11 @@
 """Persistent context-library page used by the workbench stack (#176 P1)."""
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from PySide6.QtWidgets import (
     QFrame,
+    QLabel,
     QPushButton,
     QStackedWidget,
     QVBoxLayout,
@@ -17,7 +20,7 @@ from .task_controls import TaskPageLayout, TaskStatusActionRow
 
 
 class ContextLibraryPage(QFrame):
-    """Page-local presentation for RAG and source-index preparation."""
+    """Page-local presentation for RAG, source-index, and project-analysis status."""
 
     supported_modes = (
         WorkMode.BOOTSTRAP_RAG,
@@ -31,6 +34,7 @@ class ContextLibraryPage(QFrame):
         self._running = False
         self._rag_enabled = False
         self._source_index_enabled = False
+        self._project_analysis_present = False
         self._active_mode = WorkMode.BOOTSTRAP_RAG
 
         outer = QVBoxLayout(self)
@@ -80,6 +84,22 @@ class ContextLibraryPage(QFrame):
         self.source_index_status_label = self.source_index_status_row.status_label
         self.status_layout.root.addWidget(self.source_index_status_row)
 
+        # Phase 1 (#256): readonly status only; generation/publish land in later issues.
+        self.project_analysis_readonly_label = QLabel("只读")
+        self.project_analysis_readonly_label.setObjectName(
+            "context_project_analysis_readonly_label"
+        )
+        self.project_analysis_readonly_label.setToolTip(
+            "项目分析当前仅提供状态查看；生成与发布在后续阶段实现。"
+        )
+        self.project_analysis_status_row = TaskStatusActionRow(
+            "项目分析",
+            self.project_analysis_readonly_label,
+            parent=self.status_page,
+        )
+        self.project_analysis_status_label = self.project_analysis_status_row.status_label
+        self.status_layout.root.addWidget(self.project_analysis_status_row)
+
         self.context_actions = self.status_layout.add_section(
             "上下文任务",
             role="context_library",
@@ -122,6 +142,8 @@ class ContextLibraryPage(QFrame):
         rag_enabled: bool,
         source_index_enabled: bool,
         game_root: str,
+        project_analysis_status: Mapping[str, Any] | None = None,
+        project_analysis_label: str = "",
     ) -> None:
         self._rag_enabled = rag_enabled
         self._source_index_enabled = source_index_enabled
@@ -134,8 +156,31 @@ class ContextLibraryPage(QFrame):
             f"{'已启用' if source_index_enabled else '未启用'} · 项目 {root_hint}"
             + ("" if source_index_enabled else " · 请先在设置 · 上下文开启并保存")
         )
+        if project_analysis_label:
+            analysis_text = project_analysis_label
+        elif project_analysis_status is not None:
+            from project_analysis import format_status_label
+
+            analysis_text = format_status_label(project_analysis_status)
+        else:
+            analysis_text = "未检测"
+        self.project_analysis_status_row.set_status(f"{analysis_text} · 项目 {root_hint}")
+        overall = ""
+        if project_analysis_status is not None:
+            overall = str(project_analysis_status.get("overall_status") or "")
+            self._project_analysis_present = bool(
+                project_analysis_status.get("store_exists")
+            ) or overall not in {"", "missing"}
+        else:
+            self._project_analysis_present = bool(project_analysis_label) and project_analysis_label not in {
+                "未检测",
+                "未生成",
+            }
+        show_status = (
+            rag_enabled or source_index_enabled or self._project_analysis_present
+        )
         self.page_stack.setCurrentWidget(
-            self.status_page if rag_enabled or source_index_enabled else self.empty_state
+            self.status_page if show_status else self.empty_state
         )
         self._refresh_action_states()
 
@@ -148,6 +193,8 @@ class ContextLibraryPage(QFrame):
             rag_enabled=False,
             source_index_enabled=False,
             game_root="",
+            project_analysis_status=None,
+            project_analysis_label="未检测",
         )
 
     def _refresh_action_states(self) -> None:

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -266,11 +266,28 @@ def digest_upstream_artifacts(artifact_ids: Sequence[str]) -> str:
 
 
 def normalize_summary_record(raw: Any, *, default_kind: str | None = None) -> dict[str, Any]:
-    """Validate and normalize one summary / brief artifact record."""
+    """Validate and normalize one summary / brief artifact record.
+
+    When *default_kind* is set (loader/writer bound to a specific artifact file),
+    an explicit record ``kind`` must match that file kind.
+    """
     if not isinstance(raw, Mapping):
         raise ProjectAnalysisSchemaError("summary record must be an object")
 
-    kind = normalize_kind(raw.get("kind") or default_kind)
+    raw_kind = raw.get("kind")
+    if default_kind is not None:
+        expected_kind = normalize_kind(default_kind)
+        if raw_kind is not None and str(raw_kind).strip() != "":
+            actual_kind = normalize_kind(raw_kind)
+            if actual_kind != expected_kind:
+                raise ProjectAnalysisSchemaError(
+                    f"summary kind {actual_kind!r} does not match expected file kind "
+                    f"{expected_kind!r}"
+                )
+        kind = expected_kind
+    else:
+        kind = normalize_kind(raw_kind)
+
     artifact_id = _as_optional_str(raw.get("id") or raw.get("artifact_id"))
     if not artifact_id:
         raise ProjectAnalysisSchemaError("summary record requires a stable id")
@@ -876,6 +893,86 @@ class ProjectAnalysisStore:
         manifest["updated_at"] = utc_now_iso()
         return self.save_manifest(manifest)
 
+    def _disk_brief_presence(self) -> tuple[bool, bool]:
+        draft_present = os.path.isfile(self.artifact_path(PROJECT_BRIEF_DRAFT_FILENAME))
+        published_present = os.path.isfile(
+            self.artifact_path(PROJECT_BRIEF_PUBLISHED_FILENAME)
+        )
+        return draft_present, published_present
+
+    @staticmethod
+    def _evaluate_aggregate_entry(
+        entry: Mapping[str, Any],
+        *,
+        kind: str,
+        expected_source_fingerprint: str = "",
+    ) -> str:
+        """Apply publish/freshness contract to a manifest aggregate entry."""
+        status = normalize_status(entry.get("status") or STATUS_MISSING, allow_missing=True)
+        if status == STATUS_MISSING:
+            return STATUS_MISSING
+        if status not in RECORD_STATUSES:
+            return status
+        synthetic = {
+            "id": _as_optional_str(entry.get("id") or f"{kind}-aggregate"),
+            "kind": kind,
+            "status": status,
+            "source_files": [],
+            "evidence_item_ids": [],
+            "upstream_artifact_ids": [],
+            "source_checksum": "",
+            "lineage": entry.get("lineage") or empty_lineage(),
+        }
+        return evaluate_record_status(
+            synthetic,
+            expected_source_fingerprint=expected_source_fingerprint,
+        )
+
+    def _evaluate_brief_status(
+        self,
+        entry: Mapping[str, Any],
+        *,
+        draft_present: bool,
+        published_present: bool,
+        expected_source_fingerprint: str = "",
+    ) -> str:
+        """Brief status requires on-disk published file for injectability."""
+        claimed = normalize_status(entry.get("status") or STATUS_MISSING, allow_missing=True)
+        if not draft_present and not published_present:
+            # Manifest may claim publish, but missing files are not injectable.
+            if claimed in {STATUS_PUBLISHED, STATUS_DRAFT, STATUS_REVIEW_REQUIRED}:
+                return STATUS_STALE
+            return STATUS_MISSING if claimed == STATUS_MISSING else claimed
+
+        if claimed == STATUS_PUBLISHED and not published_present:
+            # Never treat a missing published file as published.
+            status = STATUS_STALE
+        elif claimed == STATUS_MISSING:
+            if published_present:
+                status = STATUS_PUBLISHED
+            elif draft_present:
+                status = STATUS_DRAFT
+            else:
+                status = STATUS_MISSING
+        else:
+            status = claimed
+
+        if status not in RECORD_STATUSES:
+            return status
+        return evaluate_record_status(
+            {
+                "id": _as_optional_str(entry.get("id") or "project_brief"),
+                "kind": KIND_PROJECT_BRIEF,
+                "status": status,
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": [],
+                "source_checksum": "",
+                "lineage": entry.get("lineage") or empty_lineage(),
+            },
+            expected_source_fingerprint=expected_source_fingerprint,
+        )
+
     def collect_status(
         self,
         *,
@@ -885,160 +982,141 @@ class ProjectAnalysisStore:
         """Readonly status snapshot for CLI / GUI / doctor (no side effects)."""
         error = ""
         manifest: dict[str, Any] | None = None
+        overall = STATUS_MISSING
         try:
+            draft_present, published_present = self._disk_brief_presence()
             if not self.exists():
+                manifest = empty_manifest(
+                    project_identity=project_identity or {},
+                    store_dir=self.store_dir,
+                )
                 overall = STATUS_MISSING
             else:
                 manifest = self.load_manifest()
                 if manifest is None:
-                    # Artifacts without manifest still report via rebuild-in-memory.
+                    # Artifacts without manifest: derive aggregates from files.
                     chunks = self.load_summaries(KIND_CHUNK)
                     scenes = self.load_summaries(KIND_SCENE)
                     labels = self.load_summaries(KIND_LABEL)
                     routes = self.load_routes()
-                    statuses = []
-                    for _kind, records in (
+                    manifest = empty_manifest(
+                        project_identity=project_identity or {},
+                        store_dir=self.store_dir,
+                    )
+                    for kind, records in (
                         (KIND_CHUNK, chunks),
                         (KIND_SCENE, scenes),
                         (KIND_LABEL, labels),
                         (KIND_ROUTE, routes),
                     ):
-                        statuses.extend(
+                        statuses = [
                             evaluate_record_status(
-                                r, expected_source_fingerprint=expected_source_fingerprint
+                                r,
+                                expected_source_fingerprint=expected_source_fingerprint,
                             )
                             for r in records
+                        ]
+                        lineage = (
+                            normalize_lineage(records[0].get("lineage"))
+                            if records
+                            else empty_lineage()
                         )
-                    draft_present = os.path.isfile(
-                        self.artifact_path(PROJECT_BRIEF_DRAFT_FILENAME)
+                        manifest["artifacts"][kind] = {
+                            "status": _aggregate_status(statuses),
+                            "count": len(records),
+                            "lineage": lineage,
+                        }
+                    brief_entry = {
+                        "status": (
+                            STATUS_PUBLISHED
+                            if published_present
+                            else STATUS_DRAFT
+                            if draft_present
+                            else STATUS_MISSING
+                        ),
+                        "lineage": empty_lineage(),
+                        "id": "project_brief",
+                    }
+                    manifest["artifacts"][KIND_PROJECT_BRIEF] = brief_entry
+
+                # Freshness + brief disk contract (always re-check on read).
+                overall_statuses: list[str] = []
+                for kind in (KIND_CHUNK, KIND_SCENE, KIND_LABEL, KIND_ROUTE):
+                    entry = dict(manifest["artifacts"].get(kind) or {})
+                    status = self._evaluate_aggregate_entry(
+                        entry,
+                        kind=kind,
+                        expected_source_fingerprint=expected_source_fingerprint,
                     )
-                    published_present = os.path.isfile(
-                        self.artifact_path(PROJECT_BRIEF_PUBLISHED_FILENAME)
-                    )
-                    if published_present:
-                        statuses.append(STATUS_PUBLISHED)
-                    elif draft_present:
-                        statuses.append(STATUS_DRAFT)
-                    overall = _aggregate_status(statuses)
-                    manifest = empty_manifest(
-                        project_identity=project_identity or {},
-                        store_dir=self.store_dir,
-                    )
-                    manifest["artifacts"][KIND_CHUNK]["count"] = len(chunks)
-                    manifest["artifacts"][KIND_CHUNK]["status"] = _aggregate_status(
-                        [
-                            evaluate_record_status(
-                                r, expected_source_fingerprint=expected_source_fingerprint
-                            )
-                            for r in chunks
-                        ]
-                    )
-                    manifest["artifacts"][KIND_SCENE]["count"] = len(scenes)
-                    manifest["artifacts"][KIND_SCENE]["status"] = _aggregate_status(
-                        [
-                            evaluate_record_status(
-                                r, expected_source_fingerprint=expected_source_fingerprint
-                            )
-                            for r in scenes
-                        ]
-                    )
-                    manifest["artifacts"][KIND_LABEL]["count"] = len(labels)
-                    manifest["artifacts"][KIND_LABEL]["status"] = _aggregate_status(
-                        [
-                            evaluate_record_status(
-                                r, expected_source_fingerprint=expected_source_fingerprint
-                            )
-                            for r in labels
-                        ]
-                    )
-                    manifest["artifacts"][KIND_ROUTE]["count"] = len(routes)
-                    manifest["artifacts"][KIND_ROUTE]["status"] = _aggregate_status(
-                        [
-                            evaluate_record_status(
-                                r, expected_source_fingerprint=expected_source_fingerprint
-                            )
-                            for r in routes
-                        ]
-                    )
-                    brief_status = (
-                        STATUS_PUBLISHED
-                        if published_present
-                        else STATUS_DRAFT
-                        if draft_present
-                        else STATUS_MISSING
-                    )
-                    manifest["artifacts"][KIND_PROJECT_BRIEF]["status"] = brief_status
-                    manifest["artifacts"][KIND_PROJECT_BRIEF]["draft_present"] = draft_present
-                    manifest["artifacts"][KIND_PROJECT_BRIEF][
-                        "published_present"
-                    ] = published_present
-                else:
-                    # Re-evaluate published → stale when expected fingerprint provided.
-                    overall_statuses = []
-                    for kind in (KIND_CHUNK, KIND_SCENE, KIND_LABEL, KIND_ROUTE):
-                        entry = manifest["artifacts"][kind]
-                        status = entry.get("status") or STATUS_MISSING
-                        if status == STATUS_PUBLISHED and expected_source_fingerprint:
-                            lineage = normalize_lineage(entry.get("lineage"))
-                            if (
-                                lineage["source_fingerprint"]
-                                and lineage["source_fingerprint"] != expected_source_fingerprint
-                            ):
-                                status = STATUS_STALE
-                                entry = dict(entry)
-                                entry["status"] = STATUS_STALE
-                                manifest["artifacts"][kind] = entry
-                        overall_statuses.append(status)
-                    brief = manifest["artifacts"][KIND_PROJECT_BRIEF]
-                    brief_status = brief.get("status") or STATUS_MISSING
-                    if brief_status == STATUS_PUBLISHED and expected_source_fingerprint:
-                        lineage = normalize_lineage(brief.get("lineage"))
-                        if (
-                            lineage["source_fingerprint"]
-                            and lineage["source_fingerprint"] != expected_source_fingerprint
-                        ):
-                            brief_status = STATUS_STALE
-                            brief = dict(brief)
-                            brief["status"] = STATUS_STALE
-                            manifest["artifacts"][KIND_PROJECT_BRIEF] = brief
-                    overall_statuses.append(brief_status)
-                    overall = _aggregate_status(
-                        [s for s in overall_statuses if s != STATUS_MISSING]
-                    )
-                    if overall == STATUS_MISSING and any(
-                        s != STATUS_MISSING for s in overall_statuses
-                    ):
-                        overall = _aggregate_status(overall_statuses)
+                    entry["status"] = status
+                    if "count" not in entry:
+                        entry["count"] = 0
+                    if "lineage" not in entry:
+                        entry["lineage"] = empty_lineage()
+                    manifest["artifacts"][kind] = entry
+                    overall_statuses.append(status)
+
+                brief = dict(manifest["artifacts"].get(KIND_PROJECT_BRIEF) or {})
+                brief_status = self._evaluate_brief_status(
+                    brief,
+                    draft_present=draft_present,
+                    published_present=published_present,
+                    expected_source_fingerprint=expected_source_fingerprint,
+                )
+                brief["status"] = brief_status
+                brief["draft_present"] = draft_present
+                brief["published_present"] = published_present
+                if "lineage" not in brief:
+                    brief["lineage"] = empty_lineage()
+                if "id" not in brief:
+                    brief["id"] = "project_brief"
+                manifest["artifacts"][KIND_PROJECT_BRIEF] = brief
+                overall_statuses.append(brief_status)
+
+                non_missing = [s for s in overall_statuses if s != STATUS_MISSING]
+                overall = (
+                    _aggregate_status(non_missing)
+                    if non_missing
+                    else _aggregate_status(overall_statuses)
+                )
         except ProjectAnalysisError as exc:
             error = str(exc)
             overall = STATUS_FAILED
+            draft_present, published_present = False, False
             manifest = empty_manifest(
                 project_identity=project_identity or {}, store_dir=self.store_dir
             )
         except OSError as exc:
             error = str(exc)
             overall = STATUS_FAILED
+            draft_present, published_present = False, False
             manifest = empty_manifest(
                 project_identity=project_identity or {}, store_dir=self.store_dir
             )
 
         artifacts = (manifest or empty_manifest(store_dir=self.store_dir)).get("artifacts") or {}
         brief = artifacts.get(KIND_PROJECT_BRIEF) or {}
+        # overall==published only when every non-missing layer (incl. brief) is published
+        # and fingerprint-fresh; brief publish without on-disk file is forced to stale.
+        injectable = overall == STATUS_PUBLISHED
         return {
             "store_dir": self.store_dir,
             "store_exists": self.exists(),
             "schema_version": SCHEMA_VERSION,
             "overall_status": overall,
-            "injectable": overall == STATUS_PUBLISHED,
-            "project_identity": (manifest or {}).get("project_identity") or dict(project_identity or {}),
+            "injectable": injectable,
+            "project_identity": (manifest or {}).get("project_identity")
+            or dict(project_identity or {}),
             "artifacts": artifacts,
             "chunk_count": int((artifacts.get(KIND_CHUNK) or {}).get("count") or 0),
             "scene_count": int((artifacts.get(KIND_SCENE) or {}).get("count") or 0),
             "label_count": int((artifacts.get(KIND_LABEL) or {}).get("count") or 0),
             "route_count": int((artifacts.get(KIND_ROUTE) or {}).get("count") or 0),
             "brief_status": brief.get("status") or STATUS_MISSING,
-            "brief_draft_present": bool(brief.get("draft_present")),
-            "brief_published_present": bool(brief.get("published_present")),
+            "brief_draft_present": bool(brief.get("draft_present", draft_present)),
+            "brief_published_present": bool(
+                brief.get("published_present", published_present)
+            ),
             "updated_at": (manifest or {}).get("updated_at") or "",
             "error": error,
         }

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -517,13 +517,6 @@ def apply_invalidation_to_records(
     return out
 
 
-def get_default_project_analysis_store_dir(base_dir: str | None = None) -> str:
-    """Resolve default store path via context_storage settings."""
-    from translator_runtime import get_default_context_store_dir
-
-    return get_default_context_store_dir(STORE_NAME, base_dir)
-
-
 def resolve_under_store(store_dir: str | os.PathLike[str], relative: str) -> str:
     """Resolve *relative* under *store_dir*; reject escapes."""
     root = os.path.realpath(os.path.abspath(os.fspath(store_dir)))
@@ -904,7 +897,7 @@ class ProjectAnalysisStore:
                     labels = self.load_summaries(KIND_LABEL)
                     routes = self.load_routes()
                     statuses = []
-                    for kind, records in (
+                    for _kind, records in (
                         (KIND_CHUNK, chunks),
                         (KIND_SCENE, scenes),
                         (KIND_LABEL, labels),
@@ -1058,6 +1051,9 @@ def collect_project_analysis_status(
     expected_source_fingerprint: str = "",
     project_identity: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    # Path defaults live in translator_runtime (same pattern as rag / source_index).
+    from translator_runtime import get_default_project_analysis_store_dir
+
     resolved = (
         os.path.abspath(os.fspath(store_dir))
         if store_dir

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -1,0 +1,1132 @@
+"""Project Analysis Phase 1: artifact contract, fingerprints, and invalidation.
+
+This module owns the shared schema, atomic I/O helpers, lineage fingerprints,
+publish-state evaluation, and partial invalidation planner used by later
+route-aware generation (#254) and final-review campaigns (#255).
+
+Phase 1 intentionally does **not** call LLMs or inject analysis text into
+translation prompts. Downstream code must reuse these contracts rather than
+re-implement status or fingerprint logic in the GUI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Sequence
+
+from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
+
+SCHEMA_VERSION = 1
+STORE_NAME = "project_analysis"
+
+STATUS_MISSING = "missing"
+STATUS_DRAFT = "draft"
+STATUS_REVIEW_REQUIRED = "review_required"
+STATUS_PUBLISHED = "published"
+STATUS_STALE = "stale"
+STATUS_FAILED = "failed"
+
+VALID_STATUSES = frozenset(
+    {
+        STATUS_MISSING,
+        STATUS_DRAFT,
+        STATUS_REVIEW_REQUIRED,
+        STATUS_PUBLISHED,
+        STATUS_STALE,
+        STATUS_FAILED,
+    }
+)
+
+# Stored artifact records use these (missing is derived when files are absent).
+RECORD_STATUSES = frozenset(
+    {
+        STATUS_DRAFT,
+        STATUS_REVIEW_REQUIRED,
+        STATUS_PUBLISHED,
+        STATUS_STALE,
+        STATUS_FAILED,
+    }
+)
+
+KIND_CHUNK = "chunk"
+KIND_SCENE = "scene"
+KIND_LABEL = "label"
+KIND_ROUTE = "route"
+KIND_PROJECT_BRIEF = "project_brief"
+
+VALID_KINDS = frozenset(
+    {
+        KIND_CHUNK,
+        KIND_SCENE,
+        KIND_LABEL,
+        KIND_ROUTE,
+        KIND_PROJECT_BRIEF,
+    }
+)
+
+MANIFEST_FILENAME = "manifest.json"
+CHUNK_SUMMARIES_FILENAME = "chunk_summaries.jsonl"
+SCENE_SUMMARIES_FILENAME = "scene_summaries.jsonl"
+LABEL_SUMMARIES_FILENAME = "label_summaries.jsonl"
+ROUTE_SUMMARIES_FILENAME = "route_summaries.json"
+PROJECT_BRIEF_DRAFT_FILENAME = "project_brief.draft.md"
+PROJECT_BRIEF_PUBLISHED_FILENAME = "project_brief.published.md"
+
+JSONL_FILENAMES = {
+    KIND_CHUNK: CHUNK_SUMMARIES_FILENAME,
+    KIND_SCENE: SCENE_SUMMARIES_FILENAME,
+    KIND_LABEL: LABEL_SUMMARIES_FILENAME,
+}
+
+INJECTABLE_STATUSES = frozenset({STATUS_PUBLISHED})
+
+
+class ProjectAnalysisError(ValueError):
+    """Base error for project-analysis contract violations."""
+
+
+class ProjectAnalysisPathEscapeError(ProjectAnalysisError):
+    """Raised when a path would escape the analysis store directory."""
+
+
+class ProjectAnalysisSchemaError(ProjectAnalysisError):
+    """Raised when schema/version or record shape is invalid."""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def stable_json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def stable_json_sha256(value: Any) -> str:
+    return hashlib.sha256(stable_json_dumps(value).encode("utf-8")).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(str(text or "").encode("utf-8")).hexdigest()
+
+
+def _as_str_list(value: Any, *, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ProjectAnalysisSchemaError(f"{field_name} must be a list of strings")
+    out: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _as_optional_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _as_line_span(value: Any) -> list[int] | None:
+    if value is None or value == []:
+        return None
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ProjectAnalysisSchemaError("line_span must be [start, end] or null")
+    try:
+        start = int(value[0])
+        end = int(value[1])
+    except (TypeError, ValueError) as exc:
+        raise ProjectAnalysisSchemaError("line_span values must be integers") from exc
+    if start < 0 or end < start:
+        raise ProjectAnalysisSchemaError("line_span must satisfy 0 <= start <= end")
+    return [start, end]
+
+
+def normalize_status(value: Any, *, allow_missing: bool = False) -> str:
+    status = _as_optional_str(value).lower() or STATUS_MISSING
+    allowed = VALID_STATUSES if allow_missing else RECORD_STATUSES
+    if status not in allowed:
+        raise ProjectAnalysisSchemaError(
+            f"unknown status {status!r}; expected one of {sorted(allowed)}"
+        )
+    return status
+
+
+def normalize_kind(value: Any) -> str:
+    kind = _as_optional_str(value).lower()
+    if kind not in VALID_KINDS:
+        raise ProjectAnalysisSchemaError(
+            f"unknown kind {kind!r}; expected one of {sorted(VALID_KINDS)}"
+        )
+    return kind
+
+
+def empty_lineage(
+    *,
+    source_fingerprint: str = "",
+    prompt_schema_version: str = "",
+    provider: str = "",
+    model: str = "",
+    thinking_level: str = "",
+    upstream_dependency_digest: str = "",
+    generated_at: str = "",
+    reviewed_at: str = "",
+    published_at: str = "",
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_fingerprint": str(source_fingerprint or ""),
+        "prompt_schema_version": str(prompt_schema_version or ""),
+        "provider": str(provider or ""),
+        "model": str(model or ""),
+        "thinking_level": str(thinking_level or ""),
+        "upstream_dependency_digest": str(upstream_dependency_digest or ""),
+        "generated_at": str(generated_at or ""),
+        "reviewed_at": str(reviewed_at or ""),
+        "published_at": str(published_at or ""),
+    }
+
+
+def normalize_lineage(value: Any) -> dict[str, Any]:
+    if value is None:
+        return empty_lineage()
+    if not isinstance(value, Mapping):
+        raise ProjectAnalysisSchemaError("lineage must be an object")
+    schema_version = value.get("schema_version", SCHEMA_VERSION)
+    try:
+        schema_version_int = int(schema_version)
+    except (TypeError, ValueError) as exc:
+        raise ProjectAnalysisSchemaError("lineage.schema_version must be an integer") from exc
+    if schema_version_int != SCHEMA_VERSION:
+        raise ProjectAnalysisSchemaError(
+            f"unsupported lineage schema_version {schema_version_int}; "
+            f"expected {SCHEMA_VERSION}"
+        )
+    return empty_lineage(
+        source_fingerprint=_as_optional_str(value.get("source_fingerprint")),
+        prompt_schema_version=_as_optional_str(value.get("prompt_schema_version")),
+        provider=_as_optional_str(value.get("provider")),
+        model=_as_optional_str(value.get("model")),
+        thinking_level=_as_optional_str(value.get("thinking_level")),
+        upstream_dependency_digest=_as_optional_str(value.get("upstream_dependency_digest")),
+        generated_at=_as_optional_str(value.get("generated_at")),
+        reviewed_at=_as_optional_str(value.get("reviewed_at")),
+        published_at=_as_optional_str(value.get("published_at")),
+    )
+
+
+def lineage_digest(lineage: Mapping[str, Any]) -> str:
+    """Stable digest of fields that affect freshness (not review timestamps alone)."""
+    normalized = normalize_lineage(lineage)
+    payload = {
+        "schema_version": normalized["schema_version"],
+        "source_fingerprint": normalized["source_fingerprint"],
+        "prompt_schema_version": normalized["prompt_schema_version"],
+        "provider": normalized["provider"],
+        "model": normalized["model"],
+        "thinking_level": normalized["thinking_level"],
+        "upstream_dependency_digest": normalized["upstream_dependency_digest"],
+    }
+    return stable_json_sha256(payload)
+
+
+def digest_source_items(items: Sequence[Mapping[str, Any]]) -> str:
+    """Fingerprint a set of source translation units / evidence rows."""
+    rows: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        item_id = _as_optional_str(item.get("id") or item.get("item_id") or item.get("unit_id"))
+        checksum = _as_optional_str(
+            item.get("source_checksum") or item.get("checksum") or item.get("source_text_checksum")
+        )
+        if not checksum and item.get("source_text") is not None:
+            checksum = sha256_text(str(item.get("source_text")))
+        file_rel = _as_optional_str(item.get("file_rel_path") or item.get("file"))
+        rows.append(
+            {
+                "id": item_id,
+                "file_rel_path": file_rel,
+                "source_checksum": checksum,
+            }
+        )
+    rows.sort(key=lambda row: (row["id"], row["file_rel_path"], row["source_checksum"]))
+    return stable_json_sha256(rows)
+
+
+def digest_upstream_artifacts(artifact_ids: Sequence[str]) -> str:
+    cleaned = sorted({str(x).strip() for x in artifact_ids if str(x or "").strip()})
+    return stable_json_sha256(cleaned)
+
+
+def normalize_summary_record(raw: Any, *, default_kind: str | None = None) -> dict[str, Any]:
+    """Validate and normalize one summary / brief artifact record."""
+    if not isinstance(raw, Mapping):
+        raise ProjectAnalysisSchemaError("summary record must be an object")
+
+    kind = normalize_kind(raw.get("kind") or default_kind)
+    artifact_id = _as_optional_str(raw.get("id") or raw.get("artifact_id"))
+    if not artifact_id:
+        raise ProjectAnalysisSchemaError("summary record requires a stable id")
+
+    status = normalize_status(raw.get("status") or STATUS_DRAFT, allow_missing=False)
+    lineage = normalize_lineage(raw.get("lineage") or raw.get("fingerprint"))
+
+    record = {
+        "id": artifact_id,
+        "kind": kind,
+        "status": status,
+        "source_files": _as_str_list(raw.get("source_files") or raw.get("files"), field_name="source_files"),
+        "label_id": _as_optional_str(raw.get("label_id")),
+        "scene_id": _as_optional_str(raw.get("scene_id")),
+        "route_id": _as_optional_str(raw.get("route_id")),
+        "evidence_item_ids": _as_str_list(
+            raw.get("evidence_item_ids") or raw.get("summary_evidence_item_ids"),
+            field_name="evidence_item_ids",
+        ),
+        "line_span": _as_line_span(raw.get("line_span")),
+        "source_checksum": _as_optional_str(raw.get("source_checksum")),
+        "upstream_artifact_ids": _as_str_list(
+            raw.get("upstream_artifact_ids"),
+            field_name="upstream_artifact_ids",
+        ),
+        "lineage": lineage,
+        "summary": _as_optional_str(raw.get("summary") or raw.get("body") or raw.get("text")),
+        "error": _as_optional_str(raw.get("error")),
+    }
+
+    # Preserve optional extension fields without treating them as schema authority.
+    for key in ("title", "notes", "metadata"):
+        if key in raw and raw[key] is not None:
+            record[key] = raw[key]
+    return record
+
+
+def evaluate_record_status(
+    record: Mapping[str, Any],
+    *,
+    expected_source_fingerprint: str = "",
+    expected_upstream_digest: str = "",
+    expected_prompt_schema_version: str = "",
+    expected_provider: str = "",
+    expected_model: str = "",
+    expected_thinking_level: str = "",
+) -> str:
+    """Return effective status; published becomes stale on fingerprint mismatch."""
+    status = normalize_status(record.get("status") or STATUS_DRAFT, allow_missing=False)
+    if status in {STATUS_FAILED, STATUS_STALE, STATUS_DRAFT, STATUS_REVIEW_REQUIRED}:
+        return status
+    if status != STATUS_PUBLISHED:
+        return status
+
+    lineage = normalize_lineage(record.get("lineage"))
+    checks = (
+        (expected_source_fingerprint, lineage["source_fingerprint"]),
+        (expected_upstream_digest, lineage["upstream_dependency_digest"]),
+        (expected_prompt_schema_version, lineage["prompt_schema_version"]),
+        (expected_provider, lineage["provider"]),
+        (expected_model, lineage["model"]),
+        (expected_thinking_level, lineage["thinking_level"]),
+    )
+    for expected, actual in checks:
+        if expected and actual and expected != actual:
+            return STATUS_STALE
+        if expected and not actual:
+            return STATUS_STALE
+    return STATUS_PUBLISHED
+
+
+def is_injectable_record(
+    record: Mapping[str, Any],
+    *,
+    expected_source_fingerprint: str = "",
+    expected_upstream_digest: str = "",
+    expected_prompt_schema_version: str = "",
+    expected_provider: str = "",
+    expected_model: str = "",
+    expected_thinking_level: str = "",
+) -> bool:
+    """Only published artifacts with matching fingerprints may be injected later."""
+    effective = evaluate_record_status(
+        record,
+        expected_source_fingerprint=expected_source_fingerprint,
+        expected_upstream_digest=expected_upstream_digest,
+        expected_prompt_schema_version=expected_prompt_schema_version,
+        expected_provider=expected_provider,
+        expected_model=expected_model,
+        expected_thinking_level=expected_thinking_level,
+    )
+    return effective in INJECTABLE_STATUSES
+
+
+@dataclass
+class InvalidationPlan:
+    """Artifacts that must be marked stale after an upstream change."""
+
+    stale_artifact_ids: set[str] = field(default_factory=set)
+    stale_by_kind: dict[str, set[str]] = field(default_factory=dict)
+    brief_stale: bool = False
+    reasons: dict[str, list[str]] = field(default_factory=dict)
+
+    def add(self, artifact_id: str, kind: str, reason: str) -> None:
+        artifact_id = str(artifact_id or "").strip()
+        if not artifact_id:
+            return
+        self.stale_artifact_ids.add(artifact_id)
+        self.stale_by_kind.setdefault(kind, set()).add(artifact_id)
+        self.reasons.setdefault(artifact_id, []).append(reason)
+        if kind == KIND_PROJECT_BRIEF:
+            self.brief_stale = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stale_artifact_ids": sorted(self.stale_artifact_ids),
+            "stale_by_kind": {
+                kind: sorted(ids) for kind, ids in sorted(self.stale_by_kind.items())
+            },
+            "brief_stale": self.brief_stale,
+            "reasons": {key: list(vals) for key, vals in sorted(self.reasons.items())},
+        }
+
+
+def plan_invalidation(
+    *,
+    chunks: Sequence[Mapping[str, Any]] = (),
+    scenes: Sequence[Mapping[str, Any]] = (),
+    labels: Sequence[Mapping[str, Any]] = (),
+    routes: Sequence[Mapping[str, Any]] = (),
+    project_brief: Mapping[str, Any] | None = None,
+    changed_item_ids: Iterable[str] | None = None,
+    changed_artifact_ids: Iterable[str] | None = None,
+    always_stale_brief_on_any: bool = True,
+) -> InvalidationPlan:
+    """Mark dependent artifacts stale when source items or upstream artifacts change.
+
+    Rules (Phase 1 contract):
+    - A changed evidence item invalidates chunks that cite it, then scenes/labels
+      that depend on those chunks, then routes that depend on those labels/scenes,
+      then the global project brief.
+    - Unrelated routes stay valid when their dependency closure is untouched.
+    - Prompt/schema/provider/model changes are expressed by feeding the affected
+      artifact ids into ``changed_artifact_ids`` (caller computes digest mismatch).
+    """
+    plan = InvalidationPlan()
+    changed_items = {str(x).strip() for x in (changed_item_ids or []) if str(x or "").strip()}
+    seed_artifacts = {
+        str(x).strip() for x in (changed_artifact_ids or []) if str(x or "").strip()
+    }
+
+    chunk_records = [normalize_summary_record(r, default_kind=KIND_CHUNK) for r in chunks]
+    scene_records = [normalize_summary_record(r, default_kind=KIND_SCENE) for r in scenes]
+    label_records = [normalize_summary_record(r, default_kind=KIND_LABEL) for r in labels]
+    route_records = [normalize_summary_record(r, default_kind=KIND_ROUTE) for r in routes]
+
+    # 1) Seed from evidence items → chunks.
+    for chunk in chunk_records:
+        if seed_artifacts and chunk["id"] in seed_artifacts:
+            plan.add(chunk["id"], KIND_CHUNK, "artifact marked changed")
+            continue
+        if changed_items and changed_items.intersection(chunk["evidence_item_ids"]):
+            hit = sorted(changed_items.intersection(chunk["evidence_item_ids"]))
+            plan.add(chunk["id"], KIND_CHUNK, f"evidence items changed: {', '.join(hit)}")
+
+    stale_ids = set(plan.stale_artifact_ids)
+
+    def _depends_on_stale(record: Mapping[str, Any]) -> list[str]:
+        deps = set(record.get("upstream_artifact_ids") or [])
+        # Label/scene may also embed evidence items directly.
+        if changed_items and changed_items.intersection(record.get("evidence_item_ids") or []):
+            return sorted(changed_items.intersection(record.get("evidence_item_ids") or []))
+        return sorted(deps.intersection(stale_ids | seed_artifacts))
+
+    # 2) Scenes / labels depending on stale chunks or changed items.
+    for scene in scene_records:
+        if scene["id"] in seed_artifacts:
+            plan.add(scene["id"], KIND_SCENE, "artifact marked changed")
+            continue
+        deps = _depends_on_stale(scene)
+        if deps:
+            plan.add(scene["id"], KIND_SCENE, f"upstream/evidence changed: {', '.join(deps)}")
+
+    stale_ids = set(plan.stale_artifact_ids)
+    for label in label_records:
+        if label["id"] in seed_artifacts:
+            plan.add(label["id"], KIND_LABEL, "artifact marked changed")
+            continue
+        deps = _depends_on_stale(label)
+        if deps:
+            plan.add(label["id"], KIND_LABEL, f"upstream/evidence changed: {', '.join(deps)}")
+
+    # 3) Routes depending on stale labels/scenes/chunks.
+    stale_ids = set(plan.stale_artifact_ids)
+    for route in route_records:
+        if route["id"] in seed_artifacts:
+            plan.add(route["id"], KIND_ROUTE, "artifact marked changed")
+            continue
+        deps = _depends_on_stale(route)
+        if deps:
+            plan.add(route["id"], KIND_ROUTE, f"upstream/evidence changed: {', '.join(deps)}")
+
+    # 4) Global brief depends on any affected analysis product.
+    brief_id = "project_brief"
+    if project_brief is not None:
+        brief = normalize_summary_record(project_brief, default_kind=KIND_PROJECT_BRIEF)
+        brief_id = brief["id"] or brief_id
+        if brief_id in seed_artifacts:
+            plan.add(brief_id, KIND_PROJECT_BRIEF, "artifact marked changed")
+        elif always_stale_brief_on_any and plan.stale_artifact_ids:
+            plan.add(
+                brief_id,
+                KIND_PROJECT_BRIEF,
+                "downstream of stale analysis artifacts",
+            )
+        else:
+            deps = _depends_on_stale(brief)
+            if deps:
+                plan.add(
+                    brief_id,
+                    KIND_PROJECT_BRIEF,
+                    f"upstream/evidence changed: {', '.join(deps)}",
+                )
+    elif always_stale_brief_on_any and plan.stale_artifact_ids:
+        plan.add(brief_id, KIND_PROJECT_BRIEF, "downstream of stale analysis artifacts")
+
+    return plan
+
+
+def apply_invalidation_to_records(
+    records: Sequence[Mapping[str, Any]],
+    plan: InvalidationPlan,
+    *,
+    default_kind: str,
+) -> list[dict[str, Any]]:
+    """Return copies of records with planned ids flipped to stale."""
+    out: list[dict[str, Any]] = []
+    for raw in records:
+        record = normalize_summary_record(raw, default_kind=default_kind)
+        if record["id"] in plan.stale_artifact_ids:
+            record = dict(record)
+            record["status"] = STATUS_STALE
+        out.append(record)
+    return out
+
+
+def get_default_project_analysis_store_dir(base_dir: str | None = None) -> str:
+    """Resolve default store path via context_storage settings."""
+    from translator_runtime import get_default_context_store_dir
+
+    return get_default_context_store_dir(STORE_NAME, base_dir)
+
+
+def resolve_under_store(store_dir: str | os.PathLike[str], relative: str) -> str:
+    """Resolve *relative* under *store_dir*; reject escapes."""
+    root = os.path.realpath(os.path.abspath(os.fspath(store_dir)))
+    rel = str(relative or "").replace("\\", "/").lstrip("/")
+    if not rel or rel in {".", ".."} or ".." in rel.split("/"):
+        raise ProjectAnalysisPathEscapeError(
+            f"refusing path that escapes project analysis store: {relative!r}"
+        )
+    # Absolute or drive-relative inputs are never allowed as relative store paths.
+    if os.path.isabs(rel) or re.match(r"^[A-Za-z]:", rel):
+        raise ProjectAnalysisPathEscapeError(
+            f"refusing absolute path outside project analysis store: {relative!r}"
+        )
+    candidate = os.path.realpath(os.path.join(root, *rel.split("/")))
+    try:
+        common = os.path.commonpath([root, candidate])
+    except ValueError as exc:
+        # Different drives on Windows.
+        raise ProjectAnalysisPathEscapeError(
+            f"refusing path that escapes project analysis store: {relative!r}"
+        ) from exc
+    if common != root:
+        raise ProjectAnalysisPathEscapeError(
+            f"refusing path that escapes project analysis store: {relative!r}"
+        )
+    return candidate
+
+
+def empty_manifest(
+    *,
+    project_identity: Mapping[str, Any] | None = None,
+    store_dir: str = "",
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "store_name": STORE_NAME,
+        "store_dir": store_dir,
+        "project_identity": dict(project_identity or {}),
+        "artifacts": {
+            KIND_CHUNK: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
+            KIND_SCENE: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
+            KIND_LABEL: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
+            KIND_ROUTE: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
+            KIND_PROJECT_BRIEF: {
+                "status": STATUS_MISSING,
+                "draft_present": False,
+                "published_present": False,
+                "lineage": empty_lineage(),
+            },
+        },
+        "updated_at": "",
+    }
+
+
+def normalize_manifest(raw: Any, *, store_dir: str = "") -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ProjectAnalysisSchemaError("manifest must be an object")
+    try:
+        schema_version = int(raw.get("schema_version", SCHEMA_VERSION))
+    except (TypeError, ValueError) as exc:
+        raise ProjectAnalysisSchemaError("manifest.schema_version must be an integer") from exc
+    if schema_version != SCHEMA_VERSION:
+        raise ProjectAnalysisSchemaError(
+            f"unsupported project analysis schema_version {schema_version}; "
+            f"expected {SCHEMA_VERSION}"
+        )
+    base = empty_manifest(
+        project_identity=raw.get("project_identity")
+        if isinstance(raw.get("project_identity"), Mapping)
+        else {},
+        store_dir=store_dir or _as_optional_str(raw.get("store_dir")),
+    )
+    artifacts_in = raw.get("artifacts") if isinstance(raw.get("artifacts"), Mapping) else {}
+    for kind in (
+        KIND_CHUNK,
+        KIND_SCENE,
+        KIND_LABEL,
+        KIND_ROUTE,
+        KIND_PROJECT_BRIEF,
+    ):
+        entry = artifacts_in.get(kind) if isinstance(artifacts_in.get(kind), Mapping) else {}
+        status = normalize_status(entry.get("status") or STATUS_MISSING, allow_missing=True)
+        if kind == KIND_PROJECT_BRIEF:
+            base["artifacts"][kind] = {
+                "status": status,
+                "draft_present": bool(entry.get("draft_present", False)),
+                "published_present": bool(entry.get("published_present", False)),
+                "lineage": normalize_lineage(entry.get("lineage")),
+                "id": _as_optional_str(entry.get("id") or "project_brief"),
+            }
+        else:
+            try:
+                count = int(entry.get("count", 0) or 0)
+            except (TypeError, ValueError) as exc:
+                raise ProjectAnalysisSchemaError(f"artifacts.{kind}.count must be an integer") from exc
+            base["artifacts"][kind] = {
+                "status": status,
+                "count": max(0, count),
+                "lineage": normalize_lineage(entry.get("lineage")),
+            }
+    base["updated_at"] = _as_optional_str(raw.get("updated_at"))
+    return base
+
+
+def _aggregate_status(statuses: Sequence[str]) -> str:
+    if not statuses:
+        return STATUS_MISSING
+    unique = set(statuses)
+    if STATUS_FAILED in unique:
+        return STATUS_FAILED
+    if STATUS_STALE in unique:
+        return STATUS_STALE
+    if STATUS_REVIEW_REQUIRED in unique:
+        return STATUS_REVIEW_REQUIRED
+    if unique == {STATUS_PUBLISHED}:
+        return STATUS_PUBLISHED
+    if STATUS_DRAFT in unique or STATUS_PUBLISHED in unique:
+        return STATUS_DRAFT
+    return next(iter(unique))
+
+
+def _read_json_object(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ProjectAnalysisSchemaError(f"expected JSON object in {path}")
+    return data
+
+
+def _read_jsonl_objects(path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ProjectAnalysisSchemaError(
+                    f"invalid JSONL at {path}:{line_no}: {exc}"
+                ) from exc
+            if not isinstance(data, dict):
+                raise ProjectAnalysisSchemaError(
+                    f"JSONL row at {path}:{line_no} must be an object"
+                )
+            rows.append(data)
+    return rows
+
+
+class ProjectAnalysisStore:
+    """Filesystem-backed project analysis artifact store (Phase 1 I/O)."""
+
+    def __init__(self, store_dir: str | os.PathLike[str]):
+        self.store_dir = os.path.abspath(os.fspath(store_dir))
+
+    def ensure_dir(self) -> None:
+        os.makedirs(self.store_dir, exist_ok=True)
+
+    def path_for(self, relative: str) -> str:
+        return resolve_under_store(self.store_dir, relative)
+
+    @property
+    def manifest_path(self) -> str:
+        return self.path_for(MANIFEST_FILENAME)
+
+    def artifact_path(self, filename: str) -> str:
+        return self.path_for(filename)
+
+    def exists(self) -> bool:
+        return os.path.isfile(self.manifest_path) or any(
+            os.path.isfile(self.artifact_path(name))
+            for name in (
+                CHUNK_SUMMARIES_FILENAME,
+                SCENE_SUMMARIES_FILENAME,
+                LABEL_SUMMARIES_FILENAME,
+                ROUTE_SUMMARIES_FILENAME,
+                PROJECT_BRIEF_DRAFT_FILENAME,
+                PROJECT_BRIEF_PUBLISHED_FILENAME,
+            )
+        )
+
+    def load_manifest(self) -> dict[str, Any] | None:
+        if not os.path.isfile(self.manifest_path):
+            return None
+        try:
+            raw = _read_json_object(self.manifest_path)
+        except json.JSONDecodeError as exc:
+            raise ProjectAnalysisSchemaError(
+                f"corrupt project analysis manifest: {self.manifest_path}: {exc}"
+            ) from exc
+        return normalize_manifest(raw, store_dir=self.store_dir)
+
+    def save_manifest(self, manifest: Mapping[str, Any]) -> dict[str, Any]:
+        self.ensure_dir()
+        normalized = normalize_manifest(manifest, store_dir=self.store_dir)
+        normalized["updated_at"] = normalized.get("updated_at") or utc_now_iso()
+        atomic_write_json(self.manifest_path, normalized)
+        return normalized
+
+    def load_summaries(self, kind: str) -> list[dict[str, Any]]:
+        kind = normalize_kind(kind)
+        if kind not in JSONL_FILENAMES:
+            raise ProjectAnalysisSchemaError(f"{kind} is not a JSONL summary kind")
+        path = self.artifact_path(JSONL_FILENAMES[kind])
+        if not os.path.isfile(path):
+            return []
+        rows = _read_jsonl_objects(path)
+        return [normalize_summary_record(row, default_kind=kind) for row in rows]
+
+    def save_summaries(self, kind: str, records: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        kind = normalize_kind(kind)
+        if kind not in JSONL_FILENAMES:
+            raise ProjectAnalysisSchemaError(f"{kind} is not a JSONL summary kind")
+        self.ensure_dir()
+        normalized = [normalize_summary_record(row, default_kind=kind) for row in records]
+        atomic_write_jsonl(self.artifact_path(JSONL_FILENAMES[kind]), normalized)
+        return normalized
+
+    def load_routes(self) -> list[dict[str, Any]]:
+        path = self.artifact_path(ROUTE_SUMMARIES_FILENAME)
+        if not os.path.isfile(path):
+            return []
+        try:
+            raw = _read_json_object(path)
+        except json.JSONDecodeError as exc:
+            raise ProjectAnalysisSchemaError(
+                f"corrupt route_summaries.json: {path}: {exc}"
+            ) from exc
+        routes = raw.get("routes")
+        if routes is None and isinstance(raw.get("items"), list):
+            routes = raw["items"]
+        if not isinstance(routes, list):
+            raise ProjectAnalysisSchemaError("route_summaries.json must contain a routes list")
+        return [normalize_summary_record(row, default_kind=KIND_ROUTE) for row in routes]
+
+    def save_routes(self, records: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        self.ensure_dir()
+        normalized = [normalize_summary_record(row, default_kind=KIND_ROUTE) for row in records]
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "routes": normalized,
+            "updated_at": utc_now_iso(),
+        }
+        atomic_write_json(self.artifact_path(ROUTE_SUMMARIES_FILENAME), payload)
+        return normalized
+
+    def load_brief_text(self, *, published: bool) -> str:
+        name = (
+            PROJECT_BRIEF_PUBLISHED_FILENAME if published else PROJECT_BRIEF_DRAFT_FILENAME
+        )
+        path = self.artifact_path(name)
+        if not os.path.isfile(path):
+            return ""
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            return handle.read()
+
+    def save_brief_text(self, text: str, *, published: bool) -> None:
+        self.ensure_dir()
+        name = (
+            PROJECT_BRIEF_PUBLISHED_FILENAME if published else PROJECT_BRIEF_DRAFT_FILENAME
+        )
+        atomic_write_text(self.artifact_path(name), text if text.endswith("\n") else text + "\n")
+
+    def load_brief_record(self, *, published: bool = True) -> dict[str, Any] | None:
+        """Load brief metadata from manifest artifacts entry when present."""
+        manifest = self.load_manifest()
+        if not manifest:
+            return None
+        entry = (manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {}
+        status = normalize_status(entry.get("status") or STATUS_MISSING, allow_missing=True)
+        if status == STATUS_MISSING:
+            return None
+        text = self.load_brief_text(published=published)
+        if published and not text and not entry.get("published_present"):
+            text = self.load_brief_text(published=False)
+        return normalize_summary_record(
+            {
+                "id": entry.get("id") or "project_brief",
+                "kind": KIND_PROJECT_BRIEF,
+                "status": STATUS_DRAFT if status == STATUS_MISSING else status,
+                "summary": text,
+                "lineage": entry.get("lineage") or empty_lineage(),
+                "source_files": entry.get("source_files") or [],
+                "evidence_item_ids": entry.get("evidence_item_ids") or [],
+                "upstream_artifact_ids": entry.get("upstream_artifact_ids") or [],
+                "source_checksum": entry.get("source_checksum") or "",
+            },
+            default_kind=KIND_PROJECT_BRIEF,
+        )
+
+    def rebuild_manifest(
+        self,
+        *,
+        project_identity: Mapping[str, Any] | None = None,
+        expected_source_fingerprint: str = "",
+    ) -> dict[str, Any]:
+        """Derive manifest aggregate status from on-disk artifacts."""
+        chunks = self.load_summaries(KIND_CHUNK)
+        scenes = self.load_summaries(KIND_SCENE)
+        labels = self.load_summaries(KIND_LABEL)
+        routes = self.load_routes()
+
+        def _kind_entry(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+            statuses = [
+                evaluate_record_status(
+                    r, expected_source_fingerprint=expected_source_fingerprint
+                )
+                for r in records
+            ]
+            lineage = empty_lineage(source_fingerprint=expected_source_fingerprint)
+            if records:
+                lineage = normalize_lineage(records[0].get("lineage"))
+            return {
+                "status": _aggregate_status(statuses),
+                "count": len(records),
+                "lineage": lineage,
+            }
+
+        draft_present = os.path.isfile(self.artifact_path(PROJECT_BRIEF_DRAFT_FILENAME))
+        published_present = os.path.isfile(
+            self.artifact_path(PROJECT_BRIEF_PUBLISHED_FILENAME)
+        )
+        previous = self.load_manifest()
+        prev_brief = ((previous or {}).get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {}
+        brief_status = normalize_status(
+            prev_brief.get("status") or STATUS_MISSING, allow_missing=True
+        )
+        if published_present and brief_status == STATUS_MISSING:
+            brief_status = STATUS_PUBLISHED
+        elif draft_present and brief_status == STATUS_MISSING:
+            brief_status = STATUS_DRAFT
+        if brief_status == STATUS_PUBLISHED and expected_source_fingerprint:
+            brief_lineage = normalize_lineage(prev_brief.get("lineage"))
+            if (
+                brief_lineage["source_fingerprint"]
+                and brief_lineage["source_fingerprint"] != expected_source_fingerprint
+            ):
+                brief_status = STATUS_STALE
+
+        identity = dict(project_identity or {})
+        if not identity and previous:
+            identity = dict(previous.get("project_identity") or {})
+
+        manifest = empty_manifest(project_identity=identity, store_dir=self.store_dir)
+        manifest["artifacts"][KIND_CHUNK] = _kind_entry(chunks)
+        manifest["artifacts"][KIND_SCENE] = _kind_entry(scenes)
+        manifest["artifacts"][KIND_LABEL] = _kind_entry(labels)
+        manifest["artifacts"][KIND_ROUTE] = _kind_entry(routes)
+        manifest["artifacts"][KIND_PROJECT_BRIEF] = {
+            "status": brief_status,
+            "draft_present": draft_present,
+            "published_present": published_present,
+            "lineage": normalize_lineage(prev_brief.get("lineage")),
+            "id": _as_optional_str(prev_brief.get("id") or "project_brief"),
+        }
+        manifest["updated_at"] = utc_now_iso()
+        return self.save_manifest(manifest)
+
+    def collect_status(
+        self,
+        *,
+        expected_source_fingerprint: str = "",
+        project_identity: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Readonly status snapshot for CLI / GUI / doctor (no side effects)."""
+        error = ""
+        manifest: dict[str, Any] | None = None
+        try:
+            if not self.exists():
+                overall = STATUS_MISSING
+            else:
+                manifest = self.load_manifest()
+                if manifest is None:
+                    # Artifacts without manifest still report via rebuild-in-memory.
+                    chunks = self.load_summaries(KIND_CHUNK)
+                    scenes = self.load_summaries(KIND_SCENE)
+                    labels = self.load_summaries(KIND_LABEL)
+                    routes = self.load_routes()
+                    statuses = []
+                    for kind, records in (
+                        (KIND_CHUNK, chunks),
+                        (KIND_SCENE, scenes),
+                        (KIND_LABEL, labels),
+                        (KIND_ROUTE, routes),
+                    ):
+                        statuses.extend(
+                            evaluate_record_status(
+                                r, expected_source_fingerprint=expected_source_fingerprint
+                            )
+                            for r in records
+                        )
+                    draft_present = os.path.isfile(
+                        self.artifact_path(PROJECT_BRIEF_DRAFT_FILENAME)
+                    )
+                    published_present = os.path.isfile(
+                        self.artifact_path(PROJECT_BRIEF_PUBLISHED_FILENAME)
+                    )
+                    if published_present:
+                        statuses.append(STATUS_PUBLISHED)
+                    elif draft_present:
+                        statuses.append(STATUS_DRAFT)
+                    overall = _aggregate_status(statuses)
+                    manifest = empty_manifest(
+                        project_identity=project_identity or {},
+                        store_dir=self.store_dir,
+                    )
+                    manifest["artifacts"][KIND_CHUNK]["count"] = len(chunks)
+                    manifest["artifacts"][KIND_CHUNK]["status"] = _aggregate_status(
+                        [
+                            evaluate_record_status(
+                                r, expected_source_fingerprint=expected_source_fingerprint
+                            )
+                            for r in chunks
+                        ]
+                    )
+                    manifest["artifacts"][KIND_SCENE]["count"] = len(scenes)
+                    manifest["artifacts"][KIND_SCENE]["status"] = _aggregate_status(
+                        [
+                            evaluate_record_status(
+                                r, expected_source_fingerprint=expected_source_fingerprint
+                            )
+                            for r in scenes
+                        ]
+                    )
+                    manifest["artifacts"][KIND_LABEL]["count"] = len(labels)
+                    manifest["artifacts"][KIND_LABEL]["status"] = _aggregate_status(
+                        [
+                            evaluate_record_status(
+                                r, expected_source_fingerprint=expected_source_fingerprint
+                            )
+                            for r in labels
+                        ]
+                    )
+                    manifest["artifacts"][KIND_ROUTE]["count"] = len(routes)
+                    manifest["artifacts"][KIND_ROUTE]["status"] = _aggregate_status(
+                        [
+                            evaluate_record_status(
+                                r, expected_source_fingerprint=expected_source_fingerprint
+                            )
+                            for r in routes
+                        ]
+                    )
+                    brief_status = (
+                        STATUS_PUBLISHED
+                        if published_present
+                        else STATUS_DRAFT
+                        if draft_present
+                        else STATUS_MISSING
+                    )
+                    manifest["artifacts"][KIND_PROJECT_BRIEF]["status"] = brief_status
+                    manifest["artifacts"][KIND_PROJECT_BRIEF]["draft_present"] = draft_present
+                    manifest["artifacts"][KIND_PROJECT_BRIEF][
+                        "published_present"
+                    ] = published_present
+                else:
+                    # Re-evaluate published → stale when expected fingerprint provided.
+                    overall_statuses = []
+                    for kind in (KIND_CHUNK, KIND_SCENE, KIND_LABEL, KIND_ROUTE):
+                        entry = manifest["artifacts"][kind]
+                        status = entry.get("status") or STATUS_MISSING
+                        if status == STATUS_PUBLISHED and expected_source_fingerprint:
+                            lineage = normalize_lineage(entry.get("lineage"))
+                            if (
+                                lineage["source_fingerprint"]
+                                and lineage["source_fingerprint"] != expected_source_fingerprint
+                            ):
+                                status = STATUS_STALE
+                                entry = dict(entry)
+                                entry["status"] = STATUS_STALE
+                                manifest["artifacts"][kind] = entry
+                        overall_statuses.append(status)
+                    brief = manifest["artifacts"][KIND_PROJECT_BRIEF]
+                    brief_status = brief.get("status") or STATUS_MISSING
+                    if brief_status == STATUS_PUBLISHED and expected_source_fingerprint:
+                        lineage = normalize_lineage(brief.get("lineage"))
+                        if (
+                            lineage["source_fingerprint"]
+                            and lineage["source_fingerprint"] != expected_source_fingerprint
+                        ):
+                            brief_status = STATUS_STALE
+                            brief = dict(brief)
+                            brief["status"] = STATUS_STALE
+                            manifest["artifacts"][KIND_PROJECT_BRIEF] = brief
+                    overall_statuses.append(brief_status)
+                    overall = _aggregate_status(
+                        [s for s in overall_statuses if s != STATUS_MISSING]
+                    )
+                    if overall == STATUS_MISSING and any(
+                        s != STATUS_MISSING for s in overall_statuses
+                    ):
+                        overall = _aggregate_status(overall_statuses)
+        except ProjectAnalysisError as exc:
+            error = str(exc)
+            overall = STATUS_FAILED
+            manifest = empty_manifest(
+                project_identity=project_identity or {}, store_dir=self.store_dir
+            )
+        except OSError as exc:
+            error = str(exc)
+            overall = STATUS_FAILED
+            manifest = empty_manifest(
+                project_identity=project_identity or {}, store_dir=self.store_dir
+            )
+
+        artifacts = (manifest or empty_manifest(store_dir=self.store_dir)).get("artifacts") or {}
+        brief = artifacts.get(KIND_PROJECT_BRIEF) or {}
+        return {
+            "store_dir": self.store_dir,
+            "store_exists": self.exists(),
+            "schema_version": SCHEMA_VERSION,
+            "overall_status": overall,
+            "injectable": overall == STATUS_PUBLISHED,
+            "project_identity": (manifest or {}).get("project_identity") or dict(project_identity or {}),
+            "artifacts": artifacts,
+            "chunk_count": int((artifacts.get(KIND_CHUNK) or {}).get("count") or 0),
+            "scene_count": int((artifacts.get(KIND_SCENE) or {}).get("count") or 0),
+            "label_count": int((artifacts.get(KIND_LABEL) or {}).get("count") or 0),
+            "route_count": int((artifacts.get(KIND_ROUTE) or {}).get("count") or 0),
+            "brief_status": brief.get("status") or STATUS_MISSING,
+            "brief_draft_present": bool(brief.get("draft_present")),
+            "brief_published_present": bool(brief.get("published_present")),
+            "updated_at": (manifest or {}).get("updated_at") or "",
+            "error": error,
+        }
+
+
+def collect_project_analysis_status(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+    expected_source_fingerprint: str = "",
+    project_identity: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    resolved = (
+        os.path.abspath(os.fspath(store_dir))
+        if store_dir
+        else get_default_project_analysis_store_dir(base_dir)
+    )
+    store = ProjectAnalysisStore(resolved)
+    return store.collect_status(
+        expected_source_fingerprint=expected_source_fingerprint,
+        project_identity=project_identity,
+    )
+
+
+def format_status_lines(status: Mapping[str, Any]) -> list[str]:
+    lines = [
+        "Project analysis status:",
+        f"- Store dir: {status.get('store_dir') or ''}",
+        f"- Store exists: {bool(status.get('store_exists'))}",
+        f"- Schema version: {status.get('schema_version')}",
+        f"- Overall: {status.get('overall_status') or STATUS_MISSING}",
+        f"- Injectable (published+fresh): {bool(status.get('injectable'))}",
+        f"- Chunks: {status.get('chunk_count', 0)} "
+        f"({((status.get('artifacts') or {}).get(KIND_CHUNK) or {}).get('status') or STATUS_MISSING})",
+        f"- Scenes: {status.get('scene_count', 0)} "
+        f"({((status.get('artifacts') or {}).get(KIND_SCENE) or {}).get('status') or STATUS_MISSING})",
+        f"- Labels: {status.get('label_count', 0)} "
+        f"({((status.get('artifacts') or {}).get(KIND_LABEL) or {}).get('status') or STATUS_MISSING})",
+        f"- Routes: {status.get('route_count', 0)} "
+        f"({((status.get('artifacts') or {}).get(KIND_ROUTE) or {}).get('status') or STATUS_MISSING})",
+        f"- Project brief: {status.get('brief_status') or STATUS_MISSING} "
+        f"(draft={bool(status.get('brief_draft_present'))}, "
+        f"published={bool(status.get('brief_published_present'))})",
+        f"- Updated at: {status.get('updated_at') or ''}",
+    ]
+    if status.get("error"):
+        lines.append(f"- Error: {status.get('error')}")
+    return lines
+
+
+def format_status_label(status: Mapping[str, Any] | None) -> str:
+    """Single-line Chinese status for GUI context library."""
+    if not status:
+        return "未检测"
+    overall = str(status.get("overall_status") or STATUS_MISSING)
+    labels = {
+        STATUS_MISSING: "未生成",
+        STATUS_DRAFT: "草稿",
+        STATUS_REVIEW_REQUIRED: "待审核",
+        STATUS_PUBLISHED: "已发布",
+        STATUS_STALE: "已过期",
+        STATUS_FAILED: "失败",
+    }
+    human = labels.get(overall, overall)
+    parts = [human]
+    if status.get("store_exists"):
+        parts.append(
+            f"chunk {status.get('chunk_count', 0)} / "
+            f"label {status.get('label_count', 0)} / "
+            f"route {status.get('route_count', 0)}"
+        )
+        brief = status.get("brief_status") or STATUS_MISSING
+        if brief != STATUS_MISSING:
+            parts.append(f"brief {labels.get(brief, brief)}")
+    if status.get("error"):
+        parts.append("读取错误")
+    if overall == STATUS_PUBLISHED and not status.get("injectable"):
+        parts.append("不可注入")
+    return " · ".join(parts)
+
+
+def print_status(status: Mapping[str, Any]) -> None:
+    for line in format_status_lines(status):
+        print(line)

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -554,8 +554,10 @@ class GuiTaskPageTests(unittest.TestCase):
         page = self.window.context_library_page
         self.assertEqual(page.rag_status_row.title_label.text(), "记忆库")
         self.assertEqual(page.source_index_status_row.title_label.text(), "原文索引")
+        self.assertEqual(page.project_analysis_status_row.title_label.text(), "项目分析")
         self.assertIn("项目", self.window.context_rag_status_label.text())
         self.assertIn("项目", self.window.context_source_index_status_label.text())
+        self.assertIn("项目", self.window.context_project_analysis_status_label.text())
         self.assertIs(
             page.bootstrap_rag_btn.parentWidget(),
             page.rag_status_row,
@@ -564,6 +566,7 @@ class GuiTaskPageTests(unittest.TestCase):
             page.bootstrap_source_index_btn.parentWidget(),
             page.source_index_status_row,
         )
+        self.assertEqual(page.project_analysis_readonly_label.text(), "只读")
 
     def test_context_page_uses_callbacks_and_owns_empty_state(self) -> None:
         page = self.window.context_library_page
@@ -580,6 +583,7 @@ class GuiTaskPageTests(unittest.TestCase):
             rag_enabled=False,
             source_index_enabled=False,
             game_root="",
+            project_analysis_label="未生成",
         )
         self.assertIs(page.page_stack.currentWidget(), page.empty_state)
         page.empty_state.action_clicked.emit()
@@ -589,9 +593,30 @@ class GuiTaskPageTests(unittest.TestCase):
             rag_enabled=True,
             source_index_enabled=False,
             game_root="C:/Games/Example/work",
+            project_analysis_status={
+                "overall_status": "missing",
+                "store_exists": False,
+            },
         )
         page.bootstrap_rag_btn.click()
         self.assertEqual(prebuilds, ["rag"])
+
+        page.set_context_status(
+            rag_enabled=False,
+            source_index_enabled=False,
+            game_root="C:/Games/Example/work",
+            project_analysis_status={
+                "overall_status": "published",
+                "store_exists": True,
+                "chunk_count": 1,
+                "label_count": 0,
+                "route_count": 0,
+                "brief_status": "published",
+                "injectable": True,
+            },
+        )
+        self.assertIs(page.page_stack.currentWidget(), page.status_page)
+        self.assertIn("已发布", page.project_analysis_status_label.text())
 
     def test_global_prep_buttons_visible_on_all_task_pages(self) -> None:
         for mode in (

--- a/tests/test_project_analysis.py
+++ b/tests/test_project_analysis.py
@@ -253,6 +253,180 @@ class StoreIoTests(unittest.TestCase):
             pa.is_injectable_record(record, expected_source_fingerprint="other")
         )
 
+    def test_missing_fingerprint_on_published_is_stale(self):
+        """P1: expected fingerprint + empty lineage must not stay injectable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_summaries(
+                pa.KIND_CHUNK,
+                [
+                    {
+                        **_chunk("chunk-1", ["item-1"]),
+                        "lineage": pa.empty_lineage(),  # published but no fingerprint
+                    }
+                ],
+            )
+            manifest = store.rebuild_manifest()
+            # Aggregate lineage is empty; claim published.
+            manifest["artifacts"][pa.KIND_CHUNK]["status"] = pa.STATUS_PUBLISHED
+            manifest["artifacts"][pa.KIND_CHUNK]["lineage"] = pa.empty_lineage()
+            store.save_manifest(manifest)
+
+            status = store.collect_status(expected_source_fingerprint="src-fp-1")
+            self.assertEqual(status["overall_status"], pa.STATUS_STALE)
+            self.assertFalse(status["injectable"])
+            self.assertEqual(
+                status["artifacts"][pa.KIND_CHUNK]["status"], pa.STATUS_STALE
+            )
+
+    def test_manifest_published_brief_without_file_not_injectable(self):
+        """P1: manifest alone cannot claim published brief without the md file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_summaries(
+                pa.KIND_CHUNK, [_chunk("chunk-1", ["item-1"])]
+            )
+            manifest = store.rebuild_manifest(expected_source_fingerprint="src-fp-1")
+            # Ensure chunk layer is published+fresh.
+            manifest["artifacts"][pa.KIND_CHUNK]["status"] = pa.STATUS_PUBLISHED
+            manifest["artifacts"][pa.KIND_CHUNK]["lineage"] = _lineage()
+            # Claim brief published without writing project_brief.published.md
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF] = {
+                "status": pa.STATUS_PUBLISHED,
+                "draft_present": False,
+                "published_present": True,
+                "lineage": _lineage(),
+                "id": "project_brief",
+            }
+            store.save_manifest(manifest)
+            self.assertFalse(
+                os.path.isfile(store.artifact_path(pa.PROJECT_BRIEF_PUBLISHED_FILENAME))
+            )
+
+            status = store.collect_status(expected_source_fingerprint="src-fp-1")
+            self.assertEqual(status["brief_status"], pa.STATUS_STALE)
+            self.assertFalse(status["brief_published_present"])
+            self.assertNotEqual(status["overall_status"], pa.STATUS_PUBLISHED)
+            self.assertFalse(status["injectable"])
+
+    def test_kind_must_match_target_file(self):
+        """P2: chunk_summaries.jsonl must not accept kind=route rows."""
+        with self.assertRaises(pa.ProjectAnalysisSchemaError):
+            pa.normalize_summary_record(
+                {
+                    "id": "r1",
+                    "kind": pa.KIND_ROUTE,
+                    "status": pa.STATUS_DRAFT,
+                    "lineage": pa.empty_lineage(),
+                },
+                default_kind=pa.KIND_CHUNK,
+            )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            with self.assertRaises(pa.ProjectAnalysisSchemaError):
+                store.save_summaries(
+                    pa.KIND_CHUNK,
+                    [
+                        {
+                            "id": "bad",
+                            "kind": pa.KIND_ROUTE,
+                            "status": pa.STATUS_DRAFT,
+                            "source_files": [],
+                            "evidence_item_ids": [],
+                            "upstream_artifact_ids": [],
+                            "lineage": pa.empty_lineage(),
+                        }
+                    ],
+                )
+            # Loader rejects mismatched rows already on disk.
+            path = store.artifact_path(pa.CHUNK_SUMMARIES_FILENAME)
+            os.makedirs(tmp, exist_ok=True)
+            Path(path).write_text(
+                json.dumps(
+                    {
+                        "id": "bad",
+                        "kind": "route",
+                        "status": "draft",
+                        "source_files": [],
+                        "evidence_item_ids": [],
+                        "upstream_artifact_ids": [],
+                        "lineage": pa.empty_lineage(),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(pa.ProjectAnalysisSchemaError):
+                store.load_summaries(pa.KIND_CHUNK)
+
+
+class PathAndCliContractTests(unittest.TestCase):
+    def test_base_dir_selects_distinct_tool_store_slugs(self):
+        """P2: project switch must resolve different analysis store dirs."""
+        import translator_runtime as runtime
+
+        previous_location = runtime.CONTEXT_STORAGE_LOCATION
+        try:
+            runtime.CONTEXT_STORAGE_LOCATION = "tool"
+            path_a = runtime.get_default_project_analysis_store_dir(
+                r"C:\Games\ProjectA\work"
+            )
+            path_b = runtime.get_default_project_analysis_store_dir(
+                r"C:\Games\ProjectB\work"
+            )
+            self.assertNotEqual(path_a, path_b)
+            self.assertIn("project_analysis", path_a.replace("\\", "/"))
+            self.assertTrue(path_a.endswith("ProjectA") or "ProjectA" in path_a)
+            self.assertTrue(path_b.endswith("ProjectB") or "ProjectB" in path_b)
+            status_a = pa.collect_project_analysis_status(
+                base_dir=r"C:\Games\ProjectA\work"
+            )
+            status_b = pa.collect_project_analysis_status(
+                base_dir=r"C:\Games\ProjectB\work"
+            )
+            self.assertEqual(status_a["store_dir"], path_a)
+            self.assertEqual(status_b["store_dir"], path_b)
+        finally:
+            runtime.CONTEXT_STORAGE_LOCATION = previous_location
+
+    def test_json_status_stdout_is_pure_json_when_path_warns(self):
+        """P2: --json must not mix path-resolution warnings into stdout."""
+        import io
+        from contextlib import redirect_stdout
+
+        import gemini_translate_batch as batch_mod
+
+        def noisy_collect(*_args, **_kwargs):
+            print(
+                "Warning: context_storage.location is 'game' but game_root is unset; "
+                "using tool logs root with an 'unset' project slug."
+            )
+            return {
+                "overall_status": pa.STATUS_MISSING,
+                "store_dir": "C:/tmp/project_analysis/unset",
+                "store_exists": False,
+                "schema_version": pa.SCHEMA_VERSION,
+                "injectable": False,
+                "chunk_count": 0,
+                "label_count": 0,
+                "route_count": 0,
+                "brief_status": pa.STATUS_MISSING,
+                "error": "",
+            }
+
+        buf = io.StringIO()
+        with mock.patch(
+            "project_analysis.collect_project_analysis_status",
+            side_effect=noisy_collect,
+        ), redirect_stdout(buf):
+            batch_mod.main(["project-analysis-status", "--json", "--store-dir", "C:/tmp"])
+        raw = buf.getvalue()
+        self.assertNotIn("Warning:", raw, msg=f"stdout mixed warning: {raw!r}")
+        payload = json.loads(raw)
+        self.assertEqual(payload["overall_status"], pa.STATUS_MISSING)
+        self.assertIn("store_dir", payload)
+
 
 class CliStatusTests(unittest.TestCase):
     def test_project_analysis_status_command(self):

--- a/tests/test_project_analysis.py
+++ b/tests/test_project_analysis.py
@@ -314,15 +314,8 @@ class DoctorIntegrationTests(unittest.TestCase):
         import gemini_translate_batch as batch_mod
 
         with tempfile.TemporaryDirectory() as tmp:
-            with mock.patch.object(
-                pa,
-                "get_default_project_analysis_store_dir",
-                return_value=tmp,
-            ):
-                # collect_doctor_context_status imports collect_project_analysis_status
-                # which resolves default store; patch at call site via store_dir path.
-                status = pa.collect_project_analysis_status(store_dir=tmp)
-                self.assertEqual(status["overall_status"], pa.STATUS_MISSING)
+            status = pa.collect_project_analysis_status(store_dir=tmp)
+            self.assertEqual(status["overall_status"], pa.STATUS_MISSING)
 
             context = batch_mod.collect_doctor_context_status()
             self.assertIn("project_analysis", context)

--- a/tests/test_project_analysis.py
+++ b/tests/test_project_analysis.py
@@ -369,26 +369,59 @@ class PathAndCliContractTests(unittest.TestCase):
         previous_location = runtime.CONTEXT_STORAGE_LOCATION
         try:
             runtime.CONTEXT_STORAGE_LOCATION = "tool"
-            path_a = runtime.get_default_project_analysis_store_dir(
-                r"C:\Games\ProjectA\work"
-            )
-            path_b = runtime.get_default_project_analysis_store_dir(
-                r"C:\Games\ProjectB\work"
-            )
+            # Platform-native fixtures: .../ProjectA/work → slug ProjectA.
+            root = Path(tempfile.gettempdir()) / "rtl-pa-slug-fixture"
+            base_a = str(root / "ProjectA" / "work")
+            base_b = str(root / "ProjectB" / "work")
+            slug_a = runtime._project_slug_from_base_dir(base_a)
+            slug_b = runtime._project_slug_from_base_dir(base_b)
+            self.assertEqual(slug_a, "ProjectA")
+            self.assertEqual(slug_b, "ProjectB")
+
+            path_a = runtime.get_default_project_analysis_store_dir(base_a)
+            path_b = runtime.get_default_project_analysis_store_dir(base_b)
             self.assertNotEqual(path_a, path_b)
-            self.assertIn("project_analysis", path_a.replace("\\", "/"))
-            self.assertTrue(path_a.endswith("ProjectA") or "ProjectA" in path_a)
-            self.assertTrue(path_b.endswith("ProjectB") or "ProjectB" in path_b)
-            status_a = pa.collect_project_analysis_status(
-                base_dir=r"C:\Games\ProjectA\work"
-            )
-            status_b = pa.collect_project_analysis_status(
-                base_dir=r"C:\Games\ProjectB\work"
-            )
+            self.assertEqual(os.path.basename(path_a), slug_a)
+            self.assertEqual(os.path.basename(path_b), slug_b)
+            self.assertEqual(os.path.basename(os.path.dirname(path_a)), "project_analysis")
+            status_a = pa.collect_project_analysis_status(base_dir=base_a)
+            status_b = pa.collect_project_analysis_status(base_dir=base_b)
             self.assertEqual(status_a["store_dir"], path_a)
             self.assertEqual(status_b["store_dir"], path_b)
         finally:
             runtime.CONTEXT_STORAGE_LOCATION = previous_location
+
+    def test_project_analysis_status_does_not_persist_game_root(self):
+        """Readonly status must not rewrite translator_config.json."""
+        import gemini_translate_batch as batch_mod
+        import translator_runtime as runtime
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "Game_Example"
+            work = project / "work"
+            original_game = project / "original" / "game"
+            work.mkdir(parents=True)
+            original_game.mkdir(parents=True)
+            config_path = root / "translator_config.json"
+            # Point at project root; loader would normally normalize to work/ and persist.
+            config_path.write_text(
+                json.dumps({"game_root": str(project)}),
+                encoding="utf-8",
+            )
+            before = config_path.read_text(encoding="utf-8")
+
+            with mock.patch.object(runtime, "TRANSLATOR_CONFIG", str(config_path)):
+                with mock.patch("builtins.print"):
+                    batch_mod.main(["project-analysis-status"])
+
+            after = config_path.read_text(encoding="utf-8")
+            self.assertEqual(after, before)
+            saved = json.loads(after)
+            self.assertEqual(
+                runtime.canonical_abs_path(saved["game_root"]),
+                runtime.canonical_abs_path(str(project)),
+            )
 
     def test_json_status_stdout_is_pure_json_when_path_warns(self):
         """P2: --json must not mix path-resolution warnings into stdout."""

--- a/tests/test_project_analysis.py
+++ b/tests/test_project_analysis.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""Tests for Project Analysis Phase 1 contract (#256)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import project_analysis as pa
+
+
+def _lineage(source_fp: str = "src-fp-1", upstream: str = "up-1") -> dict:
+    return pa.empty_lineage(
+        source_fingerprint=source_fp,
+        upstream_dependency_digest=upstream,
+        prompt_schema_version="prompt-v1",
+        generated_at="2026-07-22T00:00:00Z",
+    )
+
+
+def _chunk(cid: str, item_ids: list[str], *, status: str = pa.STATUS_PUBLISHED) -> dict:
+    return {
+        "id": cid,
+        "kind": pa.KIND_CHUNK,
+        "status": status,
+        "source_files": ["script.rpy"],
+        "evidence_item_ids": item_ids,
+        "line_span": [10, 20],
+        "source_checksum": "chk-" + cid,
+        "upstream_artifact_ids": [],
+        "lineage": _lineage(),
+        "summary": f"summary for {cid}",
+    }
+
+
+def _label(lid: str, upstream: list[str], *, status: str = pa.STATUS_PUBLISHED) -> dict:
+    return {
+        "id": lid,
+        "kind": pa.KIND_LABEL,
+        "status": status,
+        "source_files": ["script.rpy"],
+        "label_id": lid,
+        "evidence_item_ids": [],
+        "upstream_artifact_ids": upstream,
+        "source_checksum": "chk-" + lid,
+        "lineage": _lineage(),
+        "summary": f"label {lid}",
+    }
+
+
+def _route(rid: str, upstream: list[str], *, status: str = pa.STATUS_PUBLISHED) -> dict:
+    return {
+        "id": rid,
+        "kind": pa.KIND_ROUTE,
+        "status": status,
+        "source_files": ["script.rpy"],
+        "route_id": rid,
+        "evidence_item_ids": [],
+        "upstream_artifact_ids": upstream,
+        "source_checksum": "chk-" + rid,
+        "lineage": _lineage(),
+        "summary": f"route {rid}",
+    }
+
+
+def _brief(*, status: str = pa.STATUS_PUBLISHED) -> dict:
+    return {
+        "id": "project_brief",
+        "kind": pa.KIND_PROJECT_BRIEF,
+        "status": status,
+        "source_files": ["script.rpy"],
+        "evidence_item_ids": [],
+        "upstream_artifact_ids": ["route-a", "route-b"],
+        "lineage": _lineage(),
+        "summary": "global brief",
+    }
+
+
+class SchemaAndFingerprintTests(unittest.TestCase):
+    def test_normalize_summary_requires_id_and_kind(self):
+        with self.assertRaises(pa.ProjectAnalysisSchemaError):
+            pa.normalize_summary_record({"kind": "chunk", "status": "draft"})
+        with self.assertRaises(pa.ProjectAnalysisSchemaError):
+            pa.normalize_summary_record({"id": "c1", "kind": "nope", "status": "draft"})
+
+    def test_unknown_schema_version_rejected(self):
+        with self.assertRaises(pa.ProjectAnalysisSchemaError):
+            pa.normalize_lineage({"schema_version": 99})
+        with self.assertRaises(pa.ProjectAnalysisSchemaError):
+            pa.normalize_manifest({"schema_version": 99})
+
+    def test_published_becomes_stale_on_fingerprint_mismatch(self):
+        record = _chunk("chunk-1", ["item-1"])
+        self.assertEqual(
+            pa.evaluate_record_status(record, expected_source_fingerprint="src-fp-1"),
+            pa.STATUS_PUBLISHED,
+        )
+        self.assertEqual(
+            pa.evaluate_record_status(record, expected_source_fingerprint="src-fp-OTHER"),
+            pa.STATUS_STALE,
+        )
+        self.assertFalse(
+            pa.is_injectable_record(record, expected_source_fingerprint="src-fp-OTHER")
+        )
+        self.assertTrue(
+            pa.is_injectable_record(record, expected_source_fingerprint="src-fp-1")
+        )
+
+    def test_digest_source_items_stable(self):
+        items = [
+            {"id": "b", "source_checksum": "2"},
+            {"id": "a", "source_checksum": "1", "file_rel_path": "a.rpy"},
+        ]
+        d1 = pa.digest_source_items(items)
+        d2 = pa.digest_source_items(list(reversed(items)))
+        self.assertEqual(d1, d2)
+        self.assertEqual(len(d1), 64)
+
+
+class InvalidationPlannerTests(unittest.TestCase):
+    def test_local_item_change_invalidates_same_route_only(self):
+        chunks = [
+            _chunk("chunk-a1", ["item-a"]),
+            _chunk("chunk-b1", ["item-b"]),
+        ]
+        labels = [
+            _label("label-a", ["chunk-a1"]),
+            _label("label-b", ["chunk-b1"]),
+        ]
+        routes = [
+            _route("route-a", ["label-a"]),
+            _route("route-b", ["label-b"]),
+        ]
+        plan = pa.plan_invalidation(
+            chunks=chunks,
+            labels=labels,
+            routes=routes,
+            project_brief=_brief(),
+            changed_item_ids=["item-a"],
+        )
+        self.assertIn("chunk-a1", plan.stale_artifact_ids)
+        self.assertIn("label-a", plan.stale_artifact_ids)
+        self.assertIn("route-a", plan.stale_artifact_ids)
+        self.assertIn("project_brief", plan.stale_artifact_ids)
+        self.assertNotIn("chunk-b1", plan.stale_artifact_ids)
+        self.assertNotIn("label-b", plan.stale_artifact_ids)
+        self.assertNotIn("route-b", plan.stale_artifact_ids)
+        self.assertTrue(plan.brief_stale)
+
+    def test_unrelated_route_survives_other_route_change(self):
+        plan = pa.plan_invalidation(
+            chunks=[_chunk("chunk-a1", ["item-a"]), _chunk("chunk-b1", ["item-b"])],
+            labels=[_label("label-a", ["chunk-a1"]), _label("label-b", ["chunk-b1"])],
+            routes=[_route("route-a", ["label-a"]), _route("route-b", ["label-b"])],
+            project_brief=_brief(),
+            changed_item_ids=["item-b"],
+        )
+        self.assertIn("route-b", plan.stale_artifact_ids)
+        self.assertNotIn("route-a", plan.stale_artifact_ids)
+
+    def test_apply_invalidation_marks_records_stale(self):
+        records = [_chunk("chunk-a1", ["item-a"]), _chunk("chunk-b1", ["item-b"])]
+        plan = pa.plan_invalidation(chunks=records, changed_item_ids=["item-a"])
+        updated = pa.apply_invalidation_to_records(
+            records, plan, default_kind=pa.KIND_CHUNK
+        )
+        by_id = {r["id"]: r for r in updated}
+        self.assertEqual(by_id["chunk-a1"]["status"], pa.STATUS_STALE)
+        self.assertEqual(by_id["chunk-b1"]["status"], pa.STATUS_PUBLISHED)
+
+
+class StoreIoTests(unittest.TestCase):
+    def test_atomic_roundtrip_and_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_summaries(
+                pa.KIND_CHUNK,
+                [_chunk("chunk-a1", ["item-a"]), _chunk("chunk-b1", ["item-b"])],
+            )
+            store.save_summaries(
+                pa.KIND_LABEL,
+                [_label("label-a", ["chunk-a1"]), _label("label-b", ["chunk-b1"])],
+            )
+            store.save_routes(
+                [_route("route-a", ["label-a"]), _route("route-b", ["label-b"])]
+            )
+            store.save_brief_text("# draft\n", published=False)
+            store.save_brief_text("# published\n", published=True)
+            manifest = store.rebuild_manifest(
+                project_identity={"game_root": "/game"},
+                expected_source_fingerprint="src-fp-1",
+            )
+            # Force brief lineage so published stays fresh under expected fp.
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF]["status"] = pa.STATUS_PUBLISHED
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF]["lineage"] = _lineage()
+            store.save_manifest(manifest)
+
+            status = store.collect_status(expected_source_fingerprint="src-fp-1")
+            self.assertTrue(status["store_exists"])
+            self.assertEqual(status["chunk_count"], 2)
+            self.assertEqual(status["route_count"], 2)
+            self.assertEqual(status["brief_status"], pa.STATUS_PUBLISHED)
+            self.assertEqual(status["overall_status"], pa.STATUS_PUBLISHED)
+            self.assertTrue(status["injectable"])
+
+            stale_status = store.collect_status(
+                expected_source_fingerprint="src-fp-OTHER"
+            )
+            self.assertEqual(stale_status["overall_status"], pa.STATUS_STALE)
+            self.assertFalse(stale_status["injectable"])
+
+    def test_path_escape_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            with self.assertRaises(pa.ProjectAnalysisPathEscapeError):
+                store.path_for("../outside.json")
+            with self.assertRaises(pa.ProjectAnalysisPathEscapeError):
+                pa.resolve_under_store(tmp, "..\\secret.txt")
+            if os.name == "nt":
+                with self.assertRaises(pa.ProjectAnalysisPathEscapeError):
+                    pa.resolve_under_store(tmp, "C:/Windows/system32/drivers")
+
+    def test_corrupt_json_and_unknown_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            Path(store.manifest_path).write_text("{not-json", encoding="utf-8")
+            status = store.collect_status()
+            self.assertEqual(status["overall_status"], pa.STATUS_FAILED)
+            self.assertIn("corrupt", status["error"].lower())
+
+            Path(store.manifest_path).write_text(
+                json.dumps({"schema_version": 99}), encoding="utf-8"
+            )
+            status = store.collect_status()
+            self.assertEqual(status["overall_status"], pa.STATUS_FAILED)
+            self.assertIn("schema_version", status["error"])
+
+    def test_missing_store_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(os.path.join(tmp, "empty"))
+            status = store.collect_status()
+            self.assertEqual(status["overall_status"], pa.STATUS_MISSING)
+            self.assertFalse(status["store_exists"])
+            self.assertFalse(status["injectable"])
+
+    def test_stale_published_not_injectable_via_helper(self):
+        record = _chunk("chunk-1", ["item-1"], status=pa.STATUS_PUBLISHED)
+        self.assertFalse(
+            pa.is_injectable_record(record, expected_source_fingerprint="other")
+        )
+
+
+class CliStatusTests(unittest.TestCase):
+    def test_project_analysis_status_command(self):
+        import gemini_translate_batch as batch_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_summaries(pa.KIND_CHUNK, [_chunk("chunk-1", ["item-1"])])
+            store.rebuild_manifest(expected_source_fingerprint="src-fp-1")
+
+            with mock.patch("builtins.print") as print_mock:
+                batch_mod.main(
+                    [
+                        "project-analysis-status",
+                        "--store-dir",
+                        tmp,
+                        "--source-fingerprint",
+                        "src-fp-1",
+                    ]
+                )
+            text = "\n".join(str(c.args[0]) for c in print_mock.call_args_list if c.args)
+            self.assertIn("Project analysis status", text)
+            self.assertIn("Overall:", text)
+
+            with mock.patch("builtins.print") as print_mock:
+                batch_mod.main(
+                    ["project-analysis-status", "--store-dir", tmp, "--json"]
+                )
+            printed = [
+                str(c.args[0]) for c in print_mock.call_args_list if c.args
+            ]
+            payload = None
+            for chunk in printed:
+                text = chunk.strip()
+                if text.startswith("{"):
+                    payload = json.loads(text)
+                    break
+            self.assertIsNotNone(payload, msg=f"no JSON status in prints: {printed!r}")
+            self.assertEqual(payload["chunk_count"], 1)
+            self.assertIn("overall_status", payload)
+
+    def test_format_status_label_chinese(self):
+        label = pa.format_status_label(
+            {
+                "overall_status": pa.STATUS_PUBLISHED,
+                "store_exists": True,
+                "chunk_count": 2,
+                "label_count": 1,
+                "route_count": 1,
+                "brief_status": pa.STATUS_PUBLISHED,
+                "injectable": True,
+            }
+        )
+        self.assertIn("已发布", label)
+
+
+class DoctorIntegrationTests(unittest.TestCase):
+    def test_doctor_context_includes_project_analysis(self):
+        import gemini_translate_batch as batch_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(
+                pa,
+                "get_default_project_analysis_store_dir",
+                return_value=tmp,
+            ):
+                # collect_doctor_context_status imports collect_project_analysis_status
+                # which resolves default store; patch at call site via store_dir path.
+                status = pa.collect_project_analysis_status(store_dir=tmp)
+                self.assertEqual(status["overall_status"], pa.STATUS_MISSING)
+
+            context = batch_mod.collect_doctor_context_status()
+            self.assertIn("project_analysis", context)
+            self.assertIn("overall_status", context["project_analysis"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2930,6 +2930,10 @@ def get_default_source_index_store_dir():
     return get_default_context_store_dir("source_index_store")
 
 
+def get_default_project_analysis_store_dir():
+    return get_default_context_store_dir("project_analysis")
+
+
 def get_default_story_memory_graph_path():
     if CONTEXT_STORAGE_LOCATION == "game":
         return os.path.join(get_context_storage_root(), "story_memory", "story_graph.json")

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -2930,8 +2930,8 @@ def get_default_source_index_store_dir():
     return get_default_context_store_dir("source_index_store")
 
 
-def get_default_project_analysis_store_dir():
-    return get_default_context_store_dir("project_analysis")
+def get_default_project_analysis_store_dir(base_dir=None):
+    return get_default_context_store_dir("project_analysis", base_dir)
 
 
 def get_default_story_memory_graph_path():

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1589,11 +1589,15 @@ def _reset_project_settings_to_defaults():
     _SYNC_STORY_GRAPH_PATH = ""
 
 
-def load_translator_settings():
+def load_translator_settings(*, persist_corrected_game_root: bool = True):
     """Loads per-game settings (game root, tl subdir) from translator_config.json or env.
 
     Always starts from code defaults for project/path/prepare fields so omitted
     keys cannot retain values from a previous load (issue #216).
+
+    When *persist_corrected_game_root* is False (readonly commands such as
+    ``project-analysis-status``), a corrected effective root is applied in
+    memory only and ``translator_config.json`` is not rewritten.
     """
     global BASE_DIR, TL_DIR, TL_SUBDIR, ENV_GAME_ROOT, WORK_GAME_DIR, SOURCE_GAME_DIR, GLOSSARY_FILE
     global PREP_ENABLED, PREP_UNPACK_RPA, PREP_GENERATE_TEMPLATE, PREP_REFRESH_EXISTING_TEMPLATE, PREP_LANGUAGE
@@ -1617,7 +1621,13 @@ def load_translator_settings():
         resolved_root = resolve_effective_game_root(original_root)
         if os.path.normcase(resolved_root) != os.path.normcase(original_root):
             ENV_GAME_ROOT = resolved_root
-            if isinstance(game_root, str) and game_root.strip() and os.path.exists(TRANSLATOR_CONFIG):
+            should_persist = (
+                persist_corrected_game_root
+                and isinstance(game_root, str)
+                and game_root.strip()
+                and os.path.exists(TRANSLATOR_CONFIG)
+            )
+            if should_persist:
                 try:
                     persist_game_root(resolved_root)
                 except Exception as exc:


### PR DESCRIPTION
## Summary

- Implement **#256** (parent **#253**): Project Analysis Phase 1 contract — schema/status, evidence + lineage fingerprints, atomic store I/O, path-escape guards, and partial invalidation planner (`project_analysis.py`).
- Add readonly CLI `project-analysis-status` (`--json` / `--store-dir` / `--source-fingerprint`), doctor context line, GUI context-library status row, and diagnostics command reference.
- Default store path follows `context_storage` (`logs/project_analysis/<slug>/` or `<game>/translation_context/project_analysis/`).
- Refresh `docs/plans/wenyi_reference_and_batch_roadmap.md` against wenyi `main@b796e45` / v0.3.4 and map learnings to #252–#256; document user-facing behavior in `context_systems.md` / `gui_workbench.md`.

**Out of scope (by design):** no LLM calls, no route/brief generation (#254), no final-review campaign (#255), no writes to glossary / story_graph / `.rpy`, no prompt injection of analysis text.

## Test plan

- [x] `python -m unittest tests.test_project_analysis`
- [x] `python -B tests/run_cli_tests.py -q`
- [x] `python -B tests/run_gui_tests.py -q`
- [x] `python scripts/run_quality_gates.py all`
- [x] `git diff --check`
- [x] Smoke: `python gemini_translate_batch.py project-analysis-status --json` (overall `missing` when empty)
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only Project Analysis (Phase 1) tracking for context data, including freshness/staleness and publish eligibility.
  * Exposed Project Analysis status in the GUI context library and diagnostics panel (status display only).
  * Added a `project-analysis-status` CLI subcommand with human-readable and `--json` output.
* **Documentation**
  * Documented Project Analysis storage paths, artifact lifecycle/state rules, injection restrictions, and GUI/doctor behavior.
  * Refreshed the batch roadmap with Project Analysis mappings and related design tradeoffs.
* **Tests**
  * Added coverage for schema/status validation, fingerprint/digest freshness behavior, store IO, invalidation, CLI output, and GUI display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->