### PR TITLE
feat: Project Analysis 阶段 2 结构草稿与发布门禁 (#254)

### DIFF
--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -102,6 +102,48 @@ logs/story_memory/story_graph.json
 - 无关 route 保持有效
 - prompt / schema / provider / model 变化按 dependency digest 判定（调用方把受影响 artifact id 传入失效规划器）
 
+### 阶段 2：结构草稿与发布门禁（#254，无 LLM 首版）
+
+典型流程：
+
+```bash
+# 1) 导入关键词 chunk 摘要为 analysis chunk drafts
+python gemini_translate_batch.py project-analysis-ingest-keywords --summary-jsonl path/to/keyword_chunk_summaries.jsonl
+
+# 2) 静态解析 label/jump/call/menu，写出 label/route drafts 与 project_brief.draft.md
+python gemini_translate_batch.py project-analysis-build-structure
+
+# 3) 审查
+python gemini_translate_batch.py project-analysis-inspect --kind routes
+python gemini_translate_batch.py project-analysis-diff
+
+# 4) 人工确认后发布（写 project_brief.published.md）
+python gemini_translate_batch.py project-analysis-publish
+# 撤销
+python gemini_translate_batch.py project-analysis-unpublish
+```
+
+配置（默认关闭；`translator_config.example.json` → `batch.project_analysis`）：
+
+```json
+{
+  "batch": {
+    "project_analysis": {
+      "enabled": false,
+      "inject_published_brief": false,
+      "store_dir": "",
+      "max_brief_chars": 4000
+    }
+  }
+}
+```
+
+- 仅当 `enabled` 且 `inject_published_brief` 为 true，并且 brief 为 **published 且 fingerprint 有效** 时，才会向翻译/订正 prompt 注入 `PROJECT BRIEF` 分区。
+- **draft 永不注入**；stale / 缺 published 文件会跳过注入。
+- 动态 `jump expression` / `call expression` 标记为 unresolved，不虚构单一路线。
+- 本阶段**不**调用 LLM 生成正文（规则聚合 + 关键词摘要）；LLM map-reduce 为后续增量。
+- **不**写 `glossary.json`、正式 `story_graph.json` 或 `.rpy`。
+
 ### 只读 CLI / GUI
 
 ```bash
@@ -111,8 +153,8 @@ python gemini_translate_batch.py project-analysis-status --store-dir <path> --so
 ```
 
 - `doctor` 报告中的 `Project analysis:` 行汇总 overall / 计数 / brief 状态。
-- GUI「上下文库」展示只读「项目分析」状态行；状态判断在 `project_analysis` 模块内完成，GUI 不重复实现失效逻辑。
-- 本阶段**不**提供生成、发布或写回按钮。
+- GUI「上下文库」展示「项目分析」状态行；状态判断在 `project_analysis` 模块内完成，GUI 不重复实现失效逻辑。
+- 诊断「命令参考」可复制 ingest / build-structure / publish / unpublish 命令。
 
 设计对照与取舍见 [plans/wenyi_reference_and_batch_roadmap.md](plans/wenyi_reference_and_batch_roadmap.md)。
 

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -141,6 +141,7 @@ python gemini_translate_batch.py project-analysis-unpublish
 - 仅当 `enabled` 且 `inject_published_brief` 为 true，并且 brief 为 **published 且 fingerprint 有效** 时，才会向翻译/订正 prompt 注入 `PROJECT BRIEF` 分区。
 - **draft 永不注入**；stale / 缺 published 文件会跳过注入。
 - 动态 `jump expression` / `call expression` 标记为 unresolved，不虚构单一路线。
+- 普通 `call label` **不是**路线分支：调用返回后继续调用者后续语句，枚举路线时不把 call 目标当成与 jump 互斥的分叉；call 仅作附属依赖/元数据。
 - 本阶段**不**调用 LLM 生成正文（规则聚合 + 关键词摘要）；LLM map-reduce 为后续增量。
 - **不**写 `glossary.json`、正式 `story_graph.json` 或 `.rpy`。
 

--- a/docs/plans/wenyi_reference_and_batch_roadmap.md
+++ b/docs/plans/wenyi_reference_and_batch_roadmap.md
@@ -34,7 +34,7 @@
 | 翻译对象 | 长篇小说电子书 | Ren'Py `game/tl/<lang>/` |
 | 主路径 | **同步在线** LLM 调用（进程内长跑） | **Batch 异步**（`build → submit → download → check → apply`） |
 | 「batch」含义 | 切段大小（字符预算） | 远端 Batch 作业 + package/manifest |
-| 全书理解 | `pipeline.book_understanding`：预扫 → 章梗概 + 全书概览，直接注入翻译 prompt | **#256 已交付**产物/状态合同与只读检查；**#254** 路线感知生成与人工 publish 后才注入（仍待做） |
+| 全书理解 | `pipeline.book_understanding`：预扫 → 章梗概 + 全书概览，直接注入翻译 prompt | **#256** 合同已交付；**#254 PR A** 结构草稿 + publish 门禁 + 可选 published brief 注入（默认关）；LLM map-reduce 仍待 |
 | 质量手段 | 多阶段 LLM（分析/梗概/译/润/审）+ 段数对齐 | glossary / macro / RAG / Story Memory + **规则闸门** + 订正/关键词 |
 | 最终审校 | 独立 `review` 命令；可 `--force` / 可选 `autofix_severe`；默认关闭 | 规划中：#255 report-only campaign → 现有 revision preview/apply |
 | 用量 | `state/.../usage.json`：provider-neutral，按 tier/stage 归因，跨续跑增量合并 | 规划中：#252 项目级账本；现有估算 + 分散在 results 的 raw usage |

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -182,6 +182,13 @@ STORY_MEMORY_INCLUDE_SCENE_SUMMARY = True
 _STORY_GRAPH = None
 _STORY_GRAPH_PATH = ''
 
+PROJECT_ANALYSIS_ENABLED = False
+PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF = False
+PROJECT_ANALYSIS_STORE_DIR = ''
+PROJECT_ANALYSIS_MAX_BRIEF_CHARS = 4000
+_PROJECT_BRIEF_CACHE = None
+_PROJECT_BRIEF_CACHE_KEY = None
+
 
 def load_json_file(path):
     if not path or not os.path.isfile(path):
@@ -312,6 +319,9 @@ def load_batch_settings():
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
+    global PROJECT_ANALYSIS_ENABLED, PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF
+    global PROJECT_ANALYSIS_STORE_DIR, PROJECT_ANALYSIS_MAX_BRIEF_CHARS
+    global _PROJECT_BRIEF_CACHE, _PROJECT_BRIEF_CACHE_KEY
     global BATCH_NON_CHINESE_RULES, SYNC_BACKEND, SYNC_MODEL
 
     config = load_json_file(legacy.CONFIG_FILE)
@@ -521,6 +531,62 @@ def load_batch_settings():
         STORY_MEMORY_GRAPH_FILE = ''
     _STORY_GRAPH = None
     _STORY_GRAPH_PATH = ''
+
+    project_analysis_config = batch.get('project_analysis')
+    if not isinstance(project_analysis_config, dict):
+        project_analysis_config = {}
+    PROJECT_ANALYSIS_ENABLED = coerce_bool(
+        project_analysis_config.get('enabled'),
+        PROJECT_ANALYSIS_ENABLED,
+    )
+    PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF = coerce_bool(
+        project_analysis_config.get('inject_published_brief'),
+        PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF,
+    )
+    PROJECT_ANALYSIS_MAX_BRIEF_CHARS = coerce_positive_int(
+        project_analysis_config.get('max_brief_chars'),
+        PROJECT_ANALYSIS_MAX_BRIEF_CHARS,
+    )
+    pa_store = project_analysis_config.get('store_dir')
+    if pa_store:
+        PROJECT_ANALYSIS_STORE_DIR = legacy._resolve_path(legacy.BASE_DIR, pa_store)
+    else:
+        PROJECT_ANALYSIS_STORE_DIR = ''
+    _PROJECT_BRIEF_CACHE = None
+    _PROJECT_BRIEF_CACHE_KEY = None
+
+
+def load_injectable_project_brief_for_prompts():
+    """Return (text, diagnostics) for published brief when injection is enabled."""
+    global _PROJECT_BRIEF_CACHE, _PROJECT_BRIEF_CACHE_KEY
+    if not PROJECT_ANALYSIS_ENABLED or not PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF:
+        return '', ''
+    from project_analysis import load_injectable_project_brief
+
+    store_dir = PROJECT_ANALYSIS_STORE_DIR or None
+    cache_key = (
+        bool(PROJECT_ANALYSIS_ENABLED),
+        bool(PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF),
+        store_dir or '',
+        int(PROJECT_ANALYSIS_MAX_BRIEF_CHARS),
+        str(legacy.BASE_DIR or ''),
+    )
+    if _PROJECT_BRIEF_CACHE is not None and _PROJECT_BRIEF_CACHE_KEY == cache_key:
+        return _PROJECT_BRIEF_CACHE
+    payload = load_injectable_project_brief(
+        store_dir=store_dir,
+        base_dir=legacy.BASE_DIR or None,
+        max_chars=PROJECT_ANALYSIS_MAX_BRIEF_CHARS,
+        enabled=True,
+    )
+    result = (
+        str(payload.get('text') or '') if payload.get('injectable') else '',
+        str(payload.get('diagnostics') or '') if payload.get('injectable') else '',
+    )
+    _PROJECT_BRIEF_CACHE = result
+    _PROJECT_BRIEF_CACHE_KEY = cache_key
+    return result
+
 
 def load_progress():
     if not os.path.exists(PROGRESS_LOG):
@@ -2404,6 +2470,7 @@ def build_user_prompt(
     story_hits=None,
     source_hits=None,
 ):
+    brief_text, brief_diag = load_injectable_project_brief_for_prompts()
     return translation_core.build_translation_user_prompt(
         translation_core.ContextWindow(context_past, context_future),
         target_items,
@@ -2412,6 +2479,8 @@ def build_user_prompt(
             history_hits=history_hits,
             story_hits=story_hits,
             source_hits=source_hits,
+            project_brief_text=brief_text,
+            project_brief_diagnostics=brief_diag,
         ),
         history_char_limit=RAG_HISTORY_CHAR_LIMIT,
         story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
@@ -2958,6 +3027,7 @@ def build_revision_system_instruction():
 
 
 def build_revision_user_prompt(chunk):
+    brief_text, brief_diag = load_injectable_project_brief_for_prompts()
     return translation_core.build_revision_user_prompt(
         translation_core.ContextWindow(
             chunk.get('context_past') or [],
@@ -2974,6 +3044,8 @@ def build_revision_user_prompt(chunk):
             history_hits=chunk.get('history_hits') or [],
             story_hits=chunk.get('story_hits'),
             rag_stats=chunk.get('rag_stats') or {},
+            project_brief_text=brief_text,
+            project_brief_diagnostics=brief_diag,
         ),
         history_char_limit=RAG_HISTORY_CHAR_LIMIT,
         story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
@@ -9452,6 +9524,73 @@ def build_arg_parser():
         help='Print machine-readable JSON status instead of the human-readable report.',
     )
 
+    pa_ingest = subparsers.add_parser(
+        'project-analysis-ingest-keywords',
+        help='Import keyword_chunk_summaries.jsonl into Project Analysis chunk drafts.',
+    )
+    pa_ingest.add_argument(
+        '--summary-jsonl',
+        required=True,
+        help='Path to keyword_chunk_summaries.jsonl from keyword export.',
+    )
+    pa_ingest.add_argument('--store-dir', default='', help='Override analysis store directory.')
+
+    pa_build = subparsers.add_parser(
+        'project-analysis-build-structure',
+        help=(
+            'Parse Ren\'Py labels/jumps into draft label/route summaries and project brief '
+            '(no LLM). Uses existing chunk drafts when present.'
+        ),
+    )
+    pa_build.add_argument('--store-dir', default='', help='Override analysis store directory.')
+    pa_build.add_argument(
+        '--script-root',
+        action='append',
+        default=None,
+        help='Script root to scan for .rpy files. Repeatable. Defaults under game_root.',
+    )
+    pa_build.add_argument(
+        '--entry-label',
+        action='append',
+        default=None,
+        help='Optional route entry label. Repeatable.',
+    )
+
+    pa_inspect = subparsers.add_parser(
+        'project-analysis-inspect',
+        help='Inspect draft/published analysis artifacts (JSON).',
+    )
+    pa_inspect.add_argument('--store-dir', default='', help='Override analysis store directory.')
+    pa_inspect.add_argument(
+        '--kind',
+        default='status',
+        choices=['status', 'labels', 'routes', 'chunks', 'brief'],
+        help='What to print (default: status).',
+    )
+
+    pa_diff = subparsers.add_parser(
+        'project-analysis-diff',
+        help='Compare draft vs published project brief.',
+    )
+    pa_diff.add_argument('--store-dir', default='', help='Override analysis store directory.')
+
+    pa_publish = subparsers.add_parser(
+        'project-analysis-publish',
+        help='Publish draft project brief for optional prompt injection.',
+    )
+    pa_publish.add_argument('--store-dir', default='', help='Override analysis store directory.')
+    pa_publish.add_argument(
+        '--force',
+        action='store_true',
+        help='Replace an existing published brief from the current draft.',
+    )
+
+    pa_unpublish = subparsers.add_parser(
+        'project-analysis-unpublish',
+        help='Unpublish project brief so it is no longer injectable.',
+    )
+    pa_unpublish.add_argument('--store-dir', default='', help='Override analysis store directory.')
+
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
     submit_parser.add_argument(
         'target',
@@ -9854,39 +9993,136 @@ def main(argv=None):
         run_generate_template()
         return
 
-    if command == 'project-analysis-status':
-        # Readonly inspect: load settings for default store path, skip batch logging.
+    if command in {
+        'project-analysis-status',
+        'project-analysis-ingest-keywords',
+        'project-analysis-build-structure',
+        'project-analysis-inspect',
+        'project-analysis-diff',
+        'project-analysis-publish',
+        'project-analysis-unpublish',
+    }:
         import contextlib
         import io
 
-        from project_analysis import collect_project_analysis_status, print_status
+        from project_analysis import (
+            ProjectAnalysisError,
+            collect_project_analysis_status,
+            format_brief_diff,
+            print_status,
+            publish_project_brief,
+            resolve_project_analysis_store,
+            unpublish_project_brief,
+        )
+        from project_analysis_generate import (
+            build_structure_drafts,
+            ingest_keyword_summaries,
+        )
 
         store_dir = getattr(args, 'store_dir', None) or None
         as_json = bool(getattr(args, 'json', False))
         source_fp = getattr(args, 'source_fingerprint', '') or ''
 
-        def _load_settings_and_status():
+        def _load_settings_quiet():
             if not store_dir:
-                # Readonly command: never rewrite translator_config.json when the
-                # configured game_root is normalized to an effective work root.
                 legacy.load_translator_settings(persist_corrected_game_root=False)
                 load_batch_settings()
-            return collect_project_analysis_status(
-                store_dir=store_dir,
-                expected_source_fingerprint=source_fp,
-            )
 
-        if as_json:
-            # Keep machine-readable stdout clean: settings load and path resolution
-            # may emit warnings via print (e.g. game_root unset under game storage).
-            with contextlib.redirect_stdout(io.StringIO()):
-                status = _load_settings_and_status()
-            print(json.dumps(status, ensure_ascii=False, indent=2, sort_keys=True))
-        else:
-            status = _load_settings_and_status()
-            print_banner()
-            print_status(status)
-        return
+        def _run_pa():
+            _load_settings_quiet()
+            if command == 'project-analysis-status':
+                return collect_project_analysis_status(
+                    store_dir=store_dir,
+                    expected_source_fingerprint=source_fp,
+                )
+            if command == 'project-analysis-ingest-keywords':
+                return ingest_keyword_summaries(
+                    args.summary_jsonl,
+                    store_dir=store_dir,
+                    base_dir=legacy.BASE_DIR or None,
+                )
+            if command == 'project-analysis-build-structure':
+                return build_structure_drafts(
+                    store_dir=store_dir,
+                    base_dir=legacy.BASE_DIR or None,
+                    script_roots=args.script_root or None,
+                    entry_labels=args.entry_label or None,
+                )
+            if command == 'project-analysis-inspect':
+                store = resolve_project_analysis_store(
+                    store_dir, base_dir=legacy.BASE_DIR or None
+                )
+                kind = getattr(args, 'kind', 'status') or 'status'
+                if kind == 'status':
+                    return store.collect_status()
+                if kind == 'chunks':
+                    return {'chunks': store.load_summaries('chunk')}
+                if kind == 'labels':
+                    return {'labels': store.load_summaries('label')}
+                if kind == 'routes':
+                    return {'routes': store.load_routes()}
+                if kind == 'brief':
+                    return {
+                        'draft': store.load_brief_text(published=False),
+                        'published': store.load_brief_text(published=True),
+                    }
+                return store.collect_status()
+            if command == 'project-analysis-diff':
+                return format_brief_diff(store_dir, base_dir=legacy.BASE_DIR or None)
+            if command == 'project-analysis-publish':
+                return publish_project_brief(
+                    store_dir,
+                    base_dir=legacy.BASE_DIR or None,
+                    force=bool(getattr(args, 'force', False)),
+                )
+            if command == 'project-analysis-unpublish':
+                return unpublish_project_brief(
+                    store_dir, base_dir=legacy.BASE_DIR or None
+                )
+            raise SystemExit(f'Unknown project-analysis command: {command}')
+
+        try:
+            if command == 'project-analysis-status' and not as_json:
+                result = _run_pa()
+                print_banner()
+                print_status(result)
+                return
+            # JSON / machine actions: keep stdout clean when possible.
+            quiet = command != 'project-analysis-status' or as_json
+            if quiet:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    result = _run_pa()
+            else:
+                result = _run_pa()
+            if command == 'project-analysis-status' and as_json:
+                print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+            elif command != 'project-analysis-status':
+                if command in {
+                    'project-analysis-inspect',
+                    'project-analysis-diff',
+                    'project-analysis-ingest-keywords',
+                    'project-analysis-build-structure',
+                    'project-analysis-publish',
+                    'project-analysis-unpublish',
+                }:
+                    # Drop full graph from build output for readability unless tiny.
+                    if (
+                        command == 'project-analysis-build-structure'
+                        and isinstance(result, dict)
+                        and 'graph' in result
+                    ):
+                        result = dict(result)
+                        result['graph'] = {
+                            'label_count': len((result['graph'] or {}).get('labels') or {}),
+                            'route_count': len((result['graph'] or {}).get('routes') or []),
+                            'unresolved_edges': len(
+                                (result['graph'] or {}).get('unresolved_edges') or []
+                            ),
+                        }
+                    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+            return
+        except ProjectAnalysisError as exc:
+            raise SystemExit(f'Project analysis error: {exc}') from exc
 
     initialize_batch_logging()
     legacy.load_config()

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -556,26 +556,57 @@ def load_batch_settings():
     _PROJECT_BRIEF_CACHE_KEY = None
 
 
+def compute_current_project_analysis_fingerprint(base_dir=None):
+    """Recompute structure fingerprint from current scripts under *base_dir*."""
+    from project_analysis_routes import digest_script_paths, discover_script_files
+
+    base = base_dir if base_dir is not None else (legacy.BASE_DIR or None)
+    if not base:
+        return ''
+    roots = []
+    for rel in ('game', os.path.join('work', 'game'), os.path.join('original', 'game')):
+        candidate = os.path.join(base, rel)
+        if os.path.isdir(candidate):
+            roots.append(candidate)
+    if not roots:
+        roots.append(base)
+    paths = discover_script_files(roots)
+    if not paths:
+        return ''
+    return digest_script_paths(paths, base_dir=base)
+
+
 def load_injectable_project_brief_for_prompts():
-    """Return (text, diagnostics) for published brief when injection is enabled."""
+    """Return (text, diagnostics) for published brief when injection is enabled.
+
+    Always passes the *current* structure fingerprint so post-publish script
+    edits mark the brief stale and block silent injection.
+    """
     global _PROJECT_BRIEF_CACHE, _PROJECT_BRIEF_CACHE_KEY
     if not PROJECT_ANALYSIS_ENABLED or not PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF:
         return '', ''
     from project_analysis import load_injectable_project_brief
 
     store_dir = PROJECT_ANALYSIS_STORE_DIR or None
+    base_dir = legacy.BASE_DIR or None
+    current_fp = compute_current_project_analysis_fingerprint(base_dir)
+    if not current_fp:
+        # Cannot verify freshness against live scripts — do not inject.
+        return '', ''
     cache_key = (
         bool(PROJECT_ANALYSIS_ENABLED),
         bool(PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF),
         store_dir or '',
         int(PROJECT_ANALYSIS_MAX_BRIEF_CHARS),
-        str(legacy.BASE_DIR or ''),
+        str(base_dir or ''),
+        current_fp,
     )
     if _PROJECT_BRIEF_CACHE is not None and _PROJECT_BRIEF_CACHE_KEY == cache_key:
         return _PROJECT_BRIEF_CACHE
     payload = load_injectable_project_brief(
         store_dir=store_dir,
-        base_dir=legacy.BASE_DIR or None,
+        base_dir=base_dir,
+        expected_source_fingerprint=current_fp,
         max_chars=PROJECT_ANALYSIS_MAX_BRIEF_CHARS,
         enabled=True,
     )
@@ -9582,7 +9613,12 @@ def build_arg_parser():
     pa_publish.add_argument(
         '--force',
         action='store_true',
-        help='Replace an existing published brief from the current draft.',
+        help='Replace published brief or force-publish stale with --source-fingerprint.',
+    )
+    pa_publish.add_argument(
+        '--source-fingerprint',
+        default='',
+        help='Current structure fingerprint (required with --force for stale/missing lineage).',
     )
 
     pa_unpublish = subparsers.add_parser(
@@ -10074,6 +10110,8 @@ def main(argv=None):
                     store_dir,
                     base_dir=legacy.BASE_DIR or None,
                     force=bool(getattr(args, 'force', False)),
+                    current_source_fingerprint=getattr(args, 'source_fingerprint', '')
+                    or '',
                 )
             if command == 'project-analysis-unpublish':
                 return unpublish_project_brief(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -556,24 +556,51 @@ def load_batch_settings():
     _PROJECT_BRIEF_CACHE_KEY = None
 
 
-def compute_current_project_analysis_fingerprint(base_dir=None):
-    """Recompute structure fingerprint from current scripts under *base_dir*."""
+def compute_current_project_analysis_fingerprint(base_dir=None, store_dir=None):
+    """Recompute structure fingerprint from scripts under build-time roots when known.
+
+    Prefers ``project_identity.script_roots`` persisted by
+    ``build_structure_drafts`` so custom ``--script-root`` builds stay injectable.
+    Falls back to default game/work/original discovery under *base_dir*.
+    """
+    from project_analysis import resolve_project_analysis_store
     from project_analysis_routes import digest_script_paths, discover_script_files
 
     base = base_dir if base_dir is not None else (legacy.BASE_DIR or None)
-    if not base:
-        return ''
     roots = []
-    for rel in ('game', os.path.join('work', 'game'), os.path.join('original', 'game')):
-        candidate = os.path.join(base, rel)
-        if os.path.isdir(candidate):
-            roots.append(candidate)
+    graph_base = base or ''
+    resolved_store = store_dir if store_dir is not None else (PROJECT_ANALYSIS_STORE_DIR or None)
+    try:
+        store = resolve_project_analysis_store(resolved_store, base_dir=base)
+        manifest = store.load_manifest() or {}
+        identity = manifest.get('project_identity') if isinstance(manifest, dict) else {}
+        if isinstance(identity, dict):
+            stored_roots = identity.get('script_roots') or []
+            if isinstance(stored_roots, list):
+                roots = [str(r) for r in stored_roots if str(r or '').strip()]
+            stored_base = str(identity.get('graph_base') or identity.get('base_dir') or '').strip()
+            if stored_base:
+                graph_base = stored_base
+            elif base:
+                graph_base = base
+    except Exception:
+        roots = []
+
     if not roots:
-        roots.append(base)
+        if not base:
+            return ''
+        for rel in ('game', os.path.join('work', 'game'), os.path.join('original', 'game')):
+            candidate = os.path.join(base, rel)
+            if os.path.isdir(candidate):
+                roots.append(candidate)
+        if not roots:
+            roots.append(base)
+        graph_base = base
+
     paths = discover_script_files(roots)
     if not paths:
         return ''
-    return digest_script_paths(paths, base_dir=base)
+    return digest_script_paths(paths, base_dir=graph_base or base)
 
 
 def load_injectable_project_brief_for_prompts():
@@ -589,7 +616,9 @@ def load_injectable_project_brief_for_prompts():
 
     store_dir = PROJECT_ANALYSIS_STORE_DIR or None
     base_dir = legacy.BASE_DIR or None
-    current_fp = compute_current_project_analysis_fingerprint(base_dir)
+    current_fp = compute_current_project_analysis_fingerprint(
+        base_dir, store_dir=store_dir
+    )
     if not current_fp:
         # Cannot verify freshness against live scripts — do not inject.
         return '', ''

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -218,6 +218,42 @@ def build_cli_commands(
                 ["project-analysis-status"],
             ),
         ),
+        DiagnosticsCommand(
+            label="项目分析·导入关键词摘要",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                [
+                    "project-analysis-ingest-keywords",
+                    "--summary-jsonl",
+                    "path/to/keyword_chunk_summaries.jsonl",
+                ],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="项目分析·构建结构草稿",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["project-analysis-build-structure"],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="项目分析·发布 brief",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["project-analysis-publish"],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="项目分析·撤销发布",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["project-analysis-unpublish"],
+            ),
+        ),
     ]
 
     mode = manifest.get("mode")

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -84,13 +84,16 @@ class ContextLibraryPage(QFrame):
         self.source_index_status_label = self.source_index_status_row.status_label
         self.status_layout.root.addWidget(self.source_index_status_row)
 
-        # Phase 1 (#256): readonly status only; generation/publish land in later issues.
-        self.project_analysis_readonly_label = QLabel("只读")
+        # Phase 2 (#254): status from core module; publish/generate remain CLI-first.
+        self.project_analysis_readonly_label = QLabel("CLI")
         self.project_analysis_readonly_label.setObjectName(
             "context_project_analysis_readonly_label"
         )
         self.project_analysis_readonly_label.setToolTip(
-            "项目分析当前仅提供状态查看；生成与发布在后续阶段实现。"
+            "项目分析：状态在此只读展示。"
+            "导入关键词摘要、构建结构草稿、发布/撤销请用诊断命令参考中的 CLI"
+            "（project-analysis-ingest-keywords / build-structure / publish）。"
+            "仅 published 且未过期的 brief 可在配置开启后注入翻译 prompt。"
         )
         self.project_analysis_status_row = TaskStatusActionRow(
             "项目分析",

--- a/gui_qt/workbench/context_library_page.py
+++ b/gui_qt/workbench/context_library_page.py
@@ -92,7 +92,7 @@ class ContextLibraryPage(QFrame):
         self.project_analysis_readonly_label.setToolTip(
             "项目分析：状态在此只读展示。"
             "导入关键词摘要、构建结构草稿、发布/撤销请用诊断命令参考中的 CLI"
-            "（project-analysis-ingest-keywords / build-structure / publish）。"
+            "（project-analysis-ingest-keywords / build-structure / publish / unpublish）。"
             "仅 published 且未过期的 brief 可在配置开启后注入翻译 prompt。"
         )
         self.project_analysis_status_row = TaskStatusActionRow(

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -1122,14 +1122,12 @@ class ProjectAnalysisStore:
         }
 
 
-def collect_project_analysis_status(
+def resolve_project_analysis_store(
     store_dir: str | os.PathLike[str] | None = None,
     *,
     base_dir: str | None = None,
-    expected_source_fingerprint: str = "",
-    project_identity: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    # Path defaults live in translator_runtime (same pattern as rag / source_index).
+) -> ProjectAnalysisStore:
+    """Resolve default or explicit analysis store directory."""
     from translator_runtime import get_default_project_analysis_store_dir
 
     resolved = (
@@ -1137,11 +1135,278 @@ def collect_project_analysis_status(
         if store_dir
         else get_default_project_analysis_store_dir(base_dir)
     )
-    store = ProjectAnalysisStore(resolved)
+    return ProjectAnalysisStore(resolved)
+
+
+def collect_project_analysis_status(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+    expected_source_fingerprint: str = "",
+    project_identity: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
     return store.collect_status(
         expected_source_fingerprint=expected_source_fingerprint,
         project_identity=project_identity,
     )
+
+
+def load_injectable_project_brief(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+    expected_source_fingerprint: str = "",
+    max_chars: int = 4000,
+    enabled: bool = True,
+) -> dict[str, Any]:
+    """Load published brief text only when it is safe to inject into prompts.
+
+    Returns a dict with:
+    - ``text``: brief body or empty string
+    - ``injectable``: bool
+    - ``reason``: why injection was skipped (empty when ok)
+    - ``status``: collect_status snapshot (subset)
+    """
+    if not enabled:
+        return {
+            "text": "",
+            "injectable": False,
+            "reason": "injection_disabled",
+            "status": {},
+            "diagnostics": "",
+        }
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    status = store.collect_status(
+        expected_source_fingerprint=expected_source_fingerprint,
+    )
+    brief_status = status.get("brief_status") or STATUS_MISSING
+    if brief_status != STATUS_PUBLISHED:
+        return {
+            "text": "",
+            "injectable": False,
+            "reason": f"brief_not_published:{brief_status}",
+            "status": status,
+            "diagnostics": "",
+        }
+    if not status.get("brief_published_present"):
+        return {
+            "text": "",
+            "injectable": False,
+            "reason": "published_file_missing",
+            "status": status,
+            "diagnostics": "",
+        }
+    # Re-check brief entry freshness with expected fingerprint when provided.
+    brief_entry = (status.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {}
+    synthetic = {
+        "id": brief_entry.get("id") or "project_brief",
+        "kind": KIND_PROJECT_BRIEF,
+        "status": STATUS_PUBLISHED,
+        "source_files": [],
+        "evidence_item_ids": [],
+        "upstream_artifact_ids": [],
+        "source_checksum": "",
+        "lineage": brief_entry.get("lineage") or empty_lineage(),
+    }
+    effective = evaluate_record_status(
+        synthetic,
+        expected_source_fingerprint=expected_source_fingerprint,
+    )
+    if effective != STATUS_PUBLISHED:
+        return {
+            "text": "",
+            "injectable": False,
+            "reason": f"brief_not_fresh:{effective}",
+            "status": status,
+            "diagnostics": "",
+        }
+    text = store.load_brief_text(published=True).strip()
+    if not text:
+        return {
+            "text": "",
+            "injectable": False,
+            "reason": "published_brief_empty",
+            "status": status,
+            "diagnostics": "",
+        }
+    if max_chars > 0 and len(text) > max_chars:
+        text = text[: max(0, max_chars - 1)].rstrip() + "…"
+    lineage = normalize_lineage(brief_entry.get("lineage"))
+    fp = lineage.get("source_fingerprint") or ""
+    diagnostics = (
+        f"schema={SCHEMA_VERSION} status=published "
+        f"fingerprint={fp[:12] + ('…' if len(fp) > 12 else '')}"
+    )
+    return {
+        "text": text,
+        "injectable": True,
+        "reason": "",
+        "status": status,
+        "diagnostics": diagnostics,
+    }
+
+
+def publish_project_brief(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+    force: bool = False,
+    project_identity: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Promote draft brief to published after gate checks.
+
+    Does not invent empty published content. Failure leaves any prior published
+    brief untouched.
+    """
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    draft = store.load_brief_text(published=False).strip()
+    if not draft:
+        raise ProjectAnalysisError(
+            "cannot publish: project_brief.draft.md is missing or empty"
+        )
+
+    manifest = store.load_manifest() or empty_manifest(
+        project_identity=project_identity or {},
+        store_dir=store.store_dir,
+    )
+    brief_entry = dict((manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {})
+    current = normalize_status(
+        brief_entry.get("status") or STATUS_DRAFT, allow_missing=True
+    )
+    if current == STATUS_PUBLISHED and not force:
+        if store.load_brief_text(published=True).strip() == draft:
+            return {
+                "status": STATUS_PUBLISHED,
+                "store_dir": store.store_dir,
+                "changed": False,
+                "message": "brief already published (identical draft)",
+            }
+        raise ProjectAnalysisError(
+            "cannot publish: brief already published; pass force=True to replace"
+        )
+    if current not in {
+        STATUS_DRAFT,
+        STATUS_REVIEW_REQUIRED,
+        STATUS_PUBLISHED,
+        STATUS_STALE,
+        STATUS_MISSING,
+    }:
+        raise ProjectAnalysisError(f"cannot publish from status {current!r}")
+
+    lineage = normalize_lineage(brief_entry.get("lineage"))
+    if not lineage.get("source_fingerprint") and not force:
+        # Allow publish when draft body exists but require fingerprint for injection
+        # safety: still set a content-based fingerprint so inject checks work.
+        lineage = empty_lineage(
+            source_fingerprint=sha256_text(draft),
+            upstream_dependency_digest=lineage.get("upstream_dependency_digest") or "",
+            prompt_schema_version=lineage.get("prompt_schema_version") or "",
+            provider=lineage.get("provider") or "",
+            model=lineage.get("model") or "",
+            thinking_level=lineage.get("thinking_level") or "",
+            generated_at=lineage.get("generated_at") or "",
+            reviewed_at=lineage.get("reviewed_at") or "",
+            published_at="",
+        )
+    lineage = dict(lineage)
+    lineage["published_at"] = utc_now_iso()
+    if not lineage.get("source_fingerprint"):
+        lineage["source_fingerprint"] = sha256_text(draft)
+
+    # Write published body first; only then flip manifest status.
+    store.save_brief_text(draft + ("\n" if not draft.endswith("\n") else ""), published=True)
+    brief_entry.update(
+        {
+            "status": STATUS_PUBLISHED,
+            "draft_present": True,
+            "published_present": True,
+            "lineage": lineage,
+            "id": brief_entry.get("id") or "project_brief",
+        }
+    )
+    manifest.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = brief_entry
+    if project_identity:
+        manifest["project_identity"] = dict(project_identity)
+    store.save_manifest(manifest)
+    # Refresh aggregate from disk so counts stay honest.
+    store.rebuild_manifest(
+        project_identity=manifest.get("project_identity") or project_identity,
+        expected_source_fingerprint=lineage.get("source_fingerprint") or "",
+    )
+    # Ensure brief stays published after rebuild (rebuild may infer from files).
+    refreshed = store.load_manifest() or manifest
+    entry = dict((refreshed.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {})
+    entry["status"] = STATUS_PUBLISHED
+    entry["published_present"] = True
+    entry["draft_present"] = True
+    entry["lineage"] = lineage
+    entry["id"] = entry.get("id") or "project_brief"
+    refreshed.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = entry
+    store.save_manifest(refreshed)
+    return {
+        "status": STATUS_PUBLISHED,
+        "store_dir": store.store_dir,
+        "changed": True,
+        "message": "brief published",
+        "source_fingerprint": lineage.get("source_fingerprint") or "",
+    }
+
+
+def unpublish_project_brief(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+    remove_published_file: bool = True,
+) -> dict[str, Any]:
+    """Revert published brief so it is no longer injectable."""
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    published_path = store.artifact_path(PROJECT_BRIEF_PUBLISHED_FILENAME)
+    had_published = os.path.isfile(published_path)
+    if remove_published_file and had_published:
+        os.unlink(published_path)
+
+    manifest = store.load_manifest() or empty_manifest(store_dir=store.store_dir)
+    brief_entry = dict((manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {})
+    draft_present = os.path.isfile(store.artifact_path(PROJECT_BRIEF_DRAFT_FILENAME))
+    brief_entry.update(
+        {
+            "status": STATUS_DRAFT if draft_present else STATUS_MISSING,
+            "draft_present": draft_present,
+            "published_present": False,
+            "id": brief_entry.get("id") or "project_brief",
+            "lineage": normalize_lineage(brief_entry.get("lineage")),
+        }
+    )
+    manifest.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = brief_entry
+    store.save_manifest(manifest)
+    return {
+        "status": brief_entry["status"],
+        "store_dir": store.store_dir,
+        "changed": had_published or True,
+        "message": "brief unpublished",
+    }
+
+
+def format_brief_diff(
+    store_dir: str | os.PathLike[str] | None = None,
+    *,
+    base_dir: str | None = None,
+) -> dict[str, Any]:
+    """Compare draft vs published brief texts and report presence."""
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    draft = store.load_brief_text(published=False)
+    published = store.load_brief_text(published=True)
+    return {
+        "store_dir": store.store_dir,
+        "draft_present": bool(draft.strip()),
+        "published_present": bool(published.strip()),
+        "identical": draft == published,
+        "draft_chars": len(draft),
+        "published_chars": len(published),
+        "draft_preview": draft[:500],
+        "published_preview": published[:500],
+    }
 
 
 def format_status_lines(status: Mapping[str, Any]) -> list[str]:

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -1403,8 +1403,8 @@ def unpublish_project_brief(
     return {
         "status": brief_entry["status"],
         "store_dir": store.store_dir,
-        "changed": had_published or True,
-        "message": "brief unpublished",
+        "changed": bool(had_published),
+        "message": "brief unpublished" if had_published else "brief was not published",
     }
 
 

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -1252,12 +1252,18 @@ def publish_project_brief(
     *,
     base_dir: str | None = None,
     force: bool = False,
+    current_source_fingerprint: str = "",
     project_identity: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Promote draft brief to published after gate checks.
 
     Does not invent empty published content. Failure leaves any prior published
     brief untouched.
+
+    Stale briefs and missing lineage source fingerprints cannot be published
+    unless ``force=True`` **and** ``current_source_fingerprint`` is provided
+    (structure rebuild fingerprint). Brief body hashes never substitute for
+    source fingerprints.
     """
     store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
     draft = store.load_brief_text(published=False).strip()
@@ -1285,6 +1291,13 @@ def publish_project_brief(
         raise ProjectAnalysisError(
             "cannot publish: brief already published; pass force=True to replace"
         )
+    if current == STATUS_STALE and not force:
+        raise ProjectAnalysisError(
+            "cannot publish: brief is stale; rebuild structure then publish, "
+            "or pass force=True with current_source_fingerprint"
+        )
+    if current == STATUS_FAILED:
+        raise ProjectAnalysisError(f"cannot publish from status {current!r}")
     if current not in {
         STATUS_DRAFT,
         STATUS_REVIEW_REQUIRED,
@@ -1294,25 +1307,32 @@ def publish_project_brief(
     }:
         raise ProjectAnalysisError(f"cannot publish from status {current!r}")
 
-    lineage = normalize_lineage(brief_entry.get("lineage"))
-    if not lineage.get("source_fingerprint") and not force:
-        # Allow publish when draft body exists but require fingerprint for injection
-        # safety: still set a content-based fingerprint so inject checks work.
-        lineage = empty_lineage(
-            source_fingerprint=sha256_text(draft),
-            upstream_dependency_digest=lineage.get("upstream_dependency_digest") or "",
-            prompt_schema_version=lineage.get("prompt_schema_version") or "",
-            provider=lineage.get("provider") or "",
-            model=lineage.get("model") or "",
-            thinking_level=lineage.get("thinking_level") or "",
-            generated_at=lineage.get("generated_at") or "",
-            reviewed_at=lineage.get("reviewed_at") or "",
-            published_at="",
+    lineage = dict(normalize_lineage(brief_entry.get("lineage")))
+    current_fp = str(current_source_fingerprint or "").strip()
+    if current == STATUS_STALE:
+        if not current_fp:
+            raise ProjectAnalysisError(
+                "cannot force-publish stale brief without current_source_fingerprint"
+            )
+        lineage["source_fingerprint"] = current_fp
+    elif not lineage.get("source_fingerprint"):
+        if force and current_fp:
+            lineage["source_fingerprint"] = current_fp
+        else:
+            raise ProjectAnalysisError(
+                "cannot publish: missing lineage source_fingerprint; "
+                "run project-analysis-build-structure first "
+                "(brief text hash is not a valid source fingerprint)"
+            )
+    elif current_fp and lineage.get("source_fingerprint") != current_fp and not force:
+        raise ProjectAnalysisError(
+            "cannot publish: lineage source_fingerprint does not match "
+            "current_source_fingerprint; rebuild or pass force=True"
         )
-    lineage = dict(lineage)
+    elif force and current_fp:
+        lineage["source_fingerprint"] = current_fp
+
     lineage["published_at"] = utc_now_iso()
-    if not lineage.get("source_fingerprint"):
-        lineage["source_fingerprint"] = sha256_text(draft)
 
     # Write published body first; only then flip manifest status.
     store.save_brief_text(draft + ("\n" if not draft.endswith("\n") else ""), published=True)

--- a/project_analysis_generate.py
+++ b/project_analysis_generate.py
@@ -350,9 +350,17 @@ def build_structure_drafts(
         unresolved_count=len(graph.unresolved_edges),
     )
     store.save_brief_text(brief_text, published=False)
+    # Persist absolute script roots so runtime fingerprint reuse matches build-time roots
+    # (custom --script-root must not fall back to default game/ layout only).
+    abs_roots = [os.path.abspath(r) for r in roots]
+    identity = {
+        "base_dir": os.path.abspath(base_dir) if base_dir else "",
+        "script_roots": abs_roots,
+        "graph_base": os.path.abspath(graph_base) if graph_base else "",
+    }
     # Update brief lineage in manifest.
     manifest = store.rebuild_manifest(
-        project_identity={"base_dir": base_dir or ""},
+        project_identity=identity,
         expected_source_fingerprint=source_fp,
     )
     brief_entry = dict((manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {})
@@ -370,8 +378,14 @@ def build_structure_drafts(
                 upstream_dependency_digest=digest_upstream_artifacts(upstream),
                 generated_at=utc_now_iso(),
             ),
+            "metadata": {
+                "script_roots": abs_roots,
+                "graph_base": identity["graph_base"],
+            },
         }
     )
+    # rebuild_manifest may overwrite project_identity; restore full identity.
+    manifest["project_identity"] = identity
     manifest.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = brief_entry
     store.save_manifest(manifest)
 
@@ -384,5 +398,6 @@ def build_structure_drafts(
         "chunks": len(chunks),
         "source_fingerprint": source_fp,
         "brief_draft_chars": len(brief_text),
+        "script_roots": abs_roots,
         "graph": graph.to_dict(),
     }

--- a/project_analysis_generate.py
+++ b/project_analysis_generate.py
@@ -28,6 +28,7 @@ from project_analysis import (
 )
 from project_analysis_routes import (
     build_route_graph,
+    digest_script_paths,
     discover_script_files,
     graph_to_label_records,
     graph_to_route_records,
@@ -120,36 +121,85 @@ def keyword_rows_to_chunk_records(
     return [normalize_summary_record(r, default_kind=KIND_CHUNK) for r in records]
 
 
+def _normalize_file_rel(path: str) -> str:
+    return str(path or "").replace("\\", "/").lstrip("./")
+
+
 def _guess_label_for_chunk(chunk: Mapping[str, Any], label_names: Sequence[str]) -> str:
-    """Heuristic: match label name appearing in file path or summary prefix."""
+    """Fallback heuristic when line spans are unavailable."""
     meta = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
     file_rel = str(meta.get("file_rel_path") or (chunk.get("source_files") or [""])[0])
     summary = str(chunk.get("summary") or "")
-    # Prefer longer label names to avoid partial matches.
     for name in sorted(label_names, key=len, reverse=True):
-        if name and (name in file_rel or f"`{name}`" in summary or f" {name} " in f" {summary} "):
+        if name and (
+            name in file_rel
+            or f"`{name}`" in summary
+            or f" {name} " in f" {summary} "
+        ):
             return name
     return ""
 
 
+def _label_match_for_chunk(
+    chunk: Mapping[str, Any],
+    labels: Mapping[str, Any],
+) -> str:
+    """Prefer file_rel_path + line_span overlap with label bodies; else name guess."""
+    meta = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+    file_rel = _normalize_file_rel(
+        str(meta.get("file_rel_path") or (chunk.get("source_files") or [""])[0])
+    )
+    span = chunk.get("line_span")
+    if file_rel and isinstance(span, (list, tuple)) and len(span) == 2:
+        try:
+            c_start, c_end = int(span[0]), int(span[1])
+        except (TypeError, ValueError):
+            c_start = c_end = -1
+        if c_start >= 0:
+            candidates: list[tuple[int, str]] = []
+            for name, node in labels.items():
+                node_file = _normalize_file_rel(getattr(node, "file_rel_path", "") or "")
+                if node_file != file_rel:
+                    continue
+                l_start = int(getattr(node, "line_start", 0) or 0)
+                l_end = int(getattr(node, "line_end", 0) or l_start)
+                # Overlap between chunk lines and label body span.
+                if c_start <= l_end and c_end >= l_start:
+                    # Prefer the tightest (smallest) containing/overlapping label.
+                    candidates.append((max(0, l_end - l_start), name))
+            if candidates:
+                candidates.sort(key=lambda item: (item[0], item[1]))
+                return candidates[0][1]
+    return _guess_label_for_chunk(chunk, list(labels.keys()))
+
+
 def assign_chunks_to_labels(
     chunks: Sequence[Mapping[str, Any]],
-    label_names: Sequence[str],
+    labels: Mapping[str, Any] | Sequence[str],
 ) -> dict[str, list[dict[str, Any]]]:
+    """Map chunks onto labels using line spans when possible.
+
+    *labels* may be a ``{name: LabelNode}`` map (preferred) or a sequence of names.
+    """
+    if isinstance(labels, Mapping):
+        label_map = labels
+        label_names = list(label_map.keys())
+    else:
+        label_names = list(labels)
+        label_map = {name: type("N", (), {"file_rel_path": "", "line_start": 0, "line_end": 0})() for name in label_names}
+
     by_label: dict[str, list[dict[str, Any]]] = {name: [] for name in label_names}
     unassigned: list[dict[str, Any]] = []
     for chunk in chunks:
-        name = _guess_label_for_chunk(chunk, label_names)
+        name = _label_match_for_chunk(chunk, label_map)
         if name and name in by_label:
             by_label[name].append(dict(chunk))
         else:
             unassigned.append(dict(chunk))
-    # Attach unassigned to a synthetic bucket via first label if only one exists.
     if unassigned and len(label_names) == 1:
         by_label[label_names[0]].extend(unassigned)
         unassigned = []
-    if unassigned and "_unassigned" not in by_label:
-        # Keep them available for brief only; not as a fake story label.
+    if unassigned:
         by_label["_unassigned"] = unassigned
     return by_label
 
@@ -270,21 +320,17 @@ def build_structure_drafts(
             f"no .rpy scripts found under: {', '.join(roots)}"
         )
 
+    graph_base = base_dir or (roots[0] if roots else None)
     graph = build_route_graph(
         script_paths,
-        base_dir=base_dir or (roots[0] if roots else None),
+        base_dir=graph_base,
         entry_labels=entry_labels,
     )
     chunks = store.load_summaries(KIND_CHUNK)
-    source_fp = ""
-    if chunks:
-        source_fp = str(
-            (chunks[0].get("lineage") or {}).get("source_fingerprint") or ""
-        )
-    if not source_fp:
-        source_fp = sha256_text("|".join(graph.source_files))
+    # Fingerprint must include script *contents*, not just names / chunk hashes.
+    source_fp = digest_script_paths(script_paths, base_dir=graph_base)
 
-    chunk_by_label = assign_chunks_to_labels(chunks, list(graph.labels.keys()))
+    chunk_by_label = assign_chunks_to_labels(chunks, graph.labels)
     # Drop synthetic bucket from label record generation.
     label_chunk_map = {
         k: v for k, v in chunk_by_label.items() if k != "_unassigned" and k in graph.labels

--- a/project_analysis_generate.py
+++ b/project_analysis_generate.py
@@ -1,0 +1,342 @@
+"""Project Analysis draft generation without LLM (#254 PR A).
+
+Ingest keyword chunk summaries, attach them to a static route graph, and write
+draft label/route/brief artifacts into the project_analysis store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Mapping, Sequence
+
+from project_analysis import (
+    KIND_CHUNK,
+    KIND_LABEL,
+    KIND_PROJECT_BRIEF,
+    KIND_ROUTE,
+    STATUS_DRAFT,
+    ProjectAnalysisError,
+    ProjectAnalysisStore,
+    digest_source_items,
+    digest_upstream_artifacts,
+    empty_lineage,
+    normalize_summary_record,
+    resolve_project_analysis_store,
+    sha256_text,
+    utc_now_iso,
+)
+from project_analysis_routes import (
+    build_route_graph,
+    discover_script_files,
+    graph_to_label_records,
+    graph_to_route_records,
+)
+
+
+def load_keyword_chunk_summaries(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    """Load keyword_chunk_summaries.jsonl rows."""
+    path = os.fspath(path)
+    if not os.path.isfile(path):
+        raise ProjectAnalysisError(f"keyword summary JSONL not found: {path}")
+    rows: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ProjectAnalysisError(
+                    f"invalid keyword summary JSONL at {path}:{line_no}: {exc}"
+                ) from exc
+            if not isinstance(data, dict):
+                raise ProjectAnalysisError(
+                    f"keyword summary row at {path}:{line_no} must be an object"
+                )
+            rows.append(data)
+    return rows
+
+
+def keyword_rows_to_chunk_records(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    source_fingerprint: str = "",
+) -> list[dict[str, Any]]:
+    """Map keyword export rows to analysis chunk draft records."""
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        key = str(row.get("key") or "").strip()
+        file_rel = str(row.get("file_rel_path") or "").replace("\\", "/").strip()
+        chunk_index = row.get("chunk_index")
+        try:
+            chunk_index_int = int(chunk_index) if chunk_index is not None else 0
+        except (TypeError, ValueError):
+            chunk_index_int = 0
+        artifact_id = key or f"chunk:{file_rel}:{chunk_index_int}"
+        summary = str(row.get("chunk_summary") or row.get("summary") or "").strip()
+        if not summary:
+            continue
+        evidence = [
+            str(x).strip()
+            for x in (row.get("summary_evidence_item_ids") or row.get("evidence_item_ids") or [])
+            if str(x or "").strip()
+        ]
+        line_numbers = row.get("line_numbers") or row.get("source_lines") or []
+        line_span = None
+        if isinstance(line_numbers, list) and line_numbers:
+            try:
+                nums = [int(x) for x in line_numbers]
+                line_span = [min(nums), max(nums)]
+            except (TypeError, ValueError):
+                line_span = None
+        # Best-effort label hint from translate block style ids later; keep metadata.
+        records.append(
+            {
+                "id": artifact_id,
+                "kind": KIND_CHUNK,
+                "status": STATUS_DRAFT,
+                "source_files": [file_rel] if file_rel else [],
+                "evidence_item_ids": evidence,
+                "line_span": line_span,
+                "source_checksum": sha256_text(summary),
+                "upstream_artifact_ids": [],
+                "lineage": empty_lineage(
+                    source_fingerprint=source_fingerprint
+                    or digest_source_items(
+                        [{"id": e, "source_checksum": ""} for e in evidence]
+                    ),
+                    generated_at=utc_now_iso(),
+                ),
+                "summary": summary,
+                "metadata": {
+                    "keyword_key": key,
+                    "chunk_index": chunk_index_int,
+                    "file_rel_path": file_rel,
+                },
+            }
+        )
+    return [normalize_summary_record(r, default_kind=KIND_CHUNK) for r in records]
+
+
+def _guess_label_for_chunk(chunk: Mapping[str, Any], label_names: Sequence[str]) -> str:
+    """Heuristic: match label name appearing in file path or summary prefix."""
+    meta = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+    file_rel = str(meta.get("file_rel_path") or (chunk.get("source_files") or [""])[0])
+    summary = str(chunk.get("summary") or "")
+    # Prefer longer label names to avoid partial matches.
+    for name in sorted(label_names, key=len, reverse=True):
+        if name and (name in file_rel or f"`{name}`" in summary or f" {name} " in f" {summary} "):
+            return name
+    return ""
+
+
+def assign_chunks_to_labels(
+    chunks: Sequence[Mapping[str, Any]],
+    label_names: Sequence[str],
+) -> dict[str, list[dict[str, Any]]]:
+    by_label: dict[str, list[dict[str, Any]]] = {name: [] for name in label_names}
+    unassigned: list[dict[str, Any]] = []
+    for chunk in chunks:
+        name = _guess_label_for_chunk(chunk, label_names)
+        if name and name in by_label:
+            by_label[name].append(dict(chunk))
+        else:
+            unassigned.append(dict(chunk))
+    # Attach unassigned to a synthetic bucket via first label if only one exists.
+    if unassigned and len(label_names) == 1:
+        by_label[label_names[0]].extend(unassigned)
+        unassigned = []
+    if unassigned and "_unassigned" not in by_label:
+        # Keep them available for brief only; not as a fake story label.
+        by_label["_unassigned"] = unassigned
+    return by_label
+
+
+def build_project_brief_text(
+    *,
+    routes: Sequence[Mapping[str, Any]],
+    labels: Sequence[Mapping[str, Any]],
+    unresolved_count: int = 0,
+) -> str:
+    lines = [
+        "# Project Analysis Brief (draft)",
+        "",
+        "Generated without LLM from keyword chunk summaries and static Ren'Py structure.",
+        "Review before publish. Only the published copy may be injected into prompts.",
+        "",
+        f"- Labels: {len(labels)}",
+        f"- Routes: {len(routes)}",
+        f"- Unresolved dynamic edges: {unresolved_count}",
+        "",
+    ]
+    if routes:
+        lines.append("## Routes")
+        lines.append("")
+        for route in routes:
+            rid = route.get("id") or route.get("route_id") or ""
+            meta = route.get("metadata") if isinstance(route.get("metadata"), dict) else {}
+            entry = meta.get("entry_label") or ""
+            path = meta.get("label_ids") or []
+            flag = " (unresolved)" if meta.get("unresolved") else ""
+            lines.append(f"### {rid}{flag}")
+            lines.append(f"- entry: `{entry}`")
+            if path:
+                lines.append(f"- path: {' -> '.join(f'`{x}`' for x in path)}")
+            summary = str(route.get("summary") or "").strip()
+            if summary:
+                # Keep brief shorter: first line of route summary.
+                first = summary.splitlines()[0]
+                lines.append(f"- summary: {first}")
+            lines.append("")
+    else:
+        lines.append("## Routes")
+        lines.append("")
+        lines.append("(no routes discovered)")
+        lines.append("")
+    lines.append("## Labels")
+    lines.append("")
+    for label in labels[:50]:
+        lid = label.get("label_id") or label.get("id")
+        lines.append(f"- `{lid}`")
+    if len(labels) > 50:
+        lines.append(f"- … and {len(labels) - 50} more")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def ingest_keyword_summaries(
+    summary_jsonl: str | os.PathLike[str],
+    *,
+    store_dir: str | os.PathLike[str] | None = None,
+    base_dir: str | None = None,
+) -> dict[str, Any]:
+    """Import keyword summaries into analysis chunk_summaries.jsonl as drafts."""
+    rows = load_keyword_chunk_summaries(summary_jsonl)
+    source_fp = digest_source_items(
+        [
+            {
+                "id": str(r.get("key") or ""),
+                "source_checksum": sha256_text(str(r.get("chunk_summary") or "")),
+                "file_rel_path": str(r.get("file_rel_path") or ""),
+            }
+            for r in rows
+        ]
+    )
+    chunks = keyword_rows_to_chunk_records(rows, source_fingerprint=source_fp)
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    store.save_summaries(KIND_CHUNK, chunks)
+    store.rebuild_manifest(
+        project_identity={"base_dir": base_dir or ""},
+        expected_source_fingerprint=source_fp,
+    )
+    return {
+        "store_dir": store.store_dir,
+        "chunks_written": len(chunks),
+        "source_fingerprint": source_fp,
+        "input_rows": len(rows),
+    }
+
+
+def build_structure_drafts(
+    *,
+    store_dir: str | os.PathLike[str] | None = None,
+    base_dir: str | None = None,
+    script_roots: Sequence[str] | None = None,
+    entry_labels: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Parse scripts, merge existing chunk drafts, write label/route/brief drafts."""
+    store = resolve_project_analysis_store(store_dir, base_dir=base_dir)
+    roots: list[str] = []
+    if script_roots:
+        roots.extend(script_roots)
+    elif base_dir:
+        # Prefer game scripts under work/game or original/game.
+        for rel in ("game", os.path.join("work", "game"), os.path.join("original", "game")):
+            candidate = os.path.join(base_dir, rel)
+            if os.path.isdir(candidate):
+                roots.append(candidate)
+        if not roots:
+            roots.append(base_dir)
+    else:
+        raise ProjectAnalysisError(
+            "build_structure_drafts requires base_dir or script_roots"
+        )
+
+    script_paths = discover_script_files(roots)
+    if not script_paths:
+        raise ProjectAnalysisError(
+            f"no .rpy scripts found under: {', '.join(roots)}"
+        )
+
+    graph = build_route_graph(
+        script_paths,
+        base_dir=base_dir or (roots[0] if roots else None),
+        entry_labels=entry_labels,
+    )
+    chunks = store.load_summaries(KIND_CHUNK)
+    source_fp = ""
+    if chunks:
+        source_fp = str(
+            (chunks[0].get("lineage") or {}).get("source_fingerprint") or ""
+        )
+    if not source_fp:
+        source_fp = sha256_text("|".join(graph.source_files))
+
+    chunk_by_label = assign_chunks_to_labels(chunks, list(graph.labels.keys()))
+    # Drop synthetic bucket from label record generation.
+    label_chunk_map = {
+        k: v for k, v in chunk_by_label.items() if k != "_unassigned" and k in graph.labels
+    }
+    labels = graph_to_label_records(
+        graph, chunk_by_label=label_chunk_map, source_fingerprint=source_fp
+    )
+    routes = graph_to_route_records(
+        graph, label_records=labels, source_fingerprint=source_fp
+    )
+    store.save_summaries(KIND_LABEL, labels)
+    store.save_routes(routes)
+
+    brief_text = build_project_brief_text(
+        routes=routes,
+        labels=labels,
+        unresolved_count=len(graph.unresolved_edges),
+    )
+    store.save_brief_text(brief_text, published=False)
+    # Update brief lineage in manifest.
+    manifest = store.rebuild_manifest(
+        project_identity={"base_dir": base_dir or ""},
+        expected_source_fingerprint=source_fp,
+    )
+    brief_entry = dict((manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {})
+    upstream = [r["id"] for r in routes] + [r["id"] for r in labels]
+    brief_entry.update(
+        {
+            "status": STATUS_DRAFT,
+            "draft_present": True,
+            "published_present": os.path.isfile(
+                store.artifact_path("project_brief.published.md")
+            ),
+            "id": "project_brief",
+            "lineage": empty_lineage(
+                source_fingerprint=source_fp,
+                upstream_dependency_digest=digest_upstream_artifacts(upstream),
+                generated_at=utc_now_iso(),
+            ),
+        }
+    )
+    manifest.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = brief_entry
+    store.save_manifest(manifest)
+
+    return {
+        "store_dir": store.store_dir,
+        "scripts_scanned": len(script_paths),
+        "labels": len(labels),
+        "routes": len(routes),
+        "unresolved_edges": len(graph.unresolved_edges),
+        "chunks": len(chunks),
+        "source_fingerprint": source_fp,
+        "brief_draft_chars": len(brief_text),
+        "graph": graph.to_dict(),
+    }

--- a/project_analysis_routes.py
+++ b/project_analysis_routes.py
@@ -1,0 +1,438 @@
+"""Static Ren'Py route / label graph for Project Analysis Phase 2 (#254).
+
+Parses label / jump / call / menu structure without executing Ren'Py.
+Dynamic jumps are marked unresolved; no single linear route is invented.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+from project_analysis import (
+    KIND_LABEL,
+    KIND_ROUTE,
+    STATUS_DRAFT,
+    digest_upstream_artifacts,
+    empty_lineage,
+    sha256_text,
+    stable_json_sha256,
+)
+
+# Story labels (not translate blocks).
+_LABEL_RE = re.compile(r"^\s*label\s+([A-Za-z_][\w.]*)\s*:", re.MULTILINE)
+_JUMP_RE = re.compile(r"^\s*jump\s+([A-Za-z_][\w.]*)\s*$", re.MULTILINE)
+_JUMP_EXPR_RE = re.compile(r"^\s*jump\s+expression\b", re.MULTILINE | re.IGNORECASE)
+_CALL_RE = re.compile(r"^\s*call\s+([A-Za-z_][\w.]*)\b", re.MULTILINE)
+_CALL_EXPR_RE = re.compile(r"^\s*call\s+expression\b", re.MULTILINE | re.IGNORECASE)
+_MENU_RE = re.compile(r"^\s*menu\s*(?:[A-Za-z_][\w.]*)?\s*:", re.MULTILINE)
+
+
+@dataclass
+class RouteEdge:
+    source_label: str
+    target_label: str = ""
+    kind: str = "jump"  # jump | call | menu | unresolved
+    unresolved: bool = False
+    file_rel_path: str = ""
+    line: int = 0
+    raw: str = ""
+
+
+@dataclass
+class LabelNode:
+    name: str
+    file_rel_path: str
+    line_start: int
+    line_end: int = 0
+    outgoing: list[RouteEdge] = field(default_factory=list)
+
+
+@dataclass
+class RouteGraph:
+    labels: dict[str, LabelNode] = field(default_factory=dict)
+    edges: list[RouteEdge] = field(default_factory=list)
+    routes: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_edges: list[RouteEdge] = field(default_factory=list)
+    source_files: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "labels": {
+                name: {
+                    "name": node.name,
+                    "file_rel_path": node.file_rel_path,
+                    "line_start": node.line_start,
+                    "line_end": node.line_end,
+                    "outgoing": [edge.__dict__ for edge in node.outgoing],
+                }
+                for name, node in sorted(self.labels.items())
+            },
+            "edges": [edge.__dict__ for edge in self.edges],
+            "routes": list(self.routes),
+            "unresolved_edges": [edge.__dict__ for edge in self.unresolved_edges],
+            "source_files": list(self.source_files),
+        }
+
+
+def _line_number_at(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def _normalize_rel(path: str) -> str:
+    return str(path or "").replace("\\", "/").lstrip("./")
+
+
+def parse_rpy_labels_and_edges(text: str, *, file_rel_path: str = "") -> tuple[list[LabelNode], list[RouteEdge]]:
+    """Parse one .rpy file into labels and control-flow edges."""
+    file_rel_path = _normalize_rel(file_rel_path)
+    labels: list[LabelNode] = []
+    edges: list[RouteEdge] = []
+
+    label_matches = list(_LABEL_RE.finditer(text))
+    for i, match in enumerate(label_matches):
+        name = match.group(1)
+        start = _line_number_at(text, match.start())
+        end_index = label_matches[i + 1].start() if i + 1 < len(label_matches) else len(text)
+        end = _line_number_at(text, max(end_index - 1, match.start()))
+        body = text[match.end() : end_index]
+        node = LabelNode(
+            name=name,
+            file_rel_path=file_rel_path,
+            line_start=start,
+            line_end=end,
+        )
+        # Jumps / calls inside this label body.
+        for jm in _JUMP_RE.finditer(body):
+            edge = RouteEdge(
+                source_label=name,
+                target_label=jm.group(1),
+                kind="jump",
+                file_rel_path=file_rel_path,
+                line=start + _line_number_at(body, jm.start()) - 1,
+                raw=jm.group(0).strip(),
+            )
+            node.outgoing.append(edge)
+            edges.append(edge)
+        for jm in _JUMP_EXPR_RE.finditer(body):
+            edge = RouteEdge(
+                source_label=name,
+                target_label="",
+                kind="unresolved",
+                unresolved=True,
+                file_rel_path=file_rel_path,
+                line=start + _line_number_at(body, jm.start()) - 1,
+                raw=jm.group(0).strip(),
+            )
+            node.outgoing.append(edge)
+            edges.append(edge)
+        for cm in _CALL_RE.finditer(body):
+            edge = RouteEdge(
+                source_label=name,
+                target_label=cm.group(1),
+                kind="call",
+                file_rel_path=file_rel_path,
+                line=start + _line_number_at(body, cm.start()) - 1,
+                raw=cm.group(0).strip(),
+            )
+            node.outgoing.append(edge)
+            edges.append(edge)
+        for cm in _CALL_EXPR_RE.finditer(body):
+            edge = RouteEdge(
+                source_label=name,
+                target_label="",
+                kind="unresolved",
+                unresolved=True,
+                file_rel_path=file_rel_path,
+                line=start + _line_number_at(body, cm.start()) - 1,
+                raw=cm.group(0).strip(),
+            )
+            node.outgoing.append(edge)
+            edges.append(edge)
+        # Menu blocks: treat jump/call still found above; also flag bare menu presence.
+        if _MENU_RE.search(body):
+            # Menu choices already contribute via jump/call lines inside body.
+            pass
+        labels.append(node)
+    return labels, edges
+
+
+def discover_script_files(roots: Sequence[str]) -> list[str]:
+    """Find .rpy script files under roots (skips tl/ and common dump dirs)."""
+    found: list[str] = []
+    skip_parts = {"tl", "__pycache__", ".git", "cache", "saves"}
+    for root in roots:
+        root = os.path.abspath(root)
+        if not os.path.isdir(root):
+            if os.path.isfile(root) and root.lower().endswith(".rpy"):
+                found.append(root)
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d.lower() not in skip_parts]
+            # Skip game/tl trees.
+            parts = {p.lower() for p in dirpath.replace("\\", "/").split("/")}
+            if "tl" in parts:
+                continue
+            for name in filenames:
+                if name.lower().endswith(".rpy"):
+                    found.append(os.path.join(dirpath, name))
+    found.sort()
+    return found
+
+
+def build_route_graph(
+    script_paths: Sequence[str],
+    *,
+    base_dir: str | None = None,
+    entry_labels: Sequence[str] | None = None,
+) -> RouteGraph:
+    """Build a multi-file route graph and enumerate simple routes from entries."""
+    graph = RouteGraph()
+    base = os.path.abspath(base_dir) if base_dir else ""
+    all_labels: dict[str, LabelNode] = {}
+    all_edges: list[RouteEdge] = []
+
+    for path in script_paths:
+        path = os.path.abspath(path)
+        if not os.path.isfile(path):
+            continue
+        rel = _normalize_rel(os.path.relpath(path, base) if base else os.path.basename(path))
+        with open(path, "r", encoding="utf-8-sig", errors="replace") as handle:
+            text = handle.read()
+        labels, edges = parse_rpy_labels_and_edges(text, file_rel_path=rel)
+        graph.source_files.append(rel)
+        for node in labels:
+            # Last definition wins; still records file.
+            all_labels[node.name] = node
+        all_edges.extend(edges)
+
+    graph.labels = all_labels
+    graph.edges = all_edges
+    graph.unresolved_edges = [e for e in all_edges if e.unresolved]
+
+    # Default entries: labels with no inbound edges (excluding self-unresolved only).
+    inbound: dict[str, int] = {name: 0 for name in all_labels}
+    for edge in all_edges:
+        if edge.target_label and edge.target_label in inbound:
+            inbound[edge.target_label] += 1
+    if entry_labels:
+        entries = [n for n in entry_labels if n in all_labels]
+    else:
+        entries = sorted(name for name, count in inbound.items() if count == 0)
+        if not entries:
+            entries = sorted(all_labels.keys())[:1]
+
+    routes: list[dict[str, Any]] = []
+    for entry in entries:
+        paths = _enumerate_routes(entry, all_labels, max_depth=32, max_routes=32)
+        for path_labels in paths:
+            route_id = _route_id(entry, path_labels)
+            unresolved = any(
+                e.unresolved and e.source_label in path_labels for e in all_edges
+            )
+            shared = [lab for lab in path_labels if _label_shared(lab, all_edges, path_labels)]
+            routes.append(
+                {
+                    "id": route_id,
+                    "entry_label": entry,
+                    "label_ids": path_labels,
+                    "unresolved": unresolved,
+                    "shared_labels": shared,
+                    "source_files": sorted(
+                        {
+                            all_labels[lab].file_rel_path
+                            for lab in path_labels
+                            if lab in all_labels
+                        }
+                    ),
+                }
+            )
+    # De-dupe route ids.
+    seen: set[str] = set()
+    unique_routes = []
+    for route in routes:
+        if route["id"] in seen:
+            continue
+        seen.add(route["id"])
+        unique_routes.append(route)
+    graph.routes = unique_routes
+    return graph
+
+
+def _label_shared(label: str, edges: Sequence[RouteEdge], path_labels: Sequence[str]) -> bool:
+    # Shared if inbound from labels outside this path as well — approximate:
+    # label appears as target from more than one distinct source.
+    sources = {e.source_label for e in edges if e.target_label == label}
+    return len(sources) > 1
+
+
+def _enumerate_routes(
+    entry: str,
+    labels: dict[str, LabelNode],
+    *,
+    max_depth: int,
+    max_routes: int,
+) -> list[list[str]]:
+    results: list[list[str]] = []
+
+    def walk(current: str, path: list[str], depth: int) -> None:
+        if len(results) >= max_routes:
+            return
+        if depth > max_depth:
+            results.append(list(path))
+            return
+        node = labels.get(current)
+        if node is None:
+            results.append(list(path))
+            return
+        # Resolved jump/call targets first; unresolved still ends a branch marker.
+        targets = []
+        has_unresolved = False
+        for edge in node.outgoing:
+            if edge.unresolved:
+                has_unresolved = True
+                continue
+            if edge.target_label and edge.target_label not in path:
+                targets.append(edge.target_label)
+            elif edge.target_label:
+                # cycle — close route
+                results.append(list(path))
+        if not targets:
+            results.append(list(path))
+            if has_unresolved:
+                # Record same path; unresolved flag computed later.
+                pass
+            return
+        for target in targets:
+            walk(target, path + [target], depth + 1)
+
+    if entry not in labels:
+        return []
+    walk(entry, [entry], 0)
+    if not results:
+        results.append([entry])
+    return results
+
+
+def _route_id(entry: str, path_labels: Sequence[str]) -> str:
+    digest = stable_json_sha256({"entry": entry, "path": list(path_labels)})[:10]
+    return f"route:{entry}:{digest}"
+
+
+def graph_to_label_records(
+    graph: RouteGraph,
+    *,
+    chunk_by_label: dict[str, list[dict[str, Any]]] | None = None,
+    source_fingerprint: str = "",
+) -> list[dict[str, Any]]:
+    """Build draft label summary records from the graph (+ optional chunk texts)."""
+    chunk_by_label = chunk_by_label or {}
+    records: list[dict[str, Any]] = []
+    for name, node in sorted(graph.labels.items()):
+        chunks = chunk_by_label.get(name) or []
+        evidence: list[str] = []
+        upstream: list[str] = []
+        summaries: list[str] = []
+        for chunk in chunks:
+            cid = str(chunk.get("id") or "").strip()
+            if cid:
+                upstream.append(cid)
+            for eid in chunk.get("evidence_item_ids") or []:
+                if eid and eid not in evidence:
+                    evidence.append(str(eid))
+            summary = str(chunk.get("summary") or "").strip()
+            if summary:
+                summaries.append(summary)
+        body = "\n".join(summaries) if summaries else f"Label `{name}` ({node.file_rel_path}:{node.line_start})."
+        unresolved = any(e.unresolved for e in node.outgoing)
+        if unresolved:
+            body += "\n[unresolved dynamic jump/call present]"
+        records.append(
+            {
+                "id": f"label:{name}",
+                "kind": KIND_LABEL,
+                "status": STATUS_DRAFT,
+                "label_id": name,
+                "source_files": [node.file_rel_path] if node.file_rel_path else [],
+                "evidence_item_ids": evidence,
+                "line_span": [node.line_start, node.line_end or node.line_start],
+                "source_checksum": sha256_text(body),
+                "upstream_artifact_ids": upstream,
+                "lineage": empty_lineage(
+                    source_fingerprint=source_fingerprint
+                    or sha256_text("|".join(graph.source_files)),
+                    upstream_dependency_digest=digest_upstream_artifacts(upstream),
+                    generated_at="",
+                ),
+                "summary": body,
+                "metadata": {
+                    "unresolved_outgoing": unresolved,
+                    "outgoing_targets": [
+                        e.target_label for e in node.outgoing if e.target_label
+                    ],
+                },
+            }
+        )
+    return records
+
+
+def graph_to_route_records(
+    graph: RouteGraph,
+    *,
+    label_records: Sequence[dict[str, Any]] | None = None,
+    source_fingerprint: str = "",
+) -> list[dict[str, Any]]:
+    """Build draft route summary records."""
+    label_by_name = {
+        str(r.get("label_id") or "").strip(): r
+        for r in (label_records or [])
+        if str(r.get("label_id") or "").strip()
+    }
+    records: list[dict[str, Any]] = []
+    for route in graph.routes:
+        path = list(route.get("label_ids") or [])
+        upstream = [f"label:{name}" for name in path]
+        evidence: list[str] = []
+        parts: list[str] = []
+        for name in path:
+            rec = label_by_name.get(name)
+            if rec:
+                for eid in rec.get("evidence_item_ids") or []:
+                    if eid not in evidence:
+                        evidence.append(str(eid))
+                summary = str(rec.get("summary") or "").strip()
+                if summary:
+                    parts.append(f"## {name}\n{summary}")
+            else:
+                parts.append(f"## {name}\n(no label summary)")
+        if route.get("unresolved"):
+            parts.append("[route contains unresolved dynamic jump/call]")
+        body = "\n\n".join(parts) if parts else f"Route from {route.get('entry_label')}"
+        records.append(
+            {
+                "id": route["id"],
+                "kind": KIND_ROUTE,
+                "status": STATUS_DRAFT,
+                "route_id": route["id"],
+                "source_files": list(route.get("source_files") or []),
+                "evidence_item_ids": evidence,
+                "line_span": None,
+                "source_checksum": sha256_text(body),
+                "upstream_artifact_ids": upstream,
+                "lineage": empty_lineage(
+                    source_fingerprint=source_fingerprint
+                    or sha256_text("|".join(graph.source_files)),
+                    upstream_dependency_digest=digest_upstream_artifacts(upstream),
+                ),
+                "summary": body,
+                "metadata": {
+                    "entry_label": route.get("entry_label"),
+                    "label_ids": path,
+                    "unresolved": bool(route.get("unresolved")),
+                    "shared_labels": list(route.get("shared_labels") or []),
+                },
+            }
+        )
+    return records

--- a/project_analysis_routes.py
+++ b/project_analysis_routes.py
@@ -26,7 +26,11 @@ from project_analysis import (
 _LABEL_RE = re.compile(r"^\s*label\s+([A-Za-z_][\w.]*)\s*:", re.MULTILINE)
 _JUMP_RE = re.compile(r"^\s*jump\s+([A-Za-z_][\w.]*)\s*$", re.MULTILINE)
 _JUMP_EXPR_RE = re.compile(r"^\s*jump\s+expression\b", re.MULTILINE | re.IGNORECASE)
-_CALL_RE = re.compile(r"^\s*call\s+([A-Za-z_][\w.]*)\b", re.MULTILINE)
+# Negative lookahead: "call expression ..." is unresolved, not target name "expression".
+_CALL_RE = re.compile(
+    r"^\s*call\s+(?!expression\b)([A-Za-z_][\w.]*)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
 _CALL_EXPR_RE = re.compile(r"^\s*call\s+expression\b", re.MULTILINE | re.IGNORECASE)
 _MENU_RE = re.compile(r"^\s*menu\s*(?:[A-Za-z_][\w.]*)?\s*:", re.MULTILINE)
 

--- a/project_analysis_routes.py
+++ b/project_analysis_routes.py
@@ -6,6 +6,7 @@ Dynamic jumps are marked unresolved; no single linear route is invented.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from dataclasses import dataclass, field
@@ -83,6 +84,46 @@ def _line_number_at(text: str, index: int) -> int:
 
 def _normalize_rel(path: str) -> str:
     return str(path or "").replace("\\", "/").lstrip("./")
+
+
+def safe_relpath(path: str, base_dir: str | None = None) -> str:
+    """Relative path under *base_dir*, or basename when cross-drive / outside base.
+
+    ``os.path.relpath`` raises ValueError on Windows when path and base are on
+    different drives; that must not break route builds or CI temp dirs.
+    """
+    path_abs = os.path.abspath(path)
+    if not base_dir:
+        return _normalize_rel(os.path.basename(path_abs))
+    base_abs = os.path.abspath(base_dir)
+    try:
+        common = os.path.commonpath([path_abs, base_abs])
+    except ValueError:
+        return _normalize_rel(os.path.basename(path_abs))
+    if os.path.normcase(common) != os.path.normcase(base_abs):
+        return _normalize_rel(os.path.basename(path_abs))
+    try:
+        return _normalize_rel(os.path.relpath(path_abs, base_abs))
+    except ValueError:
+        return _normalize_rel(os.path.basename(path_abs))
+
+
+def digest_script_paths(
+    script_paths: Sequence[str],
+    *,
+    base_dir: str | None = None,
+) -> str:
+    """Stable fingerprint of script relative paths + file content checksums."""
+    rows: list[dict[str, str]] = []
+    for path in sorted({os.path.abspath(p) for p in script_paths if p}):
+        if not os.path.isfile(path):
+            continue
+        rel = safe_relpath(path, base_dir)
+        with open(path, "rb") as handle:
+            digest = hashlib.sha256(handle.read()).hexdigest()
+        rows.append({"path": rel, "sha256": digest})
+    rows.sort(key=lambda row: row["path"])
+    return stable_json_sha256(rows)
 
 
 def parse_rpy_labels_and_edges(text: str, *, file_rel_path: str = "") -> tuple[list[LabelNode], list[RouteEdge]]:
@@ -198,7 +239,7 @@ def build_route_graph(
         path = os.path.abspath(path)
         if not os.path.isfile(path):
             continue
-        rel = _normalize_rel(os.path.relpath(path, base) if base else os.path.basename(path))
+        rel = safe_relpath(path, base or None)
         with open(path, "r", encoding="utf-8-sig", errors="replace") as handle:
             text = handle.read()
         labels, edges = parse_rpy_labels_and_edges(text, file_rel_path=rel)
@@ -275,6 +316,14 @@ def _enumerate_routes(
     max_depth: int,
     max_routes: int,
 ) -> list[list[str]]:
+    """Enumerate jump/menu branches only.
+
+    ``call`` is *not* treated as an exclusive branch. A call returns to the
+    caller; modeling it like jump would invent false mutually-exclusive routes
+    (e.g. ``start → helper`` vs ``start → ending`` when the real flow is
+    ``start → call helper → ending``). Call targets are recorded on edges for
+    dependency/metadata but do not fork the walk.
+    """
     results: list[list[str]] = []
 
     def walk(current: str, path: list[str], depth: int) -> None:
@@ -287,25 +336,22 @@ def _enumerate_routes(
         if node is None:
             results.append(list(path))
             return
-        # Resolved jump/call targets first; unresolved still ends a branch marker.
-        targets = []
-        has_unresolved = False
+        jump_targets: list[str] = []
         for edge in node.outgoing:
             if edge.unresolved:
-                has_unresolved = True
+                continue
+            # Calls are side dependencies, not route forks.
+            if edge.kind == "call":
                 continue
             if edge.target_label and edge.target_label not in path:
-                targets.append(edge.target_label)
+                jump_targets.append(edge.target_label)
             elif edge.target_label:
                 # cycle — close route
                 results.append(list(path))
-        if not targets:
+        if not jump_targets:
             results.append(list(path))
-            if has_unresolved:
-                # Record same path; unresolved flag computed later.
-                pass
             return
-        for target in targets:
+        for target in jump_targets:
             walk(target, path + [target], depth + 1)
 
     if entry not in labels:

--- a/prompt_context.py
+++ b/prompt_context.py
@@ -61,6 +61,15 @@ def format_source_hits_block(hits, empty_label="(none)"):
     return "\n".join(lines) if lines else empty_label
 
 
+def format_project_brief_block(brief_text, *, diagnostics="", empty_label="(none)"):
+    text = str(brief_text or "").strip()
+    if not text:
+        return empty_label
+    if diagnostics:
+        return f"{text}\n\n[{diagnostics}]"
+    return text
+
+
 def build_reference_blocks(
     *,
     include_translation_memory=True,
@@ -68,6 +77,8 @@ def build_reference_blocks(
     history_hits=None,
     story_hits=None,
     source_hits=None,
+    project_brief_text="",
+    project_brief_diagnostics="",
     history_char_limit=220,
     story_char_limit=1200,
     include_source_text=True,
@@ -81,6 +92,12 @@ def build_reference_blocks(
             f"{format_glossary_hits_block(glossary_hits or [], empty_label)}\n\n"
             "RETRIEVED MEMORY:\n"
             f"{format_history_hits_block(history_hits or [], empty_label, history_char_limit, include_source_text)}\n\n"
+        )
+    brief = str(project_brief_text or "").strip()
+    if brief:
+        blocks.append(
+            "PROJECT BRIEF:\n"
+            f"{format_project_brief_block(brief, diagnostics=project_brief_diagnostics, empty_label=empty_label)}\n\n"
         )
     if source_hits:
         blocks.append(

--- a/tests/fixtures/project_analysis_routes_minimal/keyword_chunk_summaries.jsonl
+++ b/tests/fixtures/project_analysis_routes_minimal/keyword_chunk_summaries.jsonl
@@ -1,0 +1,3 @@
+{"key": "kw-hub-0", "file_rel_path": "script.rpy", "chunk_index": 0, "line_numbers": [8, 9], "chunk_summary": "At hub the player chooses path A or B.", "summary_evidence_item_ids": ["item-hub-1"], "source_lines": [8, 9]}
+{"key": "kw-a-0", "file_rel_path": "script.rpy", "chunk_index": 1, "line_numbers": [16, 17], "chunk_summary": "Path A continues to the shared ending.", "summary_evidence_item_ids": ["item-a-1"], "source_lines": [16, 17]}
+{"key": "kw-b-0", "file_rel_path": "script.rpy", "chunk_index": 2, "line_numbers": [20, 21], "chunk_summary": "Path B hits a dynamic jump then shared ending.", "summary_evidence_item_ids": ["item-b-1"], "source_lines": [20, 21]}

--- a/tests/fixtures/project_analysis_routes_minimal/script.rpy
+++ b/tests/fixtures/project_analysis_routes_minimal/script.rpy
@@ -1,0 +1,27 @@
+# Minimal branching Ren'Py script for Project Analysis route tests.
+
+label start:
+    "Welcome."
+    jump hub
+
+label hub:
+    "Choose a path."
+    menu:
+        "Path A":
+            jump path_a
+        "Path B":
+            jump path_b
+
+label path_a:
+    "You chose A."
+    jump shared_end
+
+label path_b:
+    "You chose B."
+    # Dynamic jump — must be unresolved, not invented as a fixed target.
+    jump expression some_flag
+    jump shared_end
+
+label shared_end:
+    "Shared ending."
+    return

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -566,7 +566,7 @@ class GuiTaskPageTests(unittest.TestCase):
             page.bootstrap_source_index_btn.parentWidget(),
             page.source_index_status_row,
         )
-        self.assertEqual(page.project_analysis_readonly_label.text(), "只读")
+        self.assertEqual(page.project_analysis_readonly_label.text(), "CLI")
 
     def test_context_page_uses_callbacks_and_owns_empty_state(self) -> None:
         page = self.window.context_library_page

--- a/tests/test_project_analysis_phase2.py
+++ b/tests/test_project_analysis_phase2.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""Phase 2 (#254) route structure, generate, publish, and injection gates."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import project_analysis as pa
+import project_analysis_generate as gen
+import project_analysis_routes as routes
+import prompt_context
+import translation_core
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "project_analysis_routes_minimal"
+SCRIPT = FIXTURE_DIR / "script.rpy"
+KEYWORDS = FIXTURE_DIR / "keyword_chunk_summaries.jsonl"
+
+
+class RouteParseTests(unittest.TestCase):
+    def test_fixture_has_two_routes_shared_label_and_unresolved(self):
+        graph = routes.build_route_graph(
+            [str(SCRIPT)],
+            base_dir=str(FIXTURE_DIR),
+            entry_labels=["start"],
+        )
+        self.assertIn("hub", graph.labels)
+        self.assertIn("shared_end", graph.labels)
+        self.assertGreaterEqual(len(graph.unresolved_edges), 1)
+        self.assertTrue(any(e.unresolved for e in graph.unresolved_edges))
+
+        # At least path_a and path_b appear in some route.
+        joined = " ".join(
+            "->".join(r.get("label_ids") or []) for r in graph.routes
+        )
+        self.assertIn("path_a", joined)
+        self.assertIn("path_b", joined)
+        # shared_end is shared across branches
+        shared_hits = [
+            r for r in graph.routes if "shared_end" in (r.get("label_ids") or [])
+        ]
+        self.assertGreaterEqual(len(shared_hits), 1)
+        # unresolved flag on path_b route
+        self.assertTrue(
+            any(r.get("unresolved") for r in graph.routes),
+            msg=f"expected unresolved route in {graph.routes!r}",
+        )
+
+
+class GenerateAndPublishTests(unittest.TestCase):
+    def test_ingest_build_publish_inject_cycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "project_analysis")
+            ingest = gen.ingest_keyword_summaries(
+                str(KEYWORDS), store_dir=store_dir
+            )
+            self.assertEqual(ingest["chunks_written"], 3)
+
+            built = gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=str(FIXTURE_DIR),
+                script_roots=[str(FIXTURE_DIR)],
+                entry_labels=["start"],
+            )
+            self.assertGreaterEqual(built["labels"], 4)
+            self.assertGreaterEqual(built["routes"], 1)
+            self.assertGreaterEqual(built["unresolved_edges"], 1)
+
+            store = pa.ProjectAnalysisStore(store_dir)
+            draft = store.load_brief_text(published=False)
+            self.assertIn("Project Analysis Brief", draft)
+            self.assertFalse(store.load_brief_text(published=True).strip())
+
+            # Draft must not inject.
+            blocked = pa.load_injectable_project_brief(
+                store_dir=store_dir, enabled=True
+            )
+            self.assertFalse(blocked["injectable"])
+            self.assertEqual(blocked["text"], "")
+
+            pub = pa.publish_project_brief(store_dir=store_dir)
+            self.assertTrue(pub["changed"])
+            self.assertEqual(pub["status"], pa.STATUS_PUBLISHED)
+
+            allowed = pa.load_injectable_project_brief(
+                store_dir=store_dir, enabled=True
+            )
+            self.assertTrue(allowed["injectable"])
+            self.assertIn("Project Analysis Brief", allowed["text"])
+
+            # Stale when expected fingerprint mismatches.
+            stale = pa.load_injectable_project_brief(
+                store_dir=store_dir,
+                enabled=True,
+                expected_source_fingerprint="not-the-real-fp",
+            )
+            self.assertFalse(stale["injectable"])
+
+            unpub = pa.unpublish_project_brief(store_dir=store_dir)
+            self.assertIn(unpub["status"], {pa.STATUS_DRAFT, pa.STATUS_MISSING})
+            after = pa.load_injectable_project_brief(
+                store_dir=store_dir, enabled=True
+            )
+            self.assertFalse(after["injectable"])
+
+    def test_publish_empty_draft_fails_without_clobbering(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_brief_text("# published keep me\n", published=True)
+            with self.assertRaises(pa.ProjectAnalysisError):
+                pa.publish_project_brief(store_dir=tmp)
+            self.assertIn("keep me", store.load_brief_text(published=True))
+
+    def test_local_invalidation_does_not_touch_other_route(self):
+        chunks = [
+            {
+                "id": "chunk-a",
+                "kind": "chunk",
+                "status": "published",
+                "source_files": ["a.rpy"],
+                "evidence_item_ids": ["item-a"],
+                "upstream_artifact_ids": [],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "A",
+            },
+            {
+                "id": "chunk-b",
+                "kind": "chunk",
+                "status": "published",
+                "source_files": ["b.rpy"],
+                "evidence_item_ids": ["item-b"],
+                "upstream_artifact_ids": [],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "B",
+            },
+        ]
+        labels = [
+            {
+                "id": "label:a",
+                "kind": "label",
+                "status": "published",
+                "label_id": "a",
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": ["chunk-a"],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "A",
+            },
+            {
+                "id": "label:b",
+                "kind": "label",
+                "status": "published",
+                "label_id": "b",
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": ["chunk-b"],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "B",
+            },
+        ]
+        route_recs = [
+            {
+                "id": "route-a",
+                "kind": "route",
+                "status": "published",
+                "route_id": "route-a",
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": ["label:a"],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "A",
+            },
+            {
+                "id": "route-b",
+                "kind": "route",
+                "status": "published",
+                "route_id": "route-b",
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": ["label:b"],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "B",
+            },
+        ]
+        plan = pa.plan_invalidation(
+            chunks=chunks,
+            labels=labels,
+            routes=route_recs,
+            project_brief={
+                "id": "project_brief",
+                "kind": "project_brief",
+                "status": "published",
+                "source_files": [],
+                "evidence_item_ids": [],
+                "upstream_artifact_ids": ["route-a", "route-b"],
+                "lineage": pa.empty_lineage(source_fingerprint="fp"),
+                "summary": "brief",
+            },
+            changed_item_ids=["item-a"],
+        )
+        self.assertIn("route-a", plan.stale_artifact_ids)
+        self.assertNotIn("route-b", plan.stale_artifact_ids)
+        self.assertTrue(plan.brief_stale)
+
+
+class PromptInjectionTests(unittest.TestCase):
+    def test_reference_blocks_include_brief_only_when_text_present(self):
+        without = prompt_context.build_reference_blocks(
+            include_translation_memory=False,
+            project_brief_text="",
+        )
+        self.assertNotIn("PROJECT BRIEF", without)
+
+        with_brief = prompt_context.build_reference_blocks(
+            include_translation_memory=False,
+            project_brief_text="Hello route world",
+            project_brief_diagnostics="schema=1 status=published",
+        )
+        self.assertIn("PROJECT BRIEF", with_brief)
+        self.assertIn("Hello route world", with_brief)
+
+    def test_context_bundle_passes_brief_through(self):
+        bundle = translation_core.build_context_bundle(
+            project_brief_text="Brief body",
+            project_brief_diagnostics="fp=abc",
+        )
+        text = translation_core.build_reference_blocks(
+            bundle, include_translation_memory=False
+        )
+        self.assertIn("PROJECT BRIEF", text)
+        self.assertIn("Brief body", text)
+
+
+class CliPhase2Tests(unittest.TestCase):
+    def test_cli_ingest_publish_unpublish(self):
+        import gemini_translate_batch as batch_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "pa")
+            with mock.patch("builtins.print"):
+                batch_mod.main(
+                    [
+                        "project-analysis-ingest-keywords",
+                        "--summary-jsonl",
+                        str(KEYWORDS),
+                        "--store-dir",
+                        store_dir,
+                    ]
+                )
+                batch_mod.main(
+                    [
+                        "project-analysis-build-structure",
+                        "--store-dir",
+                        store_dir,
+                        "--script-root",
+                        str(FIXTURE_DIR),
+                        "--entry-label",
+                        "start",
+                    ]
+                )
+            # Publish prints JSON
+            printed = []
+
+            def capture(*args, **kwargs):
+                if args:
+                    printed.append(str(args[0]))
+
+            with mock.patch("builtins.print", side_effect=capture):
+                batch_mod.main(
+                    ["project-analysis-publish", "--store-dir", store_dir]
+                )
+            payload = json.loads(printed[-1])
+            self.assertEqual(payload["status"], "published")
+
+            allowed = pa.load_injectable_project_brief(store_dir=store_dir, enabled=True)
+            self.assertTrue(allowed["injectable"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_analysis_phase2.py
+++ b/tests/test_project_analysis_phase2.py
@@ -50,6 +50,59 @@ class RouteParseTests(unittest.TestCase):
             msg=f"expected unresolved route in {graph.routes!r}",
         )
 
+    def test_safe_relpath_cross_drive_does_not_raise(self):
+        # Simulate Windows cross-drive: function must not raise ValueError.
+        path = str(SCRIPT)
+        other_base = "D:\\not\\this\\drive" if os.name == "nt" else "/mnt/other"
+        rel = routes.safe_relpath(path, other_base)
+        self.assertTrue(rel)
+        self.assertNotIn("..", rel.split("/"))
+
+    def test_call_is_not_exclusive_branch(self):
+        text = (
+            "label start:\n"
+            "    call helper\n"
+            "    jump ending\n"
+            "\n"
+            "label helper:\n"
+            "    \"side\"\n"
+            "    return\n"
+            "\n"
+            "label ending:\n"
+            "    \"done\"\n"
+            "    return\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "call_flow.rpy"
+            script.write_text(text, encoding="utf-8")
+            graph = routes.build_route_graph(
+                [str(script)], base_dir=tmp, entry_labels=["start"]
+            )
+            paths = ["->".join(r.get("label_ids") or []) for r in graph.routes]
+            # Must not invent mutually exclusive start→helper vs start→ending only.
+            self.assertTrue(
+                any(p == "start->ending" or p.startswith("start->ending") for p in paths)
+                or any("ending" in p and "start" in p for p in paths),
+                msg=paths,
+            )
+            # helper should not be a sole exclusive sibling route without ending
+            exclusive_helper = [
+                p for p in paths if p == "start->helper" or p.endswith("->helper")
+            ]
+            self.assertEqual(exclusive_helper, [], msg=paths)
+
+    def test_script_content_changes_fingerprint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "s.rpy"
+            script.write_text("label a:\n    jump b\n\nlabel b:\n    return\n", encoding="utf-8")
+            fp1 = routes.digest_script_paths([str(script)], base_dir=tmp)
+            script.write_text(
+                "label a:\n    jump b\n\nlabel b:\n    \"changed\"\n    return\n",
+                encoding="utf-8",
+            )
+            fp2 = routes.digest_script_paths([str(script)], base_dir=tmp)
+            self.assertNotEqual(fp1, fp2)
+
 
 class GenerateAndPublishTests(unittest.TestCase):
     def test_ingest_build_publish_inject_cycle(self):
@@ -69,8 +122,17 @@ class GenerateAndPublishTests(unittest.TestCase):
             self.assertGreaterEqual(built["labels"], 4)
             self.assertGreaterEqual(built["routes"], 1)
             self.assertGreaterEqual(built["unresolved_edges"], 1)
+            structure_fp = built["source_fingerprint"]
+            self.assertTrue(structure_fp)
 
             store = pa.ProjectAnalysisStore(store_dir)
+            labels = store.load_summaries(pa.KIND_LABEL)
+            label_text = "\n".join(str(r.get("summary") or "") for r in labels)
+            # Keyword spans must land on path_a / path_b / hub (not only unassigned).
+            self.assertIn("Path A", label_text)
+            self.assertIn("Path B", label_text)
+            self.assertIn("hub", label_text.lower())
+
             draft = store.load_brief_text(published=False)
             self.assertIn("Project Analysis Brief", draft)
             self.assertFalse(store.load_brief_text(published=True).strip())
@@ -87,25 +149,66 @@ class GenerateAndPublishTests(unittest.TestCase):
             self.assertEqual(pub["status"], pa.STATUS_PUBLISHED)
 
             allowed = pa.load_injectable_project_brief(
-                store_dir=store_dir, enabled=True
+                store_dir=store_dir,
+                enabled=True,
+                expected_source_fingerprint=structure_fp,
             )
             self.assertTrue(allowed["injectable"])
             self.assertIn("Project Analysis Brief", allowed["text"])
 
-            # Stale when expected fingerprint mismatches.
-            stale = pa.load_injectable_project_brief(
-                store_dir=store_dir,
-                enabled=True,
-                expected_source_fingerprint="not-the-real-fp",
-            )
-            self.assertFalse(stale["injectable"])
+            # Script edit changes fingerprint → injection blocked (use temp copy).
+            with tempfile.TemporaryDirectory() as tmp2:
+                script_copy = Path(tmp2) / "script.rpy"
+                script_copy.write_text(
+                    (FIXTURE_DIR / "script.rpy").read_text(encoding="utf-8")
+                    + "\n# edited\n",
+                    encoding="utf-8",
+                )
+                new_fp = routes.digest_script_paths(
+                    [str(script_copy)], base_dir=tmp2
+                )
+                self.assertNotEqual(new_fp, structure_fp)
+                stale = pa.load_injectable_project_brief(
+                    store_dir=store_dir,
+                    enabled=True,
+                    expected_source_fingerprint=new_fp,
+                )
+                self.assertFalse(stale["injectable"])
 
             unpub = pa.unpublish_project_brief(store_dir=store_dir)
             self.assertIn(unpub["status"], {pa.STATUS_DRAFT, pa.STATUS_MISSING})
             after = pa.load_injectable_project_brief(
-                store_dir=store_dir, enabled=True
+                store_dir=store_dir,
+                enabled=True,
+                expected_source_fingerprint=structure_fp,
             )
             self.assertFalse(after["injectable"])
+
+    def test_publish_rejects_stale_without_force_fingerprint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_brief_text("# draft body\n", published=False)
+            manifest = pa.empty_manifest(store_dir=tmp)
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF] = {
+                "status": pa.STATUS_STALE,
+                "draft_present": True,
+                "published_present": False,
+                "lineage": pa.empty_lineage(source_fingerprint="old-fp"),
+                "id": "project_brief",
+            }
+            store.save_manifest(manifest)
+            with self.assertRaises(pa.ProjectAnalysisError):
+                pa.publish_project_brief(store_dir=tmp)
+            # force without current fingerprint still fails
+            with self.assertRaises(pa.ProjectAnalysisError):
+                pa.publish_project_brief(store_dir=tmp, force=True)
+            # force + current fingerprint allowed
+            out = pa.publish_project_brief(
+                store_dir=tmp,
+                force=True,
+                current_source_fingerprint="new-fp",
+            )
+            self.assertEqual(out["status"], pa.STATUS_PUBLISHED)
 
     def test_publish_empty_draft_fails_without_clobbering(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -114,6 +217,24 @@ class GenerateAndPublishTests(unittest.TestCase):
             with self.assertRaises(pa.ProjectAnalysisError):
                 pa.publish_project_brief(store_dir=tmp)
             self.assertIn("keep me", store.load_brief_text(published=True))
+
+    def test_publish_rejects_missing_lineage_fingerprint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = pa.ProjectAnalysisStore(tmp)
+            store.save_brief_text("# draft only\n", published=False)
+            manifest = pa.empty_manifest(store_dir=tmp)
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF] = {
+                "status": pa.STATUS_DRAFT,
+                "draft_present": True,
+                "published_present": False,
+                "lineage": pa.empty_lineage(),
+                "id": "project_brief",
+            }
+            store.save_manifest(manifest)
+            with self.assertRaisesRegex(
+                pa.ProjectAnalysisError, "source_fingerprint"
+            ):
+                pa.publish_project_brief(store_dir=tmp)
 
     def test_local_invalidation_does_not_touch_other_route(self):
         chunks = [

--- a/tests/test_project_analysis_phase2.py
+++ b/tests/test_project_analysis_phase2.py
@@ -103,6 +103,41 @@ class RouteParseTests(unittest.TestCase):
             fp2 = routes.digest_script_paths([str(script)], base_dir=tmp)
             self.assertNotEqual(fp1, fp2)
 
+    def test_call_expression_not_parsed_as_named_call(self):
+        text = "label a:\n    call expression some_flag\n    call helper\n"
+        labels, edges = routes.parse_rpy_labels_and_edges(text, file_rel_path="x.rpy")
+        kinds = {(e.kind, e.target_label, e.unresolved) for e in edges}
+        self.assertIn(("unresolved", "", True), kinds)
+        self.assertIn(("call", "helper", False), kinds)
+        self.assertNotIn(("call", "expression", False), kinds)
+
+    def test_persisted_script_roots_used_for_fingerprint(self):
+        import gemini_translate_batch as batch_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            custom = Path(tmp) / "custom_scripts"
+            custom.mkdir()
+            (custom / "only.rpy").write_text(
+                "label start:\n    jump end\n\nlabel end:\n    return\n",
+                encoding="utf-8",
+            )
+            store_dir = os.path.join(tmp, "pa")
+            # Default game layout under tmp is empty; structure uses custom root.
+            built = gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=tmp,
+                script_roots=[str(custom)],
+                entry_labels=["start"],
+            )
+            self.assertEqual(built["source_fingerprint"], routes.digest_script_paths(
+                [str(custom / "only.rpy")], base_dir=tmp
+            ))
+            # Runtime fingerprint must reuse stored roots, not only default layout.
+            fp = batch_mod.compute_current_project_analysis_fingerprint(
+                tmp, store_dir=store_dir
+            )
+            self.assertEqual(fp, built["source_fingerprint"])
+
 
 class GenerateAndPublishTests(unittest.TestCase):
     def test_ingest_build_publish_inject_cycle(self):

--- a/translation_core.py
+++ b/translation_core.py
@@ -83,6 +83,8 @@ class ContextBundle:
     story_hits: object = None
     rag_stats: dict = field(default_factory=dict)
     source_hits: list = field(default_factory=list)
+    project_brief_text: str = ''
+    project_brief_diagnostics: str = ''
 
 
 @dataclass
@@ -425,13 +427,23 @@ def format_revision_context_block(items, empty_label='(none)'):
     return '\n'.join(lines) if lines else empty_label
 
 
-def build_context_bundle(glossary_hits=None, history_hits=None, story_hits=None, rag_stats=None, source_hits=None):
+def build_context_bundle(
+    glossary_hits=None,
+    history_hits=None,
+    story_hits=None,
+    rag_stats=None,
+    source_hits=None,
+    project_brief_text='',
+    project_brief_diagnostics='',
+):
     return ContextBundle(
         glossary_hits=list(glossary_hits or []),
         history_hits=list(history_hits or []),
         story_hits=story_hits,
         rag_stats=dict(rag_stats or {}),
         source_hits=list(source_hits or []),
+        project_brief_text=str(project_brief_text or ''),
+        project_brief_diagnostics=str(project_brief_diagnostics or ''),
     )
 
 
@@ -450,6 +462,8 @@ def build_reference_blocks(
         history_hits=context_bundle.history_hits,
         story_hits=context_bundle.story_hits,
         source_hits=context_bundle.source_hits,
+        project_brief_text=context_bundle.project_brief_text,
+        project_brief_diagnostics=context_bundle.project_brief_diagnostics,
         history_char_limit=history_char_limit,
         story_char_limit=story_char_limit,
         include_source_text=include_source_text,

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -102,6 +102,12 @@
       "top_k_terms": 12,
       "include_scene_summary": true
     },
+    "project_analysis": {
+      "enabled": false,
+      "inject_published_brief": false,
+      "store_dir": "",
+      "max_brief_chars": 4000
+    },
     "submit_max_cost": 0,
     "non_chinese_validation": {
       "extra_static_name_credit_rel_paths": [],


### PR DESCRIPTION
## Summary

- Implement **#254 PR A** on top of #256: keyword summary ingest, static Ren'Py label/jump/call route graph, deterministic label/route/brief drafts (no LLM), publish/unpublish gates, and optional `PROJECT BRIEF` prompt injection (default **off**).
- New modules: `project_analysis_routes.py`, `project_analysis_generate.py`; extend `project_analysis.py` with publish/load_injectable APIs.
- CLI: `project-analysis-ingest-keywords`, `build-structure`, `inspect`, `diff`, `publish`, `unpublish` (+ existing status).
- Config: `batch.project_analysis` in example config; diagnostics command reference updated.
- Offline fixture: two branches, shared label, `jump expression` → unresolved.

**Out of scope (later / PR B):** LLM map-reduce generation, full GUI generate/publish buttons, final-review campaign (#255).

## Test plan

- [x] `python -m unittest tests.test_project_analysis tests.test_project_analysis_phase2`
- [x] `python -B tests/run_cli_tests.py -q`
- [x] `python -B tests/run_gui_tests.py -q`
- [x] `python scripts/run_quality_gates.py all`
- [x] `git diff --check`
- [ ] CI green

Closes nothing yet — leave #254 open until LLM/GUI follow-up is decided or accept PR A as partial delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Project Analysis Phase 2 for building structure drafts, route information, and project briefs without LLM-generated content.
  * Added CLI commands to ingest summaries, build structures, inspect differences, publish, and unpublish briefs.
  * Published briefs can optionally appear in translation and review prompts when current project content matches.
* **Documentation**
  * Updated configuration guidance, command references, publishing rules, and feature status.
* **UI**
  * Updated the project analysis status display and provided copyable CLI commands for related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->