### PR TITLE
CLI: add versioned machine-readable output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 面向 Ren'Py 视觉小说的翻译工作台：Gemini Batch 作业流、上下文增强、轻量 RAG 记忆层，以及写回前安全校验。
 
-**稳定版（v1.0.0）。** CLI 是事实来源和高级用户主路径；可选图形工作台降低常规流程门槛。正式交付为源码安装运行，暂无零配置安装包。版本变化见 [CHANGELOG.md](CHANGELOG.md)。
+**稳定版（v1.0.0）。** GUI 是普通用户的推荐入口；CLI 是 Agent、脚本、CI 与高级用户的自动化事实来源。正式交付为源码安装运行，暂无零配置安装包。版本变化见 [CHANGELOG.md](CHANGELOG.md)。
 
 ## 这是什么
 
-- **Batch CLI**（`gemini_translate_batch.py`）：推荐主路径，覆盖 `build / submit / status / probe / download / check / apply / split / repair` 等。
+- **GUI**（`python -m gui_qt`）：普通用户的推荐入口，覆盖项目准备、翻译、检查、问题处理和安全写回。
+- **Batch CLI**（`gemini_translate_batch.py`）：Agent 与自动化主路径，覆盖 `build / submit / status / probe / download / check / apply / split / repair` 等。
 - **同步 CLI**（`gemini_translate.py`）：小范围即时翻译、补译、局部修复与 smoke test。
 - **上下文**：glossary / macro setting、RAG（`rag_memory.py`）、可选 Story Memory（`story_memory.py`）。
 - **共用 runtime**（`translator_runtime.py`）：配置、SDK、校验、响应解析与文件处理。
 - **可选分析**（`extract_relations.py` / `relation_analyzer/`）：关系与语义分析。
-- **可选 GUI**（`python -m gui_qt`）：统一侧边导航（项目与环境、批量/同步翻译、关键词、订正、上下文库、设置）；不装 GUI 时 CLI 可独立使用。
+- **可独立使用的 CLI**：不安装 GUI 依赖时，Agent、脚本和高级用户仍可完成全部核心工作流。
 
 稳定范围是翻译工作台本身；一键安装、游戏解包/重打包与面向普通用户的零配置发行不在当前支持范围内。边界与烟测记录见 [项目说明](docs/project_notes.md)。
 

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -25,7 +25,7 @@ def _json_compatible(value: Any) -> Any:
         return {str(key): _json_compatible(item) for key, item in value.items()}
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return [_json_compatible(item) for item in value]
-    if isinstance(value, set):
+    if isinstance(value, (set, frozenset)):
         return sorted((_json_compatible(item) for item in value), key=str)
     return str(value)
 

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -1,0 +1,97 @@
+"""Versioned machine-readable result contract shared by CLI frontends.
+
+The contract is deliberately independent from Batch implementation details so
+GUI and future CLI entry points can consume the same success/error envelope
+without parsing human-readable console output.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from os import PathLike
+from typing import Any, TextIO
+
+
+CLI_SCHEMA_VERSION = 1
+
+
+def _json_compatible(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, PathLike):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_compatible(item) for item in value]
+    if isinstance(value, set):
+        return sorted((_json_compatible(item) for item in value), key=str)
+    return str(value)
+
+
+def success_envelope(
+    command: str,
+    *,
+    status: str = "completed",
+    result: Mapping[str, Any] | None = None,
+    artifacts: Mapping[str, Any] | None = None,
+    warnings: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable successful command result envelope."""
+
+    return {
+        "schema_version": CLI_SCHEMA_VERSION,
+        "command": str(command),
+        "ok": True,
+        "status": str(status),
+        "result": _json_compatible(dict(result or {})),
+        "artifacts": _json_compatible(dict(artifacts or {})),
+        "warnings": _json_compatible(list(warnings or [])),
+        "error": None,
+    }
+
+
+def error_envelope(
+    command: str,
+    *,
+    code: str,
+    message: str,
+    retryable: bool = False,
+    suggested_action: str = "",
+    details: Mapping[str, Any] | None = None,
+    warnings: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable failed command result envelope."""
+
+    error = {
+        "code": str(code),
+        "message": str(message),
+        "retryable": bool(retryable),
+        "suggested_action": str(suggested_action),
+        "details": _json_compatible(dict(details or {})),
+    }
+    return {
+        "schema_version": CLI_SCHEMA_VERSION,
+        "command": str(command),
+        "ok": False,
+        "status": "failed",
+        "result": {},
+        "artifacts": {},
+        "warnings": _json_compatible(list(warnings or [])),
+        "error": error,
+    }
+
+
+def write_json_envelope(envelope: Mapping[str, Any], stream: TextIO) -> None:
+    """Write exactly one JSON document followed by a newline."""
+
+    json.dump(
+        _json_compatible(dict(envelope)),
+        stream,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+    stream.write("\n")
+    stream.flush()

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -26,6 +26,16 @@
 
 ## 命令说明
 
+普通用户推荐通过 GUI 执行这条流程；Agent、脚本和 CI 可在七个核心命令后追加 `--output json`，获得 `schema_version=1` 的统一结果 envelope：
+
+```powershell
+python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json
+```
+
+JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式保持兼容；当前仍须根据 `status` 而非单独根据退出码决定是否可以继续写回。
+
+结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
+
 - `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出。
 - Batch 产物默认写到 `logs/batch_jobs/<package>/`。
 - `doctor` 只检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，不调用 Gemini，也不会写回 `.rpy`。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -152,7 +152,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 **上方内层 Tab**（`任务上下文` / `命令参考` / `任务记录`）：
 
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
-- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
+- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -16,6 +16,44 @@ CLI 是自动化操作的事实来源。必要时可以使用 GUI 做可视验�
 - 只有 `check` 对当前 manifest/results 返回 `safe` 时才执行 `apply`。
 - 不要用 `--force` 规避安全判断；它只处理有限的重复/恢复场景，不能绕过 stale check、源快照校验或 `block`。
 
+## 机器可读输出
+
+普通用户推荐使用 GUI；Agent、脚本和 CI 调用 Batch CLI 时，核心流程命令支持 `--output json`：
+
+```powershell
+python gemini_translate_batch.py doctor --output json
+python gemini_translate_batch.py build --output json
+python gemini_translate_batch.py submit <manifest> --output json
+python gemini_translate_batch.py status <manifest> --output json
+python gemini_translate_batch.py download <manifest> --output json
+python gemini_translate_batch.py check <manifest> --output json
+python gemini_translate_batch.py apply <manifest> --output json
+```
+
+JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning 和原有文本摘要会写入 stderr，完整 Batch 控制台日志仍会落盘。成功结果使用版本化 envelope：
+
+```json
+{
+  "schema_version": 1,
+  "command": "check",
+  "ok": true,
+  "status": "safe",
+  "result": {},
+  "artifacts": {},
+  "warnings": [],
+  "error": null
+}
+```
+
+其中：
+
+- `status` 表示业务状态，例如 Batch job state、`safe / warn / block` 或 `applied`；
+- `result` 是命令摘要，`artifacts` 给出 manifest、results、检查报告等产物路径；
+- 命令拒绝执行时 `ok=false`，`error.code` 与 `error.message` 用于程序判断和诊断；
+- 当前默认退出码仍保持兼容；不要仅凭 `check` 的退出码决定是否写回，必须读取 `status`，并且只有 `safe` 才能继续 `apply`。
+
+没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
+
 ## 1. 安装核心依赖
 
 ```powershell

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import ast
+import contextlib
 import copy
 import hashlib
 import io
@@ -10,6 +11,7 @@ import re
 import sys
 import time
 import tokenize
+import traceback
 from datetime import datetime
 from pathlib import Path
 
@@ -31,6 +33,7 @@ from rag_memory import JsonRagStore, JsonSourceIndexStore, JsonSourceIndexStoreL
 import batch_cost_estimate
 import batch_non_chinese_rules
 import batch_submit_recovery
+import cli_contract
 import doctor_recommendations as doctor_rec
 import keyword_glossary_merge
 import prompt_context
@@ -64,6 +67,17 @@ REPAIR_RUNS_DIR = os.path.join(LOG_DIR, 'repair_runs')
 SYNC_RUNS_DIR = os.path.join(LOG_DIR, 'sync_runs')
 SYNC_BACKEND = 'gemini'
 SYNC_MODEL = ''
+MACHINE_OUTPUT_COMMANDS = frozenset(
+    {
+        'doctor',
+        'build',
+        'submit',
+        'status',
+        'download',
+        'check',
+        'apply',
+    }
+)
 
 
 class DualLogger(object):
@@ -10227,6 +10241,16 @@ def print_banner():
     print('=' * 60)
 
 
+def add_machine_output_argument(command_parser):
+    command_parser.add_argument(
+        '--output',
+        choices=('text', 'json'),
+        default='text',
+        help='Output human-readable text (default) or one machine-readable JSON document.',
+    )
+    return command_parser
+
+
 def build_arg_parser():
     parser = argparse.ArgumentParser(
         description='Batch translator for Ren\'Py tl files using Gemini Batch API.'
@@ -10234,7 +10258,8 @@ def build_arg_parser():
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     subparsers = parser.add_subparsers(dest='command')
 
-    subparsers.add_parser('doctor', help='Inspect prepare, SDK, and TL template compatibility without writing files.')
+    doctor_parser = subparsers.add_parser('doctor', help='Inspect prepare, SDK, and TL template compatibility without writing files.')
+    add_machine_output_argument(doctor_parser)
 
     bootstrap_work_parser = subparsers.add_parser(
         'bootstrap-work',
@@ -10252,6 +10277,7 @@ def build_arg_parser():
     )
 
     build_parser = subparsers.add_parser('build', help='Build local batch package and JSONL only.')
+    add_machine_output_argument(build_parser)
     build_parser.add_argument('--display-name', default='', help='Override Batch display name.')
     build_parser.add_argument(
         '--skip-prepare',
@@ -10597,6 +10623,7 @@ def build_arg_parser():
     pa_unpublish.add_argument('--store-dir', default='', help='Override analysis store directory.')
 
     submit_parser = subparsers.add_parser('submit', help='Create and submit a batch job.')
+    add_machine_output_argument(submit_parser)
     submit_parser.add_argument(
         'target',
         nargs='?',
@@ -10650,6 +10677,7 @@ def build_arg_parser():
     )
 
     status_parser = subparsers.add_parser('status', help='Refresh and show batch job status.')
+    add_machine_output_argument(status_parser)
     status_parser.add_argument(
         'target',
         nargs='?',
@@ -10658,6 +10686,7 @@ def build_arg_parser():
     )
 
     check_parser = subparsers.add_parser('check', help='Dry-run parse downloaded results and summarize recoverable items.')
+    add_machine_output_argument(check_parser)
     check_parser.add_argument(
         'target',
         nargs='?',
@@ -10677,6 +10706,7 @@ def build_arg_parser():
     probe_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
 
     download_parser = subparsers.add_parser('download', help='Download batch results for a succeeded job.')
+    add_machine_output_argument(download_parser)
     download_parser.add_argument(
         'target',
         nargs='?',
@@ -10686,6 +10716,7 @@ def build_arg_parser():
     download_parser.add_argument('--force', action='store_true', help='Overwrite local results.jsonl.')
 
     apply_parser = subparsers.add_parser('apply', help='Apply downloaded results back into tl files.')
+    add_machine_output_argument(apply_parser)
     apply_parser.add_argument(
         'target',
         nargs='?',
@@ -10962,9 +10993,7 @@ def build_arg_parser():
     return parser
 
 
-def main(argv=None):
-    parser = build_arg_parser()
-    args = parser.parse_args(argv)
+def dispatch_command(parser, args):
     command = args.command
     if command is None:
         parser.print_help()
@@ -10975,8 +11004,9 @@ def main(argv=None):
         legacy.load_glossary()
         load_batch_settings()
         print_banner()
-        print_doctor_report(collect_doctor_report())
-        return
+        report = collect_doctor_report()
+        print_doctor_report(report)
+        return report
 
     if command == 'bootstrap-work':
         legacy.load_translator_settings()
@@ -11273,11 +11303,10 @@ def main(argv=None):
     print_banner()
 
     if command == 'build':
-        create_batch_package(
+        return create_batch_package(
             display_name_override=args.display_name,
             skip_prepare=args.skip_prepare,
         )
-        return
 
     if command == 'build-keywords':
         create_keyword_package(
@@ -11313,7 +11342,7 @@ def main(argv=None):
         return
 
     if command == 'submit':
-        submit_manifest(
+        return submit_manifest(
             target=args.target or None,
             display_name_override=args.display_name,
             model_override=args.model,
@@ -11321,7 +11350,6 @@ def main(argv=None):
             force_resubmit=args.force,
             resume_upload=args.resume,
         )
-        return
 
     if command == 'recover-submit':
         recover_submit_manifest(
@@ -11331,12 +11359,10 @@ def main(argv=None):
         return
 
     if command == 'status':
-        show_status(args.target or None)
-        return
+        return show_status(args.target or None)
 
     if command == 'check':
-        check_results(args.target or None)
-        return
+        return check_results(args.target or None)
 
     if command == 'probe':
         probe_requests(
@@ -11348,12 +11374,10 @@ def main(argv=None):
         return
 
     if command == 'download':
-        download_results(args.target or None, force=args.force)
-        return
+        return download_results(args.target or None, force=args.force)
 
     if command == 'apply':
-        apply_results(args.target or None, force=args.force)
-        return
+        return apply_results(args.target or None, force=args.force)
 
     if command == 'export-keywords':
         export_keyword_candidates(
@@ -11481,5 +11505,183 @@ def main(argv=None):
     parser.print_help()
 
 
+def _nonempty_artifacts(**paths):
+    return {
+        name: value
+        for name, value in paths.items()
+        if value not in (None, '')
+    }
+
+
+def _machine_manifest_summary(manifest):
+    return {
+        'mode': manifest.get('mode', ''),
+        'job_name': manifest.get('job_name', ''),
+        'job_state': manifest.get('job_state', ''),
+        'summary': dict(manifest.get('summary') or {}),
+        'batch_stats': dict(manifest.get('batch_stats') or {}),
+        'last_status_checked_at': manifest.get('last_status_checked_at', ''),
+        'downloaded_at': manifest.get('downloaded_at', ''),
+        'applied_at': manifest.get('applied_at', ''),
+    }
+
+
+def _load_machine_manifest(command, value, args):
+    if isinstance(value, dict):
+        return value
+    if command in {'build', 'submit'} and value:
+        return load_manifest(value)
+    return load_manifest(getattr(args, 'target', '') or None)
+
+
+def build_machine_success_envelope(command, value, args):
+    """Translate existing command return values into the versioned CLI contract."""
+
+    if command == 'doctor':
+        report = dict(value or {})
+        recommendations = list(report.get('recommendations') or [])
+        blocked = doctor_rec.recommendations_block_workflow_state(recommendations)
+        status = (
+            'blocked'
+            if blocked
+            else report.get('workflow_state') or report.get('mode') or 'ready'
+        )
+        return cli_contract.success_envelope(
+            command,
+            status=status,
+            result=report,
+            warnings=report.get('warnings') or [],
+        )
+
+    if command in {'build', 'submit'} and not value:
+        return cli_contract.success_envelope(
+            command,
+            status='no_work',
+            result={'reason': 'no_pending_translation_work'},
+        )
+
+    manifest = _load_machine_manifest(command, value, args)
+    result = _machine_manifest_summary(manifest)
+    artifacts = _nonempty_artifacts(
+        manifest=manifest.get('_manifest_path'),
+        input_jsonl=manifest.get('input_jsonl_path'),
+        result_jsonl=manifest.get('result_jsonl_path'),
+        result_sha256=(
+            f"{manifest.get('result_jsonl_path')}.sha256"
+            if manifest.get('result_jsonl_sha256') and manifest.get('result_jsonl_path')
+            else ''
+        ),
+        status_snapshot=manifest.get('last_status_snapshot_path'),
+        check_report=manifest.get('last_check_report_path'),
+        apply_failure_report=manifest.get('last_apply_failure_report_path'),
+    )
+    warnings = list(manifest.get('build_warnings') or [])
+    status = 'completed'
+
+    if command == 'build':
+        status = str(manifest.get('job_state') or 'LOCAL_ONLY')
+        result['cost_estimate'] = dict(manifest.get('cost_estimate') or {})
+    elif command in {'submit', 'status'}:
+        status = str(manifest.get('job_state') or 'unknown')
+        if manifest.get('job_error'):
+            result['job_error'] = manifest.get('job_error')
+    elif command == 'download':
+        status = 'downloaded'
+        result['result_jsonl_sha256'] = manifest.get('result_jsonl_sha256', '')
+    elif command == 'check':
+        check_summary = dict(manifest.get('last_check_summary') or {})
+        result['check'] = check_summary
+        status = str(check_summary.get('safety_level') or 'unknown')
+    elif command == 'apply':
+        result['apply'] = dict(manifest.get('apply_summary') or {})
+        status = 'applied' if manifest.get('applied_at') else 'completed'
+
+    return cli_contract.success_envelope(
+        command,
+        status=status,
+        result=result,
+        artifacts=artifacts,
+        warnings=warnings,
+    )
+
+
+def _write_machine_diagnostics(buffer):
+    diagnostics = buffer.getvalue()
+    if not diagnostics:
+        return
+    sys.stderr.write(diagnostics)
+    if not diagnostics.endswith('\n'):
+        sys.stderr.write('\n')
+    sys.stderr.flush()
+
+
+def _system_exit_message(exc):
+    if isinstance(exc.code, str) and exc.code.strip():
+        return exc.code.strip()
+    if exc.code not in (None, 0):
+        return f'Command exited with status {exc.code}.'
+    return 'Command stopped before producing a result.'
+
+
+def run_machine_command(parser, args):
+    """Run one supported command with clean JSON stdout and text diagnostics."""
+
+    command = str(args.command or '')
+    diagnostics = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(diagnostics):
+            value = dispatch_command(parser, args)
+            envelope = build_machine_success_envelope(command, value, args)
+    except SystemExit as exc:
+        _write_machine_diagnostics(diagnostics)
+        cli_contract.write_json_envelope(
+            cli_contract.error_envelope(
+                command,
+                code='COMMAND_REFUSED',
+                message=_system_exit_message(exc),
+                details={'exit_code': exc.code if isinstance(exc.code, int) else 1},
+            ),
+            sys.stdout,
+        )
+        return exc.code if isinstance(exc.code, int) and exc.code else 1
+    except Exception as exc:
+        _write_machine_diagnostics(diagnostics)
+        traceback.print_exc(file=sys.stderr)
+        cli_contract.write_json_envelope(
+            cli_contract.error_envelope(
+                command,
+                code='INTERNAL_ERROR',
+                message=str(exc) or exc.__class__.__name__,
+                details={'exception_type': exc.__class__.__name__},
+            ),
+            sys.stdout,
+        )
+        return 1
+
+    _write_machine_diagnostics(diagnostics)
+    cli_contract.write_json_envelope(envelope, sys.stdout)
+    return 0
+
+
+def main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    output = getattr(args, 'output', 'text')
+    if output == 'json':
+        if args.command not in MACHINE_OUTPUT_COMMANDS:
+            cli_contract.write_json_envelope(
+                cli_contract.error_envelope(
+                    str(args.command or ''),
+                    code='OUTPUT_NOT_SUPPORTED',
+                    message='JSON output is not supported for this command.',
+                ),
+                sys.stdout,
+            )
+            return 2
+        return run_machine_command(parser, args)
+    dispatch_command(parser, args)
+    return 0
+
+
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -11,7 +11,11 @@ class CliContractTests(unittest.TestCase):
         envelope = cli_contract.success_envelope(
             "check",
             status="safe",
-            result={"path": Path("manifest.json"), "values": {2, 1}},
+            result={
+                "path": Path("manifest.json"),
+                "values": {2, 1},
+                "frozen_values": frozenset({4, 3}),
+            },
             artifacts={"manifest": Path("manifest.json")},
             warnings=["note"],
         )
@@ -20,6 +24,7 @@ class CliContractTests(unittest.TestCase):
         self.assertTrue(envelope["ok"])
         self.assertEqual(envelope["status"], "safe")
         self.assertEqual(envelope["result"]["path"], "manifest.json")
+        self.assertEqual(envelope["result"]["frozen_values"], [3, 4])
         self.assertEqual(envelope["result"]["values"], [1, 2])
         self.assertIsNone(envelope["error"])
 

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -1,0 +1,52 @@
+import io
+import json
+import unittest
+from pathlib import Path
+
+import cli_contract
+
+
+class CliContractTests(unittest.TestCase):
+    def test_success_envelope_has_stable_shape_and_json_safe_values(self):
+        envelope = cli_contract.success_envelope(
+            "check",
+            status="safe",
+            result={"path": Path("manifest.json"), "values": {2, 1}},
+            artifacts={"manifest": Path("manifest.json")},
+            warnings=["note"],
+        )
+
+        self.assertEqual(envelope["schema_version"], 1)
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "safe")
+        self.assertEqual(envelope["result"]["path"], "manifest.json")
+        self.assertEqual(envelope["result"]["values"], [1, 2])
+        self.assertIsNone(envelope["error"])
+
+    def test_error_envelope_exposes_programmatic_error_fields(self):
+        envelope = cli_contract.error_envelope(
+            "apply",
+            code="COMMAND_REFUSED",
+            message="unsafe",
+            suggested_action="run_check_again",
+            details={"reason": "stale"},
+        )
+
+        self.assertFalse(envelope["ok"])
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "COMMAND_REFUSED")
+        self.assertFalse(envelope["error"]["retryable"])
+        self.assertEqual(envelope["error"]["suggested_action"], "run_check_again")
+
+    def test_write_json_envelope_writes_one_parseable_document(self):
+        stream = io.StringIO()
+        envelope = cli_contract.success_envelope("doctor", status="ready")
+
+        cli_contract.write_json_envelope(envelope, stream)
+
+        self.assertEqual(json.loads(stream.getvalue()), envelope)
+        self.assertTrue(stream.getvalue().endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1,0 +1,196 @@
+import contextlib
+import io
+import json
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import gemini_translate_batch as batch
+
+
+class BatchCliContractTests(unittest.TestCase):
+    def test_core_commands_accept_json_output_after_subcommand(self):
+        parser = batch.build_arg_parser()
+
+        for command in sorted(batch.MACHINE_OUTPUT_COMMANDS):
+            with self.subTest(command=command):
+                args = parser.parse_args([command, "--output", "json"])
+                self.assertEqual(args.command, command)
+                self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_manifest_workflow(self):
+        args = SimpleNamespace(target="")
+        base_manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "translation",
+            "job_state": "JOB_STATE_PENDING",
+            "summary": {"item_count": 2},
+            "last_check_summary": {"safety_level": "safe"},
+            "apply_summary": {"applied_lines": 2},
+            "applied_at": "2026-07-29T12:00:00",
+        }
+        expected_status = {
+            "build": "JOB_STATE_PENDING",
+            "submit": "JOB_STATE_PENDING",
+            "status": "JOB_STATE_PENDING",
+            "download": "downloaded",
+            "check": "safe",
+            "apply": "applied",
+        }
+
+        for command, status in expected_status.items():
+            with self.subTest(command=command):
+                envelope = batch.build_machine_success_envelope(
+                    command,
+                    dict(base_manifest),
+                    args,
+                )
+                self.assertTrue(envelope["ok"])
+                self.assertEqual(envelope["command"], command)
+                self.assertEqual(envelope["status"], status)
+                self.assertEqual(
+                    envelope["artifacts"]["manifest"],
+                    "C:/jobs/demo/manifest.json",
+                )
+
+    def test_build_without_pending_work_does_not_load_latest_manifest(self):
+        args = SimpleNamespace(target="")
+
+        with mock.patch.object(batch, "load_manifest") as load_manifest:
+            envelope = batch.build_machine_success_envelope("build", None, args)
+
+        self.assertEqual(envelope["status"], "no_work")
+        self.assertEqual(
+            envelope["result"]["reason"],
+            "no_pending_translation_work",
+        )
+        load_manifest.assert_not_called()
+
+    def test_doctor_json_keeps_stdout_parseable_and_moves_text_to_stderr(self):
+        report = {
+            "mode": "existing_tl_only",
+            "workflow_state": "ready_to_build",
+            "recommendations": [],
+            "warnings": ["optional note"],
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner", side_effect=lambda: print("banner")),
+            mock.patch.object(batch, "collect_doctor_report", return_value=report),
+            mock.patch.object(
+                batch,
+                "print_doctor_report",
+                side_effect=lambda _report: print("doctor text"),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(["doctor", "--output", "json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["command"], "doctor")
+        self.assertEqual(payload["status"], "ready_to_build")
+        self.assertEqual(payload["warnings"], ["optional note"])
+        self.assertNotIn("banner", stdout.getvalue())
+        self.assertIn("banner", stderr.getvalue())
+        self.assertIn("doctor text", stderr.getvalue())
+
+    def test_check_json_exposes_safety_and_artifacts(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "translation",
+            "last_check_summary": {
+                "safety_level": "warn",
+                "failure_items": 1,
+            },
+            "last_check_report_path": "C:/jobs/demo/check_failures.jsonl",
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner", side_effect=lambda: print("banner")),
+            mock.patch.object(
+                batch,
+                "check_results",
+                side_effect=lambda _target: (print("check text"), manifest)[1],
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(["check", "C:/jobs/demo/manifest.json", "--output", "json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(payload["result"]["check"]["failure_items"], 1)
+        self.assertEqual(
+            payload["artifacts"]["check_report"],
+            "C:/jobs/demo/check_failures.jsonl",
+        )
+        self.assertIn("check text", stderr.getvalue())
+
+    def test_json_mode_turns_system_exit_into_error_envelope(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner"),
+            mock.patch.object(
+                batch,
+                "check_results",
+                side_effect=SystemExit("Manifest or results changed after the last check."),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(["check", "manifest.json", "--output", "json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["code"], "COMMAND_REFUSED")
+        self.assertIn("changed after the last check", payload["error"]["message"])
+
+    def test_text_mode_preserves_human_stdout(self):
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner", side_effect=lambda: print("banner")),
+            mock.patch.object(
+                batch,
+                "check_results",
+                side_effect=lambda _target: print("check text"),
+            ),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(["check", "manifest.json"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("banner", stdout.getvalue())
+        self.assertIn("check text", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the first independently mergeable stage of #276.

- add a shared `schema_version=1` CLI success/error envelope
- add `--output text|json` to the core `doctor -> build -> submit -> status -> download -> check -> apply` workflow
- keep JSON stdout parseable by moving existing banner, progress, warnings, and human summaries to stderr
- preserve the existing text mode and all Batch `check -> apply` safety gates
- return `no_work` for empty build/submit runs instead of falling back to an older latest manifest
- reposition the product docs so GUI is recommended for ordinary users and CLI is the Agent/script/CI interface
- add contract, parser, stdout/stderr, artifact, compatibility, and no-work regression tests

## User and developer impact

Agents and CI can now consume one stable JSON document from the seven core Batch commands without parsing human-oriented console text. Existing GUI flows and manual CLI usage continue to use the unchanged text mode.

This PR deliberately does not add strict semantic exit codes, fine-grained error codes, mandatory explicit targets, or capability/schema discovery. Those remain later stages of #276.

## Validation

- `python -B tests/run_cli_tests.py -q` — 743 passed, 1 skipped
- related GUI tests — 47 passed
- focused CLI contract tests — 10 passed
- real `doctor --output json` subprocess smoke — stdout parsed successfully; diagnostics stayed on stderr
- `python scripts/run_quality_gates.py all` — passed
- all tracked local Markdown links resolve
- `git diff --check` — passed

Part of #276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured JSON output for core CLI commands, including standardized success and error details.
  * Added support for machine-readable results in Agent, script, and CI workflows while preserving human-readable text mode.
  * JSON output now separates results on stdout from diagnostics on stderr and includes status, artifacts, warnings, and error information.

* **Documentation**
  * Updated the README and workflow guides to clarify GUI and CLI usage, JSON output behavior, and status-based automation decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->