### PR TITLE
Add strict Agent CLI exit codes

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -15,6 +15,130 @@ from typing import Any, TextIO
 
 CLI_SCHEMA_VERSION = 1
 
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NEEDS_ACTION = 3
+EXIT_BLOCKED = 4
+EXIT_INVALID_STATE = 5
+EXIT_RETRYABLE = 6
+
+
+def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:
+    """Classify existing CLI failures without changing their human-readable text."""
+
+    normalized = str(message or "").strip().lower()
+    stale_markers = (
+        "changed after the last check",
+        "stale check",
+        "check fingerprint",
+        "source snapshot",
+        "manifest or results changed",
+    )
+    retryable_markers = (
+        "rate limit",
+        "resource exhausted",
+        "quota",
+        "timed out",
+        "timeout",
+        "temporarily unavailable",
+        "service unavailable",
+    )
+    precondition_markers = (
+        "not succeeded yet",
+        "missing",
+        "not found",
+        "does not exist",
+        "download first",
+        "no job",
+        "api key",
+        "configuration",
+        "config ",
+    )
+    blocked_markers = (
+        "not safe",
+        "safety level",
+        "blocked",
+        "refused",
+        "already applied",
+        "disabled",
+        "cost limit",
+        "max cost",
+    )
+
+    if any(marker in normalized for marker in stale_markers):
+        return {
+            "code": "STALE_STATE",
+            "retryable": False,
+            "suggested_action": "run_check_again",
+            "exit_code": EXIT_INVALID_STATE,
+        }
+    if any(marker in normalized for marker in retryable_markers):
+        return {
+            "code": "REMOTE_RETRYABLE",
+            "retryable": True,
+            "suggested_action": "retry_later",
+            "exit_code": EXIT_RETRYABLE,
+        }
+    if any(marker in normalized for marker in precondition_markers):
+        return {
+            "code": "PRECONDITION_FAILED",
+            "retryable": False,
+            "suggested_action": "inspect_configuration_and_artifacts",
+            "exit_code": EXIT_INVALID_STATE,
+        }
+    if any(marker in normalized for marker in blocked_markers):
+        return {
+            "code": "COMMAND_BLOCKED",
+            "retryable": False,
+            "suggested_action": "inspect_diagnostics",
+            "exit_code": EXIT_BLOCKED,
+        }
+    return {
+        "code": "COMMAND_REFUSED" if exception_type == "SystemExit" else "INTERNAL_ERROR",
+        "retryable": False,
+        "suggested_action": "inspect_diagnostics",
+        "exit_code": EXIT_BLOCKED if exception_type == "SystemExit" else 1,
+    }
+
+
+def strict_exit_code(envelope: Mapping[str, Any]) -> int:
+    """Return the documented semantic exit code for a machine envelope."""
+
+    if not envelope.get("ok"):
+        error = envelope.get("error")
+        if isinstance(error, Mapping):
+            details = error.get("details")
+            if isinstance(details, Mapping):
+                semantic_code = details.get("semantic_exit_code")
+                if isinstance(semantic_code, int):
+                    return semantic_code
+        return EXIT_BLOCKED
+
+    command = str(envelope.get("command") or "")
+    status = str(envelope.get("status") or "").strip().lower()
+    if command == "check":
+        if status == "safe":
+            return EXIT_OK
+        if status == "warn":
+            return EXIT_NEEDS_ACTION
+        if status == "block":
+            return EXIT_BLOCKED
+        return EXIT_INVALID_STATE
+    if command == "doctor" and status == "blocked":
+        return EXIT_BLOCKED
+    if command in {"submit", "status"} and status in {
+        "failed",
+        "cancelled",
+        "canceled",
+        "expired",
+        "job_state_failed",
+        "job_state_cancelled",
+        "job_state_canceled",
+        "job_state_expired",
+    }:
+        return EXIT_BLOCKED
+    return EXIT_OK
+
 
 def _json_compatible(value: Any) -> Any:
     if value is None or isinstance(value, (bool, int, float, str)):

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -26,22 +26,35 @@ EXIT_RETRYABLE = 6
 def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:
     """Classify existing CLI failures without changing their human-readable text."""
 
-    normalized = str(message or "").strip().lower()
+    normalized = f"{exception_type} {message or ''}".strip().lower()
     stale_markers = (
         "changed after the last check",
         "stale check",
         "check fingerprint",
         "source snapshot",
         "manifest or results changed",
+        "has no valid check summary",
+        "older check contract",
     )
     retryable_markers = (
+        "429",
         "rate limit",
         "resource exhausted",
-        "quota",
+        "resource_exhausted",
+        "resourceexhausted",
+        "quota exceeded",
+        "503",
         "timed out",
         "timeout",
+        "connecttimeout",
+        "readtimeout",
+        "connecterror",
+        "readerror",
+        "remoteprotocolerror",
+        "unexpected_eof_while_reading",
         "temporarily unavailable",
         "service unavailable",
+        "unavailable",
     )
     precondition_markers = (
         "not succeeded yet",

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -32,15 +32,15 @@
 python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json
 ```
 
-JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式和默认退出码保持兼容；仍须根据 `status` 判断是否可以继续写回。
+JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式、默认退出码以及非严格 JSON 的既有 `COMMAND_REFUSED / INTERNAL_ERROR` 分类保持兼容；仍须根据 `status` 判断是否可以继续写回。
 
-Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`2` 用法错误，`3` 需要处理（例如 `warn`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
+Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`1` 未分类内部错误，`2` 用法错误，`3` 需要处理（例如 `warn`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
 
 ```powershell
 python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json --strict-exit-codes
 ```
 
-严格模式下也不能只看退出码：必须同时读取 envelope 的 `ok`、`status` 和 `error`。job pending/running 是成功查询，退出 `0`；`check` 只有 `safe` 才退出 `0` 并允许进入 `apply`。错误时优先使用稳定的 `error.code`、`retryable`、`suggested_action` 与 `details.semantic_exit_code`，不要解析自然语言 `message`。
+严格模式下也不能只看退出码：必须同时读取 envelope 的 `ok`、`status` 和 `error`。job pending/running 是成功查询，退出 `0`；`check` 只有 `safe` 才退出 `0` 并允许进入 `apply`。错误时优先使用稳定的 `error.code`、`retryable`、`suggested_action` 与权威的 `details.semantic_exit_code`，不要解析自然语言 `message`。
 
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -32,7 +32,15 @@
 python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json
 ```
 
-JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式保持兼容；当前仍须根据 `status` 而非单独根据退出码决定是否可以继续写回。
+JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式和默认退出码保持兼容；仍须根据 `status` 判断是否可以继续写回。
+
+Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`2` 用法错误，`3` 需要处理（例如 `warn`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
+
+```powershell
+python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json --strict-exit-codes
+```
+
+严格模式下也不能只看退出码：必须同时读取 envelope 的 `ok`、`status` 和 `error`。job pending/running 是成功查询，退出 `0`；`check` 只有 `safe` 才退出 `0` 并允许进入 `apply`。错误时优先使用稳定的 `error.code`、`retryable`、`suggested_action` 与 `details.semantic_exit_code`，不要解析自然语言 `message`。
 
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -152,7 +152,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 **上方内层 Tab**（`任务上下文` / `命令参考` / `任务记录`）：
 
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
-- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
+- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。严格模式必须与 JSON 输出组合使用。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -58,13 +58,14 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning �
 | 退出码 | 含义 | 常见场景 |
 |---:|---|---|
 | `0` | 命令成功，可继续或继续轮询 | `safe`、job pending/running、无待处理工作 |
+| `1` | 未分类的内部错误，默认不可重试 | 意外异常或未知 SDK 错误 |
 | `2` | 命令行用法错误 | 参数缺失、严格模式未配合 JSON 输出 |
 | `3` | 命令完成，但需要 Agent 处理 | `check` 返回 `warn` |
 | `4` | 被门禁阻止或进入终止失败状态 | `block`、doctor blocked、job failed/cancelled |
 | `5` | 输入、配置或状态已失效 | stale check、manifest/results 漂移、前置产物缺失 |
 | `6` | 远端临时错误，可稍后重试 | rate limit、quota、timeout、service unavailable |
 
-错误 envelope 的 `error.code` 当前可能为 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。同时读取 `retryable`、`suggested_action` 和 `details.semantic_exit_code`，不要解析 `message` 文本。
+严格模式的错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容行为：拒绝类错误仍为 `COMMAND_REFUSED`，意外异常仍为 `INTERNAL_ERROR`，且不承诺 `semantic_exit_code`。
 
 没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
 

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -50,7 +50,21 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning �
 - `status` 表示业务状态，例如 Batch job state、`safe / warn / block` 或 `applied`；
 - `result` 是命令摘要，`artifacts` 给出 manifest、results、检查报告等产物路径；
 - 命令拒绝执行时 `ok=false`，`error.code` 与 `error.message` 用于程序判断和诊断；
-- 当前默认退出码仍保持兼容；不要仅凭 `check` 的退出码决定是否写回，必须读取 `status`，并且只有 `safe` 才能继续 `apply`。
+- 默认退出码仍保持兼容。Agent 可同时传入 `--output json --strict-exit-codes`，让业务状态映射为稳定退出码；严格模式只与 JSON 输出组合使用。
+- 无论是否启用严格退出码，都必须读取 `status`；只有 `check` 的 `status=safe` 才能继续 `apply`。
+
+严格退出码约定：
+
+| 退出码 | 含义 | 常见场景 |
+|---:|---|---|
+| `0` | 命令成功，可继续或继续轮询 | `safe`、job pending/running、无待处理工作 |
+| `2` | 命令行用法错误 | 参数缺失、严格模式未配合 JSON 输出 |
+| `3` | 命令完成，但需要 Agent 处理 | `check` 返回 `warn` |
+| `4` | 被门禁阻止或进入终止失败状态 | `block`、doctor blocked、job failed/cancelled |
+| `5` | 输入、配置或状态已失效 | stale check、manifest/results 漂移、前置产物缺失 |
+| `6` | 远端临时错误，可稍后重试 | rate limit、quota、timeout、service unavailable |
+
+错误 envelope 的 `error.code` 当前可能为 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。同时读取 `retryable`、`suggested_action` 和 `details.semantic_exit_code`，不要解析 `message` 文本。
 
 没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -10248,6 +10248,14 @@ def add_machine_output_argument(command_parser):
         default='text',
         help='Output human-readable text (default) or one machine-readable JSON document.',
     )
+    command_parser.add_argument(
+        '--strict-exit-codes',
+        action='store_true',
+        help=(
+            'With --output json, return semantic exit codes for needs-action, '
+            'blocked, invalid-state, and retryable outcomes.'
+        ),
+    )
     return command_parser
 
 
@@ -11634,32 +11642,54 @@ def run_machine_command(parser, args):
             envelope = build_machine_success_envelope(command, value, args)
     except SystemExit as exc:
         _write_machine_diagnostics(diagnostics)
-        cli_contract.write_json_envelope(
-            cli_contract.error_envelope(
-                command,
-                code='COMMAND_REFUSED',
-                message=_system_exit_message(exc),
-                details={'exit_code': exc.code if isinstance(exc.code, int) else 1},
-            ),
-            sys.stdout,
+        message = _system_exit_message(exc)
+        classification = cli_contract.classify_error(
+            message,
+            exception_type='SystemExit',
         )
+        envelope = cli_contract.error_envelope(
+            command,
+            code=classification['code'],
+            message=message,
+            retryable=classification['retryable'],
+            suggested_action=classification['suggested_action'],
+            details={
+                'exit_code': exc.code if isinstance(exc.code, int) else 1,
+                'semantic_exit_code': classification['exit_code'],
+            },
+        )
+        cli_contract.write_json_envelope(envelope, sys.stdout)
+        if args.strict_exit_codes:
+            return cli_contract.strict_exit_code(envelope)
         return exc.code if isinstance(exc.code, int) and exc.code else 1
     except Exception as exc:
         _write_machine_diagnostics(diagnostics)
         traceback.print_exc(file=sys.stderr)
-        cli_contract.write_json_envelope(
-            cli_contract.error_envelope(
-                command,
-                code='INTERNAL_ERROR',
-                message=str(exc) or exc.__class__.__name__,
-                details={'exception_type': exc.__class__.__name__},
-            ),
-            sys.stdout,
+        message = str(exc) or exc.__class__.__name__
+        classification = cli_contract.classify_error(
+            message,
+            exception_type=exc.__class__.__name__,
         )
+        envelope = cli_contract.error_envelope(
+            command,
+            code=classification['code'],
+            message=message,
+            retryable=classification['retryable'],
+            suggested_action=classification['suggested_action'],
+            details={
+                'exception_type': exc.__class__.__name__,
+                'semantic_exit_code': classification['exit_code'],
+            },
+        )
+        cli_contract.write_json_envelope(envelope, sys.stdout)
+        if args.strict_exit_codes:
+            return cli_contract.strict_exit_code(envelope)
         return 1
 
     _write_machine_diagnostics(diagnostics)
     cli_contract.write_json_envelope(envelope, sys.stdout)
+    if args.strict_exit_codes:
+        return cli_contract.strict_exit_code(envelope)
     return 0
 
 
@@ -11667,6 +11697,8 @@ def main(argv=None):
     parser = build_arg_parser()
     args = parser.parse_args(argv)
     output = getattr(args, 'output', 'text')
+    if getattr(args, 'strict_exit_codes', False) and output != 'json':
+        parser.error('--strict-exit-codes requires --output json')
     if output == 'json':
         if args.command not in MACHINE_OUTPUT_COMMANDS:
             cli_contract.write_json_envelope(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -11643,44 +11643,62 @@ def run_machine_command(parser, args):
     except SystemExit as exc:
         _write_machine_diagnostics(diagnostics)
         message = _system_exit_message(exc)
-        classification = cli_contract.classify_error(
-            message,
-            exception_type='SystemExit',
-        )
-        envelope = cli_contract.error_envelope(
-            command,
-            code=classification['code'],
-            message=message,
-            retryable=classification['retryable'],
-            suggested_action=classification['suggested_action'],
-            details={
-                'exit_code': exc.code if isinstance(exc.code, int) else 1,
-                'semantic_exit_code': classification['exit_code'],
-            },
-        )
+        legacy_exit_code = exc.code if isinstance(exc.code, int) and exc.code else 1
+        if args.strict_exit_codes:
+            classification = cli_contract.classify_error(
+                message,
+                exception_type='SystemExit',
+            )
+            envelope = cli_contract.error_envelope(
+                command,
+                code=classification['code'],
+                message=message,
+                retryable=classification['retryable'],
+                suggested_action=classification['suggested_action'],
+                details={
+                    'exit_code': legacy_exit_code,
+                    'semantic_exit_code': classification['exit_code'],
+                },
+            )
+        else:
+            envelope = cli_contract.error_envelope(
+                command,
+                code='COMMAND_REFUSED',
+                message=message,
+                details={'exit_code': legacy_exit_code},
+            )
         cli_contract.write_json_envelope(envelope, sys.stdout)
         if args.strict_exit_codes:
             return cli_contract.strict_exit_code(envelope)
-        return exc.code if isinstance(exc.code, int) and exc.code else 1
+        return legacy_exit_code
     except Exception as exc:
         _write_machine_diagnostics(diagnostics)
         traceback.print_exc(file=sys.stderr)
         message = str(exc) or exc.__class__.__name__
-        classification = cli_contract.classify_error(
-            message,
-            exception_type=exc.__class__.__name__,
-        )
-        envelope = cli_contract.error_envelope(
-            command,
-            code=classification['code'],
-            message=message,
-            retryable=classification['retryable'],
-            suggested_action=classification['suggested_action'],
-            details={
-                'exception_type': exc.__class__.__name__,
-                'semantic_exit_code': classification['exit_code'],
-            },
-        )
+        exception_type = exc.__class__.__name__
+        if args.strict_exit_codes:
+            classification = cli_contract.classify_error(
+                message,
+                exception_type=exception_type,
+            )
+            envelope = cli_contract.error_envelope(
+                command,
+                code=classification['code'],
+                message=message,
+                retryable=classification['retryable'],
+                suggested_action=classification['suggested_action'],
+                details={
+                    'exception_type': exception_type,
+                    'semantic_exit_code': classification['exit_code'],
+                },
+            )
+        else:
+            envelope = cli_contract.error_envelope(
+                command,
+                code='INTERNAL_ERROR',
+                message=message,
+                details={'exception_type': exception_type},
+            )
         cli_contract.write_json_envelope(envelope, sys.stdout)
         if args.strict_exit_codes:
             return cli_contract.strict_exit_code(envelope)

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -52,14 +52,13 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(json.loads(stream.getvalue()), envelope)
         self.assertTrue(stream.getvalue().endswith("\n"))
 
-
     def test_error_classification_exposes_stable_machine_actions(self):
         stale = cli_contract.classify_error(
             "Manifest or results changed after the last check.",
             exception_type="SystemExit",
         )
         retryable = cli_contract.classify_error(
-            "Service unavailable due to rate limit.",
+            "429 RESOURCE_EXHAUSTED",
             exception_type="RuntimeError",
         )
 
@@ -69,6 +68,32 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(retryable["code"], "REMOTE_RETRYABLE")
         self.assertTrue(retryable["retryable"])
         self.assertEqual(retryable["exit_code"], cli_contract.EXIT_RETRYABLE)
+
+        for message in (
+            "Manifest has no valid check summary. Run check before apply.",
+            "Manifest check summary was produced by an older check contract. "
+            "Run check again before apply.",
+        ):
+            with self.subTest(message=message):
+                preflight = cli_contract.classify_error(
+                    message,
+                    exception_type="SystemExit",
+                )
+                self.assertEqual(preflight["code"], "STALE_STATE")
+                self.assertEqual(
+                    preflight["suggested_action"],
+                    "run_check_again",
+                )
+                self.assertEqual(
+                    preflight["exit_code"],
+                    cli_contract.EXIT_INVALID_STATE,
+                )
+
+        quotation = cli_contract.classify_error(
+            "quotation ready",
+            exception_type="RuntimeError",
+        )
+        self.assertEqual(quotation["code"], "INTERNAL_ERROR")
 
     def test_strict_exit_code_maps_successful_workflow_states(self):
         warn = cli_contract.success_envelope("check", status="warn")

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -53,5 +53,55 @@ class CliContractTests(unittest.TestCase):
         self.assertTrue(stream.getvalue().endswith("\n"))
 
 
+    def test_error_classification_exposes_stable_machine_actions(self):
+        stale = cli_contract.classify_error(
+            "Manifest or results changed after the last check.",
+            exception_type="SystemExit",
+        )
+        retryable = cli_contract.classify_error(
+            "Service unavailable due to rate limit.",
+            exception_type="RuntimeError",
+        )
+
+        self.assertEqual(stale["code"], "STALE_STATE")
+        self.assertEqual(stale["suggested_action"], "run_check_again")
+        self.assertEqual(stale["exit_code"], cli_contract.EXIT_INVALID_STATE)
+        self.assertEqual(retryable["code"], "REMOTE_RETRYABLE")
+        self.assertTrue(retryable["retryable"])
+        self.assertEqual(retryable["exit_code"], cli_contract.EXIT_RETRYABLE)
+
+    def test_strict_exit_code_maps_successful_workflow_states(self):
+        warn = cli_contract.success_envelope("check", status="warn")
+        blocked = cli_contract.success_envelope("doctor", status="blocked")
+        pending = cli_contract.success_envelope(
+            "status",
+            status="JOB_STATE_PENDING",
+        )
+
+        self.assertEqual(
+            cli_contract.strict_exit_code(warn),
+            cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(blocked),
+            cli_contract.EXIT_BLOCKED,
+        )
+        self.assertEqual(cli_contract.strict_exit_code(pending), 0)
+        unknown = cli_contract.success_envelope("check", status="unknown")
+        unclassified_error = cli_contract.error_envelope(
+            "apply",
+            code="COMMAND_REFUSED",
+            message="stopped",
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(unknown),
+            cli_contract.EXIT_INVALID_STATE,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(unclassified_error),
+            cli_contract.EXIT_BLOCKED,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -23,7 +23,6 @@ class BatchCliContractTests(unittest.TestCase):
                 )
                 self.assertTrue(strict_args.strict_exit_codes)
 
-
     def test_machine_result_builder_covers_manifest_workflow(self):
         args = SimpleNamespace(target="")
         base_manifest = {
@@ -171,8 +170,30 @@ class BatchCliContractTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 1)
         self.assertFalse(payload["ok"])
-        self.assertEqual(payload["error"]["code"], "STALE_STATE")
+        self.assertEqual(payload["error"]["code"], "COMMAND_REFUSED")
         self.assertIn("changed after the last check", payload["error"]["message"])
+
+    def test_non_strict_exception_keeps_internal_error_contract(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(
+                batch,
+                "dispatch_command",
+                side_effect=RuntimeError("503 UNAVAILABLE"),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                ["status", "manifest.json", "--output", "json"]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["error"]["code"], "INTERNAL_ERROR")
+        self.assertNotIn("semantic_exit_code", payload["error"]["details"])
 
     def test_strict_check_exit_code_reports_needs_action(self):
         manifest = {
@@ -203,6 +224,141 @@ class BatchCliContractTests(unittest.TestCase):
 
         self.assertEqual(exit_code, batch.cli_contract.EXIT_NEEDS_ACTION)
         self.assertEqual(json.loads(stdout.getvalue())["status"], "warn")
+
+    def test_non_strict_check_block_keeps_compatible_zero_exit(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "last_check_summary": {"safety_level": "block"},
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                ["check", "manifest.json", "--output", "json"]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "block")
+
+    def test_strict_success_state_matrix(self):
+        cases = (
+            (
+                "check",
+                {"last_check_summary": {"safety_level": "block"}},
+                batch.cli_contract.EXIT_BLOCKED,
+            ),
+            (
+                "status",
+                {"job_state": "JOB_STATE_FAILED"},
+                batch.cli_contract.EXIT_BLOCKED,
+            ),
+        )
+
+        for command, manifest, expected_exit in cases:
+            (
+                "submit",
+                {"job_state": "JOB_STATE_FAILED"},
+                batch.cli_contract.EXIT_BLOCKED,
+            ),
+            with self.subTest(command=command):
+                stdout = io.StringIO()
+                manifest["_manifest_path"] = "C:/jobs/demo/manifest.json"
+                with (
+                    mock.patch.object(batch, "dispatch_command", return_value=manifest),
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    exit_code = batch.main(
+                        [
+                            command,
+                            "manifest.json",
+                            "--output",
+                            "json",
+                            "--strict-exit-codes",
+                        ]
+                    )
+
+                self.assertEqual(exit_code, expected_exit)
+                self.assertTrue(json.loads(stdout.getvalue())["ok"])
+
+    def test_strict_doctor_blocked_returns_blocked_exit(self):
+        report = {"recommendations": [{"code": "blocking"}]}
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=report),
+            mock.patch.object(
+                batch.doctor_rec,
+                "recommendations_block_workflow_state",
+                return_value=True,
+            ),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                ["doctor", "--output", "json", "--strict-exit-codes"]
+            )
+
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_BLOCKED)
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "blocked")
+
+    def test_strict_retryable_exception_returns_retryable_exit(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(
+                batch,
+                "dispatch_command",
+                side_effect=RuntimeError("503 UNAVAILABLE"),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                [
+                    "status", "manifest.json", "--output", "json", "--strict-exit-codes"
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_RETRYABLE)
+        self.assertEqual(payload["error"]["code"], "REMOTE_RETRYABLE")
+        self.assertTrue(payload["error"]["retryable"])
+
+    def test_strict_apply_preflight_errors_return_invalid_state(self):
+        messages = (
+            "Manifest has no valid check summary. Run check before apply.",
+            "Manifest check summary was produced by an older check contract. "
+            "Run check again before apply.",
+        )
+
+        for message in messages:
+            with self.subTest(message=message):
+                stdout = io.StringIO()
+                with (
+                    mock.patch.object(
+                        batch,
+                        "dispatch_command",
+                        side_effect=SystemExit(message),
+                    ),
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    exit_code = batch.main(
+                        [
+                            "apply", "manifest.json", "--output", "json", "--strict-exit-codes"
+                        ]
+                    )
+
+                payload = json.loads(stdout.getvalue())
+                self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+                self.assertEqual(payload["error"]["code"], "STALE_STATE")
+                self.assertEqual(
+                    payload["error"]["suggested_action"],
+                    "run_check_again",
+                )
 
     def test_strict_system_exit_uses_stale_state_code(self):
         stdout = io.StringIO()
@@ -248,6 +404,7 @@ class BatchCliContractTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("requires --output json", stderr.getvalue())
+
     def test_text_mode_preserves_human_stdout(self):
         stdout = io.StringIO()
 

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -17,6 +17,12 @@ class BatchCliContractTests(unittest.TestCase):
                 args = parser.parse_args([command, "--output", "json"])
                 self.assertEqual(args.command, command)
                 self.assertEqual(args.output, "json")
+                self.assertFalse(args.strict_exit_codes)
+                strict_args = parser.parse_args(
+                    [command, "--output", "json", "--strict-exit-codes"]
+                )
+                self.assertTrue(strict_args.strict_exit_codes)
+
 
     def test_machine_result_builder_covers_manifest_workflow(self):
         args = SimpleNamespace(target="")
@@ -165,9 +171,83 @@ class BatchCliContractTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 1)
         self.assertFalse(payload["ok"])
-        self.assertEqual(payload["error"]["code"], "COMMAND_REFUSED")
+        self.assertEqual(payload["error"]["code"], "STALE_STATE")
         self.assertIn("changed after the last check", payload["error"]["message"])
 
+    def test_strict_check_exit_code_reports_needs_action(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "last_check_summary": {"safety_level": "warn"},
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner"),
+            mock.patch.object(batch, "check_results", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "check",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--strict-exit-codes",
+                ]
+            )
+
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_NEEDS_ACTION)
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "warn")
+
+    def test_strict_system_exit_uses_stale_state_code(self):
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner"),
+            mock.patch.object(
+                batch,
+                "check_results",
+                side_effect=SystemExit("Manifest or results changed after the last check."),
+            ),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "check",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--strict-exit-codes",
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+        self.assertEqual(payload["error"]["code"], "STALE_STATE")
+        self.assertEqual(
+            payload["error"]["suggested_action"],
+            "run_check_again",
+        )
+
+    def test_strict_exit_codes_requires_json_output(self):
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as raised:
+                batch.main(["doctor", "--strict-exit-codes"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("requires --output json", stderr.getvalue())
     def test_text_mode_preserves_human_stdout(self):
         stdout = io.StringIO()
 


### PR DESCRIPTION
## Summary

- add stable machine error classification with retryability and suggested actions
- add `--strict-exit-codes` to the seven core JSON workflow commands
- preserve existing text output and default exit-code behavior
- document the semantic exit-code contract for Agent, Batch, and GUI command references

## Exit code contract

- `0`: success or continue polling
- `2`: CLI usage error
- `3`: completed but needs action, such as `check: warn`
- `4`: blocked by a safety gate or terminal job failure
- `5`: invalid or stale input/configuration/state
- `6`: retryable remote failure

## Validation

- `python -m unittest tests.test_cli_contract tests.test_gemini_translate_batch_cli_contract`
- `python -B tests/run_cli_tests.py -q` — 748 passed, 1 skipped
- `python scripts/run_quality_gates.py all`
- `git diff --check`

Part of #276.