### PR TITLE
Productize Project Analysis operations (#262 P3)

### DIFF
--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -15,7 +15,7 @@
 
 **开关分层**：
 
-- **是否启用**批量 RAG / 原文索引 / build 时暖库：优先读当前项目 `work/project_context_settings.json`（见 [setup.md](setup.md#项目级上下文开关)）；无项目文件时回退 `translator_config.json` 的 `batch.rag` / `batch.source_index`。
+- **是否启用**批量 RAG / 原文索引 / build 时暖库，以及项目分析的启用 / 注入开关：优先读当前项目 `work/project_context_settings.json`（见 [setup.md](setup.md#项目级上下文开关)）；无项目文件时回退 `translator_config.json` 的对应 `batch` 默认值。
 - **库文件放哪**：由下方 `context_storage` 与可选的 `store_dir` 决定（与开关是否按项目是两件独立的事）。
 
 ## 上下文文件存放位置
@@ -125,7 +125,7 @@ python gemini_translate_batch.py project-analysis-publish
 python gemini_translate_batch.py project-analysis-unpublish
 ```
 
-配置（默认关闭；`translator_config.example.json` → `batch.project_analysis`）：
+配置（默认关闭；模型、预算、路径等工具级默认值位于 `translator_config.example.json` → `batch.project_analysis`）：
 
 ```json
 {
@@ -146,13 +146,18 @@ python gemini_translate_batch.py project-analysis-unpublish
 }
 ```
 
+其中 `enabled` / `inject_published_brief` 在 GUI 保存后写入当前项目的 `project_context_settings.json`；上述全局值仅作为该项目尚无设置文件时的回退默认值。模型、思考等级、长度、输出上限与价格表仍是工具级配置。
+
 - 仅当 `enabled` 且 `inject_published_brief` 为 true，并且 brief 为 **published 且 fingerprint 有效** 时，才会向翻译/订正 prompt 注入 `PROJECT BRIEF` 分区。
 - **draft 永不注入**；stale / 缺 published 文件会跳过注入。
 - 动态 `jump expression` / `call expression` 标记为 unresolved，不虚构单一路线。
 - 普通 `call label` **不是**路线分支：调用返回后继续调用者后续语句，枚举路线时不把 call 目标当成与 jump 互斥的分叉；call 仅作附属依赖/元数据。
 - **结构草稿**可无 LLM；**精炼摘要**使用 `project-analysis-generate`（可 mock 的 Sync 路径），结果仍为 draft，须人工 publish。
+- 结构重建使用 **label / route 局部 fingerprint**：只改一个 label 时，未受影响的 label 与路线会复用已有 LLM 摘要；项目级 fingerprint 仍单独用于 brief 发布与注入 freshness 门禁。
+- 项目内的脚本根以相对路径写入 manifest；项目整体移动或复制后会相对当前 `base_dir` 重新解析。旧 manifest 中位于旧项目根下的绝对路径也会兼容重定位。
+- `project-analysis-generate` 会输出逐 label / route / brief 的机器可读进度，并汇总请求数、输入/输出 Token 与按 `batch.pricing` 当前模型费率计算的**估算成本**。结果保存在 manifest 的 `generation`，GUI 完成摘要会显示同一份统计。
 - GUI「上下文库」把项目分析注册为正式 `WorkMode`，通过统一工作流运行 ingest → build → generate；停止后可根据已落盘产物从当前生命周期阶段重新开始。
-- 首次或重新分析时会自动定位当前项目最近的 `keyword_chunk_summaries.jsonl`，但导入前必须明确确认；也可以明确跳过，未找到时可手动选择文件。
+- 首次或重新分析时会自动定位当前项目最近的 `keyword_chunk_summaries.jsonl`，但导入前必须明确确认；也可以明确跳过，未找到时可手动选择文件。未导入时仍允许静态结构分析，但 CLI 状态、上下文库状态和实际注入预览会持续显示“仅结构分析”的非阻断警告。
 - 生成完成后进入审查工作区：显示完整 draft / published 差异与全文，可搜索 chunk / label / route，并展示 evidence item、来源文件和行跨度；来源文件可打开，`path:line` 可复制定位。
 - 审查工作区的「实际注入预览」直接调用翻译使用的 published + freshness + `max_brief_chars` 装载器，因此会如实显示开关关闭、未发布、陈旧、截断后的正文和诊断。
 - 「确认已审查」写入当前 brief lineage 的 `reviewed_at`；从审查界面启用会先记录审查，再经 fingerprint 门禁发布。停止使用会二次确认并移除 published 副本，保留 draft 与 `.rpy`。
@@ -167,7 +172,7 @@ python gemini_translate_batch.py project-analysis-status --json
 python gemini_translate_batch.py project-analysis-status --store-dir <path> --source-fingerprint <digest>
 ```
 
-- `doctor` 报告中的 `Project analysis:` 行汇总 overall / 计数 / brief 状态。
+- `doctor` 报告中的 `Project analysis:` 行汇总 overall / 计数 / brief 状态；功能已启用时，还会针对产物缺失、已过期、缺少生成模型或 API Key 给出可执行建议。这些属于项目分析的可选准备，不会阻断正常翻译。
 - GUI「上下文库」展示「项目分析」状态行；状态判断在 `project_analysis` 模块内完成，GUI 不重复实现失效逻辑。
 - 诊断「命令参考」可复制 ingest / build-structure / publish / unpublish 命令。
 - GUI 的证据与注入预览同样复用 `project_analysis` store / loader，不建立 GUI 专属产物格式。

--- a/docs/doctor_recommendations.md
+++ b/docs/doctor_recommendations.md
@@ -199,7 +199,7 @@ GUI 主文案通常取**第一条**（最高优先的必需准备）；其余建
 
 `start_pending_batch`、`start_incremental_batch`、`substantially_complete` 和 `no_pending_lines` 现在作为 `workflow_state` 输出，不进入建议列表；对旧版 CLI 建议行仍保留解析兼容。
 
-当存在**必需准备**建议（例如 `bootstrap_source_index` / `bootstrap_rag`）时，`workflow_state` 应留空，避免 CLI 同时出现「可开始翻译」与「必须先准备」。可选优化（`bootstrap_rag_or_warm_on_build`、`enable_rag_for_consistency`、`enable_source_index_for_new_project`，以及 `build_project_analysis` / `refresh_project_analysis` / 项目分析模型与 API 配置建议）不抑制 `workflow_state`。
+当存在**必须执行的准备**建议（例如 `bootstrap_source_index` / `bootstrap_rag`）时，`workflow_state` 应留空，避免 CLI 同时出现「可开始翻译」与「必须先准备」。可选优化（`bootstrap_rag_or_warm_on_build`、`enable_rag_for_consistency`、`enable_source_index_for_new_project`，以及 `build_project_analysis` / `refresh_project_analysis` / 项目分析模型与 API 配置建议）不抑制 `workflow_state`。
 
 ## 文案要求
 

--- a/docs/doctor_recommendations.md
+++ b/docs/doctor_recommendations.md
@@ -46,6 +46,7 @@ GUI 文案入口名称（须与界面一致）：
 - 工作量：待译条目数、待译文件数、翻译块和原文注释数量。
 - 翻译阶段：是否已有旧译、是否属于全新初译或增量补译。
 - 上下文系统：RAG、原文索引是否启用，store 是否存在，记录或片段是否完整。
+- 项目分析：按当前项目解析是否启用，再检查产物是否缺失/过期、生成模型与 API Key 是否可用。
 - 项目资产：术语表和风格设定是否存在、路径是否匹配当前项目。
 - 运行条件：API 密钥是否配置。
 
@@ -90,6 +91,7 @@ rag_needs_bootstrap
 
 - 补译量较大且已有历史译文，可以考虑启用 RAG 以提高术语一致性。
 - 全新项目可以考虑启用原文索引以增加剧情上下文。
+- 项目分析已启用时，缺失/过期产物或缺少模型、API Key 会给出对应的可执行准备建议；它们不阻断普通翻译流程。
 
 文案必须包含「可选」或等价表述。可选建议不能把绿色检查结果升级成警告。
 
@@ -197,7 +199,7 @@ GUI 主文案通常取**第一条**（最高优先的必需准备）；其余建
 
 `start_pending_batch`、`start_incremental_batch`、`substantially_complete` 和 `no_pending_lines` 现在作为 `workflow_state` 输出，不进入建议列表；对旧版 CLI 建议行仍保留解析兼容。
 
-当存在**必需准备**建议（例如 `bootstrap_source_index` / `bootstrap_rag`）时，`workflow_state` 应留空，避免 CLI 同时出现「可开始翻译」与「必须先准备」。可选优化（`bootstrap_rag_or_warm_on_build`、`enable_rag_for_consistency`、`enable_source_index_for_new_project`）不抑制 `workflow_state`。
+当存在**必需准备**建议（例如 `bootstrap_source_index` / `bootstrap_rag`）时，`workflow_state` 应留空，避免 CLI 同时出现「可开始翻译」与「必须先准备」。可选优化（`bootstrap_rag_or_warm_on_build`、`enable_rag_for_consistency`、`enable_source_index_for_new_project`，以及 `build_project_analysis` / `refresh_project_analysis` / 项目分析模型与 API 配置建议）不抑制 `workflow_state`。
 
 ## 文案要求
 

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -120,7 +120,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 - **项目**：术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。Ren'Py SDK 须显式配置： **查找 SDK**（用户点击后才扫描附近）、**浏览…**，或确认后 **下载推荐 SDK…**（官方固定版本）；留空不会自动搜其它目录或联网。结果写入 `prepare.renpy_sdk_dir`，保存设置后生效。当前 `game_root` 只读展示；需换项目请用「项目与环境」或「项目列表」。
 - **模型**：同步 / 批量翻译模型、embedding model、批量 thinking level。
 - **上下文**：
-  - **按当前项目保存**（`work/project_context_settings.json`）：启用批量 RAG、启用原文索引、开始翻译时自动暖 RAG。切换游戏互不影响。
+  - **按当前项目保存**（`work/project_context_settings.json`）：启用批量 RAG、启用原文索引、开始翻译时自动暖 RAG，以及项目分析的启用 / 用于翻译。切换游戏互不影响。
   - **工具全局**（`translator_config.json`）：上下文库保存位置（工具 `logs/` 或游戏旁 `translation_context/`）；以及 **同步 RAG / 同步·批量剧情记忆主开关**（仅在本分区编辑，高级页不重复）。
   - 启用项目级开关后须点 **保存设置**，再到工作台 **上下文库** 页预建。
 - **外观**：浅色 / 深色 / 跟随系统。切换主题会立即预览，保存设置后才写入 `translator_config.json`。
@@ -133,7 +133,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 底部 **重新加载 / 恢复推荐值 / 保存设置**：
 - 全局项写入 `translator_config.json`；
-- 上述三项上下文开关写入**当前项目**的 `project_context_settings.json`；
+- 上述五项上下文开关写入**当前项目**的 `project_context_settings.json`；
 - **工作区**总表与切换项目即时写 registry，不依赖「保存设置」。
 - 进入**项目列表**时底部改为显示即时保存提示，不显示上述三个配置按钮。
 - 若其他设置尚未保存，项目列表底部会保留 **重新加载** 与 **保存设置**（仍不显示「恢复推荐值」）；切换项目时必须先选择保存、放弃或取消。
@@ -346,7 +346,7 @@ build-keywords -> submit -> status -> download -> export-keywords
 
 「确认已审查」会写入 `reviewed_at`；「审查并启用到翻译」还会二次确认并走实时 fingerprint 发布门禁。停止用于翻译同样需要确认，只移除 published 副本，不删除 draft 或修改 `.rpy`。任务中断后可根据上下文库显示的已落盘阶段重新开始。
 
-启用开关、是否用于翻译、模型和思考等级集中在「设置 → 上下文 → 项目剧情分析」；其余长度、并发等参数仍在高级设置。详见 [上下文系统 · Project Analysis](context_systems.md#project-analysis项目分析)。
+启用开关和是否用于翻译按当前项目保存；模型和思考等级是工具全局设置。它们集中在「设置 → 上下文 → 项目剧情分析」；其余长度、并发等参数仍在高级设置。详见 [上下文系统 · Project Analysis](context_systems.md#project-analysis项目分析)。
 
 预建流程：
 
@@ -365,7 +365,7 @@ bootstrap-source-index
 project-analysis-status
 ```
 
-预建和项目分析结果以普通语言摘要显示；失败细节可在「诊断与运行日志」的原始输出查看。任务运行中，上下文库内其他动作会禁用并提供与当前任务对应的停止按钮，避免叠跑。项目分析状态还会明确显示功能是否启用，以及当前发布摘要是否实际用于翻译。
+预建和项目分析结果以普通语言摘要显示；项目分析生成完成后还会显示 label / route 进度、请求数、输入/输出 Token 和按当前价格表估算的成本。失败细节可在「诊断与运行日志」的原始输出查看。任务运行中，上下文库内其他动作会禁用并提供与当前任务对应的停止按钮，避免叠跑。项目分析状态还会明确显示功能是否启用，以及当前发布摘要是否实际用于翻译。
 
 若开启了 build 时自动补建，后续 `build` 仍可能自动补建；图形预建入口适合在首次翻译前手动确认 store 状态。
 
@@ -399,7 +399,7 @@ GUI 不提供普通用户入口来运行 `apply --force`。`apply --force` 只�
 当前 GUI 是稳定版支持范围内的正式工作台，采用源码安装运行。以下是当前明确限制：
 
 - 暂不提供打包安装器；源码安装是当前正式交付方式。
-- 模型 / chunk 等多数参数仍是**工具全局**一份配置；仅批量 RAG / 原文索引 / 暖库开关按项目隔离（`project_context_settings.json`）。
+- 模型 / chunk 等多数参数仍是**工具全局**一份配置；批量 RAG / 原文索引 / 暖库开关和项目分析的启用 / 注入开关按项目隔离（`project_context_settings.json`）。
 - 还没有完整可视化 diff 编辑器。
 - 同步修补会直接改翻译文件，不提供内嵌 diff 编辑器；复杂问题仍需 CLI 或人工处理。
 - 同步关键词 / 同步订正不支持从任务记录恢复（与批量模式不同）。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@
 说明：
 
 - `api_keys.json` 保存 Gemini API Key；旧的 `batch_size/max_chars` 等字段仍兼容，但不再推荐写在这里。
-- `translator_config.json` 保存**工具级**设置：可选 `workspace_root`（多项目工作区，须显式指定）、当前 `game_root`、模型、include 过滤、同步 / Batch 分块参数，以及 RAG/原文索引的**全局默认值**（当前项目尚未写过项目文件时使用）。可选 `model_catalog.gemini` / `model_catalog.gemini_embedding` 用于扩展内置模型列表；可选 `rotation` 控制 API Key / 模型轮换（见下文）。
+- `translator_config.json` 保存**工具级**设置：可选 `workspace_root`（多项目工作区，须显式指定）、当前 `game_root`、模型、include 过滤、同步 / Batch 分块参数，以及 RAG / 原文索引 / 项目分析开关的**全局默认值**（当前项目尚未写过项目文件时使用）。可选 `model_catalog.gemini` / `model_catalog.gemini_embedding` 用于扩展内置模型列表；可选 `rotation` 控制 API Key / 模型轮换（见下文）。
 - **按项目生效**的批量上下文开关见下一节 `project_context_settings.json`。
 - `glossary.json` 通常包含项目私有术语；不存在时脚本会退回内置默认术语规则。`translator_config.json` 的 `glossary_file` 应指向当前项目的文件。
 - `macro_setting.md` 往往包含剧情、角色口吻、世界观约束，可供 Batch 的 `batch.macro_setting_file` 使用。
@@ -31,7 +31,7 @@
 
 ## 项目级上下文开关
 
-批量 **启用 RAG**、**启用原文索引**、**build 时自动暖库** 跟随**当前游戏 work 目录**，不写进全局配置以免切换项目互相覆盖。
+批量 **启用 RAG**、**启用原文索引**、**build 时自动暖库**，以及项目分析的 **启用** / **用于翻译** 开关跟随**当前游戏 work 目录**，不写进全局配置以免切换项目互相覆盖。
 
 路径：
 
@@ -46,7 +46,9 @@
   "schema_version": 1,
   "batch_rag_enabled": true,
   "batch_source_index_enabled": true,
-  "batch_rag_bootstrap_on_build": true
+  "batch_rag_bootstrap_on_build": true,
+  "batch_project_analysis_enabled": true,
+  "batch_project_analysis_inject_published_brief": false
 }
 ```
 
@@ -54,7 +56,7 @@
 
 - GUI「设置 · 上下文」保存时写入该文件；加载时按当前 `game_root` 读取。
 - CLI 的 `load_batch_settings` 会在解析 `translator_config.json` 后套用该文件。
-- 文件不存在时：回退到 `translator_config.json` 里 `batch.rag.enabled` / `batch.source_index.enabled` / `batch.rag.bootstrap_on_build`。
+- 文件不存在时：回退到 `translator_config.json` 里 `batch.rag.enabled` / `batch.source_index.enabled` / `batch.rag.bootstrap_on_build` / `batch.project_analysis.enabled` / `batch.project_analysis.inject_published_brief`。
 - 实现见 `project_context_settings.py`。
 - 如果你不想使用 `api_keys.json`，也可以改用环境变量 `GEMINI_API_KEY`、`GEMINI_API_KEY_2`、`GEMINI_API_KEY_3`。
 - 如果你不想使用 `translator_config.json`，也可以至少通过 `GAME_ROOT` 或 `SA_GAME_ROOT` 指向目标 `work` 目录。

--- a/doctor_recommendations.py
+++ b/doctor_recommendations.py
@@ -15,6 +15,10 @@ BOOTSTRAP_SOURCE_INDEX_INCOMPLETE = "bootstrap_source_index_incomplete"
 BOOTSTRAP_RAG = "bootstrap_rag"
 BOOTSTRAP_RAG_OR_WARM_ON_BUILD = "bootstrap_rag_or_warm_on_build"
 ENABLE_RAG_FOR_CONSISTENCY = "enable_rag_for_consistency"
+BUILD_PROJECT_ANALYSIS = "build_project_analysis"
+REFRESH_PROJECT_ANALYSIS = "refresh_project_analysis"
+CONFIGURE_PROJECT_ANALYSIS_MODEL = "configure_project_analysis_model"
+CONFIGURE_PROJECT_ANALYSIS_API = "configure_project_analysis_api"
 SUBSTANTIALLY_COMPLETE = "substantially_complete"
 ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT = "enable_source_index_for_new_project"
 START_INCREMENTAL_BATCH = "start_incremental_batch"
@@ -34,6 +38,10 @@ ALL_CODES = frozenset(
         BOOTSTRAP_RAG,
         BOOTSTRAP_RAG_OR_WARM_ON_BUILD,
         ENABLE_RAG_FOR_CONSISTENCY,
+        BUILD_PROJECT_ANALYSIS,
+        REFRESH_PROJECT_ANALYSIS,
+        CONFIGURE_PROJECT_ANALYSIS_MODEL,
+        CONFIGURE_PROJECT_ANALYSIS_API,
         SUBSTANTIALLY_COMPLETE,
         ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT,
         START_INCREMENTAL_BATCH,
@@ -41,7 +49,6 @@ ALL_CODES = frozenset(
         NO_PENDING_LINES,
     }
 )
-
 WORKFLOW_STATE_CODES = frozenset(
     {
         SUBSTANTIALLY_COMPLETE,
@@ -57,9 +64,12 @@ OPTIONAL_RECOMMENDATION_CODES = frozenset(
         BOOTSTRAP_RAG_OR_WARM_ON_BUILD,
         ENABLE_RAG_FOR_CONSISTENCY,
         ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT,
+        BUILD_PROJECT_ANALYSIS,
+        REFRESH_PROJECT_ANALYSIS,
+        CONFIGURE_PROJECT_ANALYSIS_MODEL,
+        CONFIGURE_PROJECT_ANALYSIS_API,
     }
 )
-
 _BOOTSTRAP_WORK_MESSAGE = (
     "work directory is missing or empty and original/game exists; "
     "run: python gemini_translate_batch.py bootstrap-work "
@@ -88,6 +98,20 @@ _BOOTSTRAP_RAG_MESSAGE = (
 _BOOTSTRAP_RAG_OR_WARM_MESSAGE = (
     "RAG store is empty; run bootstrap-rag before batch translation, "
     "or start batch translation to warm the store automatically on build."
+)
+_BUILD_PROJECT_ANALYSIS_MESSAGE = (
+    "Project Analysis is enabled but missing; run project-analysis-build-structure "
+    "then project-analysis-generate, or use Context Library > Project Analysis."
+)
+_REFRESH_PROJECT_ANALYSIS_MESSAGE = (
+    "Project Analysis is stale; rebuild structure and regenerate the affected summaries."
+)
+_CONFIGURE_PROJECT_ANALYSIS_MODEL_MESSAGE = (
+    "Project Analysis has no generation model; set batch.project_analysis.model "
+    "or configure a Batch/sync model."
+)
+_CONFIGURE_PROJECT_ANALYSIS_API_MESSAGE = (
+    "Project Analysis generation needs an API key; configure api_keys.json or GEMINI_API_KEY."
 )
 _ENABLE_RAG_MESSAGE = (
     "Existing translations detected with RAG disabled; enable RAG and run bootstrap-rag "
@@ -139,6 +163,10 @@ _DETAIL_MESSAGES: dict[str, str] = {
     BOOTSTRAP_RAG: _BOOTSTRAP_RAG_MESSAGE,
     BOOTSTRAP_RAG_OR_WARM_ON_BUILD: _BOOTSTRAP_RAG_OR_WARM_MESSAGE,
     ENABLE_RAG_FOR_CONSISTENCY: _ENABLE_RAG_MESSAGE,
+    BUILD_PROJECT_ANALYSIS: _BUILD_PROJECT_ANALYSIS_MESSAGE,
+    REFRESH_PROJECT_ANALYSIS: _REFRESH_PROJECT_ANALYSIS_MESSAGE,
+    CONFIGURE_PROJECT_ANALYSIS_MODEL: _CONFIGURE_PROJECT_ANALYSIS_MODEL_MESSAGE,
+    CONFIGURE_PROJECT_ANALYSIS_API: _CONFIGURE_PROJECT_ANALYSIS_API_MESSAGE,
     SUBSTANTIALLY_COMPLETE: _SUBSTANTIALLY_COMPLETE_MESSAGE,
     ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT: _ENABLE_SOURCE_INDEX_MESSAGE,
     START_INCREMENTAL_BATCH: _START_INCREMENTAL_MESSAGE,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -635,6 +635,10 @@ def compute_current_project_analysis_fingerprint(base_dir=None, store_dir=None):
     Prefers ``project_identity.script_roots`` persisted by
     ``build_structure_drafts`` so custom ``--script-root`` builds stay injectable.
     Falls back to default game/work/original discovery under *base_dir*.
+
+    When a project moves or is copied, relative graph/root paths are rebased onto
+    the current *base_dir*. Legacy absolute paths that were inside the stored
+    project base are rebased by the same relative offset; external roots stay put.
     """
     from project_analysis import resolve_project_analysis_store
     from project_analysis_routes import digest_script_paths, discover_script_files

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -648,14 +648,40 @@ def compute_current_project_analysis_fingerprint(base_dir=None, store_dir=None):
         manifest = store.load_manifest() or {}
         identity = manifest.get('project_identity') if isinstance(manifest, dict) else {}
         if isinstance(identity, dict):
-            stored_roots = identity.get('script_roots') or []
-            if isinstance(stored_roots, list):
-                roots = [str(r) for r in stored_roots if str(r or '').strip()]
-            stored_base = str(identity.get('graph_base') or identity.get('base_dir') or '').strip()
+            stored_identity_base = str(identity.get('base_dir') or '').strip()
+            stored_base = str(identity.get('graph_base') or stored_identity_base).strip()
+            if base and stored_base and os.path.isabs(stored_base) and stored_identity_base:
+                try:
+                    relative_graph_base = os.path.relpath(stored_base, stored_identity_base)
+                except ValueError:
+                    relative_graph_base = ''
+                if relative_graph_base and not relative_graph_base.startswith('..'):
+                    stored_base = os.path.join(base, relative_graph_base)
             if stored_base:
-                graph_base = stored_base
+                if not os.path.isabs(stored_base) and base:
+                    graph_base = os.path.abspath(os.path.join(base, stored_base))
+                else:
+                    graph_base = stored_base
             elif base:
                 graph_base = base
+            stored_roots = identity.get('script_roots') or []
+            if isinstance(stored_roots, list):
+                for raw_root in stored_roots:
+                    root = str(raw_root or '').strip()
+                    if not root:
+                        continue
+                    if not os.path.isabs(root):
+                        relocation_base = base or stored_base
+                        if relocation_base:
+                            root = os.path.join(relocation_base, root)
+                    elif base and stored_identity_base:
+                        try:
+                            relative_root = os.path.relpath(root, stored_identity_base)
+                        except ValueError:
+                            relative_root = ''
+                        if relative_root and not relative_root.startswith('..'):
+                            root = os.path.join(base, relative_root)
+                    roots.append(root)
     except Exception:
         roots = []
 
@@ -9164,6 +9190,7 @@ def collect_doctor_recommendations(report):
     context_status = report.get('context_status') or {}
     source_index = context_status.get('source_index') or {}
     rag = context_status.get('rag') or {}
+    project_analysis = context_status.get('project_analysis') or {}
 
     source_index_status = _doctor_source_index_needs_bootstrap(source_index)
     if source_index_status == 'missing':
@@ -9194,6 +9221,32 @@ def collect_doctor_recommendations(report):
             doctor_rec.make_doctor_recommendation(doctor_rec.ENABLE_RAG_FOR_CONSISTENCY)
         )
 
+    if project_analysis.get('enabled'):
+        if not project_analysis.get('model'):
+            recommendations.append(
+                doctor_rec.make_doctor_recommendation(
+                    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL
+                )
+            )
+        if int(project_analysis.get('api_key_count') or 0) <= 0:
+            recommendations.append(
+                doctor_rec.make_doctor_recommendation(
+                    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API
+                )
+            )
+        analysis_status = str(project_analysis.get('overall_status') or 'missing')
+        if analysis_status == 'missing':
+            recommendations.append(
+                doctor_rec.make_doctor_recommendation(
+                    doctor_rec.BUILD_PROJECT_ANALYSIS
+                )
+            )
+        elif analysis_status == 'stale':
+            recommendations.append(
+                doctor_rec.make_doctor_recommendation(
+                    doctor_rec.REFRESH_PROJECT_ANALYSIS
+                )
+            )
     if (
         not source_index.get('enabled')
         and pending > 0
@@ -9308,6 +9361,14 @@ def collect_doctor_context_status():
         from project_analysis import collect_project_analysis_status
 
         project_analysis_status = collect_project_analysis_status()
+        project_analysis_status.update(
+            {
+                'enabled': bool(PROJECT_ANALYSIS_ENABLED),
+                'inject_published_brief': bool(PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF),
+                'model': PROJECT_ANALYSIS_MODEL or BATCH_MODEL or SYNC_MODEL or '',
+                'api_key_count': len(getattr(legacy, 'API_KEYS', []) or []),
+            }
+        )
     except Exception as exc:
         project_analysis_status = {
             'store_dir': '',
@@ -10927,6 +10988,20 @@ def main(argv=None):
                         usage_metadata=dict(raw.get('usage_metadata') or {}),
                     )
 
+                pricing_config = batch_cost_estimate.load_pricing_config(
+                    _read_translator_config_object()
+                )
+                model_rates = (
+                    batch_cost_estimate.resolve_model_pricing(model, pricing_config) or {}
+                )
+
+                def _project_analysis_progress(event):
+                    print(
+                        "PROJECT_ANALYSIS_PROGRESS "
+                        + json.dumps(dict(event), ensure_ascii=False, sort_keys=True),
+                        file=sys.stderr,
+                        flush=True,
+                    )
                 return run_mapreduce_drafts(
                     store_dir=store_dir,
                     base_dir=legacy.BASE_DIR or None,
@@ -10943,6 +11018,12 @@ def main(argv=None):
                     force=bool(getattr(args, 'force', False)),
                     provider=SYNC_BACKEND or 'gemini',
                     model=model,
+                    progress=_project_analysis_progress,
+                    pricing={
+                        "currency": pricing_config.get("currency") or "USD",
+                        "input_per_million": model_rates.get("input_per_million") or 0.0,
+                        "output_per_million": model_rates.get("output_per_million") or 0.0,
+                    },
                 )
             if command == 'project-analysis-inspect':
                 store = resolve_project_analysis_store(

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -285,6 +285,7 @@ from .settings_schema import (
     grouped_advanced_fields,
     read_advanced_settings,
     recommended_advanced_settings,
+    resolve_project_analysis_flags_for_save,
     validate_advanced_settings,
 )
 
@@ -12051,6 +12052,7 @@ class MainWindow(QMainWindow):
             write_gui_theme_to_config(config, self._current_theme_preference_from_ui())
 
             advanced_values = self._advanced_settings_values_from_ui()
+            complete_advanced_values: dict[str, Any] = {}
             if advanced_values:
                 complete_advanced_values = read_advanced_settings(config)
                 complete_advanced_values.update(advanced_values)
@@ -12098,27 +12100,12 @@ class MainWindow(QMainWindow):
                 config,
                 game_root=self._game_root_str_for_flags(),
             )
-            project_analysis_enabled = bool(
-                saved_context_flags.get("project_analysis_enabled")
-            )
-            project_analysis_inject_enabled = bool(
-                saved_context_flags.get("project_analysis_inject_enabled")
-            )
-            if "batch_project_analysis_enabled" in advanced_values:
-                project_analysis_enabled = bool(
-                    complete_advanced_values.get("batch_project_analysis_enabled")
-                )
-            if "batch_project_analysis_inject_published_brief" in advanced_values:
-                project_analysis_inject_enabled = bool(
-                    complete_advanced_values.get(
-                        "batch_project_analysis_inject_published_brief"
-                    )
-                )
             project_context_flags.update(
-                {
-                    "project_analysis_enabled": project_analysis_enabled,
-                    "project_analysis_inject_enabled": project_analysis_inject_enabled,
-                }
+                resolve_project_analysis_flags_for_save(
+                    saved_context_flags,
+                    advanced_values,
+                    complete_advanced_values,
+                )
             )
             # Validate every field before either settings file is written. This
             # avoids persisting project flags when the UI reports "未保存".

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -9411,12 +9411,13 @@ class MainWindow(QMainWindow):
         )
 
     def _saved_project_analysis_flags(self) -> dict[str, bool]:
-        values = read_advanced_settings(self.state.load_translator_config())
+        flags = read_batch_context_flags(
+            self.state.load_translator_config(),
+            game_root=self._game_root_str_for_flags(),
+        )
         return {
-            "enabled": bool(values.get("batch_project_analysis_enabled")),
-            "inject_enabled": bool(
-                values.get("batch_project_analysis_inject_published_brief")
-            ),
+            "enabled": bool(flags.get("project_analysis_enabled")),
+            "inject_enabled": bool(flags.get("project_analysis_inject_enabled")),
         }
 
     def _submit_max_cost_from_config(self) -> float | None:
@@ -11900,6 +11901,16 @@ class MainWindow(QMainWindow):
 
             if want is None or "advanced" in want or "context" in want:
                 advanced_values = read_advanced_settings(config)
+                project_flags = read_batch_context_flags(
+                    config,
+                    game_root=self._game_root_str_for_flags(),
+                )
+                advanced_values["batch_project_analysis_enabled"] = project_flags[
+                    "project_analysis_enabled"
+                ]
+                advanced_values[
+                    "batch_project_analysis_inject_published_brief"
+                ] = project_flags["project_analysis_inject_enabled"]
                 get_game_root = getattr(self.state, "get_game_root", None)
                 current_game_root = get_game_root() if callable(get_game_root) else None
                 if current_game_root and not self._config_string(
@@ -11991,7 +12002,7 @@ class MainWindow(QMainWindow):
                 )
                 or "translation_context"
             )
-            # RAG / source-index / bootstrap_on_build are per-project only.
+            # Context enablement is per-project only; model/budget defaults stay global.
             # Do not write them into the global translator_config.json.
             project_context_flags = {
                 "rag_enabled": self.rag_enabled_cb.isChecked(),
@@ -12056,6 +12067,22 @@ class MainWindow(QMainWindow):
                     return False
                 self._clear_advanced_setting_errors()
                 apply_advanced_settings(config, complete_advanced_values)
+                # These two values are persisted in the current project's
+                # project_context_settings.json, not as shared global state.
+                original_project_analysis = self._config_section(
+                    self._config_section(original_config, "batch"),
+                    "project_analysis",
+                )
+                saved_project_analysis = self._ensure_config_section(
+                    batch_config, "project_analysis"
+                )
+                for setting_key in ("enabled", "inject_published_brief"):
+                    if setting_key in original_project_analysis:
+                        saved_project_analysis[setting_key] = original_project_analysis[
+                            setting_key
+                        ]
+                    else:
+                        saved_project_analysis.pop(setting_key, None)
                 # Persist only non-builtin catalog extensions; drop empty keys.
                 write_model_catalog_extras(
                     config,
@@ -12067,6 +12094,23 @@ class MainWindow(QMainWindow):
                     ),
                 )
 
+            project_values = (
+                complete_advanced_values
+                if advanced_values
+                else read_advanced_settings(config)
+            )
+            project_context_flags.update(
+                {
+                    "project_analysis_enabled": bool(
+                        project_values.get("batch_project_analysis_enabled")
+                    ),
+                    "project_analysis_inject_enabled": bool(
+                        project_values.get(
+                            "batch_project_analysis_inject_published_brief"
+                        )
+                    ),
+                }
+            )
             # Validate every field before either settings file is written. This
             # avoids persisting project flags when the UI reports "未保存".
             from project_context_settings import save_project_context_settings
@@ -12103,7 +12147,7 @@ class MainWindow(QMainWindow):
                 self._apply_work_mode_ui(refresh_manifest_writeback=False)
             self._append_log(
                 "设置已成功保存（全局项 → translator_config.json；"
-                "RAG/原文索引 → 当前项目 project_context_settings.json）。"
+                "RAG/原文索引/项目分析开关 → 当前项目 project_context_settings.json）。"
             )
             # Refresh select-only model dropdowns / rotation checklist from catalog.
             try:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -12094,21 +12094,30 @@ class MainWindow(QMainWindow):
                     ),
                 )
 
-            project_values = (
-                complete_advanced_values
-                if advanced_values
-                else read_advanced_settings(config)
+            saved_context_flags = read_batch_context_flags(
+                config,
+                game_root=self._game_root_str_for_flags(),
             )
+            project_analysis_enabled = bool(
+                saved_context_flags.get("project_analysis_enabled")
+            )
+            project_analysis_inject_enabled = bool(
+                saved_context_flags.get("project_analysis_inject_enabled")
+            )
+            if "batch_project_analysis_enabled" in advanced_values:
+                project_analysis_enabled = bool(
+                    complete_advanced_values.get("batch_project_analysis_enabled")
+                )
+            if "batch_project_analysis_inject_published_brief" in advanced_values:
+                project_analysis_inject_enabled = bool(
+                    complete_advanced_values.get(
+                        "batch_project_analysis_inject_published_brief"
+                    )
+                )
             project_context_flags.update(
                 {
-                    "project_analysis_enabled": bool(
-                        project_values.get("batch_project_analysis_enabled")
-                    ),
-                    "project_analysis_inject_enabled": bool(
-                        project_values.get(
-                            "batch_project_analysis_inject_published_brief"
-                        )
-                    ),
+                    "project_analysis_enabled": project_analysis_enabled,
+                    "project_analysis_inject_enabled": project_analysis_inject_enabled,
                 }
             )
             # Validate every field before either settings file is written. This

--- a/gui_qt/project_analysis_workflow.py
+++ b/gui_qt/project_analysis_workflow.py
@@ -2,12 +2,46 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Mapping
 
 from .translation_workflow import WorkflowStep, WorkflowUpdate
 
 
+
+PROGRESS_PREFIX = "PROJECT_ANALYSIS_PROGRESS "
+
+
+def generation_facts_from_output(output: str) -> list[str]:
+    """Render the latest machine progress event as compact GUI facts."""
+    latest: dict[str, Any] = {}
+    for raw_line in str(output or "").splitlines():
+        line = raw_line.strip()
+        if not line.startswith(PROGRESS_PREFIX):
+            continue
+        try:
+            event = json.loads(line[len(PROGRESS_PREFIX) :])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            latest = event
+    usage = latest.get("usage") if isinstance(latest.get("usage"), dict) else {}
+    if not latest:
+        return []
+    facts = [
+        f"生成进度：{latest.get('stage') or 'unknown'} "
+        f"{latest.get('completed', 0)}/{latest.get('total', 0)}",
+        f"模型请求：{usage.get('requests', 0)} · "
+        f"输入 Token {usage.get('input_tokens', 0)} · "
+        f"输出 Token {usage.get('output_tokens', 0)}",
+    ]
+    if usage.get("estimated_cost") is not None:
+        facts.append(
+            f"估算成本：{float(usage.get('estimated_cost') or 0.0):.6f} "
+            f"{usage.get('currency') or 'USD'}（按当前配置价格表）"
+        )
+    return facts
 STEP_TEXT = {
     "project-analysis-ingest-keywords": (
         "正在导入剧情概要",
@@ -96,7 +130,7 @@ class ProjectAnalysisWorkflow:
             status="done",
             heading="项目分析摘要待审查",
             message="结构与摘要已生成。请审查全文、差异、证据与实际注入预览后再启用。",
-            facts=[],
+            facts=generation_facts_from_output(output),
         )
 
 

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -1060,6 +1060,37 @@ def read_advanced_settings(config: dict[str, Any]) -> dict[str, SettingValue]:
     return {field.key: read_setting(config, field) for field in ADVANCED_SETTING_FIELDS}
 
 
+def resolve_project_analysis_flags_for_save(
+    saved_context_flags: dict[str, Any],
+    advanced_values: dict[str, Any],
+    complete_advanced_values: dict[str, Any],
+) -> dict[str, bool]:
+    """Resolve project-scoped analysis flags, with present UI values winning.
+
+    Missing/unmaterialized context widgets preserve the current project's saved
+    flags. When those widgets are present, their validated complete values override
+    the saved defaults.
+    """
+    enabled = bool(saved_context_flags.get("project_analysis_enabled"))
+    inject_enabled = bool(
+        saved_context_flags.get("project_analysis_inject_enabled")
+    )
+    if "batch_project_analysis_enabled" in advanced_values:
+        enabled = bool(
+            complete_advanced_values.get("batch_project_analysis_enabled")
+        )
+    if "batch_project_analysis_inject_published_brief" in advanced_values:
+        inject_enabled = bool(
+            complete_advanced_values.get(
+                "batch_project_analysis_inject_published_brief"
+            )
+        )
+    return {
+        "project_analysis_enabled": enabled,
+        "project_analysis_inject_enabled": inject_enabled,
+    }
+
+
 def recommended_advanced_settings() -> dict[str, SettingValue]:
     return {field.key: field.recommended_value for field in ADVANCED_SETTING_FIELDS}
 

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -91,6 +91,10 @@ DOCTOR_RECOMMENDATION_CODE_TRANSLATIONS: dict[str, str] = {
     doctor_rec.ENABLE_PREPARE: "建议：在「设置 · 高级」启用 prepare 后，再点「开始翻译」生成模板",
     doctor_rec.BOOTSTRAP_SOURCE_INDEX: "建议：先到左侧「上下文库」运行「预建原文索引」",
     doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE: "建议：继续在「上下文库」运行「预建原文索引」补全索引",
+    doctor_rec.BUILD_PROJECT_ANALYSIS: "建议：到「上下文库」开始项目分析并生成待审查摘要",
+    doctor_rec.REFRESH_PROJECT_ANALYSIS: "建议：到「上下文库」重新分析；只会重建受影响的摘要",
+    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL: "建议：在「设置 · 上下文」配置项目分析模型",
+    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API: "建议：配置 Gemini API Key 后再生成项目分析摘要",
     doctor_rec.BOOTSTRAP_RAG: "建议：先到左侧「上下文库」运行「预建记忆库」，再开始批量翻译",
     doctor_rec.BOOTSTRAP_RAG_OR_WARM_ON_BUILD: (
         "可选准备：记忆库为空；可先到「上下文库」预建记忆库，也可直接「开始翻译」并自动暖库"
@@ -134,6 +138,10 @@ DOCTOR_RECOMMENDATION_PRIMARY_MESSAGES: dict[str, str] = {
     ),
     doctor_rec.BOOTSTRAP_SOURCE_INDEX: "原文索引尚未就绪，请先到左侧「上下文库」预建原文索引。",
     doctor_rec.BOOTSTRAP_SOURCE_INDEX_INCOMPLETE: "原文索引尚未就绪，请先到左侧「上下文库」继续预建。",
+    doctor_rec.BUILD_PROJECT_ANALYSIS: "项目分析已启用但尚未生成；可到「上下文库」开始分析。",
+    doctor_rec.REFRESH_PROJECT_ANALYSIS: "项目分析已过期；请到「上下文库」增量更新。",
+    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL: "项目分析缺少生成模型；请先在设置中配置。",
+    doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API: "项目分析生成缺少 API Key；请先完成配置。",
     doctor_rec.BOOTSTRAP_WORK: "请先准备工作目录，再开始翻译流程。",
     doctor_rec.ENABLE_SOURCE_INDEX_FOR_NEW_PROJECT: (
         "可选优化：全新项目可在「设置 · 上下文」启用原文索引，再到「上下文库」预建。"

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -882,6 +882,7 @@ class ProjectAnalysisStore:
             identity = dict(previous.get("project_identity") or {})
 
         manifest = empty_manifest(project_identity=identity, store_dir=self.store_dir)
+        manifest["generation"] = dict((previous or {}).get("generation") or {})
         manifest["artifacts"][KIND_CHUNK] = _kind_entry(chunks)
         manifest["artifacts"][KIND_SCENE] = _kind_entry(scenes)
         manifest["artifacts"][KIND_LABEL] = _kind_entry(labels)

--- a/project_analysis.py
+++ b/project_analysis.py
@@ -572,6 +572,7 @@ def empty_manifest(
         "store_name": STORE_NAME,
         "store_dir": store_dir,
         "project_identity": dict(project_identity or {}),
+        "generation": {},
         "artifacts": {
             KIND_CHUNK: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
             KIND_SCENE: {"status": STATUS_MISSING, "count": 0, "lineage": empty_lineage()},
@@ -634,6 +635,8 @@ def normalize_manifest(raw: Any, *, store_dir: str = "") -> dict[str, Any]:
                 "count": max(0, count),
                 "lineage": normalize_lineage(entry.get("lineage")),
             }
+    generation = raw.get("generation") if isinstance(raw.get("generation"), Mapping) else {}
+    base["generation"] = dict(generation)
     base["updated_at"] = _as_optional_str(raw.get("updated_at"))
     return base
 
@@ -1111,6 +1114,10 @@ class ProjectAnalysisStore:
             and os.path.isfile(self.artifact_path(ROUTE_SUMMARIES_FILENAME))
             and (draft_present or published_present)
         )
+        chunk_count = int((artifacts.get(KIND_CHUNK) or {}).get("count") or 0)
+        semantic_evidence_warning = (
+            "keyword_summaries_missing" if structure_present and chunk_count == 0 else ""
+        )
         return {
             "store_dir": self.store_dir,
             "store_exists": self.exists(),
@@ -1121,7 +1128,8 @@ class ProjectAnalysisStore:
             "project_identity": (manifest or {}).get("project_identity")
             or dict(project_identity or {}),
             "artifacts": artifacts,
-            "chunk_count": int((artifacts.get(KIND_CHUNK) or {}).get("count") or 0),
+            "chunk_count": chunk_count,
+            "semantic_evidence_warning": semantic_evidence_warning,
             "scene_count": int((artifacts.get(KIND_SCENE) or {}).get("count") or 0),
             "label_count": int((artifacts.get(KIND_LABEL) or {}).get("count") or 0),
             "route_count": int((artifacts.get(KIND_ROUTE) or {}).get("count") or 0),
@@ -1130,6 +1138,7 @@ class ProjectAnalysisStore:
             "brief_published_present": bool(
                 brief.get("published_present", published_present)
             ),
+            "generation": dict((manifest or {}).get("generation") or {}),
             "updated_at": (manifest or {}).get("updated_at") or "",
             "error": error,
         }
@@ -1251,6 +1260,8 @@ def load_injectable_project_brief(
         f"schema={SCHEMA_VERSION} status=published "
         f"fingerprint={fp[:12] + ('…' if len(fp) > 12 else '')}"
     )
+    if status.get("semantic_evidence_warning"):
+        diagnostics += " warning=keyword_summaries_missing(structure_only)"
     return {
         "text": text,
         "injectable": True,
@@ -1512,6 +1523,10 @@ def format_status_lines(status: Mapping[str, Any]) -> list[str]:
         f"published={bool(status.get('brief_published_present'))})",
         f"- Updated at: {status.get('updated_at') or ''}",
     ]
+    if status.get("semantic_evidence_warning"):
+        lines.append(
+            "- Warning: keyword summaries missing; analysis uses static structure only"
+        )
     if status.get("error"):
         lines.append(f"- Error: {status.get('error')}")
     return lines
@@ -1541,6 +1556,8 @@ def format_status_label(status: Mapping[str, Any] | None) -> str:
         brief = status.get("brief_status") or STATUS_MISSING
         if brief != STATUS_MISSING:
             parts.append(f"brief {labels.get(brief, brief)}")
+    if status.get("semantic_evidence_warning"):
+        parts.append("缺少关键词剧情概要（仅结构分析）")
     if status.get("error"):
         parts.append("读取错误")
     if overall == STATUS_PUBLISHED and not status.get("injectable"):

--- a/project_analysis_generate.py
+++ b/project_analysis_generate.py
@@ -463,13 +463,29 @@ def build_structure_drafts(
             unresolved_count=len(graph.unresolved_edges),
         )
     store.save_brief_text(brief_text, published=False)
-    # Persist absolute script roots so runtime fingerprint reuse matches build-time roots
-    # (custom --script-root must not fall back to default game/ layout only).
     abs_roots = [os.path.abspath(r) for r in roots]
+    # Store roots relative to the project whenever possible. This keeps the
+    # analysis reusable after a project directory is moved or copied.
+    identity_base = os.path.abspath(base_dir) if base_dir else ""
+    stored_roots: list[str] = []
+    for root in abs_roots:
+        if identity_base:
+            try:
+                common = os.path.commonpath([identity_base, root])
+            except ValueError:
+                common = ""
+            if os.path.normcase(common) == os.path.normcase(identity_base):
+                stored_roots.append(os.path.relpath(root, identity_base))
+                continue
+        stored_roots.append(root)
     identity = {
-        "base_dir": os.path.abspath(base_dir) if base_dir else "",
-        "script_roots": abs_roots,
-        "graph_base": os.path.abspath(graph_base) if graph_base else "",
+        "base_dir": identity_base,
+        "script_roots": stored_roots,
+        "script_roots_relative_to_base": bool(identity_base),
+        "graph_base": "."
+        if identity_base
+        and os.path.normcase(os.path.abspath(graph_base)) == os.path.normcase(identity_base)
+        else (os.path.abspath(graph_base) if graph_base else ""),
     }
     # Update brief lineage in manifest.
     manifest = store.rebuild_manifest(
@@ -492,7 +508,7 @@ def build_structure_drafts(
                 generated_at=utc_now_iso(),
             ),
             "metadata": {
-                "script_roots": abs_roots,
+                "script_roots": stored_roots,
                 "graph_base": identity["graph_base"],
             },
         }
@@ -511,7 +527,7 @@ def build_structure_drafts(
         "chunks": len(chunks),
         "source_fingerprint": source_fp,
         "brief_draft_chars": len(brief_text),
-        "script_roots": abs_roots,
+        "script_roots": stored_roots,
         "label_merge": label_merge_stats,
         "route_merge": route_merge_stats,
         "graph": graph.to_dict(),

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -505,13 +505,10 @@ def run_mapreduce_drafts(
     source_fp = str(
         normalize_lineage(brief.get("lineage")).get("source_fingerprint") or ""
     )
-    if not source_fp and labels:
-        source_fp = str(
-            normalize_lineage(labels[0].get("lineage")).get("source_fingerprint") or ""
-        )
-    if not source_fp and routes:
-        source_fp = str(
-            normalize_lineage(routes[0].get("lineage")).get("source_fingerprint") or ""
+    if not source_fp:
+        raise ProjectAnalysisError(
+            "project-wide structure fingerprint is missing; "
+            "rerun project-analysis-build-structure before generation"
         )
 
     prov = provider or getattr(backend, "provider", "") or ""

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -403,6 +403,8 @@ def run_mapreduce_drafts(
     force: bool = False,
     provider: str = "",
     model: str = "",
+    progress: Callable[[Mapping[str, Any]], None] | None = None,
+    pricing: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """LLM-refine label → route → brief drafts in the analysis store.
 
@@ -415,6 +417,71 @@ def run_mapreduce_drafts(
         def generate(request: SyncGenerationRequest) -> SyncGenerationResult:
             return backend.generate(request)
 
+    usage_summary: dict[str, Any] = {
+        "requests": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "by_stage": {},
+    }
+    current_request = {"stage": "", "artifact_id": ""}
+    raw_generate = generate
+
+    def _usage_int(metadata: Mapping[str, Any], *keys: str) -> int:
+        for key in keys:
+            try:
+                value = int(metadata.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+            if value:
+                return value
+        return 0
+
+    def _tracked_generate(request: SyncGenerationRequest) -> SyncGenerationResult:
+        result = raw_generate(request)
+        metadata = dict(getattr(result, "usage_metadata", None) or {})
+        input_tokens = _usage_int(metadata, "prompt_token_count", "prompt_tokens", "input_tokens")
+        output_tokens = _usage_int(
+            metadata, "candidates_token_count", "completion_tokens", "output_tokens"
+        )
+        total_tokens = _usage_int(metadata, "total_token_count", "total_tokens")
+        if not total_tokens:
+            total_tokens = input_tokens + output_tokens
+        usage_summary["requests"] += 1
+        usage_summary["input_tokens"] += input_tokens
+        usage_summary["output_tokens"] += output_tokens
+        usage_summary["total_tokens"] += total_tokens
+        stage = current_request["stage"] or "unknown"
+        stage_usage = usage_summary["by_stage"].setdefault(
+            stage,
+            {"requests": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+        stage_usage["requests"] += 1
+        stage_usage["input_tokens"] += input_tokens
+        stage_usage["output_tokens"] += output_tokens
+        stage_usage["total_tokens"] += total_tokens
+        return result
+
+    def _emit_progress(stage: str, completed: int, total: int, action: str) -> None:
+        if progress is None:
+            return
+        progress(
+            {
+                "stage": stage,
+                "artifact_id": current_request["artifact_id"],
+                "completed": completed,
+                "total": total,
+                "action": action,
+                "usage": {
+                    "requests": usage_summary["requests"],
+                    "input_tokens": usage_summary["input_tokens"],
+                    "output_tokens": usage_summary["output_tokens"],
+                    "total_tokens": usage_summary["total_tokens"],
+                },
+            }
+        )
+
+    generate = _tracked_generate
     cfg = merge_llm_config(config)
     if model:
         cfg["model"] = model
@@ -431,28 +498,28 @@ def run_mapreduce_drafts(
             "no label/route drafts found; run project-analysis-build-structure first"
         )
 
-    # Prefer structure fingerprint from existing records / manifest.
+    # The brief/injection contract uses the project-wide structure fingerprint.
+    # Individual label/route records carry narrower fingerprints for cache reuse.
     source_fp = ""
-    if labels:
+    existing_manifest = store.load_manifest() or {}
+    brief = (existing_manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {}
+    source_fp = str(
+        normalize_lineage(brief.get("lineage")).get("source_fingerprint") or ""
+    )
+    if not source_fp and labels:
         source_fp = str(
-            (normalize_lineage(labels[0].get("lineage")).get("source_fingerprint") or "")
+            normalize_lineage(labels[0].get("lineage")).get("source_fingerprint") or ""
         )
     if not source_fp and routes:
         source_fp = str(
-            (normalize_lineage(routes[0].get("lineage")).get("source_fingerprint") or "")
-        )
-    if not source_fp:
-        manifest = store.load_manifest() or {}
-        brief = (manifest.get("artifacts") or {}).get(KIND_PROJECT_BRIEF) or {}
-        source_fp = str(
-            (normalize_lineage(brief.get("lineage")).get("source_fingerprint") or "")
+            normalize_lineage(routes[0].get("lineage")).get("source_fingerprint") or ""
         )
 
     prov = provider or getattr(backend, "provider", "") or ""
     model_name = cfg["model"]
 
     base_sig = generation_signature(
-        source_fingerprint=source_fp,
+        source_fingerprint="",
         provider=prov,
         model=model_name,
         thinking_level=cfg["thinking_level"],
@@ -463,21 +530,30 @@ def run_mapreduce_drafts(
     labels_refined = 0
     labels_skipped = 0
     for rec in labels:
-        if not _needs_llm_refresh(rec, expected_signature=base_sig, force=force):
+        record_fp = str(
+            normalize_lineage(rec.get("lineage")).get("source_fingerprint") or source_fp
+        )
+        record_sig = dict(base_sig, source_fingerprint=record_fp)
+        if not _needs_llm_refresh(rec, expected_signature=record_sig, force=force):
             labels_out.append(normalize_summary_record(rec, default_kind=KIND_LABEL))
             labels_skipped += 1
+            current_request.update(stage="label", artifact_id=str(rec.get("id") or ""))
+            _emit_progress("label", labels_refined + labels_skipped, len(labels), "skipped")
             continue
+        current_request.update(stage="label", artifact_id=str(rec.get("id") or ""))
+        _emit_progress("label", labels_refined + labels_skipped, len(labels), "requesting")
         labels_out.append(
             refine_label_record(
                 rec,
                 generate=generate,
                 config=cfg,
-                source_fingerprint=source_fp,
+                source_fingerprint=record_fp,
                 provider=prov,
                 model=model_name,
             )
         )
         labels_refined += 1
+        _emit_progress("label", labels_refined + labels_skipped, len(labels), "refined")
 
     label_by_id = {r["id"]: r for r in labels_out}
     for r in labels_out:
@@ -488,22 +564,31 @@ def run_mapreduce_drafts(
     routes_refined = 0
     routes_skipped = 0
     for rec in routes:
-        if not _needs_llm_refresh(rec, expected_signature=base_sig, force=force):
+        record_fp = str(
+            normalize_lineage(rec.get("lineage")).get("source_fingerprint") or source_fp
+        )
+        record_sig = dict(base_sig, source_fingerprint=record_fp)
+        if not _needs_llm_refresh(rec, expected_signature=record_sig, force=force):
             routes_out.append(normalize_summary_record(rec, default_kind=KIND_ROUTE))
             routes_skipped += 1
+            current_request.update(stage="route", artifact_id=str(rec.get("id") or ""))
+            _emit_progress("route", routes_refined + routes_skipped, len(routes), "skipped")
             continue
+        current_request.update(stage="route", artifact_id=str(rec.get("id") or ""))
+        _emit_progress("route", routes_refined + routes_skipped, len(routes), "requesting")
         routes_out.append(
             refine_route_record(
                 rec,
                 label_by_id,
                 generate=generate,
                 config=cfg,
-                source_fingerprint=source_fp,
+                source_fingerprint=record_fp,
                 provider=prov,
                 model=model_name,
             )
         )
         routes_refined += 1
+        _emit_progress("route", routes_refined + routes_skipped, len(routes), "refined")
 
     store.save_summaries(KIND_LABEL, labels_out)
     store.save_routes(routes_out)
@@ -554,6 +639,8 @@ def run_mapreduce_drafts(
 
     brief_refined = False
     if brief_needs_refresh:
+        current_request.update(stage="brief", artifact_id="project_brief")
+        _emit_progress("brief", 0, 1, "requesting")
         brief_text = refine_project_brief(
             routes_out,
             generate=generate,
@@ -568,6 +655,7 @@ def run_mapreduce_drafts(
             brief_text = "# Project Analysis Brief (LLM draft)\n\n" + brief_text
         store.save_brief_text(brief_text, published=False)
         brief_refined = True
+        _emit_progress("brief", 1, 1, "refined")
         brief_lineage = empty_lineage(
             source_fingerprint=source_fp,
             prompt_schema_version=PROMPT_SCHEMA_VERSION,
@@ -581,6 +669,24 @@ def run_mapreduce_drafts(
         brief_text = previous_brief_text
         brief_lineage = normalize_lineage(previous_brief_entry.get("lineage"))
 
+    price = dict(pricing or {})
+    try:
+        input_rate = float(price.get("input_per_million") or 0.0)
+        output_rate = float(price.get("output_per_million") or 0.0)
+    except (TypeError, ValueError):
+        input_rate = output_rate = 0.0
+    usage_summary["currency"] = str(price.get("currency") or "USD")
+    usage_summary["input_per_million"] = input_rate
+    usage_summary["output_per_million"] = output_rate
+    usage_summary["estimated_cost"] = round(
+        (usage_summary["input_tokens"] * input_rate
+         + usage_summary["output_tokens"] * output_rate)
+        / 1_000_000,
+        6,
+    )
+    usage_summary["cost_is_estimate"] = True
+    current_request.update(stage="complete", artifact_id="project_brief")
+    _emit_progress("complete", 1, 1, "done")
     manifest = store.rebuild_manifest(
         project_identity=identity,
         expected_source_fingerprint=source_fp,
@@ -597,6 +703,18 @@ def run_mapreduce_drafts(
     if identity:
         manifest["project_identity"] = identity
     manifest.setdefault("artifacts", {})[KIND_PROJECT_BRIEF] = brief_entry
+    manifest["generation"] = {
+        "model": model_name,
+        "provider": prov,
+        "prompt_schema_version": PROMPT_SCHEMA_VERSION,
+        "completed_at": utc_now_iso(),
+        "labels_refined": labels_refined,
+        "labels_skipped": labels_skipped,
+        "routes_refined": routes_refined,
+        "routes_skipped": routes_skipped,
+        "brief_refined": brief_refined,
+        "usage": usage_summary,
+    }
     store.save_manifest(manifest)
 
     return {
@@ -611,5 +729,6 @@ def run_mapreduce_drafts(
         "routes_skipped": routes_skipped,
         "brief_refined": brief_refined,
         "brief_draft_chars": len(brief_text),
+        "usage": usage_summary,
         "force": bool(force),
     }

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -409,6 +409,10 @@ def run_mapreduce_drafts(
     """LLM-refine label → route → brief drafts in the analysis store.
 
     Requires structure drafts already present (run build-structure first).
+    When provided, ``progress`` receives mappings with ``stage``, ``artifact_id``,
+    ``completed``, ``total``, ``action``, and a ``usage`` mapping. ``pricing`` may
+    provide ``currency``, ``input_per_million``, and ``output_per_million``; the
+    final progress event, return value, and manifest then include estimated cost.
     """
     if generate is None:
         if backend is None:
@@ -472,12 +476,7 @@ def run_mapreduce_drafts(
                 "completed": completed,
                 "total": total,
                 "action": action,
-                "usage": {
-                    "requests": usage_summary["requests"],
-                    "input_tokens": usage_summary["input_tokens"],
-                    "output_tokens": usage_summary["output_tokens"],
-                    "total_tokens": usage_summary["total_tokens"],
-                },
+                "usage": dict(usage_summary),
             }
         )
 

--- a/project_analysis_routes.py
+++ b/project_analysis_routes.py
@@ -380,7 +380,11 @@ def graph_to_label_records(
     chunk_by_label: dict[str, list[dict[str, Any]]] | None = None,
     source_fingerprint: str = "",
 ) -> list[dict[str, Any]]:
-    """Build draft label summary records from the graph (+ optional chunk texts)."""
+    """Build label drafts with a local content fingerprint for selective refresh.
+
+    ``lineage.source_fingerprint`` prefers the label body plus assigned chunk hash;
+    the project-wide ``source_fingerprint`` remains a compatibility fallback.
+    """
     chunk_by_label = chunk_by_label or {}
     records: list[dict[str, Any]] = []
     for name, node in sorted(graph.labels.items()):
@@ -451,7 +455,11 @@ def graph_to_route_records(
     label_records: Sequence[dict[str, Any]] | None = None,
     source_fingerprint: str = "",
 ) -> list[dict[str, Any]]:
-    """Build draft route summary records."""
+    """Build route drafts with a dependency-local fingerprint for cache reuse.
+
+    ``lineage.source_fingerprint`` prefers a hash of the route and member-label
+    fingerprints; the project-wide ``source_fingerprint`` is only a fallback.
+    """
     label_by_name = {
         str(r.get("label_id") or "").strip(): r
         for r in (label_records or [])

--- a/project_analysis_routes.py
+++ b/project_analysis_routes.py
@@ -52,6 +52,7 @@ class LabelNode:
     file_rel_path: str
     line_start: int
     line_end: int = 0
+    content_fingerprint: str = ""
     outgoing: list[RouteEdge] = field(default_factory=list)
 
 
@@ -71,6 +72,7 @@ class RouteGraph:
                     "file_rel_path": node.file_rel_path,
                     "line_start": node.line_start,
                     "line_end": node.line_end,
+                    "content_fingerprint": node.content_fingerprint,
                     "outgoing": [edge.__dict__ for edge in node.outgoing],
                 }
                 for name, node in sorted(self.labels.items())
@@ -148,6 +150,7 @@ def parse_rpy_labels_and_edges(text: str, *, file_rel_path: str = "") -> tuple[l
             file_rel_path=file_rel_path,
             line_start=start,
             line_end=end,
+            content_fingerprint=sha256_text(text[match.start() : end_index]),
         )
         # Jumps / calls inside this label body.
         for jm in _JUMP_RE.finditer(body):
@@ -399,6 +402,19 @@ def graph_to_label_records(
         unresolved = any(e.unresolved for e in node.outgoing)
         if unresolved:
             body += "\n[unresolved dynamic jump/call present]"
+        local_fingerprint = stable_json_sha256(
+            {
+                "label_body": node.content_fingerprint,
+                "chunks": [
+                    {
+                        "id": chunk.get("id") or "",
+                        "source_checksum": chunk.get("source_checksum") or "",
+                        "summary": chunk.get("summary") or "",
+                    }
+                    for chunk in chunks
+                ],
+            }
+        )
         records.append(
             {
                 "id": f"label:{name}",
@@ -411,7 +427,8 @@ def graph_to_label_records(
                 "source_checksum": sha256_text(body),
                 "upstream_artifact_ids": upstream,
                 "lineage": empty_lineage(
-                    source_fingerprint=source_fingerprint
+                    source_fingerprint=local_fingerprint
+                    or source_fingerprint
                     or sha256_text("|".join(graph.source_files)),
                     upstream_dependency_digest=digest_upstream_artifacts(upstream),
                     generated_at="",
@@ -460,6 +477,23 @@ def graph_to_route_records(
         if route.get("unresolved"):
             parts.append("[route contains unresolved dynamic jump/call]")
         body = "\n\n".join(parts) if parts else f"Route from {route.get('entry_label')}"
+        route_fingerprint = stable_json_sha256(
+            {
+                "route_id": route["id"],
+                "labels": [
+                    {
+                        "id": name,
+                        "source_fingerprint": (
+                            (label_by_name.get(name) or {}).get("lineage") or {}
+                        ).get("source_fingerprint")
+                        or "",
+                    }
+                    for name in path
+                ],
+                "unresolved": bool(route.get("unresolved")),
+                "shared_labels": list(route.get("shared_labels") or []),
+            }
+        )
         records.append(
             {
                 "id": route["id"],
@@ -472,7 +506,8 @@ def graph_to_route_records(
                 "source_checksum": sha256_text(body),
                 "upstream_artifact_ids": upstream,
                 "lineage": empty_lineage(
-                    source_fingerprint=source_fingerprint
+                    source_fingerprint=route_fingerprint
+                    or source_fingerprint
                     or sha256_text("|".join(graph.source_files)),
                     upstream_dependency_digest=digest_upstream_artifacts(upstream),
                 ),

--- a/project_context_settings.py
+++ b/project_context_settings.py
@@ -1,9 +1,11 @@
-"""Per-project batch context flags (RAG / source index / bootstrap_on_build).
+"""Per-project batch context flags (RAG / source index / Project Analysis).
 
-Global defaults still live in translator_config.json under batch.rag / batch.source_index.
+Global defaults still live in translator_config.json under batch.rag / batch.source_index /
+batch.project_analysis.
 When a game work directory has project_context_settings.json, those values override the
 global defaults for that project only.
 """
+
 from __future__ import annotations
 
 import json
@@ -21,6 +23,8 @@ PROJECT_CONTEXT_FLAG_KEYS = (
     "batch_rag_enabled",
     "batch_source_index_enabled",
     "batch_rag_bootstrap_on_build",
+    "batch_project_analysis_enabled",
+    "batch_project_analysis_inject_published_brief",
 )
 
 
@@ -60,10 +64,17 @@ def default_context_flags_from_config(config: dict[str, Any] | None) -> dict[str
     source_index = batch.get("source_index")
     if not isinstance(source_index, dict):
         source_index = {}
+    project_analysis = batch.get("project_analysis")
+    if not isinstance(project_analysis, dict):
+        project_analysis = {}
     return {
         "rag_enabled": _coerce_bool(rag.get("enabled"), False),
         "source_index_enabled": _coerce_bool(source_index.get("enabled"), False),
         "bootstrap_on_build": _coerce_bool(rag.get("bootstrap_on_build"), True),
+        "project_analysis_enabled": _coerce_bool(project_analysis.get("enabled"), False),
+        "project_analysis_inject_enabled": _coerce_bool(
+            project_analysis.get("inject_published_brief"), False
+        ),
     }
 
 
@@ -82,26 +93,22 @@ def load_project_context_settings(
     if not isinstance(data, dict):
         return None
 
+    aliases = {
+        "batch_rag_enabled": ("rag_enabled", False),
+        "batch_source_index_enabled": ("source_index_enabled", False),
+        "batch_rag_bootstrap_on_build": ("bootstrap_on_build", True),
+        "batch_project_analysis_enabled": ("project_analysis_enabled", False),
+        "batch_project_analysis_inject_published_brief": (
+            "project_analysis_inject_enabled",
+            False,
+        ),
+    }
     flags: dict[str, bool] = {}
-    if "batch_rag_enabled" in data:
-        flags["rag_enabled"] = _coerce_bool(data.get("batch_rag_enabled"), False)
-    if "batch_source_index_enabled" in data:
-        flags["source_index_enabled"] = _coerce_bool(
-            data.get("batch_source_index_enabled"), False
-        )
-    if "batch_rag_bootstrap_on_build" in data:
-        flags["bootstrap_on_build"] = _coerce_bool(
-            data.get("batch_rag_bootstrap_on_build"), True
-        )
-    # Also accept the UI-shaped keys if present.
-    if "rag_enabled" in data and "rag_enabled" not in flags:
-        flags["rag_enabled"] = _coerce_bool(data.get("rag_enabled"), False)
-    if "source_index_enabled" in data and "source_index_enabled" not in flags:
-        flags["source_index_enabled"] = _coerce_bool(
-            data.get("source_index_enabled"), False
-        )
-    if "bootstrap_on_build" in data and "bootstrap_on_build" not in flags:
-        flags["bootstrap_on_build"] = _coerce_bool(data.get("bootstrap_on_build"), True)
+    for stored_key, (flag_key, default) in aliases.items():
+        if stored_key in data:
+            flags[flag_key] = _coerce_bool(data.get(stored_key), default)
+        elif flag_key in data:
+            flags[flag_key] = _coerce_bool(data.get(flag_key), default)
     return flags or None
 
 
@@ -118,11 +125,13 @@ def save_project_context_settings(
     payload = {
         "schema_version": SCHEMA_VERSION,
         "batch_rag_enabled": _coerce_bool(flags.get("rag_enabled"), False),
-        "batch_source_index_enabled": _coerce_bool(
-            flags.get("source_index_enabled"), False
+        "batch_source_index_enabled": _coerce_bool(flags.get("source_index_enabled"), False),
+        "batch_rag_bootstrap_on_build": _coerce_bool(flags.get("bootstrap_on_build"), True),
+        "batch_project_analysis_enabled": _coerce_bool(
+            flags.get("project_analysis_enabled"), False
         ),
-        "batch_rag_bootstrap_on_build": _coerce_bool(
-            flags.get("bootstrap_on_build"), True
+        "batch_project_analysis_inject_published_brief": _coerce_bool(
+            flags.get("project_analysis_inject_enabled"), False
         ),
     }
     tmp_path = ""
@@ -164,7 +173,7 @@ def apply_project_context_settings_to_config(
     config: dict[str, Any],
     game_root: str | os.PathLike[str] | None,
 ) -> dict[str, Any]:
-    """Mutate config so batch.rag / batch.source_index.enabled match the project."""
+    """Mutate config so context enablement matches the selected project."""
     if not isinstance(config, dict):
         return {}
     flags = resolve_batch_context_flags(config, game_root)
@@ -180,9 +189,15 @@ def apply_project_context_settings_to_config(
     if not isinstance(source_index, dict):
         source_index = {}
         batch["source_index"] = source_index
+    project_analysis = batch.get("project_analysis")
+    if not isinstance(project_analysis, dict):
+        project_analysis = {}
+        batch["project_analysis"] = project_analysis
     rag["enabled"] = flags["rag_enabled"]
     rag["bootstrap_on_build"] = flags["bootstrap_on_build"]
     source_index["enabled"] = flags["source_index_enabled"]
+    project_analysis["enabled"] = flags["project_analysis_enabled"]
+    project_analysis["inject_published_brief"] = flags["project_analysis_inject_enabled"]
     return config
 
 

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -121,6 +121,30 @@ class DoctorLayoutStatusMatrixTests(unittest.TestCase):
 
 
 class DoctorRecommendationMatrixTests(unittest.TestCase):
+    def test_enabled_project_analysis_reports_actionable_setup_and_stale_codes(self):
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=1,
+            layout_status="ready",
+        )
+        report["context_status"] = {
+            "project_analysis": {
+                "enabled": True,
+                "model": "",
+                "api_key_count": 0,
+                "overall_status": "stale",
+            }
+        }
+        codes = doctor_rec.doctor_recommendation_codes(
+            batch_mod.collect_doctor_recommendations(report)
+        )
+
+        self.assertIn(doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL, codes)
+        self.assertIn(doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API, codes)
+        self.assertIn(doctor_rec.REFRESH_PROJECT_ANALYSIS, codes)
+        self.assertTrue(
+            set(codes).issubset(doctor_rec.OPTIONAL_RECOMMENDATION_CODES)
+        )
     def test_switch_to_work_only_recommends_switch_and_bootstrap(self):
         report = _layout_report(
             base_dir="C:/Games/Example",

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -135,16 +135,21 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
                 "overall_status": "stale",
             }
         }
-        codes = doctor_rec.doctor_recommendation_codes(
-            batch_mod.collect_doctor_recommendations(report)
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+        codes = doctor_rec.doctor_recommendation_codes(recommendations)
+
+        self.assertCountEqual(
+            codes,
+            [
+                doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL,
+                doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API,
+                doctor_rec.REFRESH_PROJECT_ANALYSIS,
+            ],
+        )
+        self.assertFalse(
+            doctor_rec.recommendations_block_workflow_state(recommendations)
         )
 
-        self.assertIn(doctor_rec.CONFIGURE_PROJECT_ANALYSIS_MODEL, codes)
-        self.assertIn(doctor_rec.CONFIGURE_PROJECT_ANALYSIS_API, codes)
-        self.assertIn(doctor_rec.REFRESH_PROJECT_ANALYSIS, codes)
-        self.assertTrue(
-            set(codes).issubset(doctor_rec.OPTIONAL_RECOMMENDATION_CODES)
-        )
     def test_switch_to_work_only_recommends_switch_and_bootstrap(self):
         report = _layout_report(
             base_dir="C:/Games/Example",

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -1,4 +1,5 @@
 import copy
+import tempfile
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -456,6 +457,42 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertTrue(flags["rag_enabled"])
         self.assertFalse(flags["source_index_enabled"])
 
+    def test_saved_project_analysis_flags_reads_project_override(self):
+        from project_context_settings import save_project_context_settings
+
+        with tempfile.TemporaryDirectory() as tmp:
+            game_root = Path(tmp)
+            save_project_context_settings(
+                game_root,
+                {
+                    "rag_enabled": False,
+                    "source_index_enabled": False,
+                    "bootstrap_on_build": True,
+                    "project_analysis_enabled": True,
+                    "project_analysis_inject_enabled": True,
+                },
+            )
+
+            class FakeState:
+                def get_game_root(self):
+                    return game_root
+
+                def load_translator_config(self):
+                    return {
+                        "batch": {
+                            "project_analysis": {
+                                "enabled": False,
+                                "inject_published_brief": False,
+                            }
+                        }
+                    }
+
+            self.window.state = FakeState()
+
+            flags = self.window._saved_project_analysis_flags()
+
+            self.assertTrue(flags["enabled"])
+            self.assertTrue(flags["inject_enabled"])
     def test_save_config_persists_context_storage_and_rolls_back_on_project_failure(self):
         from gui_qt.work_modes import WorkMode
 
@@ -523,6 +560,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 "rag_enabled": True,
                 "source_index_enabled": True,
                 "bootstrap_on_build": False,
+                "project_analysis_enabled": False,
+                "project_analysis_inject_enabled": False,
             },
         )
         # Legacy global values remain fallback defaults for projects without

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -547,7 +547,18 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._refresh_project_label = lambda: None
         self.window.statusBar = lambda: FakeStatusBar()
 
-        with mock.patch("project_context_settings.save_project_context_settings") as save_project:
+        with (
+            mock.patch(
+                "gui_qt.app.read_batch_context_flags",
+                return_value={
+                    "project_analysis_enabled": True,
+                    "project_analysis_inject_enabled": True,
+                },
+            ),
+            mock.patch(
+                "project_context_settings.save_project_context_settings"
+            ) as save_project,
+        ):
             saved = self.window._on_save_config()
 
         self.assertTrue(saved)
@@ -560,8 +571,8 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 "rag_enabled": True,
                 "source_index_enabled": True,
                 "bootstrap_on_build": False,
-                "project_analysis_enabled": False,
-                "project_analysis_inject_enabled": False,
+                "project_analysis_enabled": True,
+                "project_analysis_inject_enabled": True,
             },
         )
         # Legacy global values remain fallback defaults for projects without

--- a/tests/test_gui_project_analysis.py
+++ b/tests/test_gui_project_analysis.py
@@ -9,6 +9,7 @@ import project_analysis as pa
 from gui_qt.check_report import idle_writeback_summary_for_work_mode
 from gui_qt.project_analysis_workflow import (
     ProjectAnalysisWorkflow,
+    generation_facts_from_output,
     discover_keyword_summary_path,
 )
 from gui_qt.translation_workflow import WorkflowUpdate
@@ -62,6 +63,18 @@ class ProjectAnalysisWorkflowTests(unittest.TestCase):
         self.assertEqual(update.status, "done")
         self.assertFalse(update.should_continue)
 
+    def test_generation_progress_is_rendered_as_gui_facts(self):
+        output = (
+            'PROJECT_ANALYSIS_PROGRESS '
+            '{"stage":"complete","completed":1,"total":1,'
+            '"usage":{"requests":4,"input_tokens":40,"output_tokens":16,'
+            '"estimated_cost":0.000104,"currency":"USD"}}\n'
+        )
+        facts = generation_facts_from_output(output)
+
+        self.assertIn("complete 1/1", facts[0])
+        self.assertIn("模型请求：4", facts[1])
+        self.assertIn("0.000104 USD", facts[2])
     def test_step_keys_match_concrete_requested_sequence(self):
         self.assertEqual(
             ProjectAnalysisWorkflow.start_new(build=False, generate=True).step_keys(),

--- a/tests/test_gui_settings_schema.py
+++ b/tests/test_gui_settings_schema.py
@@ -6,11 +6,54 @@ from gui_qt.settings_schema import (
     filter_gemini_rotation_models,
     read_advanced_settings,
     recommended_advanced_settings,
+    resolve_project_analysis_flags_for_save,
     validate_advanced_settings,
 )
 
 
 class GuiSettingsSchemaTests(unittest.TestCase):
+    def test_project_analysis_save_flags_preserve_saved_values_without_widgets(self):
+        flags = resolve_project_analysis_flags_for_save(
+            {
+                "project_analysis_enabled": True,
+                "project_analysis_inject_enabled": False,
+            },
+            {},
+            {},
+        )
+
+        self.assertEqual(
+            flags,
+            {
+                "project_analysis_enabled": True,
+                "project_analysis_inject_enabled": False,
+            },
+        )
+
+    def test_project_analysis_save_flags_use_present_ui_values(self):
+        flags = resolve_project_analysis_flags_for_save(
+            {
+                "project_analysis_enabled": True,
+                "project_analysis_inject_enabled": False,
+            },
+            {
+                "batch_project_analysis_enabled": False,
+                "batch_project_analysis_inject_published_brief": True,
+            },
+            {
+                "batch_project_analysis_enabled": False,
+                "batch_project_analysis_inject_published_brief": True,
+            },
+        )
+
+        self.assertEqual(
+            flags,
+            {
+                "project_analysis_enabled": False,
+                "project_analysis_inject_enabled": True,
+            },
+        )
+
     def test_read_advanced_settings_uses_defaults_for_missing_config(self):
         values = read_advanced_settings({})
 

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -222,10 +222,16 @@ class MapReduceTests(unittest.TestCase):
             self.assertEqual(result["usage"]["total_tokens"], len(backend.calls) * 14)
             self.assertGreater(result["usage"]["estimated_cost"], 0)
             self.assertEqual(events[-1]["stage"], "complete")
-            manifest = pa.ProjectAnalysisStore(store_dir).load_manifest()
+            self.assertEqual(events[-1]["usage"], result["usage"])
+            self.assertEqual(events[-1]["usage"]["currency"], "USD")
+            store = pa.ProjectAnalysisStore(store_dir)
+            manifest = store.load_manifest()
             self.assertEqual(
                 manifest["generation"]["usage"]["requests"], len(backend.calls)
             )
+            generation = manifest["generation"]
+            store.rebuild_manifest()
+            self.assertEqual(store.load_manifest()["generation"], generation)
 
     def test_script_edit_regenerates_only_affected_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -278,6 +278,33 @@ class MapReduceTests(unittest.TestCase):
             self.assertGreater(result["labels_refined"], 0)
             self.assertGreater(result["labels_skipped"], 0)
             self.assertGreater(result["routes_skipped"], 0)
+
+    def test_missing_project_fingerprint_requires_structure_rebuild(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "pa")
+            gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=str(FIXTURE_DIR),
+                script_roots=[str(FIXTURE_DIR)],
+                entry_labels=["start"],
+            )
+            store = pa.ProjectAnalysisStore(store_dir)
+            manifest = store.load_manifest()
+            manifest["artifacts"][pa.KIND_PROJECT_BRIEF]["lineage"] = pa.empty_lineage()
+            store.save_manifest(manifest)
+            backend = FakeBackend()
+
+            with self.assertRaisesRegex(
+                pa.ProjectAnalysisError, "rerun project-analysis-build-structure"
+            ):
+                llm.run_mapreduce_drafts(
+                    store_dir=store_dir,
+                    backend=backend,
+                    config={"model": "fake-model"},
+                )
+
+            self.assertEqual(backend.calls, [])
+
     def test_requires_structure(self):
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(pa.ProjectAnalysisError):

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -45,6 +45,11 @@ class FakeBackend:
             execution_mode=SYNC_EXECUTION_MODE,
             response_payload={"text": text},
             response_text=text,
+            usage_metadata={
+                "prompt_token_count": 10,
+                "candidates_token_count": 4,
+                "total_token_count": 14,
+            },
         )
 
 
@@ -187,6 +192,86 @@ class MapReduceTests(unittest.TestCase):
                 if summary and "LLM-LABEL" in str(summary):
                     self.assertEqual(after.get(lid), summary)
 
+    def test_usage_progress_and_cost_are_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "pa")
+            gen.ingest_keyword_summaries(str(KEYWORDS), store_dir=store_dir)
+            gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=str(FIXTURE_DIR),
+                script_roots=[str(FIXTURE_DIR)],
+                entry_labels=["start"],
+            )
+            backend = FakeBackend()
+            events = []
+            result = llm.run_mapreduce_drafts(
+                store_dir=store_dir,
+                backend=backend,
+                config={"model": "fake-model"},
+                force=True,
+                provider="fake",
+                progress=events.append,
+                pricing={
+                    "currency": "USD",
+                    "input_per_million": 1.0,
+                    "output_per_million": 2.0,
+                },
+            )
+
+            self.assertEqual(result["usage"]["requests"], len(backend.calls))
+            self.assertEqual(result["usage"]["total_tokens"], len(backend.calls) * 14)
+            self.assertGreater(result["usage"]["estimated_cost"], 0)
+            self.assertEqual(events[-1]["stage"], "complete")
+            manifest = pa.ProjectAnalysisStore(store_dir).load_manifest()
+            self.assertEqual(
+                manifest["generation"]["usage"]["requests"], len(backend.calls)
+            )
+
+    def test_script_edit_regenerates_only_affected_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            scripts = Path(tmp) / "scripts"
+            scripts.mkdir()
+            script = scripts / "script.rpy"
+            script.write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+            store_dir = os.path.join(tmp, "pa")
+            gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=tmp,
+                script_roots=[str(scripts)],
+                entry_labels=["start"],
+            )
+            backend = FakeBackend()
+            llm.run_mapreduce_drafts(
+                store_dir=store_dir,
+                backend=backend,
+                config={"model": "fake-model"},
+                force=True,
+                provider="fake",
+            )
+            script.write_text(
+                script.read_text(encoding="utf-8").replace(
+                    'label path_a:\n', 'label path_a:\n    "local edit"\n'
+                ),
+                encoding="utf-8",
+            )
+            rebuilt = gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=tmp,
+                script_roots=[str(scripts)],
+                entry_labels=["start"],
+            )
+            result = llm.run_mapreduce_drafts(
+                store_dir=store_dir,
+                backend=backend,
+                config={"model": "fake-model"},
+                force=False,
+                provider="fake",
+            )
+
+            self.assertGreater(rebuilt["label_merge"]["preserved"], 0)
+            self.assertGreater(result["labels_refined"], 0)
+            self.assertGreater(result["labels_skipped"], 0)
+            self.assertGreater(result["routes_skipped"], 0)
     def test_requires_structure(self):
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(pa.ProjectAnalysisError):

--- a/tests/test_project_analysis_phase2.py
+++ b/tests/test_project_analysis_phase2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -103,6 +104,34 @@ class RouteParseTests(unittest.TestCase):
             fp2 = routes.digest_script_paths([str(script)], base_dir=tmp)
             self.assertNotEqual(fp1, fp2)
 
+    def test_relative_script_roots_survive_project_relocation(self):
+        import gemini_translate_batch as batch_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "project_a"
+            scripts = source / "custom_scripts"
+            scripts.mkdir(parents=True)
+            (scripts / "script.rpy").write_text(
+                "label start:\n    return\n", encoding="utf-8"
+            )
+            store_dir = source / "analysis"
+            built = gen.build_structure_drafts(
+                store_dir=str(store_dir),
+                base_dir=str(source),
+                script_roots=[str(scripts)],
+                entry_labels=["start"],
+            )
+            identity = pa.ProjectAnalysisStore(str(store_dir)).load_manifest()[
+                "project_identity"
+            ]
+            self.assertEqual(identity["script_roots"], ["custom_scripts"])
+
+            relocated = Path(tmp) / "project_b"
+            shutil.copytree(source, relocated)
+            fingerprint = batch_mod.compute_current_project_analysis_fingerprint(
+                str(relocated), store_dir=str(relocated / "analysis")
+            )
+            self.assertEqual(fingerprint, built["source_fingerprint"])
     def test_call_expression_not_parsed_as_named_call(self):
         text = "label a:\n    call expression some_flag\n    call helper\n"
         labels, edges = routes.parse_rpy_labels_and_edges(text, file_rel_path="x.rpy")
@@ -163,6 +192,13 @@ class GenerateAndPublishTests(unittest.TestCase):
             )
             self.assertTrue(status["structure_present"])
             self.assertTrue(status["brief_draft_present"])
+            self.assertEqual(
+                status["semantic_evidence_warning"], "keyword_summaries_missing"
+            )
+            self.assertIn("仅结构分析", pa.format_status_label(status))
+            self.assertTrue(
+                any("Warning:" in line for line in pa.format_status_lines(status))
+            )
 
     def test_ingest_build_publish_inject_cycle(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -214,6 +250,7 @@ class GenerateAndPublishTests(unittest.TestCase):
             )
             self.assertTrue(allowed["injectable"])
             self.assertIn("Project Analysis Brief", allowed["text"])
+            self.assertNotIn("keyword_summaries_missing", allowed["diagnostics"])
 
             # Script edit changes fingerprint → injection blocked (use temp copy).
             with tempfile.TemporaryDirectory() as tmp2:

--- a/tests/test_project_context_settings.py
+++ b/tests/test_project_context_settings.py
@@ -101,6 +101,40 @@ class ProjectContextSettingsTests(unittest.TestCase):
             self.assertTrue(flags["source_index_enabled"])
             self.assertTrue(flags["bootstrap_on_build"])
 
+    def test_project_analysis_flags_are_project_scoped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            global_config = {
+                "batch": {
+                    "rag": {"enabled": False},
+                    "source_index": {"enabled": False},
+                    "project_analysis": {
+                        "enabled": False,
+                        "inject_published_brief": False,
+                    },
+                }
+            }
+            save_project_context_settings(
+                root,
+                {
+                    "rag_enabled": False,
+                    "source_index_enabled": False,
+                    "bootstrap_on_build": True,
+                    "project_analysis_enabled": True,
+                    "project_analysis_inject_enabled": True,
+                },
+            )
+
+            data = json.loads(Path(project_context_settings_path(root)).read_text(encoding="utf-8"))
+            self.assertTrue(data["batch_project_analysis_enabled"])
+            self.assertTrue(data["batch_project_analysis_inject_published_brief"])
+            flags = resolve_batch_context_flags(global_config, root)
+            self.assertTrue(flags["project_analysis_enabled"])
+            self.assertTrue(flags["project_analysis_inject_enabled"])
+            applied = apply_project_context_settings_to_config(dict(global_config), root)
+            self.assertTrue(applied["batch"]["project_analysis"]["enabled"])
+            self.assertTrue(applied["batch"]["project_analysis"]["inject_published_brief"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- make Project Analysis `enabled` and published-brief injection switches project-scoped through `project_context_settings.json`, while retaining global fallback defaults
- add label/route/brief generation progress, request/token usage, persisted generation summaries, and configured-price cost estimates for CLI and GUI
- add actionable optional Doctor recommendations for missing/stale analysis, missing model, and missing API key
- use label/route content fingerprints so edits only regenerate the affected dependency chain, while preserving the project-wide freshness fingerprint for publish/injection gates
- store script roots relative to the project and rebase compatible legacy absolute roots after project move/copy
- keep missing keyword summaries non-blocking but persistently visible as a structure-only warning in status and injection diagnostics
- update current setup/context/GUI/Doctor documentation and regression coverage

## Product impact

Project Analysis now follows the same per-project configuration model as the other context-library systems, reports operational progress and cost, guides users through recoverable setup states, and preserves reusable analysis when projects move or when unrelated scripts change.

## Validation

- `python -m unittest tests.test_project_analysis_phase2 tests.test_project_context_settings tests.test_gui_project_analysis tests.test_gui_app_config tests.test_project_analysis_llm tests.test_doctor_layout_status` — 140 passed
- `python -B tests/run_cli_tests.py -q` — 720 passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 862 passed
- `python scripts/run_quality_gates.py all` — Ruff scoped/critical, mypy, and all pip-audit lock checks passed
- `git diff --check`

Advances #262 P3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project Analysis can now be enabled and configured independently per project, including whether published briefs are injected for translation.
  * Project Analysis generation now shows progress with token usage and estimated cost.
  * Doctor checks provide actionable setup steps and workflow-state recommendations for Project Analysis.
* **Bug Fixes**
  * Improved compatibility when projects are moved/relocated; saved analysis data is more reliably reused.
  * Clearer warnings when only structural analysis exists (e.g., missing keyword summaries).
  * Refresh behavior regenerates only affected content.
* **Documentation**
  * Updated setup, context, GUI workbench, and troubleshooting docs for the new Project Analysis flags and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->