### PR TITLE
feat: final-review resume and result ingest (#255 PR B)

### DIFF
--- a/batch_cost_estimate.py
+++ b/batch_cost_estimate.py
@@ -168,6 +168,14 @@ def estimate_manifest_tokens(manifest, pricing_config=None):
     chunk_count = int(summary.get('chunk_count') or 0)
     if chunk_count <= 0 and isinstance(manifest.get('chunks'), list):
         chunk_count = len(manifest['chunks'])
+    # final-review and other request-only packages expose unit_count / request_count
+    # instead of translation chunks; fall back so --max-cost still bounds output.
+    if chunk_count <= 0:
+        chunk_count = int(summary.get('unit_count') or 0)
+    if chunk_count <= 0:
+        chunk_count = int(summary.get('request_count') or manifest.get('request_count') or 0)
+    if chunk_count <= 0:
+        chunk_count = int(request_count or 0)
 
     estimated_output_tokens = max(0, chunk_count * max_output_tokens)
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -67,10 +67,17 @@ python gemini_translate_batch.py sync-revisions --apply
 最终审校是**独立 campaign**，用于在翻译范围完成后批量发现问题。默认 **report-only**：不调用 autofix，也不直接写 `.rpy`。用户选中的 findings 将来会转成现有订正候选，再走 `preview-revisions → apply-revisions`。
 
 ```bash
-# 构建 campaign：完成度闸门 + 冻结上下文/译文 snapshot digest + review units
+# 构建 campaign：完成度闸门 + 冻结上下文 digest + review units + requests.jsonl
 python gemini_translate_batch.py final-review-build
+python gemini_translate_batch.py submit logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py download logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py final-review-ingest-results logs/batch_jobs/<package>/manifest.json
 python gemini_translate_batch.py final-review-status logs/batch_jobs/<package>/manifest.json
 python gemini_translate_batch.py final-review-export logs/batch_jobs/<package>/manifest.json
+
+# 续跑：跳过 digest 未变的 done unit；--force 全部重审
+python gemini_translate_batch.py final-review-resume logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py final-review-resume logs/batch_jobs/<package>/manifest.json --force
 ```
 
 ### 启动闸门
@@ -89,7 +96,9 @@ python gemini_translate_batch.py final-review-export logs/batch_jobs/<package>/m
 - 可选 Story Memory / Source Index（仅当启用）
 - 可选已启用且可注入的 published Project Analysis fingerprint（无 PA 时允许仅靠其它上下文运行）
 
-每个 review unit 保存 `input_digest`（本 unit 的 `items_digest` + **共享** `context_digest` + model + prompt schema）。`context_digest` 只绑定 glossary / macro / Story Memory / Source Index / 可注入 PA brief 等共享上下文；**不**把全项目 `translations_digest` 塞进 unit，因此改 A 文件不会让 B 文件的已完成 unit 变 stale。全量译文审计摘要仍记在 campaign 级 `snapshot_digest`。后续续跑将跳过 digest 未变的已完成 unit；相关 unit 的上游变化会使其 `stale`（执行与 resume 在后续 PR）。
+每个 review unit 保存 `input_digest`（本 unit 的 `items_digest` + **共享** `context_digest` + model + prompt schema）。`context_digest` 只绑定 glossary / macro / Story Memory / Source Index / 可注入 PA brief 等共享上下文；**不**把全项目 `translations_digest` 塞进 unit，因此改 A 文件不会让 B 文件的已完成 unit 变 stale。全量译文审计摘要仍记在 campaign 级 `snapshot_digest`。
+
+`final-review-resume` 跳过 digest 未变的 `done` unit，只为 pending / stale / failed 重建 `requests.jsonl`；`--force` 才重审全部。`final-review-ingest-results` 解析 Batch 结果：成功（含空 findings）→ `done`；解析失败 / 缺响应 → `failed`（**不会**记成「零问题 done」）。
 
 ### 产物布局
 
@@ -106,7 +115,7 @@ logs/batch_jobs/<ts>_<project>_final_review/
 
 - 不自动修改 `.rpy`，无模型直接声称 `fixed` / `applied`。
 - 不把回译抽检当作写回安全闸门。
-- 模型执行、续跑 submit/download、转 revision candidates 与 GUI 完整页在后续 PR 交付；本阶段交付合同、闸门与可重现 digest。
+- 选中 findings → revision candidates 与 GUI 工作台页在后续 PR（#255 PR C）。
 
 相关配置见 `translator_config.example.json` 的 `batch.final_review`。
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -96,17 +96,19 @@ python gemini_translate_batch.py final-review-resume logs/batch_jobs/<package>/m
 - 可选 Story Memory / Source Index（仅当启用）
 - 可选已启用且可注入的 published Project Analysis fingerprint（无 PA 时允许仅靠其它上下文运行）
 
-每个 review unit 保存 `input_digest`（本 unit 的 `items_digest` + **共享** `context_digest` + model + prompt schema）。`context_digest` 只绑定 glossary / macro / Story Memory / Source Index / 可注入 PA brief 等共享上下文；**不**把全项目 `translations_digest` 塞进 unit，因此改 A 文件不会让 B 文件的已完成 unit 变 stale。全量译文审计摘要仍记在 campaign 级 `snapshot_digest`。
+每个 review unit 保存 `input_digest`（本 unit 的 `items_digest` + **共享** `context_digest` + model + prompt schema）。`context_digest` 只绑定 glossary / macro / Story Memory / Source Index / 可注入 PA brief 等共享上下文；**不**把全项目 `translations_digest` 塞进 unit，因此改 A 文件不会让 B 文件的已完成 unit 变 stale。全量译文审计摘要仍记在 campaign 级 `snapshot_digest`。构建时会把可注入的简要上下文冻结到 `snapshot.prompt_context`（宏设定 / PA brief / glossary 词条），并写入每条 request 的 user prompt。
 
-`final-review-resume` 跳过 digest 未变的 `done` unit，只为 pending / stale / failed 重建 `requests.jsonl`；`--force` 才重审全部。`final-review-ingest-results` 解析 Batch 结果：成功（含空 findings）→ `done`；解析失败 / 缺响应 → `failed`（**不会**记成「零问题 done」）。
+`final-review-resume` 会**重新采集 live 共享上下文**（而非只读冻结 snapshot）来判断 skip / stale，只为 pending / stale / failed 重建 `requests.jsonl`；`--force` 才重审全部。有待跑 unit 时会清空 `job_name` / 下载字段，并把旧 `results.jsonl` 改名为 `results.jsonl.pre_resume_*`，避免 `download` 短路复用上一轮结果。`final-review-ingest-results` 解析 Batch 结果：成功（含空 findings）→ `done`，并在成功时写回本次 live `input_digest`；解析失败 / 缺响应 → `failed`（**不会**记成「零问题 done」）。resume 之后若尚未重新 download，默认**拒绝**用 resume 前的 `results.jsonl`（可用 `--result` 或 `--allow-stale-results` 显式覆盖）。
 
 ### 产物布局
 
 ```text
 logs/batch_jobs/<ts>_<project>_final_review/
   manifest.json          # mode=final_review, report_only=true
-  snapshot.json          # context_digest + snapshot_digest + 各层摘要
+  snapshot.json          # context_digest + snapshot_digest + prompt_context + 各层摘要
   review_units.jsonl     # unit 状态 / input_digest / items
+  requests.jsonl         # Batch 请求（build / resume 写入）
+  results.jsonl          # download 后的模型结果（resume 会作废上一份）
   findings.jsonl         # 审校发现（执行后填充；build 时为空）
   report.md              # 人类可读报告
 ```

--- a/final_review_llm.py
+++ b/final_review_llm.py
@@ -1,0 +1,858 @@
+"""Final-review campaign execution: prompts, Batch requests, result ingest (#255 PR B).
+
+Report-only: never writes ``.rpy``. Parses model findings into the campaign package
+and updates unit status. Resume skips completed units whose ``input_digest`` is
+unchanged; ``--force`` re-queues them. Parse/row failures mark units ``failed``
+and never invent a clean ``done`` with zero findings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Callable, Mapping, Sequence
+
+from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
+from final_review import (
+    FINDINGS_FILENAME,
+    MANIFEST_FILENAME,
+    PROMPT_SCHEMA_VERSION,
+    REPORT_MD_FILENAME,
+    REQUESTS_JSONL_FILENAME,
+    REVIEW_UNITS_FILENAME,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    STATUS_STALE,
+    FinalReviewError,
+    FinalReviewSchemaError,
+    assert_failure_not_done,
+    collect_campaign_status,
+    derive_campaign_status,
+    export_findings,
+    format_campaign_report_markdown,
+    load_campaign_package,
+    mark_unit_done,
+    mark_unit_failed,
+    normalize_finding,
+    reevaluate_campaign_units,
+    should_skip_unit,
+    summarize_unit_statuses,
+    utc_now_iso,
+)
+
+RESULT_JSONL_FILENAME = "results.jsonl"
+
+# Finding types accepted from the model (unknown → needs_confirmation via normalize_finding).
+FINDING_TYPE_ENUM = [
+    "omission",
+    "mistranslation",
+    "addition",
+    "format",
+    "terminology",
+    "address",
+    "style_drift",
+    "needs_confirmation",
+]
+
+SEVERITY_ENUM = ["high", "medium", "low", "info"]
+
+
+def build_system_instruction() -> str:
+    return (
+        "你是 Ren'Py 视觉小说中文译文的最终审校助手。根据给定的原文/当前译文对照，"
+        "报告明确的问题；不确定时标记为 needs_confirmation，不要伪装成确定错误。\n"
+        "规则：\n"
+        "1) 只依据提供的条目与简要上下文，不要编造未给出的剧情或术语；\n"
+        "2) 问题类型仅使用：omission（漏译）、mistranslation（误译）、addition（增译）、"
+        "format（格式/占位符/标签）、terminology（术语）、address（人物称谓/代词）、"
+        "style_drift（明显文体漂移）、needs_confirmation（需人工确认）；\n"
+        "3) 无问题则返回空 findings 列表；\n"
+        "4) 不要声称 fixed / applied / done；不要直接改写游戏脚本；\n"
+        "5) 严格输出 JSON，符合给定 schema。"
+    )
+
+
+def build_user_prompt(unit: Mapping[str, Any]) -> str:
+    items = list(unit.get("items") or [])
+    lines = [
+        f"Review unit: {unit.get('unit_id') or ''}",
+        f"File: {unit.get('file_rel_path') or ''}",
+        f"Chunk index: {unit.get('chunk_index') or 0}",
+        f"Item count: {len(items)}",
+        "",
+        "对照条目（source → current_translation）：",
+    ]
+    for index, item in enumerate(items, start=1):
+        if not isinstance(item, Mapping):
+            continue
+        item_id = str(item.get("id") or item.get("identity_v2") or f"item-{index}")
+        source = str(item.get("source") or item.get("text") or "")
+        current = str(item.get("current_translation") or item.get("translation") or "")
+        speaker = str(item.get("speaker_id") or "").strip()
+        speaker_part = f" speaker={speaker}" if speaker else ""
+        lines.append(f"[{index}] id={item_id}{speaker_part}")
+        lines.append(f"  source: {source}")
+        lines.append(f"  current_translation: {current}")
+    lines.extend(
+        [
+            "",
+            "请输出 JSON：{\"findings\":[...]}。",
+            "每条 finding 必须包含 item_id（对应该条目 id）、finding_type、severity、"
+            "reason；可选 evidence、suggested_revision。",
+            "若无问题：{\"findings\":[]}。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_response_json_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "item_id": {"type": "string"},
+                        "finding_type": {"type": "string", "enum": FINDING_TYPE_ENUM},
+                        "severity": {"type": "string", "enum": SEVERITY_ENUM},
+                        "evidence": {"type": "string"},
+                        "reason": {"type": "string"},
+                        "suggested_revision": {"type": "string"},
+                    },
+                    "required": ["item_id", "finding_type", "severity", "reason"],
+                },
+            }
+        },
+        "required": ["findings"],
+    }
+
+
+def build_generation_config(
+    *,
+    temperature: float = 0.2,
+    max_output_tokens: int = 8192,
+    thinking_level: str = "",
+    model: str = "",
+) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "temperature": float(temperature),
+        "max_output_tokens": int(max_output_tokens),
+        "response_mime_type": "application/json",
+        "response_json_schema": build_response_json_schema(),
+    }
+    if thinking_level and str(model or "").startswith("gemini-3"):
+        config["thinking_config"] = {"thinking_level": str(thinking_level).upper()}
+    return config
+
+
+def build_batch_request(
+    unit: Mapping[str, Any],
+    *,
+    temperature: float = 0.2,
+    max_output_tokens: int = 8192,
+    thinking_level: str = "",
+    model: str = "",
+    safety_settings: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Gemini Batch JSONL row: ``{key, request}`` keyed by unit_id."""
+    unit_id = str(unit.get("unit_id") or "").strip()
+    if not unit_id:
+        raise FinalReviewSchemaError("unit_id is required to build a batch request")
+    request: dict[str, Any] = {
+        "system_instruction": {"parts": [{"text": build_system_instruction()}]},
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": build_user_prompt(unit)}],
+            }
+        ],
+        "generation_config": build_generation_config(
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            thinking_level=thinking_level,
+            model=model or str(unit.get("model") or ""),
+        ),
+    }
+    if safety_settings:
+        request["safety_settings"] = list(safety_settings)
+    return {"key": unit_id, "request": request}
+
+
+def write_requests_jsonl(
+    path: str | os.PathLike[str],
+    units: Sequence[Mapping[str, Any]],
+    *,
+    temperature: float = 0.2,
+    max_output_tokens: int = 8192,
+    thinking_level: str = "",
+    model: str = "",
+    safety_settings: Sequence[Mapping[str, Any]] | None = None,
+) -> int:
+    rows = [
+        build_batch_request(
+            unit,
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            thinking_level=thinking_level,
+            model=model,
+            safety_settings=safety_settings,
+        )
+        for unit in units
+    ]
+    atomic_write_jsonl(path, rows, ensure_ascii=False)
+    return len(rows)
+
+
+def plan_units_for_run(
+    units: Sequence[Mapping[str, Any]],
+    *,
+    force: bool = False,
+    live_context_digest: str = "",
+) -> dict[str, Any]:
+    """Split units into skip / run lists for resume.
+
+    Done units with matching digest are skipped unless *force*.
+    Failed / stale / pending always run (failed re-queues).
+    """
+    to_run: list[dict[str, Any]] = []
+    to_skip: list[dict[str, Any]] = []
+    refreshed: list[dict[str, Any]] = []
+
+    for unit in units or []:
+        row = dict(unit)
+        live = live_context_digest or str(row.get("context_digest") or "")
+        # Recompute digest from stored items + live context when possible.
+        items = row.get("items") or []
+        if items and live:
+            from final_review import compute_unit_input_digest, digest_translation_items
+
+            items_digest = digest_translation_items(items)
+            item_ids = [
+                str(i.get("id") or "") if isinstance(i, Mapping) else "" for i in items
+            ]
+            live_digest = compute_unit_input_digest(
+                item_ids=item_ids,
+                items_digest=items_digest,
+                context_digest=live,
+                model=str(row.get("model") or ""),
+                prompt_schema_version=str(
+                    row.get("prompt_schema_version") or PROMPT_SCHEMA_VERSION
+                ),
+                chunk_index=int(row.get("chunk_index") or 0),
+                file_rel_path=str(row.get("file_rel_path") or ""),
+            )
+        else:
+            live_digest = str(row.get("input_digest") or "")
+
+        if force:
+            row["status"] = STATUS_PENDING
+            row["error"] = ""
+            row["live_input_digest"] = live_digest
+            to_run.append(row)
+            refreshed.append(row)
+            continue
+
+        if should_skip_unit(row, live_input_digest=live_digest, force=False):
+            row["live_input_digest"] = live_digest
+            to_skip.append(row)
+            refreshed.append(row)
+            continue
+
+        # Stale done/failed → pending for re-run.
+        stored = str(row.get("input_digest") or "")
+        status = str(row.get("status") or STATUS_PENDING)
+        if stored and live_digest and stored != live_digest:
+            row["status"] = STATUS_STALE
+            row["error"] = row.get("error") or "input_digest_mismatch"
+        if status in {STATUS_DONE, STATUS_FAILED, STATUS_STALE, STATUS_RUNNING}:
+            # Queue for re-run (except pure skip done handled above).
+            if status == STATUS_DONE and stored and live_digest and stored == live_digest:
+                # should_skip already handled; defensive
+                to_skip.append(row)
+                refreshed.append(row)
+                continue
+            row["status"] = STATUS_PENDING
+            if status != STATUS_FAILED:
+                row["error"] = ""
+        row["live_input_digest"] = live_digest
+        to_run.append(row)
+        refreshed.append(row)
+
+    return {
+        "to_run": to_run,
+        "to_skip": to_skip,
+        "units": refreshed,
+        "run_count": len(to_run),
+        "skip_count": len(to_skip),
+    }
+
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)\s*```", re.IGNORECASE)
+
+
+def parse_json_payload(text: str) -> Any:
+    body = str(text or "").strip()
+    if not body:
+        raise FinalReviewSchemaError("empty model response")
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        match = _JSON_FENCE_RE.search(body)
+        if match:
+            return json.loads(match.group(1).strip())
+        # Try first object slice.
+        start = body.find("{")
+        end = body.rfind("}")
+        if start >= 0 and end > start:
+            return json.loads(body[start : end + 1])
+        raise
+
+
+def extract_text_from_response_payload(response_payload: Any) -> str:
+    """Best-effort text extraction from Gemini-style response payloads."""
+    if response_payload is None:
+        return ""
+    if isinstance(response_payload, str):
+        return response_payload.strip()
+    if not isinstance(response_payload, Mapping):
+        return str(response_payload).strip()
+
+    # Common shapes: {candidates:[{content:{parts:[{text:…}]}}]}, {text:…}, {response_text:…}
+    for key in ("response_text", "text", "output_text"):
+        value = response_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    candidates = response_payload.get("candidates")
+    if isinstance(candidates, list):
+        texts: list[str] = []
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            content = candidate.get("content") or {}
+            if not isinstance(content, Mapping):
+                continue
+            parts = content.get("parts") or []
+            if not isinstance(parts, list):
+                continue
+            for part in parts:
+                if isinstance(part, Mapping) and isinstance(part.get("text"), str):
+                    texts.append(part["text"])
+                elif isinstance(part, str):
+                    texts.append(part)
+        joined = "\n".join(t for t in texts if t).strip()
+        if joined:
+            return joined
+    return ""
+
+
+def parse_unit_findings(
+    response_text: str,
+    unit: Mapping[str, Any],
+    *,
+    provider: str = "",
+    model: str = "",
+) -> tuple[list[dict[str, Any]], str]:
+    """Parse model JSON into normalized findings.
+
+    Returns ``(findings, error)``. On success *error* is empty (findings may be []).
+    On failure *findings* is empty and *error* explains why — caller must mark failed.
+    """
+    unit_id = str(unit.get("unit_id") or "")
+    unit_digest = str(unit.get("input_digest") or "")
+    item_by_id: dict[str, Mapping[str, Any]] = {}
+    for item in unit.get("items") or []:
+        if isinstance(item, Mapping):
+            iid = str(item.get("id") or item.get("identity_v2") or "").strip()
+            if iid:
+                item_by_id[iid] = item
+
+    try:
+        payload = parse_json_payload(response_text)
+    except Exception as exc:  # noqa: BLE001 — surface as unit failure
+        return [], f"failed_to_parse_model_json: {exc}"
+
+    if not isinstance(payload, Mapping):
+        return [], "failed_to_parse_model_json: root is not an object"
+
+    raw_findings = payload.get("findings")
+    if raw_findings is None:
+        # Allow alternate key "issues" as soft alias, else fail (not silent zero).
+        raw_findings = payload.get("issues")
+    if raw_findings is None:
+        return [], "failed_to_parse_model_json: missing findings array"
+    if not isinstance(raw_findings, list):
+        return [], "failed_to_parse_model_json: findings is not an array"
+
+    findings: list[dict[str, Any]] = []
+    for raw in raw_findings:
+        if not isinstance(raw, Mapping):
+            return [], "failed_to_parse_model_json: finding entry is not an object"
+        item_id = str(raw.get("item_id") or raw.get("id") or raw.get("identity_v2") or "").strip()
+        item = item_by_id.get(item_id) if item_id else None
+        record = {
+            "identity_v2": item_id
+            or (str(item.get("identity_v2") or item.get("id") or "") if item else ""),
+            "file_rel_path": (item or {}).get("file_rel_path") or unit.get("file_rel_path") or "",
+            "source": (item or {}).get("source") or raw.get("source") or "",
+            "current_translation": (item or {}).get("current_translation")
+            or raw.get("current_translation")
+            or "",
+            "finding_type": raw.get("finding_type") or raw.get("type") or "",
+            "severity": raw.get("severity") or "medium",
+            "evidence": raw.get("evidence") or "",
+            "reason": raw.get("reason") or raw.get("detail") or "",
+            "suggested_revision": raw.get("suggested_revision") or raw.get("suggestion") or "",
+            # Strip model-claimed applied/fixed in normalize_finding.
+            "revision_state": raw.get("revision_state") or "none",
+        }
+        findings.append(
+            normalize_finding(
+                record,
+                review_unit_id=unit_id,
+                review_unit_digest=unit_digest,
+                provider=provider,
+                model=model or str(unit.get("model") or ""),
+                prompt_schema_version=str(
+                    unit.get("prompt_schema_version") or PROMPT_SCHEMA_VERSION
+                ),
+            )
+        )
+    return findings, ""
+
+
+def apply_unit_result(
+    unit: Mapping[str, Any],
+    *,
+    response_text: str = "",
+    row_error: Any = None,
+    provider: str = "",
+    model: str = "",
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Update one unit from a result row. Returns (unit, findings)."""
+    if row_error:
+        failed = mark_unit_failed(unit, f"row_error: {row_error}")
+        assert_failure_not_done(failed)
+        return failed, []
+
+    text = str(response_text or "").strip()
+    if not text:
+        failed = mark_unit_failed(unit, "missing_response_text")
+        assert_failure_not_done(failed)
+        return failed, []
+
+    findings, error = parse_unit_findings(
+        text, unit, provider=provider, model=model
+    )
+    if error:
+        failed = mark_unit_failed(unit, error)
+        assert_failure_not_done(failed)
+        return failed, []
+
+    done = mark_unit_done(unit, finding_count=len(findings))
+    return done, findings
+
+
+def ingest_result_rows(
+    units: Sequence[Mapping[str, Any]],
+    result_rows: Sequence[Mapping[str, Any]],
+    *,
+    provider: str = "",
+    model: str = "",
+    extract_text: Callable[[Any], str] | None = None,
+) -> dict[str, Any]:
+    """Merge Batch/sync result rows into units and aggregate findings.
+
+    Units with no matching result row that were expected to run remain pending
+    (or become failed if they were running). Already-done skipped units stay done.
+    """
+    extract = extract_text or extract_text_from_response_payload
+    unit_map = {str(u.get("unit_id") or ""): dict(u) for u in units if u.get("unit_id")}
+    findings_all: list[dict[str, Any]] = []
+    processed: set[str] = set()
+    summary = {
+        "result_rows": 0,
+        "processed_units": 0,
+        "done_units": 0,
+        "failed_units": 0,
+        "finding_count": 0,
+        "missing_units": 0,
+        "unknown_keys": 0,
+        "reason_counts": {},
+    }
+
+    def bump(reason: str) -> None:
+        counts = summary["reason_counts"]
+        counts[reason] = int(counts.get(reason) or 0) + 1
+
+    for row in result_rows or []:
+        if not isinstance(row, Mapping):
+            bump("invalid_result_row")
+            continue
+        summary["result_rows"] += 1
+        key = str(row.get("key") or row.get("unit_id") or "").strip()
+        if not key or key not in unit_map:
+            summary["unknown_keys"] += 1
+            bump("unknown_chunk_key")
+            continue
+        processed.add(key)
+        unit = unit_map[key]
+        if row.get("error"):
+            updated, findings = apply_unit_result(
+                unit, row_error=row.get("error"), provider=provider, model=model
+            )
+        else:
+            response_payload = row.get("response", row.get("response_payload", {}))
+            # Allow pre-extracted text for tests.
+            text = str(row.get("response_text") or "").strip()
+            if not text:
+                text = extract(response_payload)
+            updated, findings = apply_unit_result(
+                unit,
+                response_text=text,
+                provider=provider,
+                model=model or str(row.get("model") or unit.get("model") or ""),
+            )
+        unit_map[key] = updated
+        summary["processed_units"] += 1
+        if updated.get("status") == STATUS_DONE:
+            summary["done_units"] += 1
+            findings_all.extend(findings)
+            summary["finding_count"] += len(findings)
+        elif updated.get("status") == STATUS_FAILED:
+            summary["failed_units"] += 1
+            bump(str(updated.get("error") or "failed")[:80])
+
+    # Units that were running but missing from results → failed (not silent done).
+    for unit_id, unit in list(unit_map.items()):
+        if unit_id in processed:
+            continue
+        status = str(unit.get("status") or "")
+        if status == STATUS_RUNNING:
+            unit_map[unit_id] = mark_unit_failed(unit, "missing_result_row")
+            summary["missing_units"] += 1
+            summary["failed_units"] += 1
+            bump("missing_result_row")
+
+    ordered = []
+    for unit in units:
+        uid = str(unit.get("unit_id") or "")
+        ordered.append(unit_map.get(uid, dict(unit)))
+
+    for unit in ordered:
+        assert_failure_not_done(unit)
+
+    status_counts = summarize_unit_statuses(ordered)
+    return {
+        "units": ordered,
+        "findings": findings_all,
+        "summary": {
+            **summary,
+            "status_counts": status_counts,
+            "campaign_status": derive_campaign_status(status_counts),
+        },
+    }
+
+
+def load_result_jsonl(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    if not os.path.isfile(path):
+        raise FinalReviewError(f"result JSONL not found: {path}")
+    rows: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            text = raw.strip()
+            if not text:
+                continue
+            try:
+                row = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise FinalReviewSchemaError(
+                    f"invalid result JSONL at {path}:{line_no}: {exc}"
+                ) from exc
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def persist_campaign_state(
+    package_dir: str,
+    *,
+    manifest: Mapping[str, Any],
+    snapshot: Mapping[str, Any] | None = None,
+    units: Sequence[Mapping[str, Any]],
+    findings: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    """Rewrite units/findings/manifest/report after ingest or resume."""
+    root = os.path.abspath(package_dir)
+    for unit in units:
+        assert_failure_not_done(unit)
+
+    status_counts = summarize_unit_statuses(units)
+    campaign_status = derive_campaign_status(status_counts)
+    finding_rows = [normalize_finding(f) for f in findings]
+
+    manifest_out = dict(manifest)
+    manifest_out["status"] = campaign_status
+    manifest_out["package_dir"] = root
+    manifest_out["_package_dir"] = root
+    manifest_path = os.path.join(root, MANIFEST_FILENAME)
+    manifest_out["_manifest_path"] = manifest_path
+    manifest_out["summary"] = {
+        **dict(manifest_out.get("summary") or {}),
+        "unit_count": len(list(units)),
+        "item_count": sum(int(u.get("item_count") or 0) for u in units),
+        "finding_count": len(finding_rows),
+        "status_counts": status_counts,
+    }
+    manifest_out["last_ingest_at"] = utc_now_iso()
+
+    units_path = os.path.join(root, REVIEW_UNITS_FILENAME)
+    findings_path = os.path.join(root, FINDINGS_FILENAME)
+    report_path = os.path.join(root, REPORT_MD_FILENAME)
+
+    atomic_write_jsonl(units_path, list(units), ensure_ascii=False)
+    atomic_write_jsonl(findings_path, finding_rows, ensure_ascii=False)
+    atomic_write_text(
+        report_path,
+        format_campaign_report_markdown(manifest_out, units, finding_rows),
+    )
+    if snapshot is not None:
+        from final_review import SNAPSHOT_FILENAME
+
+        atomic_write_json(
+            os.path.join(root, SNAPSHOT_FILENAME),
+            dict(snapshot),
+            ensure_ascii=False,
+            indent=2,
+        )
+    atomic_write_json(manifest_path, manifest_out, ensure_ascii=False, indent=2)
+
+    return {
+        "package_dir": root,
+        "manifest": manifest_path,
+        "review_units": units_path,
+        "findings": findings_path,
+        "report": report_path,
+    }
+
+
+def merge_findings_preserve_selection(
+    existing: Sequence[Mapping[str, Any]],
+    new_findings: Sequence[Mapping[str, Any]],
+    *,
+    replaced_unit_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Keep findings from units not re-run; replace findings for re-ingested units."""
+    kept = [
+        normalize_finding(f)
+        for f in existing
+        if str(f.get("review_unit_id") or "") not in replaced_unit_ids
+    ]
+    kept.extend(normalize_finding(f) for f in new_findings)
+    return kept
+
+
+def prepare_resume_requests(
+    package_dir: str,
+    *,
+    force: bool = False,
+    live_context_digest: str = "",
+    temperature: float = 0.2,
+    max_output_tokens: int = 8192,
+    thinking_level: str = "",
+    model: str = "",
+    safety_settings: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Plan resume, rewrite requests.jsonl for units to run, update unit statuses."""
+    package = load_campaign_package(package_dir)
+    manifest = dict(package["manifest"])
+    units = list(package["units"])
+    findings = list(package["findings"])
+    snapshot = dict(package.get("snapshot") or {})
+
+    context = live_context_digest or str(
+        snapshot.get("context_digest") or manifest.get("context_digest") or ""
+    )
+    plan = plan_units_for_run(units, force=force, live_context_digest=context)
+    to_run = plan["to_run"]
+
+    # Mark running for units about to be submitted.
+    updated_units: list[dict[str, Any]] = []
+    run_ids = {str(u.get("unit_id") or "") for u in to_run}
+    for unit in plan["units"]:
+        row = dict(unit)
+        if str(row.get("unit_id") or "") in run_ids:
+            row["status"] = STATUS_RUNNING if to_run else STATUS_PENDING
+            if force:
+                row["error"] = ""
+        updated_units.append(row)
+
+    requests_path = os.path.join(package_dir, REQUESTS_JSONL_FILENAME)
+    request_count = write_requests_jsonl(
+        requests_path,
+        to_run,
+        temperature=temperature,
+        max_output_tokens=max_output_tokens,
+        thinking_level=thinking_level,
+        model=model or str(manifest.get("model") or ""),
+        safety_settings=safety_settings,
+    )
+
+    manifest["input_jsonl_path"] = requests_path
+    manifest["job_state"] = "LOCAL_ONLY" if request_count else "NO_PENDING_UNITS"
+    manifest["job_name"] = ""
+    manifest["result_jsonl_path"] = ""
+    manifest["last_resume_at"] = utc_now_iso()
+    manifest["last_resume"] = {
+        "force": bool(force),
+        "run_count": request_count,
+        "skip_count": plan["skip_count"],
+    }
+
+    paths = persist_campaign_state(
+        package_dir,
+        manifest=manifest,
+        snapshot=snapshot,
+        units=updated_units,
+        findings=findings,
+    )
+    return {
+        "paths": paths,
+        "run_count": request_count,
+        "skip_count": plan["skip_count"],
+        "to_run_unit_ids": [str(u.get("unit_id") or "") for u in to_run],
+        "status": collect_campaign_status(
+            package={
+                "manifest": {**manifest, **{"_package_dir": package_dir}},
+                "units": updated_units,
+                "findings": findings,
+                "snapshot": snapshot,
+            }
+        ),
+    }
+
+
+def ingest_results_into_package(
+    package_dir: str,
+    *,
+    result_path: str = "",
+    provider: str = "",
+    model: str = "",
+    extract_text: Callable[[Any], str] | None = None,
+) -> dict[str, Any]:
+    """Load result JSONL, update units/findings, persist package."""
+    package = load_campaign_package(package_dir)
+    manifest = dict(package["manifest"])
+    units = list(package["units"])
+    existing_findings = list(package["findings"])
+    snapshot = dict(package.get("snapshot") or {})
+
+    resolved_result = result_path.strip() if result_path else ""
+    if not resolved_result:
+        candidate = manifest.get("result_jsonl_path") or ""
+        if candidate and not os.path.isabs(str(candidate)):
+            candidate = os.path.join(package_dir, str(candidate))
+        if candidate and os.path.isfile(str(candidate)):
+            resolved_result = str(candidate)
+        else:
+            fallback = os.path.join(package_dir, RESULT_JSONL_FILENAME)
+            if os.path.isfile(fallback):
+                resolved_result = fallback
+    if not resolved_result:
+        raise FinalReviewError(
+            "result JSONL not found; pass --result or run download first"
+        )
+
+    rows = load_result_jsonl(resolved_result)
+    # Only replace findings for units present in this result set.
+    result_keys = {
+        str(r.get("key") or r.get("unit_id") or "")
+        for r in rows
+        if isinstance(r, Mapping)
+    }
+    # Also treat running units as candidates for replacement on missing-row fail.
+    for unit in units:
+        if str(unit.get("status") or "") == STATUS_RUNNING:
+            result_keys.add(str(unit.get("unit_id") or ""))
+
+    ingested = ingest_result_rows(
+        units,
+        rows,
+        provider=provider,
+        model=model or str(manifest.get("model") or ""),
+        extract_text=extract_text,
+    )
+    merged_findings = merge_findings_preserve_selection(
+        existing_findings,
+        ingested["findings"],
+        replaced_unit_ids={k for k in result_keys if k},
+    )
+
+    manifest["result_jsonl_path"] = resolved_result
+    manifest["job_state"] = "RESULTS_INGESTED"
+    paths = persist_campaign_state(
+        package_dir,
+        manifest=manifest,
+        snapshot=snapshot,
+        units=ingested["units"],
+        findings=merged_findings,
+    )
+    return {
+        "paths": paths,
+        "summary": {
+            **ingested["summary"],
+            "finding_count": len(merged_findings),
+        },
+        "status": collect_campaign_status(
+            package={
+                "manifest": {**manifest, "_package_dir": package_dir},
+                "units": ingested["units"],
+                "findings": merged_findings,
+                "snapshot": snapshot,
+            }
+        ),
+    }
+
+
+def run_units_with_generate(
+    units: Sequence[Mapping[str, Any]],
+    generate: Callable[[str, str], str],
+    *,
+    force: bool = False,
+    live_context_digest: str = "",
+    provider: str = "mock",
+    model: str = "",
+) -> dict[str, Any]:
+    """Sync helper for tests: *generate(system, user) -> response_text*."""
+    plan = plan_units_for_run(
+        units, force=force, live_context_digest=live_context_digest
+    )
+    result_rows: list[dict[str, Any]] = []
+    for unit in plan["to_run"]:
+        system = build_system_instruction()
+        user = build_user_prompt(unit)
+        try:
+            text = generate(system, user)
+            result_rows.append(
+                {
+                    "key": unit.get("unit_id"),
+                    "response_text": text,
+                    "model": model or unit.get("model") or "",
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            result_rows.append({"key": unit.get("unit_id"), "error": str(exc)})
+
+    # Merge skip units as-is with run results.
+    return ingest_result_rows(
+        plan["units"],
+        result_rows,
+        provider=provider,
+        model=model,
+        extract_text=lambda payload: str(payload or ""),
+    )

--- a/final_review_llm.py
+++ b/final_review_llm.py
@@ -31,19 +31,20 @@ from final_review import (
     assert_failure_not_done,
     collect_campaign_status,
     derive_campaign_status,
-    export_findings,
     format_campaign_report_markdown,
     load_campaign_package,
     mark_unit_done,
     mark_unit_failed,
     normalize_finding,
-    reevaluate_campaign_units,
     should_skip_unit,
     summarize_unit_statuses,
     utc_now_iso,
 )
 
 RESULT_JSONL_FILENAME = "results.jsonl"
+PROMPT_CONTEXT_MACRO_LIMIT = 8000
+PROMPT_CONTEXT_BRIEF_LIMIT = 8000
+PROMPT_CONTEXT_GLOSSARY_HITS_LIMIT = 40
 
 # Finding types accepted from the model (unknown → needs_confirmation via normalize_finding).
 FINDING_TYPE_ENUM = [
@@ -75,16 +76,106 @@ def build_system_instruction() -> str:
     )
 
 
-def build_user_prompt(unit: Mapping[str, Any]) -> str:
+def _truncate_text(text: str, limit: int) -> str:
+    body = str(text or "")
+    if limit <= 0 or len(body) <= limit:
+        return body
+    return body[: max(0, limit - 1)] + "…"
+
+
+def glossary_hits_for_unit(
+    unit: Mapping[str, Any],
+    glossary_terms: Sequence[Mapping[str, Any]] | None,
+    *,
+    limit: int = PROMPT_CONTEXT_GLOSSARY_HITS_LIMIT,
+) -> list[dict[str, str]]:
+    """Pick glossary terms that appear in the unit's source text."""
+    if not glossary_terms:
+        return []
+    sources: list[str] = []
+    for item in unit.get("items") or []:
+        if isinstance(item, Mapping):
+            sources.append(str(item.get("source") or item.get("text") or ""))
+    combined = "\n".join(sources)
+    if not combined:
+        return []
+    hits: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for term in glossary_terms:
+        if not isinstance(term, Mapping):
+            continue
+        source = str(term.get("source") or "").strip()
+        if not source or source in seen or source not in combined:
+            continue
+        target = str(term.get("target") or source).strip() or source
+        hits.append({"source": source, "target": target})
+        seen.add(source)
+        if len(hits) >= max(1, int(limit)):
+            break
+    return hits
+
+
+def format_shared_review_context(
+    unit: Mapping[str, Any],
+    shared_context: Mapping[str, Any] | None = None,
+) -> str:
+    """Compact digest-aligned context block for the review prompt."""
+    ctx = dict(shared_context or {})
+    sections: list[str] = []
+
+    glossary_hits = glossary_hits_for_unit(unit, ctx.get("glossary_terms") or [])
+    if glossary_hits:
+        term_lines = []
+        for hit in glossary_hits:
+            source = hit["source"]
+            target = hit["target"]
+            if source == target:
+                term_lines.append(f"- Keep unchanged: {source}")
+            else:
+                term_lines.append(f"- {source} -> {target}")
+        sections.append("术语（本 unit 命中）：\n" + "\n".join(term_lines))
+
+    macro = _truncate_text(
+        str(ctx.get("macro_setting") or ctx.get("macro_setting_text") or ""),
+        PROMPT_CONTEXT_MACRO_LIMIT,
+    ).strip()
+    if macro:
+        sections.append("宏设定 / 风格约束：\n" + macro)
+
+    brief = _truncate_text(
+        str(
+            ctx.get("project_analysis_brief")
+            or ctx.get("project_analysis_brief_text")
+            or ""
+        ),
+        PROMPT_CONTEXT_BRIEF_LIMIT,
+    ).strip()
+    if brief:
+        sections.append("项目分析简报：\n" + brief)
+
+    return "\n\n".join(sections)
+
+
+def build_user_prompt(
+    unit: Mapping[str, Any],
+    shared_context: Mapping[str, Any] | None = None,
+) -> str:
     items = list(unit.get("items") or [])
     lines = [
         f"Review unit: {unit.get('unit_id') or ''}",
         f"File: {unit.get('file_rel_path') or ''}",
         f"Chunk index: {unit.get('chunk_index') or 0}",
         f"Item count: {len(items)}",
-        "",
-        "对照条目（source → current_translation）：",
     ]
+    context_block = format_shared_review_context(unit, shared_context)
+    if context_block:
+        lines.extend(["", "简要上下文：", context_block])
+    lines.extend(
+        [
+            "",
+            "对照条目（source → current_translation）：",
+        ]
+    )
     for index, item in enumerate(items, start=1):
         if not isinstance(item, Mapping):
             continue
@@ -158,6 +249,7 @@ def build_batch_request(
     thinking_level: str = "",
     model: str = "",
     safety_settings: Sequence[Mapping[str, Any]] | None = None,
+    shared_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Gemini Batch JSONL row: ``{key, request}`` keyed by unit_id."""
     unit_id = str(unit.get("unit_id") or "").strip()
@@ -168,7 +260,11 @@ def build_batch_request(
         "contents": [
             {
                 "role": "user",
-                "parts": [{"text": build_user_prompt(unit)}],
+                "parts": [
+                    {
+                        "text": build_user_prompt(unit, shared_context=shared_context),
+                    }
+                ],
             }
         ],
         "generation_config": build_generation_config(
@@ -192,6 +288,7 @@ def write_requests_jsonl(
     thinking_level: str = "",
     model: str = "",
     safety_settings: Sequence[Mapping[str, Any]] | None = None,
+    shared_context: Mapping[str, Any] | None = None,
 ) -> int:
     rows = [
         build_batch_request(
@@ -201,6 +298,7 @@ def write_requests_jsonl(
             thinking_level=thinking_level,
             model=model,
             safety_settings=safety_settings,
+            shared_context=shared_context,
         )
         for unit in units
     ]
@@ -253,12 +351,14 @@ def plan_units_for_run(
             row["status"] = STATUS_PENDING
             row["error"] = ""
             row["live_input_digest"] = live_digest
+            row["live_context_digest"] = live
             to_run.append(row)
             refreshed.append(row)
             continue
 
         if should_skip_unit(row, live_input_digest=live_digest, force=False):
             row["live_input_digest"] = live_digest
+            row["live_context_digest"] = live
             to_skip.append(row)
             refreshed.append(row)
             continue
@@ -280,6 +380,7 @@ def plan_units_for_run(
             if status != STATUS_FAILED:
                 row["error"] = ""
         row["live_input_digest"] = live_digest
+        row["live_context_digest"] = live
         to_run.append(row)
         refreshed.append(row)
 
@@ -455,6 +556,14 @@ def apply_unit_result(
         return failed, []
 
     done = mark_unit_done(unit, finding_count=len(findings))
+    # After a stale re-run (or any run with a live digest), pin the digests that
+    # were actually reviewed so the next plan can skip instead of re-queueing forever.
+    live_digest = str(unit.get("live_input_digest") or "").strip()
+    if live_digest:
+        done["input_digest"] = live_digest
+    live_context = str(unit.get("live_context_digest") or "").strip()
+    if live_context:
+        done["context_digest"] = live_context
     return done, findings
 
 
@@ -602,12 +711,22 @@ def persist_campaign_state(
     manifest_out["_package_dir"] = root
     manifest_path = os.path.join(root, MANIFEST_FILENAME)
     manifest_out["_manifest_path"] = manifest_path
+    unit_list = list(units)
+    prior_summary = dict(manifest_out.get("summary") or {})
+    chunk_count = int(
+        prior_summary.get("chunk_count")
+        or prior_summary.get("request_count")
+        or manifest_out.get("request_count")
+        or len(unit_list)
+        or 0
+    )
     manifest_out["summary"] = {
-        **dict(manifest_out.get("summary") or {}),
-        "unit_count": len(list(units)),
-        "item_count": sum(int(u.get("item_count") or 0) for u in units),
+        **prior_summary,
+        "unit_count": len(unit_list),
+        "item_count": sum(int(u.get("item_count") or 0) for u in unit_list),
         "finding_count": len(finding_rows),
         "status_counts": status_counts,
+        "chunk_count": chunk_count,
     }
     manifest_out["last_ingest_at"] = utc_now_iso()
 
@@ -657,11 +776,83 @@ def merge_findings_preserve_selection(
     return kept
 
 
+def _safe_filename_stamp(value: str) -> str:
+    return re.sub(r"[^0-9A-Za-z_.-]+", "_", str(value or ""))[:48] or "ts"
+
+
+def invalidate_package_download_artifacts(
+    package_dir: str,
+    manifest: dict[str, Any],
+) -> list[str]:
+    """Clear submit/download fields and quarantine prior results.jsonl.
+
+    After resume rewrites requests, a subsequent download must not short-circuit
+    on the previous job's local results + SHA.
+    """
+    moved: list[str] = []
+    stamp = _safe_filename_stamp(utc_now_iso())
+    results_path = os.path.join(package_dir, RESULT_JSONL_FILENAME)
+    for path in (results_path, f"{results_path}.sha256"):
+        if not os.path.isfile(path):
+            continue
+        backup = f"{path}.pre_resume_{stamp}"
+        try:
+            os.replace(path, backup)
+            moved.append(backup)
+        except OSError:
+            try:
+                os.remove(path)
+                moved.append(path)
+            except OSError:
+                pass
+
+    manifest["job_name"] = ""
+    manifest["job_state"] = "LOCAL_ONLY"
+    manifest["result_jsonl_path"] = ""
+    manifest["result_jsonl_sha256"] = ""
+    manifest["result_file_name"] = ""
+    manifest["uploaded_file_name"] = ""
+    if isinstance(manifest.get("uploaded_file_names"), list):
+        manifest["uploaded_file_names"] = []
+    manifest.pop("cost_estimate", None)
+    manifest.pop("downloaded_at", None)
+    return moved
+
+
+def _iso_or_empty(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _result_is_stale_after_resume(
+    manifest: Mapping[str, Any],
+    *,
+    explicit_result: bool,
+    allow_stale_results: bool,
+) -> bool:
+    if allow_stale_results or explicit_result:
+        return False
+    last_resume = _iso_or_empty(manifest.get("last_resume_at"))
+    if not last_resume:
+        return False
+    last_resume_meta = manifest.get("last_resume")
+    run_count = 0
+    if isinstance(last_resume_meta, Mapping):
+        run_count = int(last_resume_meta.get("run_count") or 0)
+    if run_count <= 0:
+        return False
+    downloaded_at = _iso_or_empty(manifest.get("downloaded_at"))
+    # ISO timestamps from utc_now_iso / datetime.isoformat compare lexicographically.
+    if downloaded_at and downloaded_at >= last_resume:
+        return False
+    return True
+
+
 def prepare_resume_requests(
     package_dir: str,
     *,
     force: bool = False,
     live_context_digest: str = "",
+    shared_context: Mapping[str, Any] | None = None,
     temperature: float = 0.2,
     max_output_tokens: int = 8192,
     thinking_level: str = "",
@@ -677,6 +868,9 @@ def prepare_resume_requests(
 
     context = live_context_digest or str(
         snapshot.get("context_digest") or manifest.get("context_digest") or ""
+    )
+    prompt_context = dict(shared_context) if shared_context is not None else dict(
+        snapshot.get("prompt_context") or {}
     )
     plan = plan_units_for_run(units, force=force, live_context_digest=context)
     to_run = plan["to_run"]
@@ -701,18 +895,30 @@ def prepare_resume_requests(
         thinking_level=thinking_level,
         model=model or str(manifest.get("model") or ""),
         safety_settings=safety_settings,
+        shared_context=prompt_context,
     )
 
     manifest["input_jsonl_path"] = requests_path
-    manifest["job_state"] = "LOCAL_ONLY" if request_count else "NO_PENDING_UNITS"
-    manifest["job_name"] = ""
-    manifest["result_jsonl_path"] = ""
     manifest["last_resume_at"] = utc_now_iso()
     manifest["last_resume"] = {
         "force": bool(force),
         "run_count": request_count,
         "skip_count": plan["skip_count"],
+        "live_context_digest": context,
     }
+    if request_count:
+        invalidate_package_download_artifacts(package_dir, manifest)
+        manifest["job_state"] = "LOCAL_ONLY"
+        # Keep summary.chunk_count aligned with the new request set for cost estimate.
+        summary = dict(manifest.get("summary") or {})
+        summary["chunk_count"] = request_count
+        summary["request_count"] = request_count
+        manifest["summary"] = summary
+        manifest["request_count"] = request_count
+    else:
+        manifest["job_state"] = "NO_PENDING_UNITS"
+        manifest["job_name"] = ""
+        manifest["result_jsonl_path"] = ""
 
     paths = persist_campaign_state(
         package_dir,
@@ -744,6 +950,7 @@ def ingest_results_into_package(
     provider: str = "",
     model: str = "",
     extract_text: Callable[[Any], str] | None = None,
+    allow_stale_results: bool = False,
 ) -> dict[str, Any]:
     """Load result JSONL, update units/findings, persist package."""
     package = load_campaign_package(package_dir)
@@ -752,18 +959,36 @@ def ingest_results_into_package(
     existing_findings = list(package["findings"])
     snapshot = dict(package.get("snapshot") or {})
 
+    explicit_result = bool(str(result_path or "").strip())
+    stale_after_resume = _result_is_stale_after_resume(
+        manifest,
+        explicit_result=explicit_result,
+        allow_stale_results=allow_stale_results,
+    )
+
     resolved_result = result_path.strip() if result_path else ""
     if not resolved_result:
         candidate = manifest.get("result_jsonl_path") or ""
         if candidate and not os.path.isabs(str(candidate)):
             candidate = os.path.join(package_dir, str(candidate))
-        if candidate and os.path.isfile(str(candidate)):
+        # After resume with pending work, only accept a download that set
+        # downloaded_at (>= last_resume_at). manifest.result_jsonl_path alone
+        # from a previous job is insufficient.
+        if candidate and os.path.isfile(str(candidate)) and not stale_after_resume:
             resolved_result = str(candidate)
-        else:
+        if not resolved_result:
             fallback = os.path.join(package_dir, RESULT_JSONL_FILENAME)
-            if os.path.isfile(fallback):
+            if os.path.isfile(fallback) and (
+                allow_stale_results or not stale_after_resume
+            ):
                 resolved_result = fallback
     if not resolved_result:
+        if stale_after_resume and not explicit_result:
+            raise FinalReviewError(
+                "stale results after resume: run download (or pass --result / "
+                "--allow-stale-results) before final-review-ingest-results; "
+                "pre-resume results.jsonl is not accepted automatically"
+            )
         raise FinalReviewError(
             "result JSONL not found; pass --result or run download first"
         )
@@ -825,6 +1050,7 @@ def run_units_with_generate(
     *,
     force: bool = False,
     live_context_digest: str = "",
+    shared_context: Mapping[str, Any] | None = None,
     provider: str = "mock",
     model: str = "",
 ) -> dict[str, Any]:
@@ -835,7 +1061,7 @@ def run_units_with_generate(
     result_rows: list[dict[str, Any]] = []
     for unit in plan["to_run"]:
         system = build_system_instruction()
-        user = build_user_prompt(unit)
+        user = build_user_prompt(unit, shared_context=shared_context)
         try:
             text = generate(system, user)
             result_rows.append(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3535,6 +3535,19 @@ def create_final_review_package(
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
         display_name = f'{FINAL_REVIEW_DISPLAY_NAME_PREFIX}-{guess_project_slug()}-{timestamp}'
 
+    import final_review_llm as fr_llm
+
+    requests_path = os.path.join(package_dir, fr.REQUESTS_JSONL_FILENAME)
+    request_count = fr_llm.write_requests_jsonl(
+        requests_path,
+        units,
+        temperature=BATCH_TEMPERATURE,
+        max_output_tokens=BATCH_MAX_OUTPUT_TOKENS,
+        thinking_level=BATCH_THINKING_LEVEL,
+        model=model,
+        safety_settings=BATCH_SAFETY_SETTINGS or None,
+    )
+
     manifest = fr.build_campaign_manifest(
         package_dir=package_dir,
         display_name=display_name,
@@ -3555,6 +3568,8 @@ def create_final_review_package(
         extra={
             **_manifest_target_language_fields(),
             'build_warnings': get_batch_risk_warnings(),
+            'input_jsonl_path': requests_path,
+            'request_count': request_count,
         },
     )
     paths = fr.write_campaign_package(
@@ -3570,10 +3585,14 @@ def create_final_review_package(
     print(f'Created final-review campaign: {package_dir}')
     print(f"Units: {manifest['summary']['unit_count']}")
     print(f"Items: {manifest['summary']['item_count']}")
+    print(f'Requests: {request_count} → {requests_path}')
     print(f"Context digest: {str(snapshot.get('context_digest') or '')[:16]}…")
     print(f"Snapshot digest: {str(snapshot.get('snapshot_digest') or '')[:16]}…")
     print('Mode: final_review (report-only; no autofix)')
-    print('Next: final-review-status <package>  (LLM run lands in a follow-up PR)')
+    print(
+        'Next: submit → download → final-review-ingest-results '
+        '(or final-review-resume after partial completion)'
+    )
     if readiness.reasons:
         print('Notes:')
         for reason in readiness.reasons:
@@ -3612,6 +3631,74 @@ def run_final_review_export(target=None, output_jsonl='', output_markdown=''):
     print(f"Report Markdown: {result['markdown_path']}")
     print(f"Finding count: {result['finding_count']}")
     print(f"Campaign status: {result['status'].get('status')}")
+    return result
+
+
+def run_final_review_resume(target=None, force=False):
+    """Rebuild requests for pending/stale/failed units; skip unchanged done units."""
+    import final_review as fr
+    import final_review_llm as fr_llm
+
+    package_target = manifest_path_for_target(target)
+    package = fr.load_campaign_package(package_target)
+    package_dir = package['paths']['package_dir']
+    try:
+        result = fr_llm.prepare_resume_requests(
+            package_dir,
+            force=bool(force),
+            live_context_digest=str(
+                (package.get('snapshot') or {}).get('context_digest') or ''
+            ),
+            temperature=BATCH_TEMPERATURE,
+            max_output_tokens=BATCH_MAX_OUTPUT_TOKENS,
+            thinking_level=BATCH_THINKING_LEVEL,
+            model=FINAL_REVIEW_MODEL or BATCH_MODEL or '',
+            safety_settings=BATCH_SAFETY_SETTINGS or None,
+        )
+    except fr.FinalReviewError as exc:
+        raise SystemExit(f'Final review resume error: {exc}') from exc
+
+    remember_latest_manifest(result['paths']['manifest'])
+    print(f"Resume package: {package_dir}")
+    print(f"Units to run: {result['run_count']}")
+    print(f"Units skipped (done+same digest): {result['skip_count']}")
+    print(f"Force: {bool(force)}")
+    print(f"Requests JSONL: {os.path.join(package_dir, fr.REQUESTS_JSONL_FILENAME)}")
+    if result['run_count']:
+        print('Next: submit → download → final-review-ingest-results')
+    else:
+        print('No units to run; campaign is up to date for current digests.')
+    return result
+
+
+def run_final_review_ingest_results(target=None, result_path=''):
+    """Parse downloaded Batch/sync results into findings (report-only)."""
+    import final_review as fr
+    import final_review_llm as fr_llm
+
+    package_target = manifest_path_for_target(target)
+    package = fr.load_campaign_package(package_target)
+    package_dir = package['paths']['package_dir']
+    try:
+        result = fr_llm.ingest_results_into_package(
+            package_dir,
+            result_path=result_path or '',
+            provider=str(SYNC_BACKEND or 'gemini'),
+            model=FINAL_REVIEW_MODEL or BATCH_MODEL or '',
+            extract_text=extract_text_from_response_payload,
+        )
+    except fr.FinalReviewError as exc:
+        raise SystemExit(f'Final review ingest error: {exc}') from exc
+
+    remember_latest_manifest(result['paths']['manifest'])
+    summary = result.get('summary') or {}
+    print(f"Ingested results for: {package_dir}")
+    print(f"Result rows: {summary.get('result_rows', 0)}")
+    print(f"Done units: {summary.get('done_units', 0)}")
+    print(f"Failed units: {summary.get('failed_units', 0)}")
+    print(f"Findings: {summary.get('finding_count', 0)}")
+    print(f"Campaign status: {(result.get('status') or {}).get('status')}")
+    print('Report-only: no .rpy writes. Use final-review-export; revision hand-off is PR C.')
     return result
 
 
@@ -9980,6 +10067,44 @@ def build_arg_parser():
         help='Output report Markdown path (default: package report.md).',
     )
 
+    final_review_resume_parser = subparsers.add_parser(
+        'final-review-resume',
+        help=(
+            'Rebuild Batch requests for pending/stale/failed review units; '
+            'skip done units whose input_digest is unchanged. Pass --force to re-run all.'
+        ),
+    )
+    final_review_resume_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Campaign package dir or manifest path. Defaults to latest package.',
+    )
+    final_review_resume_parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Re-queue all units, including done units with matching digests.',
+    )
+
+    final_review_ingest_parser = subparsers.add_parser(
+        'final-review-ingest-results',
+        help=(
+            'Parse downloaded final-review result JSONL into findings and unit status '
+            '(report-only; does not write .rpy).'
+        ),
+    )
+    final_review_ingest_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Campaign package dir or manifest path. Defaults to latest package.',
+    )
+    final_review_ingest_parser.add_argument(
+        '--result',
+        default='',
+        help='Result JSONL path. Defaults to manifest result_jsonl_path or package results.jsonl.',
+    )
+
     project_analysis_status_parser = subparsers.add_parser(
         'project-analysis-status',
         help=(
@@ -10504,6 +10629,8 @@ def main(argv=None):
         'final-review-build',
         'final-review-status',
         'final-review-export',
+        'final-review-resume',
+        'final-review-ingest-results',
     }:
         legacy.load_translator_settings(persist_corrected_game_root=False)
         legacy.load_glossary()
@@ -10531,6 +10658,20 @@ def main(argv=None):
                 getattr(args, 'target', '') or None,
                 output_jsonl=getattr(args, 'jsonl', '') or '',
                 output_markdown=getattr(args, 'markdown', '') or '',
+            )
+            return
+        if command == 'final-review-resume':
+            print_banner()
+            run_final_review_resume(
+                getattr(args, 'target', '') or None,
+                force=bool(getattr(args, 'force', False)),
+            )
+            return
+        if command == 'final-review-ingest-results':
+            print_banner()
+            run_final_review_ingest_results(
+                getattr(args, 'target', '') or None,
+                result_path=getattr(args, 'result', '') or '',
             )
             return
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3362,6 +3362,41 @@ def _pending_file_rows_for_final_review(file_jobs):
     return rows
 
 
+def _load_final_review_glossary_terms(glossary_path, limit=200):
+    """Lightweight glossary term list for final-review prompt injection."""
+    path = str(glossary_path or '').strip()
+    if not path or not os.path.isfile(path):
+        return []
+    try:
+        with open(path, 'r', encoding='utf-8-sig') as handle:
+            data = json.load(handle) or {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    pairs = []
+    seen = set()
+    normalize_map = data.get('normalize_map') or {}
+    if isinstance(normalize_map, dict):
+        for source, target in normalize_map.items():
+            key = str(source or '').strip()
+            if not key or key in seen:
+                continue
+            pairs.append({'source': key, 'target': str(target or key).strip() or key})
+            seen.add(key)
+            if len(pairs) >= limit:
+                return pairs
+    for term in data.get('preserve_terms') or []:
+        key = str(term or '').strip()
+        if not key or key in seen:
+            continue
+        pairs.append({'source': key, 'target': key})
+        seen.add(key)
+        if len(pairs) >= limit:
+            break
+    return pairs
+
+
 def _collect_final_review_context_snapshot(translation_items):
     """Build the frozen context snapshot for a final-review campaign."""
     import final_review as fr
@@ -3439,11 +3474,13 @@ def _collect_final_review_context_snapshot(translation_items):
     if SOURCE_INDEX_ENABLED:
         source_index_path = SOURCE_INDEX_STORE_DIR or get_default_source_index_store_dir()
 
-    return fr.build_context_snapshot(
+    glossary_path = getattr(legacy, 'GLOSSARY_FILE', '') or ''
+    macro_text = BATCH_MACRO_SETTING or ''
+    snapshot = fr.build_context_snapshot(
         translation_items=translation_items,
-        glossary_path=getattr(legacy, 'GLOSSARY_FILE', '') or '',
+        glossary_path=glossary_path,
         glossary_enabled=True,
-        macro_setting_text=BATCH_MACRO_SETTING or '',
+        macro_setting_text=macro_text,
         macro_setting_path=macro_path or None,
         story_memory_enabled=bool(STORY_MEMORY_ENABLED),
         story_memory_graph_path=STORY_MEMORY_GRAPH_FILE or None,
@@ -3461,6 +3498,13 @@ def _collect_final_review_context_snapshot(translation_items):
         base_dir=legacy.BASE_DIR or '',
         tl_dir=legacy.TL_DIR or '',
     )
+    # Frozen text actually injected into review prompts (digest-aligned).
+    snapshot['prompt_context'] = {
+        'macro_setting': str(macro_text)[:8000],
+        'project_analysis_brief': str(pa_brief_text or '')[:8000],
+        'glossary_terms': _load_final_review_glossary_terms(glossary_path),
+    }
+    return snapshot
 
 
 def create_final_review_package(
@@ -3546,6 +3590,7 @@ def create_final_review_package(
         thinking_level=BATCH_THINKING_LEVEL,
         model=model,
         safety_settings=BATCH_SAFETY_SETTINGS or None,
+        shared_context=snapshot.get('prompt_context') or {},
     )
 
     manifest = fr.build_campaign_manifest(
@@ -3572,6 +3617,10 @@ def create_final_review_package(
             'request_count': request_count,
         },
     )
+    # batch_cost_estimate uses summary.chunk_count for max output tokens.
+    manifest.setdefault('summary', {})
+    manifest['summary']['chunk_count'] = request_count
+    manifest['summary']['request_count'] = request_count
     paths = fr.write_campaign_package(
         package_dir,
         manifest=manifest,
@@ -3635,20 +3684,43 @@ def run_final_review_export(target=None, output_jsonl='', output_markdown=''):
 
 
 def run_final_review_resume(target=None, force=False):
-    """Rebuild requests for pending/stale/failed units; skip unchanged done units."""
+    """Rebuild requests for pending/stale/failed units; skip unchanged done units.
+
+    Recomputes live shared context (glossary/macro/PA…) so digest-based skip /
+    stale detection matches the current workspace, not only the frozen build
+    snapshot. Request prompts also inject the live prompt_context block.
+    """
     import final_review as fr
     import final_review_llm as fr_llm
 
     package_target = manifest_path_for_target(target)
     package = fr.load_campaign_package(package_target)
     package_dir = package['paths']['package_dir']
+    frozen_snapshot = dict(package.get('snapshot') or {})
+    frozen_context = str(
+        frozen_snapshot.get('context_digest') or package['manifest'].get('context_digest') or ''
+    )
+    frozen_prompt_context = dict(frozen_snapshot.get('prompt_context') or {})
+
+    items = []
+    for unit in package.get('units') or []:
+        if isinstance(unit, dict):
+            items.extend(unit.get('items') or [])
+    try:
+        live_snapshot = _collect_final_review_context_snapshot(items)
+        live_context = str(live_snapshot.get('context_digest') or '') or frozen_context
+        live_prompt_context = dict(live_snapshot.get('prompt_context') or {}) or frozen_prompt_context
+    except Exception as exc:
+        print(f'Warning: live context refresh failed ({exc}); using frozen campaign snapshot.')
+        live_context = frozen_context
+        live_prompt_context = frozen_prompt_context
+
     try:
         result = fr_llm.prepare_resume_requests(
             package_dir,
             force=bool(force),
-            live_context_digest=str(
-                (package.get('snapshot') or {}).get('context_digest') or ''
-            ),
+            live_context_digest=live_context,
+            shared_context=live_prompt_context,
             temperature=BATCH_TEMPERATURE,
             max_output_tokens=BATCH_MAX_OUTPUT_TOKENS,
             thinking_level=BATCH_THINKING_LEVEL,
@@ -3663,15 +3735,20 @@ def run_final_review_resume(target=None, force=False):
     print(f"Units to run: {result['run_count']}")
     print(f"Units skipped (done+same digest): {result['skip_count']}")
     print(f"Force: {bool(force)}")
+    if live_context and frozen_context and live_context != frozen_context:
+        print('Live shared context differs from frozen build snapshot; stale units re-queued.')
     print(f"Requests JSONL: {os.path.join(package_dir, fr.REQUESTS_JSONL_FILENAME)}")
     if result['run_count']:
-        print('Next: submit → download → final-review-ingest-results')
+        print(
+            'Next: submit → download → final-review-ingest-results '
+            '(do not reuse pre-resume results.jsonl)'
+        )
     else:
         print('No units to run; campaign is up to date for current digests.')
     return result
 
 
-def run_final_review_ingest_results(target=None, result_path=''):
+def run_final_review_ingest_results(target=None, result_path='', allow_stale_results=False):
     """Parse downloaded Batch/sync results into findings (report-only)."""
     import final_review as fr
     import final_review_llm as fr_llm
@@ -3686,6 +3763,7 @@ def run_final_review_ingest_results(target=None, result_path=''):
             provider=str(SYNC_BACKEND or 'gemini'),
             model=FINAL_REVIEW_MODEL or BATCH_MODEL or '',
             extract_text=extract_text_from_response_payload,
+            allow_stale_results=bool(allow_stale_results),
         )
     except fr.FinalReviewError as exc:
         raise SystemExit(f'Final review ingest error: {exc}') from exc
@@ -10071,7 +10149,8 @@ def build_arg_parser():
         'final-review-resume',
         help=(
             'Rebuild Batch requests for pending/stale/failed review units; '
-            'skip done units whose input_digest is unchanged. Pass --force to re-run all.'
+            'skip done units whose input_digest is unchanged against live shared context. '
+            'Pass --force to re-run all. Invalidates prior results.jsonl so download cannot reuse it.'
         ),
     )
     final_review_resume_parser.add_argument(
@@ -10102,7 +10181,19 @@ def build_arg_parser():
     final_review_ingest_parser.add_argument(
         '--result',
         default='',
-        help='Result JSONL path. Defaults to manifest result_jsonl_path or package results.jsonl.',
+        help=(
+            'Result JSONL path. Defaults to a post-resume download path '
+            '(manifest result_jsonl_path). Pre-resume package results.jsonl is rejected '
+            'unless --allow-stale-results is set.'
+        ),
+    )
+    final_review_ingest_parser.add_argument(
+        '--allow-stale-results',
+        action='store_true',
+        help=(
+            'Allow ingesting package results.jsonl even when it may predate the last '
+            'resume (escape hatch / re-parse). Prefer a fresh download or --result.'
+        ),
     )
 
     project_analysis_status_parser = subparsers.add_parser(
@@ -10672,6 +10763,7 @@ def main(argv=None):
             run_final_review_ingest_results(
                 getattr(args, 'target', '') or None,
                 result_path=getattr(args, 'result', '') or '',
+                allow_stale_results=bool(getattr(args, 'allow_stale_results', False)),
             )
             return
 

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -286,6 +286,22 @@ def build_cli_commands(
                 ["final-review-export", manifest_path],
             ),
         ),
+        DiagnosticsCommand(
+            label="最终审校·续跑 requests",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["final-review-resume", manifest_path],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="最终审校·摄入结果",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["final-review-ingest-results", manifest_path],
+            ),
+        ),
     ]
 
     mode = manifest.get("mode")
@@ -309,7 +325,35 @@ def build_cli_commands(
                         ["final-review-export", manifest_path],
                     ),
                 ),
+                DiagnosticsCommand(
+                    label="续跑最终审校 requests",
+                    command=format_cli_command(
+                        python_exe,
+                        batch_script_path,
+                        ["final-review-resume", manifest_path],
+                    ),
+                ),
+                DiagnosticsCommand(
+                    label="摄入最终审校结果",
+                    command=format_cli_command(
+                        python_exe,
+                        batch_script_path,
+                        ["final-review-ingest-results", manifest_path],
+                    ),
+                ),
             ]
+        )
+        commands.extend(
+            build_cloud_job_commands(
+                python_exe=python_exe,
+                batch_script_path=batch_script_path,
+                manifest_path=manifest_path,
+                manifest=manifest,
+                submit_max_cost=submit_max_cost,
+                submit_label="提交最终审校任务",
+                status_label="查询最终审校状态",
+                download_label="下载最终审校结果",
+            )
         )
     if mode_text == "revision":
         commands.extend(

--- a/tests/test_batch_cost_estimate.py
+++ b/tests/test_batch_cost_estimate.py
@@ -50,6 +50,51 @@ class BatchCostEstimateTests(unittest.TestCase):
         self.assertTrue(batch_cost_estimate.cost_estimate_exceeds_max(estimate, 10))
         self.assertFalse(batch_cost_estimate.cost_estimate_exceeds_max(estimate, 12.5))
 
+    def test_estimate_final_review_uses_unit_or_request_count(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            jsonl_path = os.path.join(tmp_dir, 'requests.jsonl')
+            with open(jsonl_path, 'w', encoding='utf-8') as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            'key': 'fr-u1',
+                            'request': {
+                                'contents': [
+                                    {'role': 'user', 'parts': [{'text': 'abcd'}]},
+                                ],
+                            },
+                        },
+                        ensure_ascii=False,
+                    )
+                    + '\n'
+                )
+                handle.write(
+                    json.dumps(
+                        {
+                            'key': 'fr-u2',
+                            'request': {
+                                'contents': [
+                                    {'role': 'user', 'parts': [{'text': 'efgh'}]},
+                                ],
+                            },
+                        },
+                        ensure_ascii=False,
+                    )
+                    + '\n'
+                )
+
+            manifest = {
+                'batch_model': 'gemini-3.1-flash-lite',
+                'input_jsonl_path': jsonl_path,
+                'settings': {'max_output_tokens': 1000},
+                'mode': 'final_review',
+                'summary': {'unit_count': 2, 'request_count': 2},
+            }
+            tokens = batch_cost_estimate.estimate_manifest_tokens(manifest)
+            self.assertEqual(tokens['request_count'], 2)
+            self.assertEqual(tokens['chunk_count'], 2)
+            self.assertEqual(tokens['estimated_output_tokens_max'], 2000)
+
     def test_ensure_manifest_cost_estimate_exits_when_jsonl_missing(self):
         manifest = {
             'input_jsonl_path': 'missing.jsonl',

--- a/tests/test_final_review_llm.py
+++ b/tests/test_final_review_llm.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+"""Tests for final-review LLM execution and resume (#255 PR B)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import final_review as fr
+import final_review_llm as frl
+
+
+def _unit(
+    unit_id: str = "fr-u1",
+    *,
+    status: str = fr.STATUS_PENDING,
+    items: list[dict] | None = None,
+    context_digest: str = "ctx-1",
+    model: str = "test-model",
+) -> dict:
+    if items is None:
+        items = [
+            {
+                "id": "id-a",
+                "identity_v2": "id-a",
+                "file_rel_path": "a.rpy",
+                "source": "Hello",
+                "current_translation": "你好",
+            },
+            {
+                "id": "id-b",
+                "identity_v2": "id-b",
+                "file_rel_path": "a.rpy",
+                "source": "World",
+                "current_translation": "世界",
+            },
+        ]
+    items_digest = fr.digest_translation_items(items)
+    item_ids = [i["id"] for i in items]
+    input_digest = fr.compute_unit_input_digest(
+        item_ids=item_ids,
+        items_digest=items_digest,
+        context_digest=context_digest,
+        model=model,
+        prompt_schema_version=fr.PROMPT_SCHEMA_VERSION,
+        chunk_index=1,
+        file_rel_path="a.rpy",
+    )
+    return {
+        "unit_id": unit_id,
+        "status": status,
+        "file_rel_path": "a.rpy",
+        "chunk_index": 1,
+        "item_ids": item_ids,
+        "item_count": len(items),
+        "items": items,
+        "items_digest": items_digest,
+        "input_digest": input_digest,
+        "context_digest": context_digest,
+        "snapshot_digest": "snap-1",
+        "model": model,
+        "prompt_schema_version": fr.PROMPT_SCHEMA_VERSION,
+        "error": "",
+        "finding_count": 0,
+        "completed_at": "",
+    }
+
+
+class PromptAndRequestTests(unittest.TestCase):
+    def test_batch_request_key_is_unit_id(self):
+        unit = _unit("fr-abc")
+        row = frl.build_batch_request(unit, model="gemini-test")
+        self.assertEqual(row["key"], "fr-abc")
+        self.assertIn("request", row)
+        self.assertEqual(
+            row["request"]["generation_config"]["response_mime_type"],
+            "application/json",
+        )
+        schema = row["request"]["generation_config"]["response_json_schema"]
+        self.assertIn("findings", schema["properties"])
+
+
+class ParseFindingsTests(unittest.TestCase):
+    def test_parse_findings_and_strip_applied_claim(self):
+        unit = _unit()
+        text = json.dumps(
+            {
+                "findings": [
+                    {
+                        "item_id": "id-a",
+                        "finding_type": "mistranslation",
+                        "severity": "high",
+                        "reason": "tone",
+                        "suggested_revision": "您好",
+                        "revision_state": "applied",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        )
+        findings, error = frl.parse_unit_findings(text, unit, model="m")
+        self.assertEqual(error, "")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["finding_type"], "mistranslation")
+        self.assertEqual(findings[0]["revision_state"], fr.REVISION_STATE_NONE)
+        self.assertEqual(findings[0]["identity_v2"], "id-a")
+
+    def test_empty_findings_is_success(self):
+        unit = _unit()
+        findings, error = frl.parse_unit_findings('{"findings":[]}', unit)
+        self.assertEqual(error, "")
+        self.assertEqual(findings, [])
+
+    def test_malformed_json_is_error_not_zero_findings(self):
+        unit = _unit()
+        findings, error = frl.parse_unit_findings("not-json{{{", unit)
+        self.assertTrue(error.startswith("failed_to_parse_model_json"))
+        self.assertEqual(findings, [])
+
+    def test_missing_findings_key_is_error(self):
+        unit = _unit()
+        findings, error = frl.parse_unit_findings('{"issues_count": 0}', unit)
+        self.assertIn("missing findings", error)
+        self.assertEqual(findings, [])
+
+    def test_apply_unit_result_failed_not_done(self):
+        unit = _unit()
+        updated, findings = frl.apply_unit_result(unit, response_text="{{{")
+        self.assertEqual(updated["status"], fr.STATUS_FAILED)
+        self.assertEqual(findings, [])
+        self.assertNotEqual(updated["status"], fr.STATUS_DONE)
+        fr.assert_failure_not_done(updated)
+
+    def test_apply_unit_result_empty_findings_done(self):
+        unit = _unit()
+        updated, findings = frl.apply_unit_result(unit, response_text='{"findings":[]}')
+        self.assertEqual(updated["status"], fr.STATUS_DONE)
+        self.assertEqual(updated["finding_count"], 0)
+        self.assertEqual(findings, [])
+
+
+class ResumePlanTests(unittest.TestCase):
+    def test_skip_done_same_digest(self):
+        unit = fr.mark_unit_done(_unit(), finding_count=0)
+        plan = frl.plan_units_for_run([unit], force=False, live_context_digest="ctx-1")
+        self.assertEqual(plan["skip_count"], 1)
+        self.assertEqual(plan["run_count"], 0)
+
+    def test_force_reruns_done(self):
+        unit = fr.mark_unit_done(_unit(), finding_count=0)
+        plan = frl.plan_units_for_run([unit], force=True, live_context_digest="ctx-1")
+        self.assertEqual(plan["run_count"], 1)
+        self.assertEqual(plan["skip_count"], 0)
+        self.assertEqual(plan["to_run"][0]["status"], fr.STATUS_PENDING)
+
+    def test_failed_is_requed(self):
+        unit = fr.mark_unit_failed(_unit(), "parse_error")
+        plan = frl.plan_units_for_run([unit], force=False, live_context_digest="ctx-1")
+        self.assertEqual(plan["run_count"], 1)
+
+    def test_context_change_stales_done(self):
+        unit = fr.mark_unit_done(_unit(context_digest="ctx-1"), finding_count=0)
+        plan = frl.plan_units_for_run(
+            [unit], force=False, live_context_digest="ctx-CHANGED"
+        )
+        self.assertEqual(plan["run_count"], 1)
+        # Recomputed live digest differs → queued
+        self.assertEqual(plan["to_run"][0]["status"], fr.STATUS_PENDING)
+
+
+class IngestRowsTests(unittest.TestCase):
+    def test_ingest_mixed_done_and_failed(self):
+        u1 = _unit("u1")
+        u2 = _unit("u2")
+        rows = [
+            {
+                "key": "u1",
+                "response_text": json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "item_id": "id-a",
+                                "finding_type": "terminology",
+                                "severity": "medium",
+                                "reason": "term",
+                            }
+                        ]
+                    }
+                ),
+            },
+            {"key": "u2", "response_text": "not-json"},
+        ]
+        result = frl.ingest_result_rows([u1, u2], rows, model="m")
+        by_id = {u["unit_id"]: u for u in result["units"]}
+        self.assertEqual(by_id["u1"]["status"], fr.STATUS_DONE)
+        self.assertEqual(by_id["u2"]["status"], fr.STATUS_FAILED)
+        self.assertEqual(result["summary"]["done_units"], 1)
+        self.assertEqual(result["summary"]["failed_units"], 1)
+        self.assertEqual(result["summary"]["finding_count"], 1)
+        self.assertEqual(result["summary"]["campaign_status"], fr.STATUS_FAILED)
+
+    def test_missing_result_for_running_is_failed(self):
+        u1 = dict(_unit("u1"), status=fr.STATUS_RUNNING)
+        result = frl.ingest_result_rows([u1], [], model="m")
+        self.assertEqual(result["units"][0]["status"], fr.STATUS_FAILED)
+        self.assertIn("missing_result_row", result["units"][0]["error"])
+
+
+class PackageResumeIngestTests(unittest.TestCase):
+    def _write_package(self, tmp: str, units: list[dict], findings: list | None = None):
+        items = []
+        for unit in units:
+            items.extend(unit.get("items") or [])
+        readiness = fr.evaluate_readiness(
+            pending_task_count=0, review_item_count=max(1, len(items))
+        )
+        snap = fr.build_context_snapshot(translation_items=items or [{"id": "x", "source": "s", "current_translation": "t"}])
+        # Align unit digests with snap context when possible
+        for unit in units:
+            unit["context_digest"] = snap["context_digest"]
+            unit["input_digest"] = fr.compute_unit_input_digest(
+                item_ids=unit["item_ids"],
+                items_digest=unit["items_digest"],
+                context_digest=snap["context_digest"],
+                model=unit.get("model") or "",
+                prompt_schema_version=unit.get("prompt_schema_version") or fr.PROMPT_SCHEMA_VERSION,
+                chunk_index=int(unit.get("chunk_index") or 0),
+                file_rel_path=str(unit.get("file_rel_path") or ""),
+            )
+        package_dir = os.path.join(tmp, "fr_pkg")
+        os.makedirs(package_dir, exist_ok=True)
+        manifest = fr.build_campaign_manifest(
+            package_dir=package_dir,
+            display_name="test",
+            snapshot=snap,
+            units=units,
+            readiness=readiness,
+            model="test-model",
+        )
+        fr.write_campaign_package(
+            package_dir,
+            manifest=manifest,
+            snapshot=snap,
+            units=units,
+            findings=findings or [],
+        )
+        return package_dir, snap
+
+    def test_resume_skips_done_writes_only_pending_requests(self):
+        done = fr.mark_unit_done(_unit("done-u", context_digest="will-replace"), finding_count=0)
+        pending = _unit("pend-u", context_digest="will-replace")
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, snap = self._write_package(tmp, [done, pending])
+            result = frl.prepare_resume_requests(
+                package_dir,
+                force=False,
+                live_context_digest=snap["context_digest"],
+                model="test-model",
+            )
+            self.assertEqual(result["run_count"], 1)
+            self.assertEqual(result["skip_count"], 1)
+            self.assertEqual(result["to_run_unit_ids"], ["pend-u"])
+            requests_path = Path(package_dir) / fr.REQUESTS_JSONL_FILENAME
+            rows = [
+                json.loads(line)
+                for line in requests_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            self.assertEqual([r["key"] for r in rows], ["pend-u"])
+
+    def test_force_resume_all(self):
+        done = fr.mark_unit_done(_unit("done-u"), finding_count=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, snap = self._write_package(tmp, [done])
+            result = frl.prepare_resume_requests(
+                package_dir,
+                force=True,
+                live_context_digest=snap["context_digest"],
+            )
+            self.assertEqual(result["run_count"], 1)
+            self.assertEqual(result["skip_count"], 0)
+
+    def test_ingest_package_persists_findings(self):
+        unit = _unit("u1")
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, _snap = self._write_package(tmp, [unit])
+            result_path = Path(package_dir) / "results.jsonl"
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "key": "u1",
+                        "response": {
+                            "candidates": [
+                                {
+                                    "content": {
+                                        "parts": [
+                                            {
+                                                "text": json.dumps(
+                                                    {
+                                                        "findings": [
+                                                            {
+                                                                "item_id": "id-a",
+                                                                "finding_type": "omission",
+                                                                "severity": "high",
+                                                                "reason": "missing clause",
+                                                            }
+                                                        ]
+                                                    }
+                                                )
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            out = frl.ingest_results_into_package(
+                package_dir,
+                result_path=str(result_path),
+                model="m",
+            )
+            self.assertEqual(out["summary"]["done_units"], 1)
+            self.assertEqual(out["summary"]["finding_count"], 1)
+            loaded = fr.load_campaign_package(package_dir)
+            self.assertEqual(loaded["units"][0]["status"], fr.STATUS_DONE)
+            self.assertEqual(len(loaded["findings"]), 1)
+            self.assertEqual(loaded["findings"][0]["finding_type"], "omission")
+
+    def test_sync_generate_helper_zero_model_calls_on_resume_skip(self):
+        unit = fr.mark_unit_done(_unit("u1"), finding_count=0)
+        calls = {"n": 0}
+
+        def gen(_system: str, _user: str) -> str:
+            calls["n"] += 1
+            return '{"findings":[]}'
+
+        # force=False and done → no generate calls
+        plan = frl.plan_units_for_run([unit], force=False, live_context_digest="ctx-1")
+        self.assertEqual(plan["run_count"], 0)
+        result = frl.run_units_with_generate(
+            [unit], gen, force=False, live_context_digest="ctx-1"
+        )
+        self.assertEqual(calls["n"], 0)
+        # units stay done
+        self.assertEqual(result["units"][0]["status"], fr.STATUS_DONE)
+
+        result2 = frl.run_units_with_generate(
+            [unit], gen, force=True, live_context_digest="ctx-1"
+        )
+        self.assertEqual(calls["n"], 1)
+        self.assertEqual(result2["units"][0]["status"], fr.STATUS_DONE)
+
+
+class DiagnosticsCommandTests(unittest.TestCase):
+    def test_diagnostics_lists_resume_and_ingest(self):
+        from gui_qt.diagnostics_context import build_cli_commands
+
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\jobs\manifest.json",
+            manifest={"mode": "final_review", "job_name": ""},
+        )
+        labels = [c.label for c in commands]
+        self.assertIn("最终审校·续跑 requests", labels)
+        self.assertIn("最终审校·摄入结果", labels)
+        text = "\n".join(c.command for c in commands)
+        self.assertIn("final-review-resume", text)
+        self.assertIn("final-review-ingest-results", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_final_review_llm.py
+++ b/tests/test_final_review_llm.py
@@ -82,6 +82,25 @@ class PromptAndRequestTests(unittest.TestCase):
         schema = row["request"]["generation_config"]["response_json_schema"]
         self.assertIn("findings", schema["properties"])
 
+    def test_user_prompt_injects_shared_context(self):
+        unit = _unit()
+        prompt = frl.build_user_prompt(
+            unit,
+            shared_context={
+                "macro_setting": "第二人称称呼保持统一",
+                "project_analysis_brief": "世界观：学院奇幻",
+                "glossary_terms": [
+                    {"source": "Hello", "target": "你好"},
+                    {"source": "Unused", "target": "未用"},
+                ],
+            },
+        )
+        self.assertIn("简要上下文", prompt)
+        self.assertIn("第二人称称呼保持统一", prompt)
+        self.assertIn("世界观：学院奇幻", prompt)
+        self.assertIn("Hello -> 你好", prompt)
+        self.assertNotIn("Unused", prompt)
+
 
 class ParseFindingsTests(unittest.TestCase):
     def test_parse_findings_and_strip_applied_claim(self):
@@ -169,6 +188,26 @@ class ResumePlanTests(unittest.TestCase):
         self.assertEqual(plan["run_count"], 1)
         # Recomputed live digest differs → queued
         self.assertEqual(plan["to_run"][0]["status"], fr.STATUS_PENDING)
+
+    def test_context_change_then_done_stays_skippable(self):
+        unit = fr.mark_unit_done(_unit(context_digest="ctx-1"), finding_count=0)
+        plan = frl.plan_units_for_run(
+            [unit], force=False, live_context_digest="ctx-CHANGED"
+        )
+        self.assertEqual(plan["run_count"], 1)
+        queued = plan["to_run"][0]
+        updated, findings = frl.apply_unit_result(
+            queued, response_text='{"findings":[]}'
+        )
+        self.assertEqual(updated["status"], fr.STATUS_DONE)
+        self.assertEqual(findings, [])
+        self.assertEqual(updated["input_digest"], queued["live_input_digest"])
+        self.assertEqual(updated["context_digest"], "ctx-CHANGED")
+        plan2 = frl.plan_units_for_run(
+            [updated], force=False, live_context_digest="ctx-CHANGED"
+        )
+        self.assertEqual(plan2["run_count"], 0)
+        self.assertEqual(plan2["skip_count"], 1)
 
 
 class IngestRowsTests(unittest.TestCase):
@@ -282,6 +321,95 @@ class PackageResumeIngestTests(unittest.TestCase):
             )
             self.assertEqual(result["run_count"], 1)
             self.assertEqual(result["skip_count"], 0)
+
+    def test_resume_invalidates_prior_download_artifacts(self):
+        pending = _unit("pend-u")
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir, snap = self._write_package(tmp, [pending])
+            results_path = Path(package_dir) / "results.jsonl"
+            results_path.write_text(
+                json.dumps({"key": "old", "response_text": '{"findings":[]}'}) + "\n",
+                encoding="utf-8",
+            )
+            (Path(package_dir) / "results.jsonl.sha256").write_text(
+                "deadbeef\n", encoding="utf-8"
+            )
+            # Pretend a previous job finished and was downloaded.
+            manifest_path = Path(package_dir) / fr.MANIFEST_FILENAME
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["job_name"] = "batches/old-job"
+            manifest["result_jsonl_path"] = str(results_path)
+            manifest["result_jsonl_sha256"] = "deadbeef"
+            manifest["result_file_name"] = "files/old-result"
+            manifest["uploaded_file_name"] = "files/old-upload"
+            manifest["downloaded_at"] = "2020-01-01T00:00:00"
+            manifest["cost_estimate"] = {"estimated_cost_max": 1.23}
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+            result = frl.prepare_resume_requests(
+                package_dir,
+                force=False,
+                live_context_digest=snap["context_digest"],
+            )
+            self.assertEqual(result["run_count"], 1)
+            loaded = fr.load_campaign_package(package_dir)
+            man = loaded["manifest"]
+            self.assertEqual(man.get("job_name"), "")
+            self.assertEqual(man.get("result_jsonl_path"), "")
+            self.assertEqual(man.get("result_jsonl_sha256"), "")
+            self.assertEqual(man.get("result_file_name"), "")
+            self.assertEqual(man.get("uploaded_file_name"), "")
+            self.assertNotIn("cost_estimate", man)
+            self.assertNotIn("downloaded_at", man)
+            self.assertFalse(results_path.is_file())
+            backups = list(Path(package_dir).glob("results.jsonl.pre_resume_*"))
+            self.assertEqual(len(backups), 1)
+
+            with self.assertRaises(fr.FinalReviewError) as ctx:
+                frl.ingest_results_into_package(package_dir)
+            self.assertIn("stale results after resume", str(ctx.exception))
+
+            # Without download timestamp / explicit path, auto ingest is blocked.
+            restored = Path(package_dir) / "results.jsonl"
+            restored.write_text(
+                json.dumps({"key": "pend-u", "response_text": '{"findings":[]}'})
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(fr.FinalReviewError) as ctx2:
+                frl.ingest_results_into_package(package_dir)
+            self.assertIn("stale results after resume", str(ctx2.exception))
+
+            # Explicit --result still works as an escape hatch.
+            out = frl.ingest_results_into_package(
+                package_dir,
+                result_path=str(restored),
+            )
+            self.assertEqual(out["summary"]["done_units"], 1)
+
+        # allow_stale_results escape hatch on a separate package
+        with tempfile.TemporaryDirectory() as tmp2:
+            pending2 = _unit("pend-2")
+            package_dir2, snap2 = self._write_package(tmp2, [pending2])
+            frl.prepare_resume_requests(
+                package_dir2,
+                force=False,
+                live_context_digest=snap2["context_digest"],
+            )
+            restored2 = Path(package_dir2) / "results.jsonl"
+            restored2.write_text(
+                json.dumps({"key": "pend-2", "response_text": '{"findings":[]}'})
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(fr.FinalReviewError):
+                frl.ingest_results_into_package(package_dir2)
+            out2 = frl.ingest_results_into_package(
+                package_dir2, allow_stale_results=True
+            )
+            self.assertEqual(out2["summary"]["done_units"], 1)
 
     def test_ingest_package_persists_findings(self):
         unit = _unit("u1")


### PR DESCRIPTION
## Summary
- Add `final_review_llm.py`: review prompts, Batch request rows keyed by `unit_id`, finding parse/normalize, resume planning (skip done+same digest; `--force` re-queues), and result ingest that marks parse/missing responses as `failed` (never fake zero-finding done).
- `final-review-build` now writes `requests.jsonl`; new CLI `final-review-resume` / `final-review-ingest-results`; diagnostics commands + Batch submit/download helpers for `mode=final_review`.
- Docs: Batch workflow for submit → download → ingest and resume.

Still **report-only** (no `.rpy` writes). Findings → revision candidates is **PR C**.

Related to #255

## Test plan
- [x] `python -m unittest tests.test_final_review_llm tests.test_final_review -q`
- [x] `python -m unittest tests.test_gui_diagnostics_context -q`
- [ ] CI green
- [ ] Optional: build → (mock) result JSONL → ingest-results → status shows findings; resume skips done units