### PR TITLE
Integrate final review revision handoff

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -62,9 +62,9 @@ python gemini_translate_batch.py sync-revisions --apply
 
 `sync-revisions` 复用订正 prompt、schema、RAG / Story Memory 注入、预览报告和写回前源快照校验；默认只预览，传 `--apply` 才调用 `apply-revisions` 写回。
 
-## 最终审校 campaign（report-only）
+## 最终审校（report-only → 人工选择 → 订正预览）
 
-最终审校是**独立 campaign**，用于在翻译范围完成后批量发现问题。默认 **report-only**：不调用 autofix，也不直接写 `.rpy`。用户选中的 findings 将来会转成现有订正候选，再走 `preview-revisions → apply-revisions`。
+最终审校先以**独立 campaign** 批量发现问题，默认 **report-only**：不调用 autofix，也不直接写 `.rpy`。只有用户明确选择的 findings 才会转成普通 revision manifest，并强制走 `preview-revisions → apply-revisions`；模型不能声称问题已经修复或写回。
 
 ```bash
 # 构建 campaign：完成度闸门 + 冻结上下文 digest + review units + requests.jsonl
@@ -78,6 +78,11 @@ python gemini_translate_batch.py final-review-export logs/batch_jobs/<package>/m
 # 续跑：跳过 digest 未变的 done unit；--force 全部重审
 python gemini_translate_batch.py final-review-resume logs/batch_jobs/<package>/manifest.json
 python gemini_translate_batch.py final-review-resume logs/batch_jobs/<package>/manifest.json --force
+
+# 将明确选择的问题转换为订正候选并立即生成预览（--finding-id 可重复）
+python gemini_translate_batch.py final-review-create-revisions logs/batch_jobs/<package>/manifest.json --finding-id <finding-id>
+# 确认预览后，仍使用现有安全写回入口
+python gemini_translate_batch.py apply-revisions logs/batch_jobs/<revision-package>/manifest.json
 ```
 
 ### 启动闸门
@@ -113,11 +118,16 @@ logs/batch_jobs/<ts>_<project>_final_review/
   report.md              # 人类可读报告
 ```
 
-### 非目标（当前）
+### 选择、状态与 GUI
 
 - 不自动修改 `.rpy`，无模型直接声称 `fixed` / `applied`。
 - 不把回译抽检当作写回安全闸门。
-- 选中 findings → revision candidates 与 GUI 工作台页在后续 PR（#255 PR C）。
+- 同一译文上的多个 finding 若给出冲突建议，转换会拒绝，要求用户只保留一种建议。
+- 转换时重新校验 campaign 完成状态、review unit digest、项目 identity、原文和当前译文；任一已变化就拒绝并要求先续跑最终审校。
+- finding 状态只由真实生命周期推进：成功建包为 `candidate`，成功预览为 `previewed`，实际写入该 identity 后才是 `applied`。被二次校验跳过的条目不会误标已写回。
+- GUI 位于「订正」页面的「终审」子模式，复用统一的开始 / 继续 / 停止、云端状态和写回交互。报告完成后用“选择问题并生成预览”表格人工勾选，不占用「上下文库」。
+
+最终审校生成的 revision manifest 带有来源 campaign、snapshot digest 和 finding digest；后续预览 / 写回会验证这些 provenance，防止把被编辑或属于其他项目的报告状态写回。
 
 相关配置见 `translator_config.example.json` 的 `batch.final_review`。
 

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -53,7 +53,7 @@ logs/story_memory/story_graph.json
 
 ## Project Analysis（项目分析）
 
-> 阶段 1（#256）的产物合同与只读检查已成为后续能力的基础；#254 已接入结构构建、可选 LLM 精炼、人工发布与翻译注入。只有 fingerprint 仍匹配、状态为 `published` 且设置中开启「用于翻译」的摘要才会进入翻译 prompt。最终审校 campaign（#255）在冻结 snapshot 时也可选纳入该 Project Analysis fingerprint；没有可用 PA 时仍可仅靠其它上下文层运行。详见 [Batch 工作流 · 最终审校](batch_workflows.md#最终审校-campaignreport-only)。
+> 阶段 1（#256）的产物合同与只读检查已成为后续能力的基础；#254 已接入结构构建、可选 LLM 精炼、人工发布与翻译注入。只有 fingerprint 仍匹配、状态为 `published` 且设置中开启「用于翻译」的摘要才会进入翻译 prompt。最终审校 campaign（#255）在冻结 snapshot 时也可选纳入该 Project Analysis fingerprint；没有可用 PA 时仍可仅靠其它上下文层运行。详见 [Batch 工作流 · 最终审校](batch_workflows.md)。
 
 ### 产物目录
 

--- a/final_review.py
+++ b/final_review.py
@@ -1,8 +1,8 @@
 """Final-review campaign contract: readiness, snapshots, digests, package I/O.
 
-Phase A (#255 PR A) owns report-only campaign structure without calling models
-or writing ``.rpy`` files. Review execution (LLM / Batch) and revision hand-off
-land in later PRs; they must reuse these digests and status rules rather than
+The campaign remains report-only and never writes ``.rpy`` files. Review
+execution and the selected-finding revision hand-off reuse these digests and
+status rules rather than
 re-implement readiness or ``fixed``/``applied`` claims in the GUI.
 
 Design constraints from #255:
@@ -1341,9 +1341,15 @@ def collect_campaign_status(
     campaign_status = derive_campaign_status(status_counts)
 
     finding_type_counts: dict[str, int] = {}
+    selection_state_counts: dict[str, int] = {}
+    revision_state_counts: dict[str, int] = {}
     for finding in findings:
         ftype = _as_optional_str(finding.get("finding_type")) or "unknown"
         finding_type_counts[ftype] = finding_type_counts.get(ftype, 0) + 1
+        selection = _as_optional_str(finding.get("selection_state")) or SELECTION_STATE_OPEN
+        revision = _as_optional_str(finding.get("revision_state")) or REVISION_STATE_NONE
+        selection_state_counts[selection] = selection_state_counts.get(selection, 0) + 1
+        revision_state_counts[revision] = revision_state_counts.get(revision, 0) + 1
 
     return {
         "mode": MANIFEST_MODE_FINAL_REVIEW,
@@ -1369,6 +1375,8 @@ def collect_campaign_status(
         "finding_count": len(findings),
         "status_counts": status_counts,
         "finding_type_counts": dict(sorted(finding_type_counts.items())),
+        "selection_state_counts": dict(sorted(selection_state_counts.items())),
+        "revision_state_counts": dict(sorted(revision_state_counts.items())),
         "readiness": manifest.get("readiness") or {},
         "scope": snapshot.get("scope") or manifest.get("scope") or {},
         "created_at": manifest.get("created_at") or "",
@@ -1431,6 +1439,10 @@ def format_campaign_report_markdown(
             lines.append(
                 f"- `{finding.get('finding_id')}` · **{finding.get('finding_type')}** "
                 f"({finding.get('severity')}) · `{finding.get('identity_v2')}`"
+            )
+            lines.append(
+                f"  - state: selection=`{finding.get('selection_state') or SELECTION_STATE_OPEN}` · "
+                f"revision=`{finding.get('revision_state') or REVISION_STATE_NONE}`"
             )
             reason = str(finding.get("reason") or "").strip()
             if reason:

--- a/final_review_revision.py
+++ b/final_review_revision.py
@@ -11,6 +11,12 @@ from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
 
 
 def finding_digest(finding: Mapping[str, Any]) -> str:
+    """Return the stable content fingerprint used by write-back safety checks.
+
+    Mutable ``selection_state`` and ``revision_state`` fields are intentionally
+    excluded so the digest remains valid while a finding advances from selected
+    to candidate, previewed, and applied.
+    """
     keys = ("finding_id", "identity_v2", "file_rel_path", "source", "current_translation",
             "suggested_revision", "review_unit_id", "review_unit_digest")
     return fr.stable_json_sha256({key: finding.get(key) or "" for key in keys})

--- a/final_review_revision.py
+++ b/final_review_revision.py
@@ -1,0 +1,197 @@
+"""Safe hand-off from selected final-review findings to revision preview/apply."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+import final_review as fr
+from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
+
+
+def finding_digest(finding: Mapping[str, Any]) -> str:
+    keys = ("finding_id", "identity_v2", "file_rel_path", "source", "current_translation",
+            "suggested_revision", "review_unit_id", "review_unit_digest")
+    return fr.stable_json_sha256({key: finding.get(key) or "" for key in keys})
+
+
+def _write_findings(package: Mapping[str, Any], findings: Sequence[Mapping[str, Any]]) -> None:
+    paths = package["paths"]
+    manifest = dict(package["manifest"])
+    manifest.pop("_manifest_path", None)
+    manifest.pop("_package_dir", None)
+    manifest["summary"] = {**dict(manifest.get("summary") or {}), "finding_count": len(findings)}
+    atomic_write_jsonl(paths["findings"], findings, ensure_ascii=False)
+    atomic_write_json(paths["manifest"], manifest, ensure_ascii=False, indent=2)
+    atomic_write_text(paths["report"], fr.format_campaign_report_markdown(
+        manifest, package.get("units") or [], findings,
+    ))
+
+
+def sync_linked_findings(manifest: Mapping[str, Any], state: str, identity_ids=None) -> int:
+    """Advance finding state only after the corresponding revision step succeeds."""
+    link = manifest.get("final_review_source")
+    if not isinstance(link, Mapping):
+        return 0
+    allowed = (fr.REVISION_STATE_CANDIDATE, fr.REVISION_STATE_PREVIEWED, fr.REVISION_STATE_APPLIED)
+    if state not in allowed:
+        raise SystemExit(f"Unsupported final-review revision state: {state}")
+    source = str(link.get("manifest_path") or "").strip()
+    linked = link.get("findings")
+    if not source or not isinstance(linked, list) or not linked:
+        raise SystemExit("Final-review provenance is incomplete; refusing finding-state update.")
+    try:
+        package = fr.load_campaign_package(source)
+    except fr.FinalReviewError as exc:
+        raise SystemExit(f"Linked final-review campaign is unavailable: {exc}") from exc
+    actual_snapshot = str(package.get("snapshot", {}).get("snapshot_digest") or package["manifest"].get("snapshot_digest") or "")
+    if actual_snapshot != str(link.get("snapshot_digest") or ""):
+        raise SystemExit("Linked final-review campaign snapshot changed; refusing finding-state update.")
+    links = {str(row.get("finding_id") or ""): row for row in linked if isinstance(row, Mapping)}
+    selected_identities = None if identity_ids is None else {
+        str(value) for value in identity_ids if str(value)
+    }
+    findings = [dict(row) for row in package.get("findings") or []]
+    found = set()
+    rank = {fr.REVISION_STATE_NONE: 0, fr.REVISION_STATE_CANDIDATE: 1,
+            fr.REVISION_STATE_PREVIEWED: 2, fr.REVISION_STATE_APPLIED: 3}
+    changed = 0
+    for finding in findings:
+        finding_id = str(finding.get("finding_id") or "")
+        row = links.get(finding_id)
+        if row is None:
+            continue
+        found.add(finding_id)
+        if finding_digest(finding) != str(row.get("digest") or ""):
+            raise SystemExit(f"Linked final-review finding changed ({finding_id}); refusing state update.")
+        should_update = (
+            selected_identities is None
+            or str(finding.get("identity_v2") or "") in selected_identities
+        )
+        if should_update and rank.get(
+            str(finding.get("revision_state") or "none"), 0
+        ) <= rank[state]:
+            finding["selection_state"] = fr.SELECTION_STATE_SELECTED
+            finding["revision_state"] = state
+            changed += 1
+    missing = set(links) - found
+    if missing:
+        raise SystemExit("Linked final-review findings are missing: " + ", ".join(sorted(missing)))
+    _write_findings(package, findings)
+    return changed
+
+
+def _select(package: Mapping[str, Any], finding_ids: Sequence[str] | None) -> list[dict[str, Any]]:
+    if fr.collect_campaign_status(package=package).get("status") != fr.STATUS_DONE:
+        raise SystemExit("Final-review campaign is not complete; resolve pending/stale/failed units first.")
+    requested = {str(value).strip() for value in (finding_ids or []) if str(value).strip()}
+    findings = [dict(row) for row in package.get("findings") or []]
+    missing = requested - {str(row.get("finding_id") or "") for row in findings}
+    if missing:
+        raise SystemExit("Unknown final-review finding id(s): " + ", ".join(sorted(missing)))
+    selected = []
+    for finding in findings:
+        use = (str(finding.get("finding_id") or "") in requested if requested
+               else finding.get("selection_state") == fr.SELECTION_STATE_SELECTED)
+        if not use:
+            continue
+        if finding.get("revision_state") == fr.REVISION_STATE_APPLIED:
+            raise SystemExit(f"Finding was already applied: {finding.get('finding_id')}")
+        if not str(finding.get("suggested_revision") or "").strip():
+            raise SystemExit(f"Finding has no suggested revision: {finding.get('finding_id')}")
+        selected.append(finding)
+    if not selected:
+        raise SystemExit("No findings selected. Pass --finding-id or select findings in the GUI first.")
+    return selected
+
+
+def create_revision_package(batch: Any, target: str | None, finding_ids: Sequence[str] | None):
+    """Build local candidates and immediately use the existing revision preview gate."""
+    try:
+        package = fr.load_campaign_package(batch.manifest_path_for_target(target))
+    except fr.FinalReviewError as exc:
+        raise SystemExit(f"Unable to load final-review campaign: {exc}") from exc
+    source_manifest = package["manifest"]
+    batch.require_manifest_project_match(source_manifest, "final-review-create-revisions")
+    selected = _select(package, finding_ids)
+    units = {str(unit.get("unit_id") or ""): unit for unit in package.get("units") or []}
+    live_jobs = batch.collect_revision_file_jobs()
+    live_items = {str(item.get("id") or ""): item for job in live_jobs for item in job.get("items") or []}
+    selected_by_identity: dict[str, list[dict[str, Any]]] = {}
+    for finding in selected:
+        finding_id = str(finding.get("finding_id") or "")
+        identity = str(finding.get("identity_v2") or "")
+        unit = units.get(str(finding.get("review_unit_id") or ""))
+        item = live_items.get(identity)
+        if not identity or unit is None or item is None:
+            raise SystemExit(f"Finding no longer resolves in the active project: {finding_id}")
+        if unit.get("status") != fr.STATUS_DONE or str(unit.get("input_digest") or "") != str(finding.get("review_unit_digest") or ""):
+            raise SystemExit(f"Finding review unit is stale: {finding_id}")
+        pairs = (("file_rel_path", "file_rel_path"), ("source", "source"),
+                 ("current_translation", "current_translation"))
+        if any(str(item.get(a) or "") != str(finding.get(b) or "") for a, b in pairs):
+            raise SystemExit(f"Finding source/translation changed since review: {finding_id}. Resume final review first.")
+        selected_by_identity.setdefault(identity, []).append(finding)
+    for identity, rows in selected_by_identity.items():
+        if len({str(row.get("suggested_revision") or "").strip() for row in rows}) != 1:
+            raise SystemExit(f"Selected findings propose conflicting revisions for {identity}; choose one finding.")
+
+    filtered = []
+    for job in live_jobs:
+        items = [item for item in job.get("items") or [] if str(item.get("id") or "") in selected_by_identity]
+        if items:
+            filtered.append({**job, "items": items, "task_count": len(items)})
+    chunks = batch.build_revision_chunks(filtered, chunk_size=batch.REVISION_CHUNK_SIZE)
+    if not chunks:
+        raise SystemExit("No revision candidates could be built from the selection.")
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    package_dir = batch.create_batch_package_dir(f"{stamp}_{batch.guess_project_slug()}_final_review_revisions")
+    atomic_write_text(os.path.join(package_dir, "requests.jsonl"), "")
+    result_rows = []
+    for chunk in chunks:
+        results = []
+        for item in chunk["items"]:
+            linked = selected_by_identity[str(item.get("id") or "")]
+            reasons = [str(row.get("reason") or "").strip() for row in linked if str(row.get("reason") or "").strip()]
+            results.append({"id": item["id"], "should_update": True,
+                            "revised_translation": str(linked[0]["suggested_revision"]).strip(),
+                            "reason": "；".join(dict.fromkeys(reasons)) or "来自最终审查的人工选择"})
+        text = json.dumps(results, ensure_ascii=False)
+        result_rows.append({"key": chunk["key"], "response": {"candidates": [
+            {"content": {"parts": [{"text": text}]}, "finishReason": "STOP"}]}})
+    atomic_write_jsonl(os.path.join(package_dir, "results.jsonl"), result_rows, ensure_ascii=False)
+    snapshot = str(package.get("snapshot", {}).get("snapshot_digest") or source_manifest.get("snapshot_digest") or "")
+    manifest = {
+        "version": 2, "manifest_version": 2, "core_schema_version": 2,
+        "mode": batch.MANIFEST_MODE_REVISION, "execution": "final_review_handoff",
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+        "display_name": f"{batch.REVISION_DISPLAY_NAME_PREFIX}-{batch.guess_project_slug()}-{stamp}",
+        "batch_model": source_manifest.get("model") or source_manifest.get("batch_model") or "",
+        "base_dir": batch.legacy.BASE_DIR, "tl_dir": batch.legacy.TL_DIR,
+        **batch._manifest_target_language_fields(),
+        **batch.batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
+        "input_jsonl_path": "requests.jsonl", "result_jsonl_path": "results.jsonl",
+        "job_name": "", "job_state": "LOCAL_CANDIDATES", "submit_disabled": True,
+        "settings": {"revision_chunk_size": batch.REVISION_CHUNK_SIZE},
+        "revision_settings": {"chunk_size": batch.REVISION_CHUNK_SIZE, "candidate_source": "final_review"},
+        "summary": {"file_count": len(filtered), "chunk_count": len(chunks),
+                    "item_count": sum(len(chunk["items"]) for chunk in chunks),
+                    "finding_count": len(selected)},
+        "files": {job["file_rel_path"]: {"path": job["file_path"], "task_count": job["task_count"]} for job in filtered},
+        "chunks": chunks,
+        "final_review_source": {"manifest_path": package["paths"]["manifest"],
+            "snapshot_digest": snapshot,
+            "findings": [{"finding_id": str(row.get("finding_id") or ""),
+                          "identity_v2": str(row.get("identity_v2") or ""),
+                          "digest": finding_digest(row)} for row in selected]},
+    }
+    manifest_path = os.path.join(package_dir, "manifest.json")
+    atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+    batch.remember_latest_manifest(manifest_path)
+    loaded = batch.load_manifest(manifest_path)
+    sync_linked_findings(loaded, fr.REVISION_STATE_CANDIDATE)
+    print(f"Created final-review revision package: {package_dir}")
+    print(f"Selected findings: {len(selected)}")
+    print("No .rpy files were written; generating the required revision preview now.")
+    return batch.preview_revisions(manifest_path)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3776,8 +3776,15 @@ def run_final_review_ingest_results(target=None, result_path='', allow_stale_res
     print(f"Failed units: {summary.get('failed_units', 0)}")
     print(f"Findings: {summary.get('finding_count', 0)}")
     print(f"Campaign status: {(result.get('status') or {}).get('status')}")
-    print('Report-only: no .rpy writes. Use final-review-export; revision hand-off is PR C.')
+    print('Report-only: no .rpy writes. Select findings before creating revision candidates.')
     return result
+
+
+def run_final_review_create_revisions(target=None, finding_ids=None):
+    import final_review_revision
+    import sys
+
+    return final_review_revision.create_revision_package(sys.modules[__name__], target, finding_ids)
 
 
 def should_include_keyword_source(text):
@@ -4818,6 +4825,11 @@ def submit_manifest(
             return None
         manifest = load_manifest(manifest_path)
 
+    if manifest.get('submit_disabled'):
+        raise SystemExit(
+            'Submit disabled for this manifest: it contains local revision candidates '
+            'and must use preview-revisions/apply-revisions.'
+        )
     if manifest.get('job_name'):
         raise SystemExit(f"Manifest already submitted: {manifest['job_name']}")
 
@@ -6390,6 +6402,11 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
         'summary': summary,
     }
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
+    if manifest.get('final_review_source'):
+        import final_review as fr
+        import final_review_revision
+
+        final_review_revision.sync_linked_findings(manifest, fr.REVISION_STATE_PREVIEWED)
     print_revision_summary(summary)
     print(f'Preview JSONL: {jsonl_path}')
     print(f'Preview Markdown: {markdown_path}')
@@ -7065,6 +7082,11 @@ def apply_revisions(target=None, force=False):
         raise SystemExit('Revision manifest was already applied. Re-run apply-revisions with --force to bypass this guard; source validation still applies.')
 
     require_manifest_project_match(manifest, 'apply-revisions')
+    if manifest.get('final_review_source'):
+        import final_review as fr
+        import final_review_revision
+
+        final_review_revision.sync_linked_findings(manifest, fr.REVISION_STATE_PREVIEWED)
     transaction_path = os.path.join(
         manifest['_package_dir'],
         '.revision_writeback_transaction.json',
@@ -7150,6 +7172,26 @@ def apply_revisions(target=None, force=False):
     }
     manifest['last_revision_apply_summary'] = summary
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
+    if manifest.get('final_review_source'):
+        import final_review as fr
+        import final_review_revision
+
+        applied_lines_by_file = {
+            file_key: set(line_numbers)
+            for file_key, line_numbers, _file_path in revision_updates
+        }
+        applied_item_ids = {
+            str(item.get('id') or '')
+            for chunk in manifest.get('chunks', [])
+            for item in chunk.get('items', [])
+            if item.get('line')
+            in applied_lines_by_file.get(chunk.get('file_rel_path'), set())
+        }
+        final_review_revision.sync_linked_findings(
+            manifest,
+            fr.REVISION_STATE_APPLIED,
+            identity_ids=applied_item_ids,
+        )
 
     print_revision_summary(summary)
     print(f'Applied files: {applied_files}')
@@ -10196,6 +10238,28 @@ def build_arg_parser():
         ),
     )
 
+    final_review_revisions_parser = subparsers.add_parser(
+        'final-review-create-revisions',
+        help=(
+            'Convert explicitly selected final-review findings into a normal revision '
+            'package and run preview-revisions. Never writes .rpy files.'
+        ),
+    )
+    final_review_revisions_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Final-review campaign package or manifest. Defaults to latest package.',
+    )
+    final_review_revisions_parser.add_argument(
+        '--finding-id',
+        action='append',
+        default=[],
+        help=(
+            'Finding id to convert (repeatable). Without this option, uses findings '
+            'already marked selection_state=selected.'
+        ),
+    )
     project_analysis_status_parser = subparsers.add_parser(
         'project-analysis-status',
         help=(
@@ -10722,6 +10786,7 @@ def main(argv=None):
         'final-review-export',
         'final-review-resume',
         'final-review-ingest-results',
+        'final-review-create-revisions',
     }:
         legacy.load_translator_settings(persist_corrected_game_root=False)
         legacy.load_glossary()
@@ -10767,6 +10832,13 @@ def main(argv=None):
             )
             return
 
+        if command == 'final-review-create-revisions':
+            print_banner()
+            run_final_review_create_revisions(
+                getattr(args, 'target', '') or None,
+                finding_ids=getattr(args, 'finding_id', []) or [],
+            )
+            return
     if command in {
         'project-analysis-status',
         'project-analysis-ingest-keywords',

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -523,6 +523,8 @@ class MainWindow(QMainWindow):
             item: default_work_mode_for_nav(item) for item in WORKBENCH_NAV_ORDER
         }
         self._workflow_step_output_lines: list[str] = []
+        self._final_review_findings_cache_key: tuple[str, int] | None = None
+        self._final_review_findings_cache: tuple[str, dict[str, object] | None] | None = None
         self._apply_output_lines: list[str] = []
         self._recheck_output_lines: list[str] = []
         self._probe_output_lines: list[str] = []
@@ -7047,7 +7049,7 @@ class MainWindow(QMainWindow):
         if self._context_switching_locked():
             self._sync_task_selectors_from_work_mode()
             return
-        if mode in {WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW}:
+        if mode in self._revision_writeback_modes():
             self._set_work_mode(mode, refresh_manifest_writeback=True)
 
     def _set_work_mode(
@@ -7447,6 +7449,11 @@ class MainWindow(QMainWindow):
             self._refresh_active_workbench_page(work_mode_spec(mode))
 
     def _final_review_findings_context(self):
+        """Load the latest final-review package once per manifest revision.
+
+        The returned package is later gated on ``STATUS_DONE`` and only manual
+        finding selections are allowed to enter the revision-preview workflow.
+        """
         if self._current_work_mode() != WorkMode.FINAL_REVIEW:
             return "", None
         game_root = self.state.get_game_root()
@@ -7455,17 +7462,42 @@ class MainWindow(QMainWindow):
         path = self.state.get_latest_manifest_path_for_mode(game_root, WorkMode.FINAL_REVIEW)
         if path is None:
             return "", None
+        path_text = str(path)
+        try:
+            cache_key = (path_text, Path(path).stat().st_mtime_ns)
+        except OSError:
+            cache_key = (path_text, -1)
+        if (
+            self._final_review_findings_cache_key == cache_key
+            and self._final_review_findings_cache is not None
+        ):
+            return self._final_review_findings_cache
         try:
             import final_review as fr
 
-            package = fr.load_campaign_package(str(path))
-            return str(path), package
+            result: tuple[str, dict[str, object] | None] = (
+                path_text,
+                fr.load_campaign_package(path_text),
+            )
         except (fr.FinalReviewError, OSError, ValueError):
-            return str(path), None
+            result = (path_text, None)
+        self._final_review_findings_cache_key = cache_key
+        self._final_review_findings_cache = result
+        return result
 
     def _on_final_review_page_action(self, action: str) -> None:
+        """Start manual finding selection only for a completed review campaign."""
         if action != "select_final_review_findings":
             return
+        if bool(getattr(self, "_task_running", False)):
+            return
+        runner = getattr(self, "runner", None)
+        is_running = getattr(runner, "is_running", None) if runner is not None else None
+        if callable(is_running) and bool(is_running()):
+            return
+        if not self._confirm_unsaved_config_before_workflow():
+            return
+
         manifest_path, package = self._final_review_findings_context()
         if package is None:
             QMessageBox.information(self, "没有可审核的报告", "请先完成一个最终审校任务。")
@@ -7496,7 +7528,7 @@ class MainWindow(QMainWindow):
         if page is None:
             return
         mode = self._current_work_mode()
-        if mode not in {WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW}:
+        if mode not in self._revision_writeback_modes():
             return
         if running is None:
             running = self._task_page_running_chrome()
@@ -7811,6 +7843,8 @@ class MainWindow(QMainWindow):
 
     def _invalidate_manifest_caches(self, manifest_path: str | Path | None = None) -> None:
         state = getattr(self, "state", None)
+        self._final_review_findings_cache_key = None
+        self._final_review_findings_cache = None
         if state is None:
             return
         invalidate_history = getattr(state, "invalidate_manifest_history_cache", None)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -299,6 +299,8 @@ from .user_copy import (
     format_job_state_fact,
     format_manifest_path_fact,
 )
+from .final_review_dialog import FinalReviewFindingsDialog
+from .final_review_workflow import FinalReviewWorkflow
 from .project_analysis_review_dialog import ProjectAnalysisReviewDialog
 from .project_analysis_workflow import (
     ProjectAnalysisWorkflow,
@@ -1699,6 +1701,7 @@ class MainWindow(QMainWindow):
                         stop=self._on_kill,
                         writeback=self._on_apply_revision,
                         select_mode=self._on_revision_page_mode_selected,
+                        action=self._on_final_review_page_action,
                     )
                 )
                 self.revision_page = page
@@ -6870,7 +6873,7 @@ class MainWindow(QMainWindow):
         )
 
     def _revision_writeback_modes(self) -> frozenset[WorkMode]:
-        return frozenset({WorkMode.REVISION, WorkMode.SYNC_REVISION})
+        return frozenset({WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW})
 
     def _uses_revision_writeback(self, mode: WorkMode | None = None) -> bool:
         return work_mode_spec(mode or self._current_work_mode()).mode in (
@@ -7044,7 +7047,7 @@ class MainWindow(QMainWindow):
         if self._context_switching_locked():
             self._sync_task_selectors_from_work_mode()
             return
-        if mode in {WorkMode.REVISION, WorkMode.SYNC_REVISION}:
+        if mode in {WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW}:
             self._set_work_mode(mode, refresh_manifest_writeback=True)
 
     def _set_work_mode(
@@ -7443,19 +7446,91 @@ class MainWindow(QMainWindow):
         if workbench_nav_for_work_mode(mode) == WorkbenchNavItem.KEYWORDS:
             self._refresh_active_workbench_page(work_mode_spec(mode))
 
+    def _final_review_findings_context(self):
+        if self._current_work_mode() != WorkMode.FINAL_REVIEW:
+            return "", None
+        game_root = self.state.get_game_root()
+        if game_root is None:
+            return "", None
+        path = self.state.get_latest_manifest_path_for_mode(game_root, WorkMode.FINAL_REVIEW)
+        if path is None:
+            return "", None
+        try:
+            import final_review as fr
+
+            package = fr.load_campaign_package(str(path))
+            return str(path), package
+        except (fr.FinalReviewError, OSError, ValueError):
+            return str(path), None
+
+    def _on_final_review_page_action(self, action: str) -> None:
+        if action != "select_final_review_findings":
+            return
+        manifest_path, package = self._final_review_findings_context()
+        if package is None:
+            QMessageBox.information(self, "没有可审核的报告", "请先完成一个最终审校任务。")
+            return
+        import final_review as fr
+
+        status = fr.collect_campaign_status(package=package)
+        if status.get("status") != fr.STATUS_DONE:
+            QMessageBox.information(self, "最终审校尚未完成", "请先继续任务并整理全部审查结果。")
+            return
+        dialog = FinalReviewFindingsDialog(package.get("findings") or [], self)
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        finding_ids = dialog.selected_finding_ids()
+        if not finding_ids:
+            return
+        self._set_writeback_summary(idle_writeback_summary_for_work_mode(WorkMode.FINAL_REVIEW))
+        self._clear_log_view()
+        self._show_workbench_log_drawer()
+        self._begin_translation_workflow(
+            FinalReviewWorkflow.create_revisions(manifest_path, finding_ids),
+            log_heading="正在把所选问题生成订正预览",
+            status_tab=1,
+        )
     def _sync_revision_page_controls(self, *, running: bool | None = None) -> None:
         """Mirror coordinator-owned revision actions onto the real page."""
         page = getattr(self, "revision_page", None)
         if page is None:
             return
         mode = self._current_work_mode()
-        if mode not in {WorkMode.REVISION, WorkMode.SYNC_REVISION}:
+        if mode not in {WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW}:
             return
         if running is None:
             running = self._task_page_running_chrome()
         summary = self._current_writeback_summary()
+        findings_enabled = False
+        review_status_message = ""
+        if mode == WorkMode.FINAL_REVIEW:
+            _path, package = self._final_review_findings_context()
+            if package is not None:
+                import final_review as fr
+                review_status = fr.collect_campaign_status(package=package)
+                scope = review_status.get("scope") or {}
+                counts = review_status.get("status_counts") or {}
+                snapshot = str(review_status.get("snapshot_digest") or "")
+                review_status_message = (
+                    f"最终审校：{review_status.get('status')}；"
+                    f"范围 {scope.get('file_count', 0)} 个文件 / {scope.get('item_count', 0)} 条译文；"
+                    f"unit 完成 {counts.get('done', 0)}、失败 {counts.get('failed', 0)}、"
+                    f"过期 {counts.get('stale', 0)}；findings {review_status.get('finding_count', 0)}；"
+                    f"快照 {snapshot[:12] or '—'}。"
+                )
+
+                findings_enabled = (
+                    review_status.get("status") == fr.STATUS_DONE
+                    and any(
+                        str(row.get("suggested_revision") or "").strip()
+                        and row.get("revision_state") != fr.REVISION_STATE_APPLIED
+                        for row in package.get("findings") or []
+                    )
+                )
         if summary.can_apply:
             result_message = summary.message or "订正预览已通过，可安全写回。"
+        elif review_status_message:
+            result_message = review_status_message
         elif summary.message:
             result_message = f"订正结果：{summary.message}"
         else:
@@ -7471,6 +7546,7 @@ class MainWindow(QMainWindow):
             resume_visible=work_mode_spec(mode).supports_resume,
             resume_label=self.resume_btn.text(),
             writeback_enabled=summary.can_apply,
+            findings_enabled=findings_enabled,
             result_message=result_message,
         )
         if workbench_nav_for_work_mode(mode) == WorkbenchNavItem.REVISION:

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -378,6 +378,11 @@ def idle_writeback_summary_for_work_mode(mode) -> WritebackSummary:
                 "同步订正默认只出预览报告；请先在左侧「订正」生成预览，"
                 "再在结果区点击「写回订正」。"
             )
+        elif spec.mode == WorkMode.FINAL_REVIEW:
+            message = (
+                "最终审校必须先生成问题报告；只有人工选择的问题会进入订正预览，"
+                "确认预览后才可写回所选订正。"
+            )
         elif spec.mode == WorkMode.PROJECT_ANALYSIS:
             message = (
                 "项目分析不会写回游戏脚本。请到左侧「上下文库」使用"

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -343,6 +343,16 @@ def build_cli_commands(
                 ),
             ]
         )
+        commands.append(
+            DiagnosticsCommand(
+                label="把已选 findings 生成订正预览",
+                command=format_cli_command(
+                    python_exe,
+                    batch_script_path,
+                    ["final-review-create-revisions", manifest_path],
+                ),
+            )
+        )
         commands.extend(
             build_cloud_job_commands(
                 python_exe=python_exe,
@@ -356,18 +366,19 @@ def build_cli_commands(
             )
         )
     if mode_text == "revision":
-        commands.extend(
-            build_cloud_job_commands(
-                python_exe=python_exe,
-                batch_script_path=batch_script_path,
-                manifest_path=manifest_path,
-                manifest=manifest,
-                submit_max_cost=submit_max_cost,
-                submit_label="提交订正任务",
-                status_label="查询订正状态",
-                download_label="下载订正结果",
+        if not manifest.get("submit_disabled"):
+            commands.extend(
+                build_cloud_job_commands(
+                    python_exe=python_exe,
+                    batch_script_path=batch_script_path,
+                    manifest_path=manifest_path,
+                    manifest=manifest,
+                    submit_max_cost=submit_max_cost,
+                    submit_label="提交订正任务",
+                    status_label="查询订正状态",
+                    download_label="下载订正结果",
+                )
             )
-        )
         commands.append(
             DiagnosticsCommand(
                 label="预览订正结果",

--- a/gui_qt/final_review_dialog.py
+++ b/gui_qt/final_review_dialog.py
@@ -1,0 +1,64 @@
+"""Human selection dialog for final-review findings."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView, QDialog, QDialogButtonBox, QLabel, QTableWidget,
+    QTableWidgetItem, QVBoxLayout, QWidget,
+)
+
+
+class FinalReviewFindingsDialog(QDialog):
+    def __init__(self, findings: Sequence[Mapping[str, object]], parent: QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("选择需要订正的问题")
+        self.resize(1100, 620)
+        layout = QVBoxLayout(self)
+        hint = QLabel("最终审校默认只报告。勾选的问题会先生成订正预览；此操作不会修改 .rpy 文件。")
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+        self.table = QTableWidget(0, 7)
+        self.table.setHorizontalHeaderLabels(["选择", "严重度", "类型", "文件", "当前译文", "建议译文", "原因"])
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.setWordWrap(True)
+        self._finding_ids: list[str] = []
+        for finding in findings:
+            if not str(finding.get("suggested_revision") or "").strip():
+                continue
+            if str(finding.get("revision_state") or "") == "applied":
+                continue
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            finding_id = str(finding.get("finding_id") or "")
+            self._finding_ids.append(finding_id)
+            check = QTableWidgetItem()
+            check.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
+            check.setCheckState(Qt.CheckState.Checked if finding.get("selection_state") == "selected" else Qt.CheckState.Unchecked)
+            self.table.setItem(row, 0, check)
+            values = (
+                finding.get("severity"), finding.get("finding_type"), finding.get("file_rel_path"),
+                finding.get("current_translation"), finding.get("suggested_revision"), finding.get("reason"),
+            )
+            for column, value in enumerate(values, start=1):
+                item = QTableWidgetItem(str(value or ""))
+                item.setToolTip(str(value or ""))
+                self.table.setItem(row, column, item)
+        self.table.resizeColumnsToContents()
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table, 1)
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.button(QDialogButtonBox.StandardButton.Ok).setText("生成订正预览")
+        buttons.accepted.connect(self._accept_selection)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _accept_selection(self) -> None:
+        if self.selected_finding_ids():
+            self.accept()
+
+    def selected_finding_ids(self) -> list[str]:
+        return [finding_id for row, finding_id in enumerate(self._finding_ids)
+                if self.table.item(row, 0).checkState() == Qt.CheckState.Checked]

--- a/gui_qt/final_review_dialog.py
+++ b/gui_qt/final_review_dialog.py
@@ -9,6 +9,8 @@ from PySide6.QtWidgets import (
     QTableWidgetItem, QVBoxLayout, QWidget,
 )
 
+from final_review import REVISION_STATE_APPLIED, SELECTION_STATE_SELECTED
+
 
 class FinalReviewFindingsDialog(QDialog):
     def __init__(self, findings: Sequence[Mapping[str, object]], parent: QWidget | None = None):
@@ -28,7 +30,7 @@ class FinalReviewFindingsDialog(QDialog):
         for finding in findings:
             if not str(finding.get("suggested_revision") or "").strip():
                 continue
-            if str(finding.get("revision_state") or "") == "applied":
+            if str(finding.get("revision_state") or "") == REVISION_STATE_APPLIED:
                 continue
             row = self.table.rowCount()
             self.table.insertRow(row)
@@ -36,7 +38,11 @@ class FinalReviewFindingsDialog(QDialog):
             self._finding_ids.append(finding_id)
             check = QTableWidgetItem()
             check.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
-            check.setCheckState(Qt.CheckState.Checked if finding.get("selection_state") == "selected" else Qt.CheckState.Unchecked)
+            check.setCheckState(
+                Qt.CheckState.Checked
+                if finding.get("selection_state") == SELECTION_STATE_SELECTED
+                else Qt.CheckState.Unchecked
+            )
             self.table.setItem(row, 0, check)
             values = (
                 finding.get("severity"), finding.get("finding_type"), finding.get("file_rel_path"),
@@ -50,14 +56,20 @@ class FinalReviewFindingsDialog(QDialog):
         self.table.horizontalHeader().setStretchLastSection(True)
         layout.addWidget(self.table, 1)
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
-        buttons.button(QDialogButtonBox.StandardButton.Ok).setText("生成订正预览")
+        self._ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        self._ok_button.setText("生成订正预览")
         buttons.accepted.connect(self._accept_selection)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
+        self.table.itemChanged.connect(self._sync_accept_enabled)
+        self._sync_accept_enabled()
 
     def _accept_selection(self) -> None:
         if self.selected_finding_ids():
             self.accept()
+
+    def _sync_accept_enabled(self, *_args) -> None:
+        self._ok_button.setEnabled(bool(self.selected_finding_ids()))
 
     def selected_finding_ids(self) -> list[str]:
         return [finding_id for row, finding_id in enumerate(self._finding_ids)

--- a/gui_qt/final_review_workflow.py
+++ b/gui_qt/final_review_workflow.py
@@ -1,0 +1,145 @@
+"""Final-review Batch workflow and selected-finding hand-off for the GUI."""
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from .batch_workflow_support import build_submit_cli_args
+from .revision_report import summarize_revision_preview_output
+from .translation_workflow import (
+    TERMINAL_FAILURE_STATES, WorkflowStep, WorkflowUpdate, extract_job_state,
+    extract_manifest_path, manifest_path_for_package,
+)
+from .user_copy import format_job_state_fact, format_manifest_path_fact, job_state_label
+
+
+STEP_TEXT = {
+    "final-review-build": ("正在准备最终审校", "正在冻结项目上下文并生成审查任务。"),
+    "final-review-resume": ("正在刷新审查范围", "正在重新采集上下文并重建未完成任务。"),
+    "submit": ("正在提交最终审校", "正在上传审查请求并创建云端批量任务。"),
+    "status": ("正在刷新审查状态", "正在查询云端任务处理状态。"),
+    "download": ("正在获取审查结果", "任务已完成，正在下载问题报告。"),
+    "final-review-ingest-results": ("正在整理问题报告", "正在校验结果并写入最终审校 findings。"),
+    "final-review-create-revisions": ("正在生成订正预览", "正在把人工选择的问题转换为安全订正候选。"),
+}
+
+
+def _created_campaign(output: str) -> str:
+    match = re.search(r"^Created final-review campaign:\s*(.+?)\s*$", output, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _created_revision(output: str) -> str:
+    match = re.search(r"^Created final-review revision package:\s*(.+?)\s*$", output, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+class FinalReviewWorkflow:
+    def __init__(self, steps: list[str], manifest_path: str = "", *, finding_ids: Sequence[str] = (), submit_max_cost=None):
+        self._steps = list(steps)
+        self.manifest_path = manifest_path
+        self.finding_ids = tuple(finding_ids)
+        self.submit_max_cost = submit_max_cost
+
+    @classmethod
+    def start_new(cls, *, submit_max_cost=None):
+        return cls(["final-review-build", "submit", "status"], submit_max_cost=submit_max_cost)
+
+    @classmethod
+    def resume_manifest(cls, manifest_path, manifest, *, submit_max_cost=None):
+        summary = manifest.get("summary") if isinstance(manifest.get("summary"), dict) else {}
+        counts = summary.get("status_counts") if isinstance(summary.get("status_counts"), dict) else {}
+        if manifest.get("status") == "done" or (counts and counts.get("done") == summary.get("unit_count")):
+            return cls([], manifest_path, submit_max_cost=submit_max_cost)
+        if manifest.get("job_state") == "JOB_STATE_SUCCEEDED":
+            steps = ["download", "final-review-ingest-results"]
+        elif not manifest.get("job_name"):
+            steps = ["final-review-resume", "submit", "status"]
+        else:
+            steps = ["status"]
+        return cls(steps, manifest_path, submit_max_cost=submit_max_cost)
+
+    @classmethod
+    def create_revisions(cls, manifest_path: str, finding_ids: Sequence[str]):
+        return cls(["final-review-create-revisions"], manifest_path, finding_ids=finding_ids)
+
+    def current_step(self):
+        if not self._steps:
+            return None
+        key = self._steps[0]
+        heading, message = STEP_TEXT[key]
+        return WorkflowStep(key=key, args=self._args(key), heading=heading, message=message)
+
+    def complete_current_step(self, exit_code: int, output: str):
+        key = self._steps.pop(0)
+        if exit_code != 0:
+            self._steps.clear()
+            return WorkflowUpdate(status="failed", heading="最终审校流程中断",
+                                  message=f"{STEP_TEXT[key][0]}没有正常完成，请查看原始输出。", facts=self._facts())
+        if key == "final-review-build":
+            package = _created_campaign(output)
+            if not package:
+                self._steps.clear()
+                return WorkflowUpdate(status="failed", heading="无法准备最终审校",
+                                      message="未生成最终审校任务包，请查看诊断日志。", facts=[])
+            self.manifest_path = manifest_path_for_package(package)
+        elif key == "submit":
+            path = extract_manifest_path(output)
+            if path:
+                self.manifest_path = path
+        elif key == "status":
+            state = extract_job_state(output)
+            if state == "JOB_STATE_SUCCEEDED":
+                if getattr(self, "only_query", False):
+                    self._steps.clear()
+                    return WorkflowUpdate(
+                        status="ready",
+                        heading="最终审校云端任务已完成",
+                        message="查询完成；请点击「继续审查」下载并整理问题报告。",
+                        facts=self._facts([format_job_state_fact(state)]),
+                    )
+                self._steps[:0] = ["download", "final-review-ingest-results"]
+            elif state in TERMINAL_FAILURE_STATES:
+                self._steps.clear()
+                return WorkflowUpdate(status="failed", heading="最终审校任务失败",
+                                      message=f"云端状态为 {job_state_label(state)}。", facts=self._facts([format_job_state_fact(state)]))
+            else:
+                self._steps.clear()
+                return WorkflowUpdate(status="waiting", heading="最终审校仍在处理",
+                                      message="稍后点击「查询云端状态」继续。", facts=self._facts([format_job_state_fact(state or '未知')]))
+        elif key == "final-review-create-revisions":
+            package = _created_revision(output)
+            if package:
+                self.manifest_path = manifest_path_for_package(package)
+            update = summarize_revision_preview_output(output, 0)
+            self._steps.clear()
+            return WorkflowUpdate(status=update.status, heading="订正预览已生成",
+                                  message="所选问题已进入标准订正预览；确认后才可写回。",
+                                  facts=self._facts(list(update.facts)))
+        return self._continue()
+
+    def _continue(self):
+        step = self.current_step()
+        if step is None:
+            return WorkflowUpdate(status="done", heading="最终审校报告已就绪",
+                                  message="请审核问题并选择需要进入订正预览的项目。", facts=self._facts())
+        return WorkflowUpdate(status="running", heading=step.heading, message=step.message,
+                              facts=self._facts(), should_continue=True)
+
+    def _args(self, key: str) -> list[str]:
+        if key == "final-review-build":
+            return [key]
+        if key == "submit":
+            return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
+        if key == "final-review-create-revisions":
+            args = [key, self.manifest_path]
+            for finding_id in self.finding_ids:
+                args.extend(["--finding-id", finding_id])
+            return args
+        return [key, self.manifest_path]
+
+    def _facts(self, extra=None):
+        facts = [format_manifest_path_fact(self.manifest_path)] if self.manifest_path else []
+        if extra:
+            facts.extend(extra)
+        return facts

--- a/gui_qt/final_review_workflow.py
+++ b/gui_qt/final_review_workflow.py
@@ -49,7 +49,13 @@ class FinalReviewWorkflow:
     def resume_manifest(cls, manifest_path, manifest, *, submit_max_cost=None):
         summary = manifest.get("summary") if isinstance(manifest.get("summary"), dict) else {}
         counts = summary.get("status_counts") if isinstance(summary.get("status_counts"), dict) else {}
-        if manifest.get("status") == "done" or (counts and counts.get("done") == summary.get("unit_count")):
+        done_count = counts.get("done")
+        unit_count = summary.get("unit_count")
+        if manifest.get("status") == "done" or (
+            done_count is not None
+            and unit_count is not None
+            and done_count == unit_count
+        ):
             return cls([], manifest_path, submit_max_cost=submit_max_cost)
         if manifest.get("job_state") == "JOB_STATE_SUCCEEDED":
             steps = ["download", "final-review-ingest-results"]

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -395,7 +395,7 @@ ADVANCED_SETTING_FIELDS: tuple[SettingField, ...] = (
         "batch_final_review_model",
         ("batch", "final_review", "model"),
         "最终审校模型",
-        "后续审校执行使用的模型；留空则回退到 Batch 模型。首版 build 仅记录 digest。",
+        "最终审校执行使用的模型；留空则回退到 Batch 模型。",
         "str",
         "",
         "最终审校",

--- a/gui_qt/work_modes.py
+++ b/gui_qt/work_modes.py
@@ -19,6 +19,7 @@ class WorkMode(str, Enum):
     BOOTSTRAP_RAG = "bootstrap_rag"
     BOOTSTRAP_SOURCE_INDEX = "bootstrap_source_index"
     PROJECT_ANALYSIS = "project_analysis"
+    FINAL_REVIEW = "final_review"
     REVISION = "revision"
     SYNC_REVISION = "sync_revision"
 
@@ -78,6 +79,7 @@ TASK_CATEGORY_SPECS: dict[TaskCategory, TaskCategorySpec] = {
         work_modes=(
             WorkMode.REVISION,
             WorkMode.SYNC_REVISION,
+            WorkMode.FINAL_REVIEW,
         ),
     ),
 }
@@ -233,6 +235,25 @@ WORK_MODE_SPECS: dict[WorkMode, WorkModeSpec] = {
         is_bootstrap=False,
         bootstrap_kind="",
         manifest_mode=None,
+        not_implemented_message="",
+    ),
+    WorkMode.FINAL_REVIEW: WorkModeSpec(
+        mode=WorkMode.FINAL_REVIEW,
+        category=TaskCategory.MAINTENANCE,
+        label="最终审校",
+        start_button_label="开始最终审校",
+        resume_button_label="继续审查",
+        task_group_label="最终审校任务",
+        progress_tab_label="审查进度",
+        writeback_tab_label="订正候选",
+        idle_workflow_heading="尚未开始最终审校",
+        idle_workflow_message="先生成问题报告；只有人工选择的问题才会进入订正预览，绝不直接修改脚本。",
+        supports_resume=True,
+        supports_translation_writeback=False,
+        implemented=True,
+        is_bootstrap=False,
+        bootstrap_kind="",
+        manifest_mode="final_review",
         not_implemented_message="",
     ),
     WorkMode.REVISION: WorkModeSpec(
@@ -409,7 +430,7 @@ WORKBENCH_NAV_SPECS: dict[WorkbenchNavItem, WorkbenchNavSpec] = {
     WorkbenchNavItem.REVISION: WorkbenchNavSpec(
         item=WorkbenchNavItem.REVISION,
         label="订正",
-        work_modes=(WorkMode.REVISION, WorkMode.SYNC_REVISION),
+        work_modes=(WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW),
         show_submode=True,
     ),
     WorkbenchNavItem.CONTEXT: WorkbenchNavSpec(
@@ -429,6 +450,7 @@ WORKBENCH_NAV_SPECS: dict[WorkbenchNavItem, WorkbenchNavSpec] = {
 _WORK_MODE_SUBMODE_LABELS: dict[WorkMode, str] = {
     WorkMode.KEYWORD_EXTRACTION: "批量",
     WorkMode.SYNC_KEYWORD_EXTRACTION: "同步",
+    WorkMode.FINAL_REVIEW: "终审",
     WorkMode.REVISION: "批量",
     WorkMode.SYNC_REVISION: "同步",
     WorkMode.BOOTSTRAP_RAG: "记忆库",

--- a/gui_qt/workbench/revision_page.py
+++ b/gui_qt/workbench/revision_page.py
@@ -136,11 +136,12 @@ class RevisionPage(QFrame):
 
     def reset_project(self) -> None:
         self.set_task_running(False)
+        final_review = self._active_mode == WorkMode.FINAL_REVIEW
         self.set_controls(
             start_enabled=False,
             resume_enabled=False,
-            resume_visible=self._active_mode == WorkMode.REVISION,
-            resume_label="继续订正",
+            resume_visible=self._active_mode in (WorkMode.REVISION, WorkMode.FINAL_REVIEW),
+            resume_label="继续审查" if final_review else "继续订正",
             writeback_enabled=False,
             result_message="项目已切换；请先完成环境检查并重新生成订正预览。",
         )
@@ -167,8 +168,13 @@ class RevisionPage(QFrame):
             self._actions.stop()
 
     def _trigger_review_findings(self) -> None:
-        if not self._running and self._actions.action is not None:
+        if (
+            not self._running
+            and self.review_findings_btn.isEnabled()
+            and self._actions.action is not None
+        ):
             self._actions.action("select_final_review_findings")
+
     def _trigger_writeback(self) -> None:
         if (
             not self._running

--- a/gui_qt/workbench/revision_page.py
+++ b/gui_qt/workbench/revision_page.py
@@ -12,7 +12,7 @@ from .task_controls import TaskPageLayout
 class RevisionPage(QFrame):
     """Page-local controls for batch and synchronous revision workflows."""
 
-    supported_modes = (WorkMode.REVISION, WorkMode.SYNC_REVISION)
+    supported_modes = (WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -62,6 +62,13 @@ class RevisionPage(QFrame):
         self.writeback_btn.setToolTip("仅在订正预览通过后写回；不会使用翻译写回入口。")
         self.writeback_btn.clicked.connect(self._trigger_writeback)
         self.actions.add_action(self.writeback_btn, min_width=108)
+        self.review_findings_btn = QPushButton("选择问题并生成预览")
+        self.review_findings_btn.setObjectName("final_review_select_btn")
+        self.review_findings_btn.setEnabled(False)
+        self.review_findings_btn.setVisible(False)
+        self.review_findings_btn.setToolTip("只转换人工勾选的问题；仍需经过订正预览后才能写回。")
+        self.review_findings_btn.clicked.connect(self._trigger_review_findings)
+        self.actions.add_action(self.review_findings_btn, min_width=160)
         self.actions.finish_setup()
 
         self.result_hint = self.task_layout.add_result_hint(
@@ -84,6 +91,16 @@ class RevisionPage(QFrame):
             blocked = self.mode_combo.blockSignals(True)
             self.mode_combo.setCurrentIndex(index)
             self.mode_combo.blockSignals(blocked)
+        final_review = mode == WorkMode.FINAL_REVIEW
+        self.actions.title_label.setText("最终审校任务" if final_review else "订正任务")
+        self.start_btn.setText("开始最终审校" if final_review else "生成订正预览")
+        self.writeback_btn.setText("写回所选订正" if final_review else "写回订正")
+        self.review_findings_btn.setVisible(final_review)
+        self.result_hint.setText(
+            "审查完成后，选择需要处理的问题并生成订正预览。"
+            if final_review
+            else "生成预览后，可在此确认订正结果并安全写回。"
+        )
         del session
 
     def set_task_running(self, running: bool) -> None:
@@ -94,6 +111,7 @@ class RevisionPage(QFrame):
             self.start_btn.setEnabled(False)
             self.resume_btn.setEnabled(False)
             self.writeback_btn.setEnabled(False)
+            self.review_findings_btn.setEnabled(False)
 
     def set_controls(
         self,
@@ -104,12 +122,14 @@ class RevisionPage(QFrame):
         resume_label: str,
         writeback_enabled: bool,
         result_message: str,
+        findings_enabled: bool = False,
     ) -> None:
         self.start_btn.setEnabled(start_enabled and not self._running)
         self.resume_btn.setVisible(resume_visible)
         self.resume_btn.setText(resume_label)
         self.resume_btn.setEnabled(resume_enabled and not self._running)
         self.writeback_btn.setEnabled(writeback_enabled and not self._running)
+        self.review_findings_btn.setEnabled(findings_enabled and not self._running)
         self.result_hint.setText(result_message)
         self.task_layout.reflow()
         self.updateGeometry()
@@ -146,6 +166,9 @@ class RevisionPage(QFrame):
         if self._running and self._actions.stop is not None:
             self._actions.stop()
 
+    def _trigger_review_findings(self) -> None:
+        if not self._running and self._actions.action is not None:
+            self._actions.action("select_final_review_findings")
     def _trigger_writeback(self) -> None:
         if (
             not self._running

--- a/gui_qt/workflow_factory.py
+++ b/gui_qt/workflow_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Protocol
 
 from .project_analysis_workflow import ProjectAnalysisWorkflow
+from .final_review_workflow import FinalReviewWorkflow
 from .keyword_workflow import KeywordBatchWorkflow
 from .revision_workflow import RevisionBatchWorkflow
 from .sync_keyword_workflow import SyncKeywordWorkflow
@@ -37,6 +38,8 @@ def create_workflow(
         return KeywordBatchWorkflow.start_new(submit_max_cost=submit_max_cost)
     if spec.mode == WorkMode.SYNC_KEYWORD_EXTRACTION:
         return SyncKeywordWorkflow.start_new()
+    if spec.mode == WorkMode.FINAL_REVIEW:
+        return FinalReviewWorkflow.start_new(submit_max_cost=submit_max_cost)
     if spec.mode == WorkMode.REVISION:
         return RevisionBatchWorkflow.start_new(submit_max_cost=submit_max_cost)
     if spec.mode == WorkMode.SYNC_REVISION:
@@ -64,6 +67,12 @@ def resume_workflow(
         )
     if spec.mode == WorkMode.KEYWORD_EXTRACTION:
         return KeywordBatchWorkflow.resume_manifest(
+            manifest_path,
+            manifest,
+            submit_max_cost=submit_max_cost,
+        )
+    if spec.mode == WorkMode.FINAL_REVIEW:
+        return FinalReviewWorkflow.resume_manifest(
             manifest_path,
             manifest,
             submit_max_cost=submit_max_cost,

--- a/tests/test_final_review_revision.py
+++ b/tests/test_final_review_revision.py
@@ -1,0 +1,166 @@
+"""Final-review finding selection to revision lifecycle tests (#255 PR C)."""
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import final_review as fr
+import final_review_revision as handoff
+import gemini_translate_batch as batch
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "golden_revision_minimal" / "tl"
+
+
+class FinalReviewRevisionHandoffTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.tl_dir = self.root / "game" / "tl" / "schinese"
+        self.tl_dir.parent.mkdir(parents=True)
+        shutil.copytree(FIXTURE, self.tl_dir)
+        self.old = {
+            "base": batch.legacy.BASE_DIR,
+            "tl": batch.legacy.TL_DIR,
+            "files": set(batch.legacy.INCLUDE_FILES),
+            "prefixes": set(batch.legacy.INCLUDE_PREFIXES),
+            "log": batch.LOG_DIR,
+            "jobs": batch.BATCH_JOBS_DIR,
+            "latest": batch.LATEST_MANIFEST_FILE,
+            "progress": batch.PROGRESS_LOG,
+            "rag": batch.RAG_ENABLED,
+            "story": batch.STORY_MEMORY_ENABLED,
+        }
+        log_dir = self.root / "logs"
+        batch.legacy.BASE_DIR = str(self.root)
+        batch.legacy.TL_DIR = str(self.tl_dir)
+        batch.legacy.INCLUDE_FILES = set()
+        batch.legacy.INCLUDE_PREFIXES = set()
+        batch.LOG_DIR = str(log_dir)
+        batch.BATCH_JOBS_DIR = str(log_dir / "batch_jobs")
+        batch.LATEST_MANIFEST_FILE = str(log_dir / "batch_jobs" / "latest_manifest.txt")
+        batch.PROGRESS_LOG = str(log_dir / "translation_progress_batch.json")
+        batch.RAG_ENABLED = False
+        batch.STORY_MEMORY_ENABLED = False
+
+    def tearDown(self):
+        batch.legacy.BASE_DIR = self.old["base"]
+        batch.legacy.TL_DIR = self.old["tl"]
+        batch.legacy.INCLUDE_FILES = self.old["files"]
+        batch.legacy.INCLUDE_PREFIXES = self.old["prefixes"]
+        batch.LOG_DIR = self.old["log"]
+        batch.BATCH_JOBS_DIR = self.old["jobs"]
+        batch.LATEST_MANIFEST_FILE = self.old["latest"]
+        batch.PROGRESS_LOG = self.old["progress"]
+        batch.RAG_ENABLED = self.old["rag"]
+        batch.STORY_MEMORY_ENABLED = self.old["story"]
+        self.temp.cleanup()
+
+    def _campaign(self):
+        item = next(
+            item
+            for job in batch.collect_revision_file_jobs()
+            for item in job["items"]
+            if item["source"] == "Void Gate"
+        )
+        review_item = {
+            "identity_v2": item["id"],
+            "file_rel_path": item["file_rel_path"],
+            "source": item["source"],
+            "current_translation": item["current_translation"],
+            "line_number": item["line_number"],
+            "start": item["start"],
+            "end": item["end"],
+        }
+        snapshot = fr.build_context_snapshot(translation_items=[review_item])
+        unit = fr.build_review_units(
+            [review_item],
+            context_digest=snapshot["context_digest"],
+            snapshot_digest=snapshot["snapshot_digest"],
+        )[0]
+        unit = fr.mark_unit_done(unit, finding_count=1)
+        finding = fr.normalize_finding(
+            {
+                "identity_v2": item["id"],
+                "file_rel_path": item["file_rel_path"],
+                "source": item["source"],
+                "current_translation": item["current_translation"],
+                "finding_type": "terminology",
+                "severity": "high",
+                "reason": "统一核心术语",
+                "suggested_revision": "虚空之门",
+            },
+            review_unit_id=unit["unit_id"],
+            review_unit_digest=unit["input_digest"],
+        )
+        package_dir = self.root / "campaign"
+        manifest = fr.build_campaign_manifest(
+            package_dir=str(package_dir),
+            display_name="handoff-test",
+            snapshot=snapshot,
+            units=[unit],
+            readiness=fr.evaluate_readiness(review_item_count=1, pending_task_count=0),
+            base_dir=str(self.root),
+            tl_dir=str(self.tl_dir),
+        )
+        paths = fr.write_campaign_package(
+            package_dir,
+            manifest=manifest,
+            snapshot=snapshot,
+            units=[unit],
+            findings=[finding],
+        )
+        return paths["manifest"], finding["finding_id"]
+
+    def test_selected_finding_previews_then_apply_marks_real_state(self):
+        campaign, finding_id = self._campaign()
+        manifest = handoff.create_revision_package(batch, campaign, [finding_id])
+        self.assertEqual(manifest["execution"], "final_review_handoff")
+        self.assertTrue(manifest["submit_disabled"])
+        self.assertEqual(manifest["last_revision_preview"]["summary"]["valid_items"], 1)
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["selection_state"], fr.SELECTION_STATE_SELECTED)
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_PREVIEWED)
+
+        applied = batch.apply_revisions(manifest["_manifest_path"])
+        self.assertEqual(applied["revision_apply_summary"]["applied_lines"], 1)
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_APPLIED)
+        text = next(self.tl_dir.rglob("*.rpy")).read_text(encoding="utf-8")
+        self.assertIn("虚空之门", text)
+
+    def test_stale_translation_refuses_candidate_creation(self):
+        campaign, finding_id = self._campaign()
+        path = next(self.tl_dir.rglob("*.rpy"))
+        path.write_text(path.read_text(encoding="utf-8").replace("虚空门", "虚空门改"), encoding="utf-8")
+        with self.assertRaisesRegex(SystemExit, "changed since review"):
+            handoff.create_revision_package(batch, campaign, [finding_id])
+
+    def test_empty_apply_identity_set_does_not_claim_applied(self):
+        campaign, finding_id = self._campaign()
+        manifest = handoff.create_revision_package(batch, campaign, [finding_id])
+        handoff.sync_linked_findings(manifest, fr.REVISION_STATE_APPLIED, identity_ids=set())
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_PREVIEWED)
+    def test_local_candidate_manifest_cannot_be_submitted(self):
+        from unittest import mock
+
+        with mock.patch.object(batch, "load_manifest", return_value={
+            "submit_disabled": True,
+            "job_name": "",
+        }):
+            with self.assertRaisesRegex(SystemExit, "Submit disabled"):
+                batch.submit_manifest("candidate-manifest.json")
+    def test_cli_exposes_repeatable_explicit_selection(self):
+        help_text = batch.build_arg_parser().format_help()
+        self.assertIn("final-review-create-revisions", help_text)
+        args = batch.build_arg_parser().parse_args([
+            "final-review-create-revisions", "campaign", "--finding-id", "a", "--finding-id", "b"
+        ])
+        self.assertEqual(args.finding_id, ["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -243,6 +243,14 @@ class GuiCheckReportTests(unittest.TestCase):
         self.assertIn("同步翻译", summary.message)
         self.assertNotIn("重新检查", summary.message)
 
+    def test_idle_writeback_summary_for_final_review_explains_manual_selection(self):
+        summary = idle_writeback_summary_for_work_mode(WorkMode.FINAL_REVIEW)
+
+        self.assertFalse(summary.can_apply)
+        self.assertIn("问题报告", summary.message)
+        self.assertIn("人工选择", summary.message)
+        self.assertIn("订正预览", summary.message)
+
     def test_build_recheck_cli_args(self):
         self.assertEqual(
             build_recheck_cli_args(r"C:\pkg\manifest.json"),

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -250,6 +250,17 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn("preview-revisions", by_label["预览订正结果"])
         self.assertIn("apply-revisions", by_label["写回订正（预览确认后）"])
 
+    def test_local_final_review_candidates_omit_cloud_submit(self):
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\logs\batch_jobs\local-review\manifest.json",
+            manifest={"mode": "revision", "submit_disabled": True},
+        )
+        labels = [command.label for command in commands]
+        self.assertNotIn("提交订正任务", labels)
+        self.assertIn("预览订正结果", labels)
+        self.assertIn("写回订正（预览确认后）", labels)
     def test_applied_revision_manifest_omits_revision_apply_command(self):
         commands = build_cli_commands(
             python_exe="python",

--- a/tests/test_gui_final_review_workflow.py
+++ b/tests/test_gui_final_review_workflow.py
@@ -1,0 +1,65 @@
+"""GUI final-review workflow tests (#255 PR C)."""
+from __future__ import annotations
+
+import unittest
+
+from gui_qt.final_review_workflow import FinalReviewWorkflow
+from gui_qt.workflow_factory import create_workflow, resume_workflow
+from gui_qt.work_modes import WorkMode
+
+
+class FinalReviewWorkflowTests(unittest.TestCase):
+    def test_factory_starts_final_review_in_maintenance_workflow(self):
+        workflow = create_workflow(WorkMode.FINAL_REVIEW)
+        self.assertIsInstance(workflow, FinalReviewWorkflow)
+        self.assertEqual(workflow.current_step().args, ["final-review-build"])
+        update = workflow.complete_current_step(0, "Created final-review campaign: C:/tmp/review")
+        self.assertTrue(update.should_continue)
+        self.assertEqual(workflow.current_step().key, "submit")
+
+    def test_succeeded_status_downloads_and_ingests_report(self):
+        workflow = FinalReviewWorkflow(["status"], "C:/tmp/review/manifest.json")
+        update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED")
+        self.assertTrue(update.should_continue)
+        self.assertEqual(workflow.current_step().key, "download")
+        workflow.complete_current_step(0, "downloaded")
+        self.assertEqual(workflow.current_step().key, "final-review-ingest-results")
+        done = workflow.complete_current_step(0, "Findings: 2")
+        self.assertEqual(done.status, "done")
+        self.assertIn("选择", done.message)
+
+    def test_query_only_stops_before_download(self):
+        workflow = FinalReviewWorkflow(["status"], "C:/tmp/review/manifest.json")
+        workflow.only_query = True
+        update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED")
+        self.assertEqual(update.status, "ready")
+        self.assertFalse(update.should_continue)
+        self.assertIsNone(workflow.current_step())
+    def test_selected_findings_use_one_local_preview_step(self):
+        workflow = FinalReviewWorkflow.create_revisions("C:/tmp/review/manifest.json", ["f1", "f2"])
+        self.assertEqual(workflow.current_step().args, [
+            "final-review-create-revisions", "C:/tmp/review/manifest.json",
+            "--finding-id", "f1", "--finding-id", "f2",
+        ])
+        output = "\n".join([
+            "Created final-review revision package: C:/tmp/revisions",
+            "Recoverable revision items: 2",
+            "Failure items: 0",
+            "Preview JSONL: C:/tmp/revisions/revision_preview.jsonl",
+        ])
+        update = workflow.complete_current_step(0, output)
+        self.assertEqual(update.heading, "订正预览已生成")
+        self.assertTrue(workflow.manifest_path.replace("\\", "/").endswith("revisions/manifest.json"))
+
+    def test_resume_final_review_manifest_uses_final_review_commands(self):
+        workflow = resume_workflow(
+            WorkMode.FINAL_REVIEW,
+            "C:/tmp/review/manifest.json",
+            {"mode": "final_review", "job_name": "jobs/1", "job_state": "JOB_STATE_RUNNING"},
+        )
+        self.assertIsInstance(workflow, FinalReviewWorkflow)
+        self.assertEqual(workflow.current_step().args, ["status", "C:/tmp/review/manifest.json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_final_review_workflow.py
+++ b/tests/test_gui_final_review_workflow.py
@@ -17,6 +17,21 @@ class FinalReviewWorkflowTests(unittest.TestCase):
         self.assertTrue(update.should_continue)
         self.assertEqual(workflow.current_step().key, "submit")
 
+    def test_failed_step_stops_the_workflow(self):
+        workflow = FinalReviewWorkflow.start_new()
+        update = workflow.complete_current_step(1, "failed")
+        self.assertEqual(update.status, "failed")
+        self.assertEqual(update.heading, "最终审校流程中断")
+        self.assertIsNone(workflow.current_step())
+
+    def test_build_without_created_campaign_stops_before_submit(self):
+        workflow = FinalReviewWorkflow.start_new()
+        update = workflow.complete_current_step(0, "build completed without package")
+        self.assertEqual(update.status, "failed")
+        self.assertEqual(update.heading, "无法准备最终审校")
+        self.assertIsNone(workflow.current_step())
+
+
     def test_succeeded_status_downloads_and_ingests_report(self):
         workflow = FinalReviewWorkflow(["status"], "C:/tmp/review/manifest.json")
         update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED")
@@ -35,6 +50,7 @@ class FinalReviewWorkflowTests(unittest.TestCase):
         self.assertEqual(update.status, "ready")
         self.assertFalse(update.should_continue)
         self.assertIsNone(workflow.current_step())
+
     def test_selected_findings_use_one_local_preview_step(self):
         workflow = FinalReviewWorkflow.create_revisions("C:/tmp/review/manifest.json", ["f1", "f2"])
         self.assertEqual(workflow.current_step().args, [
@@ -60,6 +76,12 @@ class FinalReviewWorkflowTests(unittest.TestCase):
         self.assertIsInstance(workflow, FinalReviewWorkflow)
         self.assertEqual(workflow.current_step().args, ["status", "C:/tmp/review/manifest.json"])
 
+    def test_resume_does_not_treat_missing_counts_as_complete(self):
+        workflow = FinalReviewWorkflow.resume_manifest(
+            "C:/tmp/review/manifest.json",
+            {"mode": "final_review", "summary": {"status_counts": {}}},
+        )
+        self.assertEqual(workflow.current_step().key, "final-review-resume")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -37,6 +37,7 @@ class TaskPageMetaTests(unittest.TestCase):
         self.assertEqual(work_mode_submode_label(WorkMode.KEYWORD_EXTRACTION), "批量")
         self.assertEqual(work_mode_submode_label(WorkMode.SYNC_KEYWORD_EXTRACTION), "同步")
         self.assertEqual(work_mode_submode_label(WorkMode.REVISION), "批量")
+        self.assertEqual(work_mode_submode_label(WorkMode.FINAL_REVIEW), "终审")
         self.assertEqual(work_mode_submode_label(WorkMode.BOOTSTRAP_RAG), "记忆库")
 
     def test_context_nav_hides_submode_combo(self) -> None:
@@ -400,6 +401,16 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(page.writeback_btn.isEnabled())
         self.assertTrue(page.stop_btn.isEnabled())
 
+    def test_final_review_is_integrated_into_revision_page(self) -> None:
+        self.window._set_work_mode(WorkMode.FINAL_REVIEW, refresh_manifest_writeback=False)
+        page = self.window.revision_page
+        self.assertIs(self.window.workbench_stack.currentWidget(), page)
+        self.assertEqual(self.window._workbench_nav_item, WorkbenchNavItem.REVISION)
+        self.assertEqual(page.mode_combo.currentData(), WorkMode.FINAL_REVIEW.value)
+        self.assertEqual(page.start_btn.text(), "开始最终审校")
+        self.assertFalse(page.review_findings_btn.isHidden())
+        self.assertEqual(page.writeback_btn.text(), "写回所选订正")
+        self.assertIn("人工选择", self.window.work_mode_hint_label.text())
     def test_batch_page_owns_actions_and_running_lock(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 from unittest import mock
 
 try:
@@ -11,6 +12,7 @@ try:
     from gui_qt.app import MainWindow
     from gui_qt.check_report import WritebackSummary
     from gui_qt.doctor_report import DoctorSummary
+    from gui_qt.final_review_dialog import FinalReviewFindingsDialog
 except ImportError as exc:
     MainWindow = None  # type: ignore[assignment,misc]
     QApplication = None  # type: ignore[assignment,misc]
@@ -411,6 +413,96 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertFalse(page.review_findings_btn.isHidden())
         self.assertEqual(page.writeback_btn.text(), "写回所选订正")
         self.assertIn("人工选择", self.window.work_mode_hint_label.text())
+
+    def test_final_review_project_reset_preserves_resume_contract(self) -> None:
+        page = self.window.revision_page
+        page.activate(WorkMode.FINAL_REVIEW, WorkbenchModeSession())
+        page.reset_project()
+
+        self.assertFalse(page.resume_btn.isHidden())
+        self.assertEqual(page.resume_btn.text(), "继续审查")
+        self.assertFalse(page.resume_btn.isEnabled())
+
+    def test_final_review_findings_button_requires_an_enabled_action(self) -> None:
+        page = self.window.revision_page
+        actions: list[str] = []
+        page.set_action_callbacks(WorkbenchPageActions(action=actions.append))
+        page.activate(WorkMode.FINAL_REVIEW, WorkbenchModeSession())
+        page.review_findings_btn.setEnabled(False)
+        page._trigger_review_findings()
+        self.assertEqual(actions, [])
+
+        page.review_findings_btn.setEnabled(True)
+        page.review_findings_btn.click()
+        self.assertEqual(actions, ["select_final_review_findings"])
+
+    def test_final_review_dialog_disables_preview_until_selection(self) -> None:
+        dialog = FinalReviewFindingsDialog([
+            {
+                "finding_id": "f1",
+                "suggested_revision": "新译文",
+                "selection_state": "none",
+                "revision_state": "none",
+            }
+        ])
+        self.assertFalse(dialog._ok_button.isEnabled())
+        dialog.table.item(0, 0).setCheckState(Qt.CheckState.Checked)
+        self.assertTrue(dialog._ok_button.isEnabled())
+        dialog.close()
+        empty_dialog = FinalReviewFindingsDialog([])
+        self.assertFalse(empty_dialog._ok_button.isEnabled())
+        empty_dialog.close()
+
+
+    def test_final_review_context_cache_reloads_after_invalidation(self) -> None:
+        self.window._work_mode = WorkMode.FINAL_REVIEW
+        manifest_path = Path(__file__)
+        package = {"manifest": {"status": "done"}, "findings": []}
+        with mock.patch.object(
+            self.window.state,
+            "get_game_root",
+            return_value=manifest_path.parent,
+        ), mock.patch.object(
+            self.window.state,
+            "get_latest_manifest_path_for_mode",
+            return_value=manifest_path,
+        ), mock.patch(
+            "final_review.load_campaign_package",
+            return_value=package,
+        ) as load:
+            self.assertEqual(self.window._final_review_findings_context()[1], package)
+            self.assertEqual(self.window._final_review_findings_context()[1], package)
+            self.assertEqual(load.call_count, 1)
+            self.window._invalidate_manifest_caches(manifest_path)
+            self.assertEqual(self.window._final_review_findings_context()[1], package)
+            self.assertEqual(load.call_count, 2)
+
+    def test_final_review_action_rechecks_running_guards(self) -> None:
+        with mock.patch.object(
+            self.window,
+            "_confirm_unsaved_config_before_workflow",
+            return_value=True,
+        ) as confirm, mock.patch.object(
+            self.window,
+            "_final_review_findings_context",
+        ) as context:
+            self.window._task_running = True
+            self.window._on_final_review_page_action("select_final_review_findings")
+            confirm.assert_not_called()
+            context.assert_not_called()
+
+            self.window._task_running = False
+            self.window.runner.is_running = lambda: True
+            self.window._on_final_review_page_action("select_final_review_findings")
+            confirm.assert_not_called()
+            context.assert_not_called()
+
+            self.window.runner.is_running = lambda: False
+            confirm.return_value = False
+            self.window._on_final_review_page_action("select_final_review_findings")
+            confirm.assert_called_once_with()
+            context.assert_not_called()
+
     def test_batch_page_owns_actions_and_running_lock(self) -> None:
         self.window._set_work_mode(
             WorkMode.BATCH_TRANSLATION,

--- a/tests/test_gui_work_modes.py
+++ b/tests/test_gui_work_modes.py
@@ -55,10 +55,10 @@ class GuiWorkModesTests(unittest.TestCase):
 
     def test_maintenance_category_contains_revision_modes(self):
         modes = work_modes_for_category(TaskCategory.MAINTENANCE)
-        self.assertEqual(modes, (WorkMode.REVISION, WorkMode.SYNC_REVISION))
+        self.assertEqual(modes, (WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW))
 
     def test_revision_modes_are_implemented(self):
-        for mode in (WorkMode.REVISION, WorkMode.SYNC_REVISION):
+        for mode in (WorkMode.REVISION, WorkMode.SYNC_REVISION, WorkMode.FINAL_REVIEW):
             with self.subTest(mode=mode):
                 spec = work_mode_spec(mode)
                 self.assertTrue(spec.implemented)


### PR DESCRIPTION
## 概要

完成最终审校 campaign 的人工订正闭环，并把它作为“订正”页中的正式子模式接入现有产品工作流。

## 主要改动

- 将已完成 campaign 的选中 findings 转换为标准 revision manifest，并自动生成订正预览
- 在创建、预览、写回各阶段校验项目身份、campaign 快照、finding/单元摘要及当前译文，拒绝陈旧或冲突候选
- 保持人工确认边界：最终审校不会自动修改 `.rpy`，本地候选也禁止提交到云端
- 将最终审校接入统一 GUI coordinator、开始/继续/停止/查询状态、诊断命令和订正写回组件
- 增加 findings 选择对话框、campaign/范围/失败/陈旧/快照摘要和生命周期状态
- 更新 CLI、工作流文档与回归测试

## 产品影响

最终审校不再是放在“上下文库”附近的孤立功能。用户可以在“订正 → 终审”中完成 campaign、选择建议、查看标准订正预览，再通过既有安全写回流程应用所选内容。

## 验证

- `python -B tests/run_cli_tests.py -q` — 715 tests passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 851 tests passed
- `python -m unittest tests.test_final_review tests.test_batch_golden_corpus -q` — 28 tests passed（改动完成后的独立运行）
- `python scripts/run_quality_gates.py all` — 完整运行曾通过；最终复跑中 ruff/mypy 通过，pip-audit 因本机缓存目录权限超时
- `git diff --check`

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Final Review workflow in the revision workspace.
  * Select individual findings with suggested corrections and generate revision previews.
  * Added support for previewing and applying approved corrections, with clear finding status tracking.
  * Added command-line options for selecting findings explicitly.

* **Bug Fixes**
  * Prevented report-only review results from being submitted as cloud jobs.
  * Added safeguards against applying corrections when source content has changed.

* **Documentation**
  * Updated workflow guidance, selection rules, statuses, and GUI usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->