### PR TITLE
Require explicit targets for Agent CLI

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -22,6 +22,27 @@ EXIT_BLOCKED = 4
 EXIT_INVALID_STATE = 5
 EXIT_RETRYABLE = 6
 
+class MachineContractError(SystemExit):
+    """Structured refusal raised by opt-in machine invocation guards."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code_name: str,
+        suggested_action: str,
+        semantic_exit_code: int = EXIT_INVALID_STATE,
+        retryable: bool = False,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(str(message))
+        self.code_name = str(code_name)
+        self.suggested_action = str(suggested_action)
+        self.semantic_exit_code = int(semantic_exit_code)
+        self.retryable = bool(retryable)
+        self.details = dict(details or {})
+
+
 
 def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:
     """Classify existing CLI failures without changing their human-readable text."""

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -42,6 +42,14 @@ python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json -
 
 严格模式下也不能只看退出码：必须同时读取 envelope 的 `ok`、`status` 和 `error`。job pending/running 是成功查询，退出 `0`；`check` 只有 `safe` 才退出 `0` 并允许进入 `apply`。错误时优先使用稳定的 `error.code`、`retryable`、`suggested_action` 与权威的 `details.semantic_exit_code`，不要解析自然语言 `message`。
 
+
+需要确定性调用时追加 `--non-interactive`。该选项保证核心命令不等待 stdin，并让 `submit / status / download / check / apply` 必须显式接收 manifest 或 package target；因此不会读取 latest manifest，`submit` 也不会隐式 build。缺少 target 时 JSON envelope 返回 `EXPLICIT_TARGET_REQUIRED`，配合 `--strict-exit-codes` 退出 `5`。
+
+```powershell
+python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json --output json --non-interactive --strict-exit-codes
+```
+
+只需关闭 target 回退时可单独使用 `--require-explicit-target`。默认模式保持现有 latest-manifest 和 submit-build 行为；`doctor / build` 不消费 manifest，不受显式 target 要求影响。
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 - `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -152,7 +152,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 **上方内层 Tab**（`任务上下文` / `命令参考` / `任务记录`）：
 
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
-- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。严格模式必须与 JSON 输出组合使用。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
+- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -67,6 +67,25 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning �
 
 严格模式的错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容行为：拒绝类错误仍为 `COMMAND_REFUSED`，意外异常仍为 `INTERNAL_ERROR`，且不承诺 `semantic_exit_code`。
 
+
+## 严格非交互与显式 manifest
+
+七个核心命令支持 `--non-interactive`。当前核心流程本身不会读取 stdin；该选项进一步禁止 manifest 消费命令使用隐藏 target：
+
+```powershell
+python gemini_translate_batch.py status <manifest> --output json --non-interactive --strict-exit-codes
+```
+
+在 `submit / status / download / check / apply` 中，`--non-interactive` 要求显式传入 manifest 路径或 package 目录：
+
+- 不再读取 `latest_manifest.txt` 或扫描最新 package；
+- `submit` 不再因 target 为空而隐式执行 build；
+- 缺少 target 时返回 `error.code=EXPLICIT_TARGET_REQUIRED`、`suggested_action=pass_manifest_path`；
+- 同时启用 `--strict-exit-codes` 时退出码为 `5`。
+
+如果只想禁止 target 回退、但不需要声明完整非交互契约，可使用 `--require-explicit-target`。`doctor` 与 `build` 本来不消费 manifest，因此这两个命令在非交互模式下不要求 target。
+
+默认模式保持兼容：未传这两个新选项时，现有 latest-manifest 与 submit-build 回退仍然可用。Agent 应优先使用 `--output json --non-interactive --strict-exit-codes`，并始终显式传递同一 manifest。
 没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
 
 ## 1. 安装核心依赖

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -78,6 +78,7 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'apply',
     }
 )
+EXPLICIT_TARGET_COMMANDS = frozenset({'submit', 'status', 'download', 'check', 'apply'})
 
 
 class DualLogger(object):
@@ -10256,6 +10257,22 @@ def add_machine_output_argument(command_parser):
             'blocked, invalid-state, and retryable outcomes.'
         ),
     )
+    command_parser.add_argument(
+        '--non-interactive',
+        action='store_true',
+        help=(
+            'Guarantee no stdin prompts; manifest-consuming commands also require '
+            'an explicit target.'
+        ),
+    )
+    command_parser.add_argument(
+        '--require-explicit-target',
+        action='store_true',
+        help=(
+            'Reject implicit latest-manifest or submit-build fallback for commands '
+            'that consume a manifest.'
+        ),
+    )
     return command_parser
 
 
@@ -11001,11 +11018,32 @@ def build_arg_parser():
     return parser
 
 
+def validate_machine_invocation(args):
+    """Enforce opt-in deterministic invocation rules before workflow setup."""
+
+    command = str(getattr(args, 'command', '') or '')
+    require_target = bool(
+        getattr(args, 'non_interactive', False)
+        or getattr(args, 'require_explicit_target', False)
+    )
+    target = str(getattr(args, 'target', '') or '').strip()
+    if require_target and command in EXPLICIT_TARGET_COMMANDS and not target:
+        raise cli_contract.MachineContractError(
+            f'{command} requires an explicit manifest path or package directory.',
+            code_name='EXPLICIT_TARGET_REQUIRED',
+            suggested_action='pass_manifest_path',
+            details={'required_argument': 'target'},
+        )
+
+
 def dispatch_command(parser, args):
     command = args.command
     if command is None:
         parser.print_help()
         return
+
+    if command in MACHINE_OUTPUT_COMMANDS:
+        validate_machine_invocation(args)
 
     if command == 'doctor':
         legacy.load_translator_settings()
@@ -11644,7 +11682,23 @@ def run_machine_command(parser, args):
         _write_machine_diagnostics(diagnostics)
         message = _system_exit_message(exc)
         legacy_exit_code = exc.code if isinstance(exc.code, int) and exc.code else 1
-        if args.strict_exit_codes:
+        if isinstance(exc, cli_contract.MachineContractError):
+            details = dict(exc.details)
+            details.update(
+                {
+                    'exit_code': legacy_exit_code,
+                    'semantic_exit_code': exc.semantic_exit_code,
+                }
+            )
+            envelope = cli_contract.error_envelope(
+                command,
+                code=exc.code_name,
+                message=message,
+                retryable=exc.retryable,
+                suggested_action=exc.suggested_action,
+                details=details,
+            )
+        elif args.strict_exit_codes:
             classification = cli_contract.classify_error(
                 message,
                 exception_type='SystemExit',

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -21,9 +21,84 @@ class BatchCliContractTests(unittest.TestCase):
                 strict_args = parser.parse_args(
                     [command, "--output", "json", "--strict-exit-codes"]
                 )
+                strict_invocation = parser.parse_args(
+                    [command, "--non-interactive", "--require-explicit-target"]
+                )
+                self.assertTrue(strict_invocation.non_interactive)
+                self.assertTrue(strict_invocation.require_explicit_target)
+
                 self.assertTrue(strict_args.strict_exit_codes)
 
+    def test_non_interactive_requires_explicit_manifest_target(self):
+        for command in sorted(batch.EXPLICIT_TARGET_COMMANDS):
+            with self.subTest(command=command):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with (
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    exit_code = batch.main(
+                        [
+                            command,
+                            "--output",
+                            "json",
+                            "--non-interactive",
+                            "--strict-exit-codes",
+                        ]
+                    )
+
+                payload = json.loads(stdout.getvalue())
+                self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+                self.assertEqual(
+                    payload["error"]["code"],
+                    "EXPLICIT_TARGET_REQUIRED",
+                )
+                self.assertEqual(
+                    payload["error"]["suggested_action"],
+                    "pass_manifest_path",
+                )
+                self.assertEqual(
+                    payload["error"]["details"]["required_argument"],
+                    "target",
+                )
+
+    def test_explicit_target_guard_is_opt_in_and_skips_targetless_commands(self):
+        parser = batch.build_arg_parser()
+        accepted = (
+            ["doctor", "--non-interactive"],
+            ["build", "--non-interactive"],
+            ["status"],
+            ["status", "manifest.json", "--non-interactive"],
+            ["apply", "manifest.json", "--require-explicit-target"],
+        )
+
+        for argv in accepted:
+            with self.subTest(argv=argv):
+                batch.validate_machine_invocation(parser.parse_args(argv))
+
+    def test_explicit_target_error_is_structured_without_strict_exit_codes(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "--output",
+                    "json",
+                    "--require-explicit-target",
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["error"]["code"], "EXPLICIT_TARGET_REQUIRED")
+        self.assertEqual(
+            payload["error"]["details"]["semantic_exit_code"],
+            batch.cli_contract.EXIT_INVALID_STATE,
+        )
+
     def test_machine_result_builder_covers_manifest_workflow(self):
+
         args = SimpleNamespace(target="")
         base_manifest = {
             "_manifest_path": "C:/jobs/demo/manifest.json",


### PR DESCRIPTION
## Summary

- add `--non-interactive` and `--require-explicit-target` to the seven core machine-output commands
- require an explicit manifest/package target for `submit`, `status`, `download`, `check`, and `apply` in deterministic Agent mode
- return a structured `EXPLICIT_TARGET_REQUIRED` error without weakening existing Batch safety gates
- preserve current latest-manifest and submit-build fallback when the new options are absent
- document the strict invocation contract for Agent, Batch, and GUI command references

## Behavior

`--non-interactive` guarantees the core workflow does not wait for stdin and implies an explicit target for manifest-consuming commands. `--require-explicit-target` enables only the target guard. `doctor` and `build` do not consume a manifest and remain targetless.

With `--output json --strict-exit-codes`, a missing target returns exit `5`, `error.code=EXPLICIT_TARGET_REQUIRED`, and `suggested_action=pass_manifest_path`.

## Validation

- targeted CLI contract tests — 24 passed
- `python -B tests/run_cli_tests.py -q` — 757 passed, 1 skipped
- `python scripts/run_quality_gates.py all`
- `git diff --check`

Part of #276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--non-interactive` mode to prevent prompts and require explicit targets for key batch commands.
  * Added `--require-explicit-target` to disable implicit manifest selection and fallback behavior.
  * Machine-readable errors now include structured codes, suggested actions, retry guidance, and semantic exit codes.

* **Documentation**
  * Updated batch workflow, GUI workbench, and agent quickstart documentation with the new command options and behavior.

* **Tests**
  * Added coverage for explicit-target validation, structured errors, and option combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->