### PR TITLE
Improve LiteLLM provider catalog settings

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -116,7 +116,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 - **工作区 / 项目列表**：先 **创建 / 接入工作区…**（预览后初始化或接入 `games_registry.json`，成功后再写 `workspace_root`；默认未设置，不会用工具上一级），再浏览总表、扫描/刷新、同步 `GAMES.md`、编辑详情并**切换当前 `game_root`**。主工具条为项目刷新 + **维护**；展开后带「项目发现 / 总表维护」小标题，左对齐略缩进，宽屏四钮尽量同行。总览表与项目详情可拖拽分隔，详情可收起。未指定工作区时本区为空状态。「切换到此项目」成功后**留在项目列表**；术语表 / 准备流程等到「项目」分区调整。此分区的操作即时写入 registry / `workspace_root`，不使用底部「保存设置」。
 - **密钥**：读取 / 保存 `api_keys.json`；环境变量 Key 只读提示。
-- **LiteLLM**：选择 Provider 和模型、从已安装的 LiteLLM 目录刷新模型列表、在操作系统凭据管理器中单独保存供应商密钥，并可后台测试连接。
+- **LiteLLM**：按“联网加载供应商 → 选择 Provider → 配置该 Provider 凭据 → 联网加载模型 → 选择模型 → 保存设置”配置同步替代后端。首次打开不会默认选择 OpenAI 或模型，也不会静默联网；Provider / 模型均可手动填写。
 - **项目**：术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。Ren'Py SDK 须显式配置： **查找 SDK**（用户点击后才扫描附近）、**浏览…**，或确认后 **下载推荐 SDK…**（官方固定版本）；留空不会自动搜其它目录或联网。结果写入 `prepare.renpy_sdk_dir`，保存设置后生效。当前 `game_root` 只读展示；需换项目请用「项目与环境」或「项目列表」。
 - **模型**：同步 / 批量翻译模型、embedding model、批量 thinking level。
 - **上下文**：
@@ -233,7 +233,8 @@ GUI 不要求手写 JSON 变体文件。对话框以 **baseline + 可选覆盖�
 GUI 不引入新的主配置系统。
 
 - API Key 仍保存到 `api_keys.json` 的 `api_keys` 列表。
-- LiteLLM 的供应商密钥保存到操作系统凭据管理器，不写入 `api_keys.json` 或 `translator_config.json`；已有的供应商环境变量仍可使用。
+- LiteLLM 的供应商密钥按 Provider 保存到操作系统凭据管理器，不写入 `api_keys.json`、用户级目录缓存或 `translator_config.json`，也不会回显；已有的供应商环境变量仍可使用。若两者同时存在，系统凭据管理器中的密钥优先。切换或取消 Provider 会丢弃尚未保存的明文输入，但不会删除已保存凭据。
+- LiteLLM 的 Provider / 模型目录、目录来源、抓取时间和每个 Provider 的上次选择保存在用户级 GUI 缓存，不污染项目配置。只有用户点击加载按钮才会联网；失败时保留旧缓存，没有缓存则保持空白，不回填内置默认模型。LiteLLM 在线价格 / 上下文目录可能只是供应商目录的子集；无法枚举的 Provider、Azure 部署或自建 OpenAI-compatible 模型仍可手动填写，并按 LiteLLM 文档配置对应的 API Base、版本和额外认证环境变量。
 - 项目路径、准备流程、过滤器、模型、embedding model、批量 thinking level、GUI 主题、任务专用参数和上下文参数等写入 `translator_config.json`。
 - 保存设置时应保留未知字段，避免破坏手写配置。
 - 如果 API Key 来自 `GEMINI_API_KEY` 等环境变量，GUI 只提示只读状态，不强行写回文件。
@@ -257,6 +258,7 @@ build -> submit -> status -> download -> check
 #### LiteLLM 同步替代边界
 
 - **默认与回退**：Gemini Batch 始终是推荐的批量主路径。要停止使用 LiteLLM，在「设置 → LiteLLM」把同步执行后端切回「Gemini 同步（推荐）」并保存；这不会改动 Batch 模型或 RAG Embedding 配置。
+- **目录与运行配置**：用户级目录缓存只帮助恢复 GUI 选择；项目实际运行仍以 `translator_config.json` 的 `sync.backend` / `sync.litellm_model` 为准，已保存模型优先于 GUI 历史。只选择 Provider 而不选择模型时不能保存为可运行的 LiteLLM 配置。取消 Provider 不会清除目录缓存或系统凭据。
 - **费用与吞吐**：LiteLLM 同步请求按所选供应商和模型计费，不具有 Gemini Batch 的远程排队、恢复或 Batch 折扣语义；大项目可能更贵且吞吐量更低。工具不为任意供应商提供统一价格保证，正式运行前应查看供应商定价并先做小样本。
 - **隐私**：本项目直接调用 LiteLLM Python SDK，不经过本项目自建代理。待译文本、提示词和必要上下文会发送给所选模型供应商；应按该供应商的日志、训练和数据保留政策评估敏感内容。供应商密钥保存到操作系统凭据管理器或由环境变量提供，不写入 `translator_config.json`。
 - **安全边界**：同步翻译默认只生成预览，显式 apply 才会写入当前项目；仍应先备份并小范围验证。同步 manifest 使用独立的项目绑定、源文件快照和制品哈希复核，不复用 Batch manifest 的 `check=safe` 状态。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -116,7 +116,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 - **工作区 / 项目列表**：先 **创建 / 接入工作区…**（预览后初始化或接入 `games_registry.json`，成功后再写 `workspace_root`；默认未设置，不会用工具上一级），再浏览总表、扫描/刷新、同步 `GAMES.md`、编辑详情并**切换当前 `game_root`**。主工具条为项目刷新 + **维护**；展开后带「项目发现 / 总表维护」小标题，左对齐略缩进，宽屏四钮尽量同行。总览表与项目详情可拖拽分隔，详情可收起。未指定工作区时本区为空状态。「切换到此项目」成功后**留在项目列表**；术语表 / 准备流程等到「项目」分区调整。此分区的操作即时写入 registry / `workspace_root`，不使用底部「保存设置」。
 - **密钥**：读取 / 保存 `api_keys.json`；环境变量 Key 只读提示。
-- **LiteLLM**：按“联网加载供应商 → 选择 Provider → 配置该 Provider 凭据 → 联网加载模型 → 选择模型 → 保存设置”配置同步替代后端。首次打开不会默认选择 OpenAI 或模型，也不会静默联网；Provider / 模型均可手动填写。
+- **LiteLLM**：按“联网加载供应商 → 选择 Provider → 配置该 Provider 凭据 → 联网加载模型 → 选择模型 → 保存设置”配置同步替代后端。首次打开不会默认选择 OpenAI 或模型，也不会静默联网；Provider 下拉列表优先显示常用供应商，输入任意片段可搜索，也可手动填写自定义 Provider / 模型。
 - **项目**：术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。Ren'Py SDK 须显式配置： **查找 SDK**（用户点击后才扫描附近）、**浏览…**，或确认后 **下载推荐 SDK…**（官方固定版本）；留空不会自动搜其它目录或联网。结果写入 `prepare.renpy_sdk_dir`，保存设置后生效。当前 `game_root` 只读展示；需换项目请用「项目与环境」或「项目列表」。
 - **模型**：同步 / 批量翻译模型、embedding model、批量 thinking level。
 - **上下文**：

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -235,7 +235,13 @@ from .work_bootstrap_report import (
 from .litellm_worker import (
     LiteLLMConnectionTestWorker,
     LiteLLMModelCatalogWorker,
+    LiteLLMProviderCatalogWorker,
     LiteLLMVersionWorker,
+)
+from .litellm_catalog_cache import (
+    CatalogSnapshot,
+    LiteLLMCatalogCache,
+    catalog_snapshot_warning,
 )
 from .litellm_settings import (
     provider_credential_status,
@@ -251,10 +257,9 @@ from gemini_model_catalog import (
     write_model_catalog_extras,
 )
 from litellm_provider_config import (
-    DEFAULT_MODELS,
-    SUPPORTED_PROVIDERS,
     catalog_source_label,
     installed_litellm_version,
+    provider_display_label,
     version_key,
     ProviderCredentialStoreError,
     delete_provider_api_key,
@@ -457,6 +462,9 @@ _SETTINGS_LAZY_ATTR_TO_PAGE: dict[str, str] = {
     "batch_thinking_combo": "models",
     "sync_backend_combo": "litellm",
     "litellm_provider_combo": "litellm",
+    "litellm_refresh_providers_btn": "litellm",
+    "litellm_clear_provider_btn": "litellm",
+    "litellm_provider_catalog_status_label": "litellm",
     "litellm_model_combo": "litellm",
     "litellm_refresh_models_btn": "litellm",
     "litellm_catalog_status_label": "litellm",
@@ -465,6 +473,7 @@ _SETTINGS_LAZY_ATTR_TO_PAGE: dict[str, str] = {
     "litellm_check_version_btn": "litellm",
     "install_litellm_btn": "litellm",
     "litellm_install_progress": "litellm",
+    "litellm_credentials_box": "litellm",
     "litellm_provider_label": "litellm",
     "litellm_api_key_edit": "litellm",
     "litellm_save_key_btn": "litellm",
@@ -492,6 +501,7 @@ class MainWindow(QMainWindow):
         resources_dir: Path | None = None,
         project_state: ProjectState | None = None,
         bootstrap_config: dict[str, Any] | None = None,
+        litellm_catalog_cache: LiteLLMCatalogCache | None = None,
     ):
         super().__init__()
         self.setWindowTitle("Ren'Py Translation Lab - 图形工作台")
@@ -499,6 +509,7 @@ class MainWindow(QMainWindow):
         self.resize(1180, 780)
 
         self.state = project_state or ProjectState()
+        self._litellm_cache = litellm_catalog_cache or LiteLLMCatalogCache()
         self._diagnostics_context_fingerprint: tuple[object, ...] | None = None
         self._context_library_status_cache: ContextLibraryStatusResult | None = None
         self._context_library_status_cache_at = 0.0
@@ -594,15 +605,14 @@ class MainWindow(QMainWindow):
         self._last_main_tab_index = 0
         self._handling_config_tab_leave = False
         self._task_running = False
+        self._litellm_provider_catalog_worker: LiteLLMProviderCatalogWorker | None = None
         self._litellm_catalog_worker: LiteLLMModelCatalogWorker | None = None
         self._litellm_version_worker: LiteLLMVersionWorker | None = None
         self._litellm_latest_version = ""
         self._litellm_latest_compatible_version = ""
         self._litellm_latest_requires_python = ""
-        self._litellm_catalog_source = ""
         self._litellm_connection_worker: LiteLLMConnectionTestWorker | None = None
         self._font_install_worker: FontInstallWorker | None = None
-        self._litellm_catalog_models: dict[str, tuple[str, ...]] = {}
         self._updating_litellm_provider = False
         # _games_registry_panel is intentionally NOT set here so attribute access
         # triggers __getattr__ lazy materialization of 设置 · 项目列表.
@@ -3423,25 +3433,48 @@ class MainWindow(QMainWindow):
         backend_layout.addRow("同步执行后端：", self.sync_backend_combo)
 
         self.litellm_provider_combo = NoWheelComboBox()
-        for provider, label in SUPPORTED_PROVIDERS:
-            self.litellm_provider_combo.addItem(label, provider)
-        backend_layout.addRow("Provider：", self.litellm_provider_combo)
+        self._configure_editable_model_combo(self.litellm_provider_combo)
+        self.litellm_provider_combo.lineEdit().setPlaceholderText("尚未选择供应商")
+        provider_row = QWidget()
+        provider_layout = QHBoxLayout(provider_row)
+        provider_layout.setContentsMargins(0, 0, 0, 0)
+        provider_layout.setSpacing(8)
+        provider_layout.addWidget(self.litellm_provider_combo, 1)
+        self.litellm_refresh_providers_btn = QPushButton("联网加载供应商")
+        self.litellm_refresh_providers_btn.setObjectName("secondary_btn")
+        self.litellm_refresh_providers_btn.clicked.connect(
+            self._on_refresh_litellm_providers
+        )
+        provider_layout.addWidget(self.litellm_refresh_providers_btn)
+        self.litellm_clear_provider_btn = QPushButton("取消选择")
+        self.litellm_clear_provider_btn.setObjectName("secondary_btn")
+        self.litellm_clear_provider_btn.clicked.connect(self._on_clear_litellm_provider)
+        provider_layout.addWidget(self.litellm_clear_provider_btn)
+        backend_layout.addRow("Provider：", provider_row)
+        self.litellm_provider_catalog_status_label = QLabel()
+        self.litellm_provider_catalog_status_label.setWordWrap(True)
+        self.litellm_provider_catalog_status_label.setObjectName("config_hint_label")
+        backend_layout.addRow(self.litellm_provider_catalog_status_label)
+        self._populate_litellm_providers(
+            self._litellm_cache.providers.values,
+            selected=self._litellm_cache.selected_provider,
+        )
 
         self.litellm_model_combo = NoWheelComboBox()
         self._configure_editable_model_combo(self.litellm_model_combo)
-        self.litellm_model_combo.addItems(DEFAULT_MODELS["openai"])
+        self.litellm_model_combo.lineEdit().setPlaceholderText("尚未加载模型")
         self.litellm_model_combo.currentTextChanged.connect(self._on_litellm_model_changed)
         model_row = QWidget()
         model_layout = QHBoxLayout(model_row)
         model_layout.setContentsMargins(0, 0, 0, 0)
         model_layout.setSpacing(8)
         model_layout.addWidget(self.litellm_model_combo, 1)
-        self.litellm_refresh_models_btn = QPushButton("联网更新列表")
+        self.litellm_refresh_models_btn = QPushButton("联网加载模型")
         self.litellm_refresh_models_btn.setObjectName("secondary_btn")
         self.litellm_refresh_models_btn.clicked.connect(self._on_refresh_litellm_models)
         model_layout.addWidget(self.litellm_refresh_models_btn)
         backend_layout.addRow("LiteLLM 模型：", model_row)
-        self.litellm_catalog_status_label = QLabel("目录来源：内置兜底；尚未联网更新。")
+        self.litellm_catalog_status_label = QLabel("模型目录：尚未加载。")
         self.litellm_catalog_status_label.setWordWrap(True)
         self.litellm_catalog_status_label.setObjectName("config_hint_label")
         backend_layout.addRow(self.litellm_catalog_status_label)
@@ -3481,6 +3514,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(backend_box)
 
         credentials_box, credentials_layout = self._settings_group("Provider 凭据")
+        self.litellm_credentials_box = credentials_box
         credentials_hint = QLabel(
             "密钥与 Gemini 配置完全分离，并保存到操作系统凭据管理器；"
             "不会写入 translator_config.json。也可继续使用 LiteLLM 约定的环境变量。"
@@ -3525,6 +3559,11 @@ class MainWindow(QMainWindow):
         self.litellm_provider_combo.currentIndexChanged.connect(
             self._on_litellm_provider_changed
         )
+        self.litellm_provider_combo.lineEdit().editingFinished.connect(
+            self._on_litellm_provider_changed
+        )
+        self._restore_litellm_cached_selection()
+        self._refresh_litellm_catalog_status()
         self._refresh_litellm_credential_status()
         layout.addStretch(1)
         return page
@@ -6510,27 +6549,163 @@ class MainWindow(QMainWindow):
 
     def _litellm_model_text(self) -> str:
         combo = self._settings_widget("litellm_model_combo")
-        model = combo.currentText().strip() if combo is not None else ""
+        current_text = getattr(combo, "currentText", None)
+        model = str(current_text() or "").strip() if callable(current_text) else ""
         if not model or "/" in model:
             return model
-        provider_combo = self._settings_widget("litellm_provider_combo")
-        provider = (
-            str(provider_combo.currentData() or "").strip().lower()
-            if provider_combo is not None
-            else ""
-        )
+        provider = self._litellm_provider_combo_value()
         return f"{provider}/{model}" if provider else model
+
+    def _litellm_provider_combo_value(self) -> str:
+        combo = self._settings_widget("litellm_provider_combo")
+        if combo is None:
+            return ""
+        index = combo.currentIndex()
+        if index >= 0 and combo.currentText() == combo.itemText(index):
+            data = str(combo.itemData(index) or "").strip().lower()
+            if data:
+                return data
+        return combo.currentText().strip().lower()
 
     def _current_litellm_provider(self) -> str:
         model_provider = provider_from_model(self._litellm_model_text())
         if model_provider:
             return model_provider
+        return self._litellm_provider_combo_value()
+
+    def _ensure_litellm_provider_item(self, provider: str) -> int:
+        combo = self._settings_widget("litellm_provider_combo")
+        provider = str(provider or "").strip().lower()
+        if combo is None or not provider:
+            return -1
+        index = combo.findData(provider)
+        if index < 0:
+            combo.addItem(provider_display_label(provider), provider)
+            index = combo.findData(provider)
+        return index
+
+    def _populate_litellm_providers(
+        self,
+        providers: tuple[str, ...],
+        *,
+        selected: str = "",
+    ) -> None:
+        combo = self._settings_widget("litellm_provider_combo")
+        if combo is None:
+            return
+        selected = str(selected or "").strip().lower()
+        combo.blockSignals(True)
+        combo.clear()
+        for provider in providers:
+            provider = str(provider or "").strip().lower()
+            if provider:
+                combo.addItem(provider_display_label(provider), provider)
+        if selected:
+            index = self._ensure_litellm_provider_item(selected)
+            combo.setCurrentIndex(index)
+        else:
+            combo.setCurrentIndex(-1)
+            if combo.isEditable():
+                combo.lineEdit().clear()
+        combo.blockSignals(False)
+
+    @staticmethod
+    def _litellm_snapshot_status(subject: str, snapshot: CatalogSnapshot) -> str:
+        if not snapshot.values:
+            return f"{subject}：尚未联网加载。"
+        source = (
+            catalog_source_label(snapshot.source)
+            if subject == "模型目录"
+            else "来源：LiteLLM 官方在线目录。"
+        )
+        fetched = f"缓存时间：{snapshot.fetched_at}。" if snapshot.fetched_at else ""
+        version = (
+            f"LiteLLM {snapshot.litellm_version}。"
+            if snapshot.litellm_version
+            else ""
+        )
+        warning = catalog_snapshot_warning(
+            snapshot,
+            current_litellm_version=installed_litellm_version(),
+        )
+        return " ".join(
+            part
+            for part in (
+                f"{subject}：已缓存 {len(snapshot.values)} 项。",
+                source,
+                fetched,
+                version,
+                warning,
+            )
+            if part
+        )
+
+    def _refresh_litellm_catalog_status(self) -> None:
+        provider_label = self._settings_widget("litellm_provider_catalog_status_label")
+        if provider_label is not None:
+            message = self._litellm_snapshot_status(
+                "供应商目录",
+                self._litellm_cache.providers,
+            )
+            if self._litellm_cache.load_error:
+                message = f"{message} {self._litellm_cache.load_error}"
+            provider_label.setText(message)
+        model_label = self._settings_widget("litellm_catalog_status_label")
+        if model_label is not None:
+            model_label.setText(
+                self._litellm_snapshot_status(
+                    "模型目录",
+                    self._litellm_cache.models(self._litellm_provider_combo_value()),
+                )
+            )
+
+    def _save_litellm_cache(self, action) -> None:
+        try:
+            action()
+        except OSError as exc:
+            self._append_log(f"保存 LiteLLM 用户目录缓存失败：{exc}")
+            self.statusBar().showMessage(
+                "LiteLLM 选择已更新，但用户目录缓存写入失败。",
+                6000,
+            )
+
+    def _restore_litellm_cached_selection(self) -> None:
+        cache = self.__dict__.get("_litellm_cache")
+        if cache is None:
+            return
+        provider = cache.selected_provider
+        if not provider:
+            self._set_litellm_models("", ())
+            return
+        index = self._ensure_litellm_provider_item(provider)
         combo = self._settings_widget("litellm_provider_combo")
         if combo is not None:
-            provider = str(combo.currentData() or "").strip().lower()
-            if provider:
-                return provider
-        return provider_from_model(self._litellm_model_text())
+            combo.blockSignals(True)
+            combo.setCurrentIndex(index)
+            combo.blockSignals(False)
+        snapshot = cache.models(provider)
+        self._set_litellm_models(
+            provider,
+            snapshot.values,
+            selected=self._litellm_cache.selected_model(provider),
+        )
+
+    def _restore_configured_litellm_model(self, model: str) -> None:
+        model = str(model or "").strip()
+        if not model:
+            self._restore_litellm_cached_selection()
+            return
+        provider = provider_from_model(model)
+        if provider:
+            index = self._ensure_litellm_provider_item(provider)
+            combo = self._settings_widget("litellm_provider_combo")
+            if combo is not None:
+                combo.blockSignals(True)
+                combo.setCurrentIndex(index)
+                combo.blockSignals(False)
+        cache = self.__dict__.get("_litellm_cache")
+        snapshot = cache.models(provider) if cache is not None else CatalogSnapshot()
+        self._set_litellm_models(provider, snapshot.values, selected=model)
 
     def _set_litellm_models(
         self,
@@ -6538,20 +6713,25 @@ class MainWindow(QMainWindow):
         models: tuple[str, ...],
         *,
         preserve_current: bool = False,
+        selected: str = "",
     ) -> None:
         combo = self._settings_widget("litellm_model_combo")
         if combo is None:
             return
         current = combo.currentText().strip()
-        selected = current if preserve_current else ""
-        values = models or DEFAULT_MODELS.get(provider, ())
+        selected = current if preserve_current else str(selected or "").strip()
+        values = tuple(
+            dict.fromkeys(str(model).strip() for model in models if str(model).strip())
+        )
         combo.blockSignals(True)
         combo.clear()
         combo.addItems(list(values))
         if selected:
-            self._set_combo_value(combo, selected)
-        elif values:
-            combo.setCurrentIndex(0)
+            combo.setEditText(selected)
+        else:
+            combo.setCurrentIndex(-1)
+            if combo.isEditable():
+                combo.lineEdit().clear()
         combo.blockSignals(False)
         self._on_litellm_model_changed(combo.currentText())
 
@@ -6560,16 +6740,30 @@ class MainWindow(QMainWindow):
         status_label = self._settings_widget("litellm_credential_status_label")
         if provider_label is None or status_label is None:
             return
-        status = provider_credential_status(self._litellm_model_text(), os.environ)
-        provider_label.setText(
-            f"当前 provider：{status.provider}" if status.provider else "当前 provider：尚未识别"
+        provider = self._current_litellm_provider()
+        model = self._litellm_model_text()
+        status = provider_credential_status(
+            model or (f"{provider}/_" if provider else ""),
+            os.environ,
         )
+        provider_label.setText(
+            f"当前 Provider：{provider_display_label(provider)}"
+            if provider
+            else "当前 Provider：尚未选择"
+        )
+        credentials_box = self._settings_widget("litellm_credentials_box")
+        if credentials_box is not None:
+            credentials_box.setTitle(
+                f"Provider 凭据 — {provider_display_label(provider)}"
+                if provider
+                else "Provider 凭据"
+            )
         saved_message = ""
-        if status.provider and status.provider != "ollama":
+        if provider and provider != "ollama":
             try:
                 saved_message = (
-                    "系统凭据管理器中已保存密钥。"
-                    if load_provider_api_key(status.provider)
+                    "系统凭据管理器中已保存密钥；如同时存在环境变量，请求优先使用此密钥。"
+                    if load_provider_api_key(provider)
                     else "系统凭据管理器中尚未保存密钥。"
                 )
             except ProviderCredentialStoreError as exc:
@@ -6577,34 +6771,65 @@ class MainWindow(QMainWindow):
         status_label.setText(" ".join(part for part in (saved_message, status.message) if part))
 
     def _on_litellm_model_changed(self, _text: str) -> None:
-        provider = provider_from_model(self._litellm_model_text())
+        model = self._litellm_model_text()
+        provider = provider_from_model(model)
         provider_combo = self._settings_widget("litellm_provider_combo")
         if provider and provider_combo is not None and not getattr(self, "_updating_litellm_provider", False):
-            index = provider_combo.findData(provider)
-            if index >= 0 and index != provider_combo.currentIndex():
+            if provider != self._litellm_provider_combo_value():
+                api_key_edit = self._settings_widget("litellm_api_key_edit")
+                if api_key_edit is not None:
+                    api_key_edit.clear()
+            index = self._ensure_litellm_provider_item(provider)
+            if index != provider_combo.currentIndex():
                 provider_combo.blockSignals(True)
                 provider_combo.setCurrentIndex(index)
                 provider_combo.blockSignals(False)
+            if not self._loading_config_to_ui:
+                self._save_litellm_cache(
+                    lambda: self._litellm_cache.select_provider(provider)
+                )
+        provider = provider or self._litellm_provider_combo_value()
+        if provider and model and not self._loading_config_to_ui:
+            self._save_litellm_cache(
+                lambda: self._litellm_cache.select_model(provider, model)
+            )
         self._refresh_litellm_credential_status()
 
-    def _on_litellm_provider_changed(self, _index: int) -> None:
+    def _on_clear_litellm_provider(self) -> None:
+        combo = self._settings_widget("litellm_provider_combo")
+        if combo is None:
+            return
+        combo.blockSignals(True)
+        combo.setCurrentIndex(-1)
+        if combo.isEditable():
+            combo.lineEdit().clear()
+        combo.blockSignals(False)
+        self._on_litellm_provider_changed()
+
+    def _on_litellm_provider_changed(self, _value: object = None) -> None:
         if self._updating_litellm_provider:
             return
-        provider_combo = self._settings_widget("litellm_provider_combo")
-        provider = (
-            str(provider_combo.currentData() or "").strip().lower()
-            if provider_combo is not None
-            else ""
-        )
+        provider = self._litellm_provider_combo_value()
+        api_key_edit = self._settings_widget("litellm_api_key_edit")
+        if api_key_edit is not None:
+            api_key_edit.clear()
+        if not self._loading_config_to_ui:
+            self._save_litellm_cache(
+                lambda: self._litellm_cache.select_provider(provider)
+            )
         self._updating_litellm_provider = True
         try:
+            snapshot = self._litellm_cache.models(provider)
             self._set_litellm_models(
                 provider,
-                self._litellm_catalog_models.get(provider, DEFAULT_MODELS.get(provider, ())),
+                snapshot.values,
+                selected=self._litellm_cache.selected_model(provider),
             )
         finally:
             self._updating_litellm_provider = False
+        self._refresh_litellm_catalog_status()
         self._refresh_litellm_credential_status()
+        self._on_sync_backend_changed(-1)
 
     def _refresh_litellm_version_label(self) -> None:
         label = self._settings_widget("litellm_version_label")
@@ -6681,6 +6906,51 @@ class MainWindow(QMainWindow):
                 label.setText(f"{current}；检查更新失败，请稍后重试。")
         self._on_sync_backend_changed(-1)
 
+    def _on_refresh_litellm_providers(self) -> None:
+        if self._litellm_provider_catalog_worker is not None:
+            return
+        button = self._settings_widget("litellm_refresh_providers_btn")
+        if button is not None:
+            button.setEnabled(False)
+            button.setText("正在加载…")
+        worker = LiteLLMProviderCatalogWorker(self)
+        worker.completed.connect(self._on_litellm_providers_loaded)
+        self._litellm_provider_catalog_worker = worker
+        worker.start()
+
+    def _on_litellm_providers_loaded(
+        self,
+        providers: object,
+        source: str,
+        error: object,
+    ) -> None:
+        worker = self._litellm_provider_catalog_worker
+        self._litellm_provider_catalog_worker = None
+        if worker is not None:
+            worker.deleteLater()
+        button = self._settings_widget("litellm_refresh_providers_btn")
+        if button is not None:
+            button.setText("联网加载供应商")
+        self._on_sync_backend_changed(-1)
+        if error and not providers:
+            QMessageBox.warning(self, "供应商列表加载失败", str(error))
+            return
+        values = tuple(str(provider).strip().lower() for provider in providers)
+        current = self._litellm_provider_combo_value()
+        self._save_litellm_cache(
+            lambda: self._litellm_cache.update_providers(
+                values,
+                source=source,
+                litellm_version=installed_litellm_version(),
+            )
+        )
+        self._populate_litellm_providers(values, selected=current)
+        self._refresh_litellm_catalog_status()
+        self.statusBar().showMessage(
+            f"已加载 {len(values)} 个 LiteLLM 供应商；未自动选择。",
+            8000,
+        )
+
     def _on_refresh_litellm_models(self) -> None:
         if self._litellm_catalog_worker is not None:
             return
@@ -6715,17 +6985,21 @@ class MainWindow(QMainWindow):
             worker.deleteLater()
         button = self._settings_widget("litellm_refresh_models_btn")
         if button is not None:
-            button.setText("联网更新列表")
+            button.setText("联网加载模型")
         self._on_sync_backend_changed(-1)
         if error and not models:
             QMessageBox.warning(self, "模型列表加载失败", str(error))
             return
         values = tuple(str(model) for model in models)
-        self._litellm_catalog_models[provider] = values
-        self._litellm_catalog_source = source
-        source_label = self._settings_widget("litellm_catalog_status_label")
-        if source_label is not None:
-            source_label.setText(catalog_source_label(str(source or "")))
+        self._save_litellm_cache(
+            lambda: self._litellm_cache.update_models(
+                provider,
+                values,
+                source=source,
+                litellm_version=installed_litellm_version(),
+            )
+        )
+        self._refresh_litellm_catalog_status()
         if self._current_litellm_provider() == provider:
             self._set_litellm_models(provider, values, preserve_current=True)
         message = f"已加载 {len(values)} 个 {provider} 模型。"
@@ -6865,8 +7139,29 @@ class MainWindow(QMainWindow):
                 install_progress.setFormat("正在后台更新 LiteLLM…" if installed else "正在后台安装 LiteLLM…")
 
         model_combo = self._settings_widget("litellm_model_combo")
+        litellm_active = backend == "litellm" and not installing
+        provider = self._current_litellm_provider()
+        model = self._litellm_model_text()
+        provider_combo = self._settings_widget("litellm_provider_combo")
+        if provider_combo is not None:
+            provider_combo.setEnabled(litellm_active)
+        provider_button = self._settings_widget("litellm_refresh_providers_btn")
+        if provider_button is not None:
+            provider_button.setEnabled(
+                litellm_active and self._litellm_provider_catalog_worker is None
+            )
+        clear_provider = self._settings_widget("litellm_clear_provider_btn")
+        if clear_provider is not None:
+            clear_provider.setEnabled(litellm_active and bool(provider))
         if model_combo is not None:
-            model_combo.setEnabled(backend == "litellm" and not installing)
+            model_combo.setEnabled(litellm_active and bool(provider))
+        model_button = self._settings_widget("litellm_refresh_models_btn")
+        if model_button is not None:
+            model_button.setEnabled(
+                litellm_active
+                and bool(provider)
+                and self._litellm_catalog_worker is None
+            )
         # Never getattr(sync_model_combo): that would force-build the models page.
         gemini_sync_model_combo = self._settings_widget("sync_model_combo")
         if gemini_sync_model_combo is not None:
@@ -6876,17 +7171,31 @@ class MainWindow(QMainWindow):
                 if backend == "litellm"
                 else ""
             )
-        for name in (
-            "litellm_provider_combo",
-            "litellm_refresh_models_btn",
-            "litellm_api_key_edit",
-            "litellm_save_key_btn",
-            "litellm_delete_key_btn",
-            "litellm_test_connection_btn",
-        ):
+        credential_enabled = litellm_active and bool(provider) and provider != "ollama"
+        api_key_edit = self._settings_widget("litellm_api_key_edit")
+        if api_key_edit is not None:
+            api_key_edit.setEnabled(credential_enabled)
+            api_key_edit.setPlaceholderText(
+                f"输入新的 {provider_display_label(provider)} API Key（不会回显已保存密钥）"
+                if credential_enabled
+                else (
+                    "该 Provider 不需要 API Key"
+                    if provider == "ollama"
+                    else "请先选择 Provider"
+                )
+            )
+        for name in ("litellm_save_key_btn", "litellm_delete_key_btn"):
             widget = self._settings_widget(name)
             if widget is not None:
-                widget.setEnabled(backend == "litellm" and not installing)
+                widget.setEnabled(credential_enabled)
+        test_button = self._settings_widget("litellm_test_connection_btn")
+        if test_button is not None:
+            test_button.setEnabled(
+                litellm_active
+                and bool(provider)
+                and bool(model)
+                and self._litellm_connection_worker is None
+            )
         version_button = self._settings_widget("litellm_check_version_btn")
         if version_button is not None:
             checking = getattr(self, "_litellm_version_worker", None) is not None
@@ -12029,11 +12338,7 @@ class MainWindow(QMainWindow):
                         self._set_batch_thinking_value(thinking_val)
 
                 if need_litellm:
-                    litellm_combo = self._settings_widget("litellm_model_combo")
-                    if litellm_combo is not None:
-                        self._set_combo_value(
-                            litellm_combo, backend_models.litellm_model
-                        )
+                    self._restore_configured_litellm_model(backend_models.litellm_model)
                     if backend_combo is not None:
                         self._on_sync_backend_changed(backend_idx)
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -15,7 +15,7 @@ import time
 import re
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from PySide6.QtCore import (
     QEvent,
@@ -616,6 +616,8 @@ class MainWindow(QMainWindow):
         self._litellm_connection_worker: LiteLLMConnectionTestWorker | None = None
         self._font_install_worker: FontInstallWorker | None = None
         self._updating_litellm_provider = False
+        self._applied_litellm_provider = ""
+        self._litellm_saved_key_status: dict[str, str] = {}
         # _games_registry_panel is intentionally NOT set here so attribute access
         # triggers __getattr__ lazy materialization of 设置 · 项目列表.
         self._litellm_install: OptionalFeatureInstallController | None = None
@@ -6621,16 +6623,17 @@ class MainWindow(QMainWindow):
             if combo.isEditable():
                 combo.lineEdit().clear()
         combo.blockSignals(False)
+        self._applied_litellm_provider = selected
 
     @staticmethod
-    def _litellm_snapshot_status(subject: str, snapshot: CatalogSnapshot) -> str:
+    def _litellm_snapshot_status(
+        subject: str,
+        snapshot: CatalogSnapshot,
+        *,
+        source_label: str,
+    ) -> str:
         if not snapshot.values:
             return f"{subject}：尚未联网加载。"
-        source = (
-            catalog_source_label(snapshot.source)
-            if subject == "模型目录"
-            else "来源：LiteLLM 官方在线目录。"
-        )
         fetched = f"缓存时间：{snapshot.fetched_at}。" if snapshot.fetched_at else ""
         version = (
             f"LiteLLM {snapshot.litellm_version}。"
@@ -6645,7 +6648,7 @@ class MainWindow(QMainWindow):
             part
             for part in (
                 f"{subject}：已缓存 {len(snapshot.values)} 项。",
-                source,
+                source_label,
                 fetched,
                 version,
                 warning,
@@ -6659,20 +6662,23 @@ class MainWindow(QMainWindow):
             message = self._litellm_snapshot_status(
                 "供应商目录",
                 self._litellm_cache.providers,
+                source_label="来源：LiteLLM 官方在线目录。",
             )
             if self._litellm_cache.load_error:
                 message = f"{message} {self._litellm_cache.load_error}"
             provider_label.setText(message)
         model_label = self._settings_widget("litellm_catalog_status_label")
         if model_label is not None:
+            snapshot = self._litellm_cache.models(self._litellm_provider_combo_value())
             model_label.setText(
                 self._litellm_snapshot_status(
                     "模型目录",
-                    self._litellm_cache.models(self._litellm_provider_combo_value()),
+                    snapshot,
+                    source_label=catalog_source_label(snapshot.source),
                 )
             )
 
-    def _save_litellm_cache(self, action) -> None:
+    def _save_litellm_cache(self, action: Callable[[], None]) -> None:
         try:
             action()
         except OSError as exc:
@@ -6688,6 +6694,7 @@ class MainWindow(QMainWindow):
             return
         provider = cache.selected_provider
         if not provider:
+            self._applied_litellm_provider = ""
             self._set_litellm_models("", ())
             return
         index = self._ensure_litellm_provider_item(provider)
@@ -6696,6 +6703,7 @@ class MainWindow(QMainWindow):
             combo.blockSignals(True)
             combo.setCurrentIndex(index)
             combo.blockSignals(False)
+        self._applied_litellm_provider = provider
         snapshot = cache.models(provider)
         self._set_litellm_models(
             provider,
@@ -6716,6 +6724,7 @@ class MainWindow(QMainWindow):
                 combo.blockSignals(True)
                 combo.setCurrentIndex(index)
                 combo.blockSignals(False)
+            self._applied_litellm_provider = provider
         cache = self.__dict__.get("_litellm_cache")
         snapshot = cache.models(provider) if cache is not None else CatalogSnapshot()
         self._set_litellm_models(provider, snapshot.values, selected=model)
@@ -6773,14 +6782,17 @@ class MainWindow(QMainWindow):
             )
         saved_message = ""
         if provider and provider != "ollama":
-            try:
-                saved_message = (
-                    "系统凭据管理器中已保存密钥；如同时存在环境变量，请求优先使用此密钥。"
-                    if load_provider_api_key(provider)
-                    else "系统凭据管理器中尚未保存密钥。"
-                )
-            except ProviderCredentialStoreError as exc:
-                saved_message = str(exc)
+            saved_message = self._litellm_saved_key_status.get(provider, "")
+            if not saved_message:
+                try:
+                    saved_message = (
+                        "系统凭据管理器中已保存密钥；如同时存在环境变量，请求优先使用此密钥。"
+                        if load_provider_api_key(provider)
+                        else "系统凭据管理器中尚未保存密钥。"
+                    )
+                except ProviderCredentialStoreError as exc:
+                    saved_message = str(exc)
+                self._litellm_saved_key_status[provider] = saved_message
         status_label.setText(" ".join(part for part in (saved_message, status.message) if part))
 
     def _on_litellm_model_changed(self, _text: str) -> None:
@@ -6797,6 +6809,7 @@ class MainWindow(QMainWindow):
                 provider_combo.blockSignals(True)
                 provider_combo.setCurrentIndex(index)
                 provider_combo.blockSignals(False)
+            self._applied_litellm_provider = provider
             if not self._loading_config_to_ui:
                 self._save_litellm_cache(
                     lambda: self._litellm_cache.select_provider(provider)
@@ -6823,6 +6836,9 @@ class MainWindow(QMainWindow):
         if self._updating_litellm_provider:
             return
         provider = self._litellm_provider_combo_value()
+        if provider == self._applied_litellm_provider:
+            return
+        self._applied_litellm_provider = provider
         api_key_edit = self._settings_widget("litellm_api_key_edit")
         if api_key_edit is not None:
             api_key_edit.clear()
@@ -7029,6 +7045,9 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "无法保存密钥", str(exc))
             return
         self.litellm_api_key_edit.clear()
+        self._litellm_saved_key_status[provider] = (
+            "系统凭据管理器中已保存密钥；如同时存在环境变量，请求优先使用此密钥。"
+        )
         self._refresh_litellm_credential_status()
         self.statusBar().showMessage(f"已安全保存 {provider} 密钥。", 5000)
 
@@ -7040,6 +7059,7 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "无法删除密钥", str(exc))
             return
         self.litellm_api_key_edit.clear()
+        self._litellm_saved_key_status[provider] = "系统凭据管理器中尚未保存密钥。"
         self._refresh_litellm_credential_status()
         message = "已删除保存的密钥。" if deleted else "没有找到已保存的密钥。"
         self.statusBar().showMessage(message, 5000)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -38,6 +38,7 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import (
     QApplication,
+    QCompleter,
     QDialog,
     QMainWindow,
     QWidget,
@@ -260,6 +261,7 @@ from litellm_provider_config import (
     catalog_source_label,
     installed_litellm_version,
     provider_display_label,
+    sort_provider_ids,
     version_key,
     ProviderCredentialStoreError,
     delete_provider_api_key,
@@ -3434,7 +3436,18 @@ class MainWindow(QMainWindow):
 
         self.litellm_provider_combo = NoWheelComboBox()
         self._configure_editable_model_combo(self.litellm_provider_combo)
-        self.litellm_provider_combo.lineEdit().setPlaceholderText("尚未选择供应商")
+        self.litellm_provider_combo.lineEdit().setPlaceholderText(
+            "搜索或输入自定义 Provider"
+        )
+        provider_completer = self.litellm_provider_combo.completer()
+        if provider_completer is not None:
+            provider_completer.setCaseSensitivity(
+                Qt.CaseSensitivity.CaseInsensitive
+            )
+            provider_completer.setFilterMode(Qt.MatchFlag.MatchContains)
+            provider_completer.setCompletionMode(
+                QCompleter.CompletionMode.PopupCompletion
+            )
         provider_row = QWidget()
         provider_layout = QHBoxLayout(provider_row)
         provider_layout.setContentsMargins(0, 0, 0, 0)
@@ -6596,7 +6609,7 @@ class MainWindow(QMainWindow):
         selected = str(selected or "").strip().lower()
         combo.blockSignals(True)
         combo.clear()
-        for provider in providers:
+        for provider in sort_provider_ids(providers):
             provider = str(provider or "").strip().lower()
             if provider:
                 combo.addItem(provider_display_label(provider), provider)

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -261,6 +261,7 @@ from litellm_provider_config import (
     catalog_source_label,
     installed_litellm_version,
     provider_display_label,
+    resolve_provider_id,
     sort_provider_ids,
     version_key,
     ProviderCredentialStoreError,
@@ -378,6 +379,7 @@ _BATCH_STAGE_RESULT = 2  # 写回 / 结果
 
 _LOG_FLUSH_INTERVAL_MS = 80
 _LAYOUT_SYNC_DEBOUNCE_MS = 32
+_LITELLM_MODEL_SELECTION_SAVE_DEBOUNCE_MS = 400
 _UI_PROGRESS_FLUSH_INTERVAL_MS = 100
 _CONTEXT_STATUS_CACHE_TTL_S = 2.0
 
@@ -617,6 +619,15 @@ class MainWindow(QMainWindow):
         self._font_install_worker: FontInstallWorker | None = None
         self._updating_litellm_provider = False
         self._applied_litellm_provider = ""
+        self._pending_litellm_model_selection: tuple[str, str] | None = None
+        self._litellm_model_selection_save_timer = QTimer(self)
+        self._litellm_model_selection_save_timer.setSingleShot(True)
+        self._litellm_model_selection_save_timer.setInterval(
+            _LITELLM_MODEL_SELECTION_SAVE_DEBOUNCE_MS
+        )
+        self._litellm_model_selection_save_timer.timeout.connect(
+            self._flush_litellm_model_selection_save
+        )
         self._litellm_saved_key_status: dict[str, str] = {}
         # _games_registry_panel is intentionally NOT set here so attribute access
         # triggers __getattr__ lazy materialization of 设置 · 项目列表.
@@ -6580,7 +6591,7 @@ class MainWindow(QMainWindow):
             data = str(combo.itemData(index) or "").strip().lower()
             if data:
                 return data
-        return combo.currentText().strip().lower()
+        return resolve_provider_id(combo.currentText())
 
     def _current_litellm_provider(self) -> str:
         model_provider = provider_from_model(self._litellm_model_text())
@@ -6686,6 +6697,39 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(
                 "LiteLLM 选择已更新，但用户目录缓存写入失败。",
                 6000,
+            )
+
+    def _schedule_litellm_model_selection_save(self, provider: str, model: str) -> None:
+        provider = str(provider or "").strip().lower()
+        model = str(model or "").strip()
+        if not provider or not model:
+            self._cancel_litellm_model_selection_save()
+            return
+        self._pending_litellm_model_selection = (provider, model)
+        timer = getattr(self, "_litellm_model_selection_save_timer", None)
+        if timer is None:
+            self._flush_litellm_model_selection_save()
+            return
+        timer.start()
+
+    def _cancel_litellm_model_selection_save(self) -> None:
+        timer = getattr(self, "_litellm_model_selection_save_timer", None)
+        if timer is not None:
+            timer.stop()
+        self._pending_litellm_model_selection = None
+
+    def _flush_litellm_model_selection_save(self) -> None:
+        timer = getattr(self, "_litellm_model_selection_save_timer", None)
+        if timer is not None:
+            timer.stop()
+        pending = getattr(self, "_pending_litellm_model_selection", None)
+        self._pending_litellm_model_selection = None
+        if not pending:
+            return
+        provider, model = pending
+        if provider and model:
+            self._save_litellm_cache(
+                lambda p=provider, m=model: self._litellm_cache.select_model(p, m)
             )
 
     def _restore_litellm_cached_selection(self) -> None:
@@ -6797,34 +6841,56 @@ class MainWindow(QMainWindow):
 
     def _on_litellm_model_changed(self, _text: str) -> None:
         model = self._litellm_model_text()
-        provider = provider_from_model(model)
+        model_provider = provider_from_model(model)
         provider_combo = self._settings_widget("litellm_provider_combo")
-        if provider and provider_combo is not None and not getattr(self, "_updating_litellm_provider", False):
-            if provider != self._litellm_provider_combo_value():
+        updating = getattr(self, "_updating_litellm_provider", False)
+        if model_provider and provider_combo is not None and not updating:
+            previous_applied = self._applied_litellm_provider
+            if model_provider != self._litellm_provider_combo_value():
                 api_key_edit = self._settings_widget("litellm_api_key_edit")
                 if api_key_edit is not None:
                     api_key_edit.clear()
-            index = self._ensure_litellm_provider_item(provider)
+            index = self._ensure_litellm_provider_item(model_provider)
             if index != provider_combo.currentIndex():
                 provider_combo.blockSignals(True)
                 provider_combo.setCurrentIndex(index)
                 provider_combo.blockSignals(False)
-            self._applied_litellm_provider = provider
+            self._applied_litellm_provider = model_provider
             if not self._loading_config_to_ui:
                 self._save_litellm_cache(
-                    lambda: self._litellm_cache.select_provider(provider)
+                    lambda p=model_provider: self._litellm_cache.select_provider(p)
                 )
-        provider = provider or self._litellm_provider_combo_value()
+            if model_provider != previous_applied:
+                # Same side effects as provider combo switch: reload that
+                # provider's cached catalog and re-gate credential controls,
+                # while keeping the typed model as the selection.
+                self._updating_litellm_provider = True
+                try:
+                    snapshot = self._litellm_cache.models(model_provider)
+                    self._set_litellm_models(
+                        model_provider,
+                        snapshot.values,
+                        selected=model,
+                    )
+                finally:
+                    self._updating_litellm_provider = False
+                self._refresh_litellm_catalog_status()
+                # _set_litellm_models re-enters this handler for save + gating.
+                return
+
+        provider = model_provider or self._litellm_provider_combo_value()
         if provider and model and not self._loading_config_to_ui:
-            self._save_litellm_cache(
-                lambda: self._litellm_cache.select_model(provider, model)
-            )
-        self._refresh_litellm_credential_status()
+            self._schedule_litellm_model_selection_save(provider, model)
+        else:
+            self._cancel_litellm_model_selection_save()
+        # Re-run backend gating so “测试连接” tracks model text changes.
+        self._on_sync_backend_changed(-1)
 
     def _on_clear_litellm_provider(self) -> None:
         combo = self._settings_widget("litellm_provider_combo")
         if combo is None:
             return
+        self._cancel_litellm_model_selection_save()
         combo.blockSignals(True)
         combo.setCurrentIndex(-1)
         if combo.isEditable():
@@ -6838,13 +6904,14 @@ class MainWindow(QMainWindow):
         provider = self._litellm_provider_combo_value()
         if provider == self._applied_litellm_provider:
             return
+        self._cancel_litellm_model_selection_save()
         self._applied_litellm_provider = provider
         api_key_edit = self._settings_widget("litellm_api_key_edit")
         if api_key_edit is not None:
             api_key_edit.clear()
         if not self._loading_config_to_ui:
             self._save_litellm_cache(
-                lambda: self._litellm_cache.select_provider(provider)
+                lambda p=provider: self._litellm_cache.select_provider(p)
             )
         self._updating_litellm_provider = True
         try:
@@ -6857,7 +6924,6 @@ class MainWindow(QMainWindow):
         finally:
             self._updating_litellm_provider = False
         self._refresh_litellm_catalog_status()
-        self._refresh_litellm_credential_status()
         self._on_sync_backend_changed(-1)
 
     def _refresh_litellm_version_label(self) -> None:
@@ -6975,10 +7041,11 @@ class MainWindow(QMainWindow):
         )
         self._populate_litellm_providers(values, selected=current)
         self._refresh_litellm_catalog_status()
-        self.statusBar().showMessage(
-            f"已加载 {len(values)} 个 LiteLLM 供应商；未自动选择。",
-            8000,
-        )
+        if current:
+            status = f"已加载 {len(values)} 个 LiteLLM 供应商；已保留当前选择。"
+        else:
+            status = f"已加载 {len(values)} 个 LiteLLM 供应商；未自动选择。"
+        self.statusBar().showMessage(status, 8000)
 
     def _on_refresh_litellm_models(self) -> None:
         if self._litellm_catalog_worker is not None:
@@ -12454,6 +12521,8 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "未选择项目", "请先选择游戏的 work 目录。")
             return False
         self._ensure_settings_pages_for_config()
+        # Persist any debounced LiteLLM model selection before reading widgets.
+        self._flush_litellm_model_selection_save()
 
         try:
             config = self.state.load_translator_config()

--- a/gui_qt/litellm_catalog_cache.py
+++ b/gui_qt/litellm_catalog_cache.py
@@ -144,12 +144,14 @@ class LiteLLMCatalogCache:
         return self._models.get(provider, CatalogSnapshot())
 
     def select_provider(self, provider: str) -> None:
+        """Lowercase and atomically persist the provider; OSError may propagate."""
         self._selected_provider = _clean_text(
             provider, limit=_MAX_PROVIDER_LENGTH
         ).lower()
         self._save()
 
     def select_model(self, provider: str, model: str) -> None:
+        """Persist a model atomically, removing it when empty; OSError may propagate."""
         provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
         model = _clean_text(model, limit=_MAX_MODEL_LENGTH)
         if not provider:
@@ -167,6 +169,7 @@ class LiteLLMCatalogCache:
         source: str,
         litellm_version: str = "",
     ) -> None:
+        """Normalize and atomically persist providers; OSError may propagate."""
         self._providers = CatalogSnapshot(
             values=tuple(
                 value.lower()
@@ -189,6 +192,7 @@ class LiteLLMCatalogCache:
         source: str,
         litellm_version: str = "",
     ) -> None:
+        """Normalize and atomically persist provider models; OSError may propagate."""
         provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
         if not provider:
             raise ValueError("Provider 不能为空。")

--- a/gui_qt/litellm_catalog_cache.py
+++ b/gui_qt/litellm_catalog_cache.py
@@ -1,0 +1,299 @@
+"""User-level cache for LiteLLM provider/model catalogs and UI selections.
+
+This file intentionally stores no credentials.  Runtime configuration remains
+in ``translator_config.json`` and provider secrets remain in the operating
+system credential store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Callable, Mapping
+
+from atomic_io import atomic_write_json
+
+
+CACHE_SCHEMA_VERSION = 1
+CATALOG_CACHE_MAX_AGE_DAYS = 30
+_MAX_CATALOG_ITEMS = 10_000
+_MAX_PROVIDER_LENGTH = 200
+_MAX_MODEL_LENGTH = 1_000
+
+
+def default_litellm_catalog_cache_path() -> Path:
+    """Return a per-user, non-project path for LiteLLM GUI state."""
+    if sys.platform == "win32":
+        root = Path(
+            os.environ.get("LOCALAPPDATA")
+            or (Path.home() / "AppData" / "Local")
+        )
+    elif sys.platform == "darwin":
+        root = Path.home() / "Library" / "Application Support"
+    else:
+        root = Path(
+            os.environ.get("XDG_STATE_HOME")
+            or (Path.home() / ".local" / "state")
+        )
+    return root / "renpy-translation-lab" / "litellm_catalog_cache.json"
+
+
+def _clean_text(value: object, *, limit: int) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > limit or any(char in text for char in "\r\n\0"):
+        return ""
+    return text
+
+
+def _clean_values(
+    values: object,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple)):
+        return ()
+    cleaned = {
+        text
+        for value in values[:_MAX_CATALOG_ITEMS]
+        if (text := _clean_text(value, limit=limit))
+    }
+    return tuple(sorted(cleaned, key=str.casefold))
+
+
+@dataclass(frozen=True)
+class CatalogSnapshot:
+    values: tuple[str, ...] = ()
+    source: str = ""
+    fetched_at: str = ""
+    litellm_version: str = ""
+
+
+def catalog_snapshot_warning(
+    snapshot: CatalogSnapshot,
+    *,
+    current_litellm_version: str = "",
+    now: datetime | None = None,
+) -> str:
+    """Describe stale or incompatible cache metadata without discarding data."""
+    if not snapshot.values:
+        return ""
+
+    warnings: list[str] = []
+    raw_fetched_at = snapshot.fetched_at.strip()
+    if raw_fetched_at:
+        try:
+            fetched_at = datetime.fromisoformat(raw_fetched_at.replace("Z", "+00:00"))
+        except ValueError:
+            warnings.append("缓存更新时间无效，请联网刷新。")
+        else:
+            if fetched_at.tzinfo is None:
+                fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+            current = now or datetime.now(timezone.utc)
+            if current.tzinfo is None:
+                current = current.replace(tzinfo=timezone.utc)
+            if current.astimezone(timezone.utc) - fetched_at.astimezone(timezone.utc) > timedelta(
+                days=CATALOG_CACHE_MAX_AGE_DAYS
+            ):
+                warnings.append(f"缓存已超过 {CATALOG_CACHE_MAX_AGE_DAYS} 天，请联网刷新。")
+    if (
+        snapshot.litellm_version
+        and current_litellm_version
+        and snapshot.litellm_version != current_litellm_version
+    ):
+        warnings.append(
+            f"缓存适用于 LiteLLM {snapshot.litellm_version}，当前为 {current_litellm_version}。"
+        )
+    return " ".join(warnings)
+
+class LiteLLMCatalogCache:
+    """Load and atomically persist sanitized LiteLLM GUI catalog state."""
+
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        *,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.path = Path(path) if path is not None else default_litellm_catalog_cache_path()
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self.load_error = ""
+        self._selected_provider = ""
+        self._selected_models: dict[str, str] = {}
+        self._providers = CatalogSnapshot()
+        self._models: dict[str, CatalogSnapshot] = {}
+        self._load()
+
+    @property
+    def selected_provider(self) -> str:
+        return self._selected_provider
+
+    @property
+    def providers(self) -> CatalogSnapshot:
+        return self._providers
+
+    def selected_model(self, provider: str) -> str:
+        provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
+        return self._selected_models.get(provider, "")
+
+    def models(self, provider: str) -> CatalogSnapshot:
+        provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
+        return self._models.get(provider, CatalogSnapshot())
+
+    def select_provider(self, provider: str) -> None:
+        self._selected_provider = _clean_text(
+            provider, limit=_MAX_PROVIDER_LENGTH
+        ).lower()
+        self._save()
+
+    def select_model(self, provider: str, model: str) -> None:
+        provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
+        model = _clean_text(model, limit=_MAX_MODEL_LENGTH)
+        if not provider:
+            return
+        if model:
+            self._selected_models[provider] = model
+        else:
+            self._selected_models.pop(provider, None)
+        self._save()
+
+    def update_providers(
+        self,
+        providers: tuple[str, ...] | list[str],
+        *,
+        source: str,
+        litellm_version: str = "",
+    ) -> None:
+        self._providers = CatalogSnapshot(
+            values=tuple(
+                value.lower()
+                for value in _clean_values(
+                    providers,
+                    limit=_MAX_PROVIDER_LENGTH,
+                )
+            ),
+            source=_clean_text(source, limit=100),
+            fetched_at=self._timestamp(),
+            litellm_version=_clean_text(litellm_version, limit=100),
+        )
+        self._save()
+
+    def update_models(
+        self,
+        provider: str,
+        models: tuple[str, ...] | list[str],
+        *,
+        source: str,
+        litellm_version: str = "",
+    ) -> None:
+        provider = _clean_text(provider, limit=_MAX_PROVIDER_LENGTH).lower()
+        if not provider:
+            raise ValueError("Provider 不能为空。")
+        self._models[provider] = CatalogSnapshot(
+            values=_clean_values(models, limit=_MAX_MODEL_LENGTH),
+            source=_clean_text(source, limit=100),
+            fetched_at=self._timestamp(),
+            litellm_version=_clean_text(litellm_version, limit=100),
+        )
+        self._save()
+
+    def _timestamp(self) -> str:
+        value = self._now()
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _load(self) -> None:
+        if not self.path.is_file():
+            return
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+            self._apply_payload(payload)
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+            self.load_error = f"LiteLLM 目录缓存无效，已忽略：{exc}"
+
+    def _apply_payload(self, payload: object) -> None:
+        if not isinstance(payload, Mapping):
+            raise ValueError("缓存根节点必须是对象")
+        if payload.get("schema_version") != CACHE_SCHEMA_VERSION:
+            raise ValueError("不支持的缓存版本")
+
+        self._selected_provider = _clean_text(
+            payload.get("selected_provider"),
+            limit=_MAX_PROVIDER_LENGTH,
+        ).lower()
+        raw_selected = payload.get("selected_models")
+        if isinstance(raw_selected, Mapping):
+            for raw_provider, raw_model in raw_selected.items():
+                provider = _clean_text(
+                    raw_provider,
+                    limit=_MAX_PROVIDER_LENGTH,
+                ).lower()
+                model = _clean_text(raw_model, limit=_MAX_MODEL_LENGTH)
+                if provider and model:
+                    self._selected_models[provider] = model
+
+        self._providers = self._snapshot_from_payload(
+            payload.get("providers"),
+            value_limit=_MAX_PROVIDER_LENGTH,
+            lowercase=True,
+        )
+        raw_models = payload.get("models")
+        if isinstance(raw_models, Mapping):
+            for raw_provider, raw_snapshot in raw_models.items():
+                provider = _clean_text(
+                    raw_provider,
+                    limit=_MAX_PROVIDER_LENGTH,
+                ).lower()
+                if not provider:
+                    continue
+                snapshot = self._snapshot_from_payload(
+                    raw_snapshot,
+                    value_limit=_MAX_MODEL_LENGTH,
+                )
+                if snapshot.values:
+                    self._models[provider] = snapshot
+
+    @staticmethod
+    def _snapshot_from_payload(
+        payload: object,
+        *,
+        value_limit: int,
+        lowercase: bool = False,
+    ) -> CatalogSnapshot:
+        if not isinstance(payload, Mapping):
+            return CatalogSnapshot()
+        values = _clean_values(payload.get("values"), limit=value_limit)
+        if lowercase:
+            values = tuple(value.lower() for value in values)
+        return CatalogSnapshot(
+            values=values,
+            source=_clean_text(payload.get("source"), limit=100),
+            fetched_at=_clean_text(payload.get("fetched_at"), limit=100),
+            litellm_version=_clean_text(payload.get("litellm_version"), limit=100),
+        )
+
+    @staticmethod
+    def _snapshot_payload(snapshot: CatalogSnapshot) -> dict[str, object]:
+        return {
+            "values": list(snapshot.values),
+            "source": snapshot.source,
+            "fetched_at": snapshot.fetched_at,
+            "litellm_version": snapshot.litellm_version,
+        }
+
+    def _save(self) -> None:
+        payload = {
+            "schema_version": CACHE_SCHEMA_VERSION,
+            "selected_provider": self._selected_provider,
+            "selected_models": dict(sorted(self._selected_models.items())),
+            "providers": self._snapshot_payload(self._providers),
+            "models": {
+                provider: self._snapshot_payload(snapshot)
+                for provider, snapshot in sorted(self._models.items())
+            },
+        }
+        atomic_write_json(self.path, payload, ensure_ascii=False, indent=2)

--- a/gui_qt/litellm_worker.py
+++ b/gui_qt/litellm_worker.py
@@ -15,10 +15,10 @@ from litellm_provider_config import (
     build_native_catalog_headers,
     installed_litellm_version,
     latest_compatible_litellm_version,
-    models_for_provider,
     models_from_native_catalog_payload,
     models_from_remote_catalog,
     native_catalog_endpoint,
+    providers_from_remote_catalog,
 )
 from litellm_sync_backend import LiteLLMSyncBackend
 from sync_model_backend import SyncGenerationRequest
@@ -124,12 +124,34 @@ class LiteLLMModelCatalogWorker(QThread):
             models = self._fetch_litellm_catalog()
             self.completed.emit(models, "online", None)
         except Exception as exc:
-            try:
-                models = models_for_provider(self.provider)
-            except Exception as local_exc:
-                self.completed.emit((), "", f"联网失败：{exc}；本地读取失败：{local_exc}")
-                return
-            self.completed.emit(models, "local", f"联网失败，已改用本地目录：{exc}")
+            self.completed.emit((), "", f"联网加载模型失败：{exc}")
+
+
+class LiteLLMProviderCatalogWorker(QThread):
+    """Fetch the current LiteLLM provider catalog only on explicit user action."""
+
+    completed = Signal(object, object, object)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setPriority(QThread.Priority.LowPriority)
+
+    def run(self) -> None:
+        try:
+            request = Request(
+                LITELLM_CATALOG_URL,
+                headers={"User-Agent": "renpy-translation-lab"},
+            )
+            with urlopen(request, timeout=CATALOG_TIMEOUT_SECONDS) as response:
+                catalog = json.load(response)
+            if not isinstance(catalog, dict):
+                raise ValueError("LiteLLM 官方目录格式无效")
+            providers = providers_from_remote_catalog(catalog)
+            if not providers:
+                raise ValueError("LiteLLM 官方目录未返回供应商")
+            self.completed.emit(providers, "online", None)
+        except Exception as exc:
+            self.completed.emit((), "", f"联网加载供应商失败：{exc}")
 
 
 class LiteLLMVersionWorker(QThread):

--- a/gui_qt/litellm_worker.py
+++ b/gui_qt/litellm_worker.py
@@ -50,6 +50,18 @@ def _http_error_message(exc: HTTPError, label: str) -> str:
         return f"{label} 限流（HTTP 429），请稍后重试。"
     return f"{label} 请求失败（HTTP {code}）。"
 
+def _load_litellm_catalog() -> dict:
+    """Load and validate the shared LiteLLM online catalog."""
+    request = Request(
+        LITELLM_CATALOG_URL,
+        headers={"User-Agent": "renpy-translation-lab"},
+    )
+    with urlopen(request, timeout=CATALOG_TIMEOUT_SECONDS) as response:
+        catalog = json.load(response)
+    if not isinstance(catalog, dict):
+        raise ValueError("LiteLLM 官方目录格式无效")
+    return catalog
+
 
 class LiteLLMModelCatalogWorker(QThread):
     completed = Signal(object, object, object)
@@ -63,14 +75,7 @@ class LiteLLMModelCatalogWorker(QThread):
         self.setPriority(QThread.Priority.LowPriority)
 
     def _fetch_litellm_catalog(self) -> tuple[str, ...]:
-        request = Request(
-            LITELLM_CATALOG_URL,
-            headers={"User-Agent": "renpy-translation-lab"},
-        )
-        with urlopen(request, timeout=CATALOG_TIMEOUT_SECONDS) as response:
-            catalog = json.load(response)
-        if not isinstance(catalog, dict):
-            raise ValueError("LiteLLM 官方目录格式无效")
+        catalog = _load_litellm_catalog()
         models = models_from_remote_catalog(self.provider, catalog)
         if not models:
             raise ValueError(f"LiteLLM 目录中没有 {self.provider} 文本模型")
@@ -138,14 +143,7 @@ class LiteLLMProviderCatalogWorker(QThread):
 
     def run(self) -> None:
         try:
-            request = Request(
-                LITELLM_CATALOG_URL,
-                headers={"User-Agent": "renpy-translation-lab"},
-            )
-            with urlopen(request, timeout=CATALOG_TIMEOUT_SECONDS) as response:
-                catalog = json.load(response)
-            if not isinstance(catalog, dict):
-                raise ValueError("LiteLLM 官方目录格式无效")
+            catalog = _load_litellm_catalog()
             providers = providers_from_remote_catalog(catalog)
             if not providers:
                 raise ValueError("LiteLLM 官方目录未返回供应商")

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -18,6 +18,7 @@ SUPPORTED_PROVIDERS: tuple[tuple[str, str], ...] = (
     ("xai", "xAI"),
     ("ollama", "Ollama（本地）"),
 )
+_PROVIDER_LABELS = dict(SUPPORTED_PROVIDERS)
 DEFAULT_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("openai/gpt-5",),
     "anthropic": ("anthropic/claude-sonnet-4-5-20250929",),
@@ -140,6 +141,12 @@ def provider_from_model(model: str) -> str:
     return text.split("/", 1)[0].strip().lower()
 
 
+def provider_display_label(provider: str) -> str:
+    """Return a friendly label without restricting dynamic provider ids."""
+    provider = str(provider or "").strip().lower()
+    return _PROVIDER_LABELS.get(provider, provider)
+
+
 def _keyring(keyring_module: Any = None) -> Any:
     if keyring_module is not None:
         return keyring_module
@@ -248,6 +255,27 @@ def models_from_remote_catalog(
             continue
         models.add(model if model_provider == provider else f"{provider}/{model}")
     return tuple(sorted(models, key=str.casefold))
+
+
+def providers_from_remote_catalog(
+    catalog: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Discover provider ids represented by LiteLLM's current online catalog.
+
+    Native endpoints are included even when the pricing/context catalog has no
+    current entry for them. The result is a discovery aid, not a guarantee
+    that every provider exposes a native model-list endpoint.
+    """
+    providers = set(NATIVE_CATALOG_ENDPOINTS)
+    for raw_model, raw_metadata in catalog.items():
+        if not isinstance(raw_metadata, Mapping):
+            continue
+        provider = str(raw_metadata.get("litellm_provider") or "").strip().lower()
+        if not provider:
+            provider = provider_from_model(str(raw_model or ""))
+        if provider:
+            providers.add(provider)
+    return tuple(sorted(providers, key=str.casefold))
 
 
 def models_from_openrouter_payload(payload: Mapping[str, object] | object) -> tuple[str, ...]:

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from importlib import metadata
 import re
@@ -167,7 +167,9 @@ def provider_display_label(provider: str) -> str:
 
 def sort_provider_ids(providers: object) -> tuple[str, ...]:
     """Place common providers first and sort all remaining ids by name."""
-    if not isinstance(providers, (list, tuple, set, frozenset)):
+    if isinstance(providers, (str, bytes, bytearray)) or not isinstance(
+        providers, Collection
+    ):
         return ()
     cleaned = {
         str(provider or "").strip().lower()

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -13,11 +13,17 @@ KEYRING_SERVICE = "renpy-translation-lab:litellm"
 SUPPORTED_PROVIDERS: tuple[tuple[str, str], ...] = (
     ("openai", "OpenAI"),
     ("anthropic", "Anthropic"),
+    ("gemini", "Google Gemini"),
     ("openrouter", "OpenRouter"),
     ("deepseek", "DeepSeek"),
     ("xai", "xAI"),
+    ("azure", "Azure OpenAI"),
+    ("vertex_ai", "Google Vertex AI"),
     ("ollama", "Ollama（本地）"),
 )
+_COMMON_PROVIDER_INDEX = {
+    provider: index for index, (provider, _label) in enumerate(SUPPORTED_PROVIDERS)
+}
 _PROVIDER_LABELS = dict(SUPPORTED_PROVIDERS)
 DEFAULT_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("openai/gpt-5",),
@@ -145,6 +151,26 @@ def provider_display_label(provider: str) -> str:
     """Return a friendly label without restricting dynamic provider ids."""
     provider = str(provider or "").strip().lower()
     return _PROVIDER_LABELS.get(provider, provider)
+
+
+def sort_provider_ids(providers: object) -> tuple[str, ...]:
+    """Place common providers first and sort all remaining ids by name."""
+    if not isinstance(providers, (list, tuple, set, frozenset)):
+        return ()
+    cleaned = {
+        str(provider or "").strip().lower()
+        for provider in providers
+        if str(provider or "").strip()
+    }
+    return tuple(
+        sorted(
+            cleaned,
+            key=lambda provider: (
+                _COMMON_PROVIDER_INDEX.get(provider, len(_COMMON_PROVIDER_INDEX)),
+                provider.casefold(),
+            ),
+        )
+    )
 
 
 def _keyring(keyring_module: Any = None) -> Any:
@@ -275,7 +301,7 @@ def providers_from_remote_catalog(
             provider = provider_from_model(str(raw_model or ""))
         if provider:
             providers.add(provider)
-    return tuple(sorted(providers, key=str.casefold))
+    return sort_provider_ids(providers)
 
 
 def models_from_openrouter_payload(payload: Mapping[str, object] | object) -> tuple[str, ...]:

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -37,6 +37,10 @@ _PROVIDER_LABELS = dict(SUPPORTED_PROVIDERS) | {
     "azure": "Azure OpenAI",
     "vertex_ai": "Google Vertex AI",
 }
+_LABEL_TO_PROVIDER_ID = {
+    str(label).strip().casefold(): provider
+    for provider, label in _PROVIDER_LABELS.items()
+}
 DEFAULT_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("openai/gpt-5",),
     "anthropic": ("anthropic/claude-sonnet-4-5-20250929",),
@@ -163,6 +167,24 @@ def provider_display_label(provider: str) -> str:
     """Return a friendly label without restricting dynamic provider ids."""
     provider = str(provider or "").strip().lower()
     return _PROVIDER_LABELS.get(provider, provider)
+
+
+def resolve_provider_id(value: str) -> str:
+    """Map free-typed provider input to a LiteLLM provider id when possible.
+
+    Accepts known ids, known display labels (e.g. ``Ollama（本地）`` → ``ollama``),
+    and otherwise returns the lowercased free-text id for custom providers.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    lowered = text.lower()
+    if lowered in _PROVIDER_LABELS or lowered in _COMMON_PROVIDER_INDEX:
+        return lowered
+    mapped = _LABEL_TO_PROVIDER_ID.get(text.casefold())
+    if mapped:
+        return mapped
+    return lowered
 
 
 def sort_provider_ids(providers: object) -> tuple[str, ...]:
@@ -448,8 +470,6 @@ def catalog_source_label(source: str) -> str:
     token = str(source or "").strip().lower()
     if token == "online":
         return "目录来源：LiteLLM 官方在线目录。"
-    if token == "local":
-        return "目录来源：本机 LiteLLM 随包目录（联网失败，可能过时）。"
     endpoint = NATIVE_CATALOG_ENDPOINTS.get(token)
     if endpoint is not None:
         if token == "ollama":

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -13,18 +13,30 @@ KEYRING_SERVICE = "renpy-translation-lab:litellm"
 SUPPORTED_PROVIDERS: tuple[tuple[str, str], ...] = (
     ("openai", "OpenAI"),
     ("anthropic", "Anthropic"),
-    ("gemini", "Google Gemini"),
     ("openrouter", "OpenRouter"),
     ("deepseek", "DeepSeek"),
     ("xai", "xAI"),
-    ("azure", "Azure OpenAI"),
-    ("vertex_ai", "Google Vertex AI"),
     ("ollama", "Ollama（本地）"),
 )
+_COMMON_PROVIDER_ORDER = (
+    "openai",
+    "anthropic",
+    "gemini",
+    "openrouter",
+    "deepseek",
+    "xai",
+    "azure",
+    "vertex_ai",
+    "ollama",
+)
 _COMMON_PROVIDER_INDEX = {
-    provider: index for index, (provider, _label) in enumerate(SUPPORTED_PROVIDERS)
+    provider: index for index, provider in enumerate(_COMMON_PROVIDER_ORDER)
 }
-_PROVIDER_LABELS = dict(SUPPORTED_PROVIDERS)
+_PROVIDER_LABELS = dict(SUPPORTED_PROVIDERS) | {
+    "gemini": "Google Gemini",
+    "azure": "Azure OpenAI",
+    "vertex_ai": "Google Vertex AI",
+}
 DEFAULT_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("openai/gpt-5",),
     "anthropic": ("anthropic/claude-sonnet-4-5-20250929",),

--- a/tests/test_gui_litellm_catalog_cache.py
+++ b/tests/test_gui_litellm_catalog_cache.py
@@ -24,7 +24,9 @@ class LiteLLMCatalogCacheTests(unittest.TestCase):
     def test_catalogs_and_per_provider_selections_survive_reload(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "catalog.json"
-            now = lambda: datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+            def now():
+                return datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+
             cache = LiteLLMCatalogCache(path, now=now)
             cache.update_providers(
                 ["anthropic", "openai"],

--- a/tests/test_gui_litellm_catalog_cache.py
+++ b/tests/test_gui_litellm_catalog_cache.py
@@ -1,0 +1,126 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import tempfile
+import unittest
+
+from gui_qt.litellm_catalog_cache import (
+    CatalogSnapshot,
+    LiteLLMCatalogCache,
+    catalog_snapshot_warning,
+)
+
+
+class LiteLLMCatalogCacheTests(unittest.TestCase):
+    def test_fresh_cache_has_no_provider_or_model_selection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = LiteLLMCatalogCache(Path(temp_dir) / "catalog.json")
+
+            self.assertEqual(cache.selected_provider, "")
+            self.assertEqual(cache.providers.values, ())
+            self.assertEqual(cache.models("openai").values, ())
+            self.assertEqual(cache.selected_model("openai"), "")
+
+    def test_catalogs_and_per_provider_selections_survive_reload(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "catalog.json"
+            now = lambda: datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+            cache = LiteLLMCatalogCache(path, now=now)
+            cache.update_providers(
+                ["anthropic", "openai"],
+                source="online",
+                litellm_version="1.83.7",
+            )
+            cache.update_models(
+                "openai",
+                ["openai/gpt-current"],
+                source="openai",
+                litellm_version="1.83.7",
+            )
+            cache.select_provider("openai")
+            cache.select_model("openai", "openai/gpt-current")
+
+            restored = LiteLLMCatalogCache(path)
+
+            self.assertEqual(restored.selected_provider, "openai")
+            self.assertEqual(restored.providers.values, ("anthropic", "openai"))
+            self.assertEqual(
+                restored.models("openai").values,
+                ("openai/gpt-current",),
+            )
+            self.assertEqual(
+                restored.selected_model("openai"),
+                "openai/gpt-current",
+            )
+            self.assertEqual(
+                restored.models("openai").fetched_at,
+                "2026-07-28T12:00:00Z",
+            )
+
+    def test_corrupt_or_wrong_version_cache_is_ignored(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "catalog.json"
+            path.write_text("{not-json", encoding="utf-8")
+            corrupt = LiteLLMCatalogCache(path)
+            self.assertEqual(corrupt.providers.values, ())
+            self.assertIn("缓存无效", corrupt.load_error)
+
+            path.write_text(
+                json.dumps({"schema_version": 999}),
+                encoding="utf-8",
+            )
+            wrong_version = LiteLLMCatalogCache(path)
+            self.assertEqual(wrong_version.providers.values, ())
+            self.assertIn("不支持的缓存版本", wrong_version.load_error)
+
+    def test_unknown_and_sensitive_fields_are_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "catalog.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "selected_provider": "openai",
+                        "selected_models": {},
+                        "providers": {
+                            "values": ["openai"],
+                            "source": "online",
+                            "api_key": "stored-secret",
+                        },
+                        "models": {},
+                        "authorization": "Bearer stored-secret",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            cache = LiteLLMCatalogCache(path)
+            cache.select_provider("openai")
+
+            rewritten = path.read_text(encoding="utf-8")
+            self.assertNotIn("stored-secret", rewritten)
+            self.assertNotIn("authorization", rewritten.lower())
+            self.assertNotIn("api_key", rewritten.lower())
+
+
+    def test_stale_invalid_or_old_version_cache_is_warned_but_retained(self):
+        snapshot = CatalogSnapshot(
+            values=("openai/gpt-current",),
+            fetched_at="2026-01-01T00:00:00Z",
+            litellm_version="1.0.0",
+        )
+        warning = catalog_snapshot_warning(
+            snapshot,
+            current_litellm_version="2.0.0",
+            now=datetime(2026, 7, 29, tzinfo=timezone.utc),
+        )
+        self.assertIn("超过 30 天", warning)
+        self.assertIn("当前为 2.0.0", warning)
+        self.assertEqual(snapshot.values, ("openai/gpt-current",))
+
+        invalid = CatalogSnapshot(values=("openai/gpt",), fetched_at="not-a-date")
+        self.assertIn(
+            "更新时间无效",
+            catalog_snapshot_warning(invalid),
+        )
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_litellm_install.py
+++ b/tests/test_gui_litellm_install.py
@@ -93,7 +93,7 @@ class GuiLiteLLMInstallTests(unittest.TestCase):
         self.assertTrue(self.window.install_litellm_btn.enabled)
         self.assertEqual(self.window.install_litellm_btn.text, "安装 LiteLLM")
         self.assertFalse(self.window.litellm_install_progress.visible)
-        self.assertTrue(self.window.litellm_model_combo.enabled)
+        self.assertFalse(self.window.litellm_model_combo.enabled)
 
     def test_installing_shows_busy_progress_and_disables_litellm_model(self):
         self.window._litellm_install_running = mock.Mock(return_value=True)

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -1,6 +1,9 @@
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
+
+from gui_qt.litellm_catalog_cache import LiteLLMCatalogCache
 
 try:
     from PySide6.QtWidgets import QApplication, QGroupBox, QLineEdit
@@ -21,13 +24,44 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
-        cls.window = MainWindow()
+        cls._temp_dir = tempfile.TemporaryDirectory()
+        cls.cache = LiteLLMCatalogCache(
+            Path(cls._temp_dir.name) / "litellm_catalog.json"
+        )
+        cls.window = MainWindow(litellm_catalog_cache=cls.cache)
 
     @classmethod
     def tearDownClass(cls):
         cls.window.close()
         cls.window.deleteLater()
         cls._app.processEvents()
+        cls._temp_dir.cleanup()
+
+    def setUp(self):
+        self.cache = LiteLLMCatalogCache(
+            Path(self._temp_dir.name) / f"{self._testMethodName}.json"
+        )
+        self.window._litellm_cache = self.cache
+        self.window._populate_litellm_providers((), selected="")
+        self.window._set_litellm_models("", ())
+        self.window.litellm_api_key_edit.clear()
+        self.window._refresh_litellm_catalog_status()
+        self.window._on_sync_backend_changed(-1)
+
+    @classmethod
+    def _load_provider_choices(cls):
+        cls.window._populate_litellm_providers(
+            ("anthropic", "openai"),
+            selected="openai",
+        )
+
+    def test_00_fresh_state_does_not_preselect_provider_or_model(self):
+        self.assertEqual(self.window.litellm_provider_combo.count(), 0)
+        self.assertEqual(self.window.litellm_provider_combo.currentText(), "")
+        self.assertEqual(self.window.litellm_model_combo.count(), 0)
+        self.assertEqual(self.window.litellm_model_combo.currentText(), "")
+        self.assertFalse(self.window.litellm_refresh_models_btn.isEnabled())
+        self.assertFalse(self.window.litellm_api_key_edit.isEnabled())
 
     def test_litellm_has_independent_settings_page(self):
         self.assertIn("litellm", self.window._settings_nav_rows)
@@ -36,14 +70,19 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.assertEqual(page.objectName(), "settings_litellm_scroll")
         titles = {group.title() for group in page.findChildren(QGroupBox)}
         self.assertIn("LiteLLM 同步替代后端", titles)
-        self.assertIn("Provider 凭据", titles)
+        self.assertTrue(
+            any(title.startswith("Provider 凭据") for title in titles)
+        )
         self.assertTrue(self.window.litellm_model_combo.isEditable())
-        self.assertGreater(self.window.litellm_provider_combo.count(), 1)
+        self.assertTrue(self.window.litellm_provider_combo.isEditable())
         self.assertEqual(
             self.window.litellm_api_key_edit.echoMode(),
             QLineEdit.EchoMode.Password,
         )
-        self.assertEqual(self.window.litellm_refresh_models_btn.text(), "联网更新列表")
+        self.assertEqual(self.window.litellm_refresh_models_btn.text(), "联网加载模型")
+        self.assertEqual(
+            self.window.litellm_refresh_providers_btn.text(), "联网加载供应商"
+        )
         self.assertEqual(self.window.litellm_test_connection_btn.text(), "测试连接")
         self.assertTrue(self.window.litellm_version_label.wordWrap())
         self.assertEqual(self.window.litellm_version_label.minimumWidth(), 0)
@@ -55,11 +94,14 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.assertFalse(actions["combo_popup_action"].icon().isNull())
 
     def test_typed_model_prefix_takes_priority_for_credentials(self):
+        self._load_provider_choices()
         self.window.litellm_provider_combo.setCurrentIndex(
             self.window.litellm_provider_combo.findData("openai")
         )
+        self.window.litellm_api_key_edit.setText("unsaved-openai-key")
         self.window.litellm_model_combo.setEditText("azure/my-deployment")
         self.assertEqual(self.window._current_litellm_provider(), "azure")
+        self.assertEqual(self.window.litellm_api_key_edit.text(), "")
         self.window.litellm_provider_combo.setCurrentIndex(
             self.window.litellm_provider_combo.findData("openai")
         )
@@ -67,6 +109,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.assertEqual(self.window._litellm_model_text(), "openai/gpt-custom")
 
     def test_switching_provider_does_not_relabel_bare_model_as_new_provider(self):
+        self._load_provider_choices()
         openai_index = self.window.litellm_provider_combo.findData("openai")
         anthropic_index = self.window.litellm_provider_combo.findData("anthropic")
         self.window.litellm_provider_combo.setCurrentIndex(openai_index)
@@ -74,18 +117,28 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
             self.window.litellm_model_combo.setEditText("gpt-custom")
             self.window.litellm_provider_combo.setCurrentIndex(anthropic_index)
 
-            self.assertNotEqual(
-                self.window.litellm_model_combo.currentText(),
-                "anthropic/gpt-custom",
-            )
-            self.assertTrue(
-                self.window.litellm_model_combo.currentText().startswith("anthropic/")
-            )
+            self.assertEqual(self.window.litellm_model_combo.currentText(), "")
         finally:
 
             self.window.litellm_provider_combo.setCurrentIndex(openai_index)
 
+    def test_cancel_provider_discards_typed_key_but_does_not_delete_credential(self):
+        self._load_provider_choices()
+        self.window.litellm_provider_combo.setCurrentIndex(
+            self.window.litellm_provider_combo.findData("openai")
+        )
+        self.window.litellm_api_key_edit.setText("unsaved-secret")
+        with mock.patch("gui_qt.app.delete_provider_api_key") as delete_key:
+            self.window._on_clear_litellm_provider()
+
+        self.assertEqual(self.window._current_litellm_provider(), "")
+        self.assertEqual(self.window.litellm_model_combo.currentText(), "")
+        self.assertEqual(self.window.litellm_api_key_edit.text(), "")
+        self.assertEqual(self.cache.selected_provider, "")
+        delete_key.assert_not_called()
+
     def test_catalog_refresh_preserves_custom_model(self):
+        self._load_provider_choices()
         openai_index = self.window.litellm_provider_combo.findData("openai")
         self.window.litellm_provider_combo.setCurrentIndex(openai_index)
         self.window.litellm_model_combo.setEditText("gpt-custom")
@@ -100,6 +153,59 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
 
         self.assertEqual(self.window.litellm_model_combo.currentText(), "gpt-custom")
 
+    def test_catalog_failure_keeps_cached_models(self):
+        self.cache.update_models(
+            "openai",
+            ["openai/cached-model"],
+            source="online",
+            litellm_version="1.2.3",
+        )
+        self._load_provider_choices()
+        self.window.litellm_provider_combo.setCurrentIndex(
+            self.window.litellm_provider_combo.findData("openai")
+        )
+        self.window._litellm_catalog_worker = None
+
+        with mock.patch("gui_qt.app.QMessageBox.warning"):
+            self.window._on_litellm_models_loaded(
+                "openai",
+                (),
+                "offline",
+            )
+
+        self.assertEqual(
+            self.cache.models("openai").values,
+            ("openai/cached-model",),
+        )
+
+    def test_configured_model_takes_priority_over_cached_selection(self):
+        self.cache.update_models(
+            "anthropic",
+            ["anthropic/cached-model"],
+            source="online",
+        )
+        self.cache.select_provider("anthropic")
+        self.cache.select_model("anthropic", "anthropic/cached-model")
+
+        self.window._restore_configured_litellm_model("openai/configured-model")
+
+        self.assertEqual(self.window._current_litellm_provider(), "openai")
+        self.assertEqual(
+            self.window.litellm_model_combo.currentText(),
+            "openai/configured-model",
+        )
+
+    def test_saved_credential_is_reported_as_environment_override(self):
+        self._load_provider_choices()
+        with (
+            mock.patch("gui_qt.app.load_provider_api_key", return_value="saved"),
+            mock.patch.dict("gui_qt.app.os.environ", {"OPENAI_API_KEY": "env"}, clear=True),
+        ):
+            self.window.litellm_provider_combo.setCurrentIndex(
+                self.window.litellm_provider_combo.findData("openai")
+            )
+            self.window.litellm_model_combo.setEditText("openai/test")
+            self.window._refresh_litellm_credential_status()
     def test_gemini_key_page_does_not_contain_litellm_controls(self):
         row = self.window._settings_nav_rows["api_keys"]
         page = self.window.settings_stack.widget(row)

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -46,6 +46,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.window._populate_litellm_providers((), selected="")
         self.window._set_litellm_models("", ())
         self.window.litellm_api_key_edit.clear()
+        self.window._litellm_saved_key_status.clear()
         self.window._refresh_litellm_catalog_status()
         self.window._on_sync_backend_changed(-1)
 
@@ -56,7 +57,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
             selected="openai",
         )
 
-    def test_00_fresh_state_does_not_preselect_provider_or_model(self):
+    def test_fresh_state_does_not_preselect_provider_or_model(self):
         self.assertEqual(self.window.litellm_provider_combo.count(), 0)
         self.assertEqual(self.window.litellm_provider_combo.currentText(), "")
         self.assertEqual(self.window.litellm_model_combo.count(), 0)
@@ -155,6 +156,16 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
 
             self.window.litellm_provider_combo.setCurrentIndex(openai_index)
 
+    def test_unchanged_provider_focus_out_preserves_unsaved_fields(self):
+        self._load_provider_choices()
+        self.window.litellm_api_key_edit.setText("unsaved-key")
+        self.window.litellm_model_combo.setEditText("gpt-custom")
+
+        self.window._on_litellm_provider_changed()
+
+        self.assertEqual(self.window.litellm_api_key_edit.text(), "unsaved-key")
+        self.assertEqual(self.window.litellm_model_combo.currentText(), "gpt-custom")
+
     def test_cancel_provider_discards_typed_key_but_does_not_delete_credential(self):
         self._load_provider_choices()
         self.window.litellm_provider_combo.setCurrentIndex(
@@ -231,7 +242,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
     def test_saved_credential_is_reported_as_environment_override(self):
         self._load_provider_choices()
         with (
-            mock.patch("gui_qt.app.load_provider_api_key", return_value="saved"),
+            mock.patch("gui_qt.app.load_provider_api_key", return_value="saved") as load_key,
             mock.patch.dict("gui_qt.app.os.environ", {"OPENAI_API_KEY": "env"}, clear=True),
         ):
             self.window.litellm_provider_combo.setCurrentIndex(
@@ -239,6 +250,13 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
             )
             self.window.litellm_model_combo.setEditText("openai/test")
             self.window._refresh_litellm_credential_status()
+            self.window._refresh_litellm_credential_status()
+            self.window._refresh_litellm_credential_status()
+        status = self.window.litellm_credential_status_label.text()
+        self.assertIn("系统凭据管理器中已保存密钥", status)
+        self.assertIn("OPENAI_API_KEY", status)
+        load_key.assert_called_once_with("openai")
+
     def test_gemini_key_page_does_not_contain_litellm_controls(self):
         row = self.window._settings_nav_rows["api_keys"]
         page = self.window.settings_stack.widget(row)

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -142,6 +142,72 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.window.litellm_model_combo.setEditText("gpt-custom")
         self.assertEqual(self.window._litellm_model_text(), "openai/gpt-custom")
 
+    def test_model_selection_enables_test_connection_button(self):
+        litellm_index = self.window.sync_backend_combo.findData("litellm")
+        self.window.sync_backend_combo.setCurrentIndex(litellm_index)
+        self._load_provider_choices()
+        self.window.litellm_provider_combo.setCurrentIndex(
+            self.window.litellm_provider_combo.findData("openai")
+        )
+        self.window.litellm_model_combo.setEditText("")
+        self.window._on_sync_backend_changed(-1)
+        self.assertFalse(self.window.litellm_test_connection_btn.isEnabled())
+
+        self.window.litellm_model_combo.setEditText("openai/gpt-test")
+        self.assertTrue(self.window.litellm_test_connection_btn.isEnabled())
+
+        self.window.litellm_model_combo.setEditText("")
+        self.assertFalse(self.window.litellm_test_connection_btn.isEnabled())
+
+    def test_model_prefix_switch_reloads_cached_models_and_gates_credentials(self):
+        litellm_index = self.window.sync_backend_combo.findData("litellm")
+        self.window.sync_backend_combo.setCurrentIndex(litellm_index)
+        self.cache.update_models(
+            "openai",
+            ["openai/gpt-a", "openai/gpt-b"],
+            source="online",
+        )
+        self.cache.update_models(
+            "ollama",
+            ["ollama/llama3", "ollama/mistral"],
+            source="ollama",
+        )
+        self.window._populate_litellm_providers(
+            ("openai", "ollama"),
+            selected="",
+        )
+        self.window.litellm_provider_combo.setCurrentIndex(
+            self.window.litellm_provider_combo.findData("openai")
+        )
+        self.window.litellm_api_key_edit.setText("unsaved-openai-key")
+        self.assertTrue(self.window.litellm_api_key_edit.isEnabled())
+        openai_models = {
+            self.window.litellm_model_combo.itemText(index)
+            for index in range(self.window.litellm_model_combo.count())
+        }
+        self.assertEqual(openai_models, {"openai/gpt-a", "openai/gpt-b"})
+
+        self.window.litellm_model_combo.setEditText("ollama/llama3")
+
+        self.assertEqual(self.window._current_litellm_provider(), "ollama")
+        self.assertEqual(self.window.litellm_api_key_edit.text(), "")
+        self.assertFalse(self.window.litellm_api_key_edit.isEnabled())
+        model_items = {
+            self.window.litellm_model_combo.itemText(index)
+            for index in range(self.window.litellm_model_combo.count())
+        }
+        self.assertEqual(model_items, {"ollama/llama3", "ollama/mistral"})
+        self.assertEqual(self.window.litellm_model_combo.currentText(), "ollama/llama3")
+        self.assertTrue(self.window.litellm_test_connection_btn.isEnabled())
+
+    def test_display_label_free_text_resolves_to_provider_id(self):
+        self.window._populate_litellm_providers(("openai", "ollama"), selected="")
+        self.window.litellm_provider_combo.setCurrentIndex(-1)
+        self.window.litellm_provider_combo.setEditText("Ollama（本地）")
+        self.assertEqual(self.window._litellm_provider_combo_value(), "ollama")
+        self.window.litellm_provider_combo.setEditText("Google Gemini")
+        self.assertEqual(self.window._litellm_provider_combo_value(), "gemini")
+
     def test_switching_provider_does_not_relabel_bare_model_as_new_provider(self):
         self._load_provider_choices()
         openai_index = self.window.litellm_provider_combo.findData("openai")

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -6,7 +6,8 @@ from unittest import mock
 from gui_qt.litellm_catalog_cache import LiteLLMCatalogCache
 
 try:
-    from PySide6.QtWidgets import QApplication, QGroupBox, QLineEdit
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication, QCompleter, QGroupBox, QLineEdit
 
     from gui_qt.app import MainWindow
 except ImportError as exc:
@@ -75,6 +76,19 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         )
         self.assertTrue(self.window.litellm_model_combo.isEditable())
         self.assertTrue(self.window.litellm_provider_combo.isEditable())
+        provider_completer = self.window.litellm_provider_combo.completer()
+        self.assertEqual(
+            provider_completer.caseSensitivity(),
+            Qt.CaseSensitivity.CaseInsensitive,
+        )
+        self.assertEqual(
+            provider_completer.filterMode(),
+            Qt.MatchFlag.MatchContains,
+        )
+        self.assertEqual(
+            provider_completer.completionMode(),
+            QCompleter.CompletionMode.PopupCompletion,
+        )
         self.assertEqual(
             self.window.litellm_api_key_edit.echoMode(),
             QLineEdit.EchoMode.Password,
@@ -93,7 +107,26 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.assertIn("combo_popup_action", actions)
         self.assertFalse(actions["combo_popup_action"].icon().isNull())
 
+    def test_common_providers_are_listed_before_dynamic_providers(self):
+        self.window._populate_litellm_providers(
+            ("zzz_custom", "deepseek", "openrouter", "anthropic", "openai", "aaa_custom"),
+        )
+        values = tuple(
+            self.window.litellm_provider_combo.itemData(index)
+            for index in range(self.window.litellm_provider_combo.count())
+        )
+        self.assertEqual(
+            values,
+            ("openai", "anthropic", "openrouter", "deepseek", "aaa_custom", "zzz_custom"),
+        )
+        completer = self.window.litellm_provider_combo.completer()
+        completer.setCompletionPrefix("router")
+        self.assertEqual(completer.completionCount(), 1)
+        self.assertEqual(completer.currentCompletion(), "OpenRouter")
+
+
     def test_typed_model_prefix_takes_priority_for_credentials(self):
+
         self._load_provider_choices()
         self.window.litellm_provider_combo.setCurrentIndex(
             self.window.litellm_provider_combo.findData("openai")

--- a/tests/test_gui_litellm_worker.py
+++ b/tests/test_gui_litellm_worker.py
@@ -260,6 +260,23 @@ class LiteLLMConnectionTestWorkerTests(unittest.TestCase):
         self.assertIn("anthropic", completed[0][0])
         self.assertEqual(completed[0][1:], ("online", None))
 
+    def test_provider_catalog_failure_reports_empty_result(self):
+        completed = []
+        worker = LiteLLMProviderCatalogWorker()
+        worker.completed.connect(
+            lambda providers, source, error: completed.append(
+                (providers, source, error)
+            )
+        )
+        with mock.patch(
+            "gui_qt.litellm_worker.urlopen",
+            side_effect=OSError("offline"),
+        ):
+            worker.run()
+        self.assertEqual(completed[0][0], ())
+        self.assertEqual(completed[0][1], "")
+        self.assertIn("联网加载供应商失败", completed[0][2])
+
     def test_version_worker_reads_latest_stable_version_from_pypi(self):
         payload = {
             "info": {"version": "1.92.0", "requires_python": ">=3.10,<3.14"},

--- a/tests/test_gui_litellm_worker.py
+++ b/tests/test_gui_litellm_worker.py
@@ -9,6 +9,7 @@ try:
         CONNECTION_TEST_TIMEOUT_SECONDS,
         LiteLLMConnectionTestWorker,
         LiteLLMModelCatalogWorker,
+        LiteLLMProviderCatalogWorker,
         LiteLLMVersionWorker,
     )
     from litellm_sync_backend import LiteLLMBackendError
@@ -222,25 +223,42 @@ class LiteLLMConnectionTestWorkerTests(unittest.TestCase):
         self.assertEqual(completed[0][1], "online")
         self.assertIn("OpenRouter 官方列表失败", completed[0][2])
 
-    def test_model_catalog_marks_local_fallback_as_possibly_stale(self):
+    def test_model_catalog_failure_does_not_inject_local_defaults(self):
         completed = []
         worker = LiteLLMModelCatalogWorker("openai")
         worker.completed.connect(
             lambda models, source, error: completed.append((models, source, error))
         )
 
-        with (
-            mock.patch("gui_qt.litellm_worker.urlopen", side_effect=OSError("offline")),
-            mock.patch(
-                "gui_qt.litellm_worker.models_for_provider",
-                return_value=("openai/local-model",),
-            ),
+        with mock.patch(
+            "gui_qt.litellm_worker.urlopen",
+            side_effect=OSError("offline"),
         ):
             worker.run()
 
-        self.assertEqual(completed[0][0], ("openai/local-model",))
-        self.assertEqual(completed[0][1], "local")
-        self.assertIn("已改用本地目录", completed[0][2])
+        self.assertEqual(completed[0][0], ())
+        self.assertEqual(completed[0][1], "")
+        self.assertIn("联网加载模型失败", completed[0][2])
+
+    def test_provider_catalog_is_loaded_only_when_worker_runs(self):
+        payload = {
+            "gpt-current": {"litellm_provider": "openai", "mode": "chat"},
+            "claude-current": {"litellm_provider": "anthropic", "mode": "chat"},
+        }
+        response = mock.MagicMock()
+        response.__enter__.return_value = io.BytesIO(
+            json.dumps(payload).encode("utf-8")
+        )
+        completed = []
+        worker = LiteLLMProviderCatalogWorker()
+        worker.completed.connect(
+            lambda providers, source, error: completed.append((providers, source, error))
+        )
+        with mock.patch("gui_qt.litellm_worker.urlopen", return_value=response):
+            worker.run()
+        self.assertIn("openai", completed[0][0])
+        self.assertIn("anthropic", completed[0][0])
+        self.assertEqual(completed[0][1:], ("online", None))
 
     def test_version_worker_reads_latest_stable_version_from_pypi(self):
         payload = {

--- a/tests/test_litellm_provider_config.py
+++ b/tests/test_litellm_provider_config.py
@@ -131,6 +131,12 @@ class LiteLLMProviderConfigTests(unittest.TestCase):
             ("openai", "anthropic", "deepseek", "aaa_custom", "zzz_custom"),
         )
 
+    def test_provider_sort_accepts_mapping_views(self):
+        providers = sort_provider_ids(
+            {"zzz_custom": None, "openai": None, "anthropic": None}.keys()
+        )
+
+        self.assertEqual(providers, ("openai", "anthropic", "zzz_custom"))
 
     def test_openrouter_payload_prefixes_and_skips_non_text_and_aliases(self):
         payload = {

--- a/tests/test_litellm_provider_config.py
+++ b/tests/test_litellm_provider_config.py
@@ -13,6 +13,7 @@ from litellm_provider_config import (
     models_from_openrouter_payload,
     models_from_remote_catalog,
     native_catalog_endpoint,
+    providers_from_remote_catalog,
     version_key,
     provider_from_model,
     python_requirement_allows,
@@ -106,6 +107,19 @@ class LiteLLMProviderConfigTests(unittest.TestCase):
             models_from_remote_catalog("openai", catalog),
             ("openai/gpt-current", "openai/gpt-responses"),
         )
+
+    def test_remote_catalog_discovers_dynamic_and_native_providers(self):
+        catalog = {
+            "custom/model": {
+                "litellm_provider": "custom_provider",
+                "mode": "chat",
+            },
+            "other/model": {"mode": "chat"},
+        }
+        providers = providers_from_remote_catalog(catalog)
+        self.assertIn("custom_provider", providers)
+        self.assertIn("other", providers)
+        self.assertIn("ollama", providers)
 
     def test_openrouter_payload_prefixes_and_skips_non_text_and_aliases(self):
         payload = {

--- a/tests/test_litellm_provider_config.py
+++ b/tests/test_litellm_provider_config.py
@@ -14,6 +14,7 @@ from litellm_provider_config import (
     models_from_remote_catalog,
     native_catalog_endpoint,
     providers_from_remote_catalog,
+    resolve_provider_id,
     sort_provider_ids,
     version_key,
     provider_from_model,
@@ -223,6 +224,17 @@ class LiteLLMProviderConfigTests(unittest.TestCase):
         self.assertIn("OpenAI 官方模型列表", catalog_source_label("openai"))
         self.assertIn("Ollama 本机", catalog_source_label("ollama"))
         self.assertIn("LiteLLM 官方在线目录", catalog_source_label("online"))
+        self.assertEqual(catalog_source_label("local"), "目录来源：未知。")
+
+    def test_resolve_provider_id_maps_display_labels_and_known_ids(self):
+        self.assertEqual(resolve_provider_id("openai"), "openai")
+        self.assertEqual(resolve_provider_id("OpenAI"), "openai")
+        self.assertEqual(resolve_provider_id("Ollama（本地）"), "ollama")
+        self.assertEqual(resolve_provider_id("Google Gemini"), "gemini")
+        self.assertEqual(resolve_provider_id("Azure OpenAI"), "azure")
+        self.assertEqual(resolve_provider_id("Google Vertex AI"), "vertex_ai")
+        self.assertEqual(resolve_provider_id("MyCustomProvider"), "mycustomprovider")
+        self.assertEqual(resolve_provider_id(""), "")
 
     def test_python_requirement_rejects_litellm_latest_on_python_314(self):
         self.assertFalse(

--- a/tests/test_litellm_provider_config.py
+++ b/tests/test_litellm_provider_config.py
@@ -14,6 +14,7 @@ from litellm_provider_config import (
     models_from_remote_catalog,
     native_catalog_endpoint,
     providers_from_remote_catalog,
+    sort_provider_ids,
     version_key,
     provider_from_model,
     python_requirement_allows,
@@ -120,6 +121,16 @@ class LiteLLMProviderConfigTests(unittest.TestCase):
         self.assertIn("custom_provider", providers)
         self.assertIn("other", providers)
         self.assertIn("ollama", providers)
+
+    def test_provider_sort_places_common_choices_before_dynamic_catalog(self):
+        providers = sort_provider_ids(
+            ("zzz_custom", "deepseek", "anthropic", "aaa_custom", "openai")
+        )
+        self.assertEqual(
+            providers,
+            ("openai", "anthropic", "deepseek", "aaa_custom", "zzz_custom"),
+        )
+
 
     def test_openrouter_payload_prefixes_and_skips_non_text_and_aliases(self):
         payload = {


### PR DESCRIPTION
## Summary

- replace the fixed, preselected LiteLLM provider/model controls with an explicit provider → credentials → model workflow
- rank common providers first, keep dynamic providers alphabetized, and support case-insensitive contains search while preserving custom input
- add a versioned user-level provider/model catalog cache with per-provider selections, source/timestamp metadata, stale/version warnings, atomic writes, and sensitive-field sanitization
- prefer native provider model endpoints, fall back to the LiteLLM online subset with a visible warning, and retain old cache data on refresh failure
- isolate credentials by provider, clear unsaved plaintext on every provider switch path, and keep saved credentials out of project configuration and catalog cache
- preserve custom providers/models and make saved `sync.litellm_model` take precedence over GUI history
- update the GUI documentation and regression coverage

## Why

The previous settings page mixed a small built-in provider list, default models, transient online results, runtime configuration, and provider credentials. It could look configured before the user made a choice, lost catalog state on restart, and silently injected defaults when refresh failed.

This change makes each state boundary explicit: project runtime configuration remains in `translator_config.json`, catalog and UI history use a user-level cache, and secrets remain in the operating-system credential manager or provider environment variables.

## User impact

Fresh users now start with empty Provider and model selections and no startup network request. Catalog loading is always explicit, common providers stay easy to reach, loaded providers can be searched by any name fragment, cached results survive restarts, failures do not overwrite a usable cache, and custom/Azure/OpenAI-compatible configurations remain available through manual input and LiteLLM environment settings.

## Validation

- `python -m unittest tests.test_gui_litellm_catalog_cache tests.test_litellm_provider_config tests.test_gui_litellm_worker tests.test_gui_litellm_settings_page tests.test_gui_litellm_settings`
- `python -B tests/run_gui_tests.py -q` — 882 tests passed
- `python scripts/run_quality_gates.py all`
- `git diff --check`

Closes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cached LiteLLM provider/model selection workflow with an editable provider picker and snapshot-based model loading.
  * Extended supported providers to include **Gemini** and improved dynamic provider discovery from the remote catalog.
* **Documentation**
  * Refined GUI LiteLLM behavior documentation for setup order, credential storage/precedence, and caching/sync boundaries.
* **Bug Fixes**
  * Prevented unintended fallback/auto-defaults when online catalog loading fails; added clearer failure messages.
  * Updated LiteLLM install/settings enablement behavior when required components are missing.
* **Tests**
  * Expanded coverage for cache persistence, invalid/corrupt cache handling, and updated GUI expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->