### PR TITLE
Add Agent CLI machine discovery

### DIFF
--- a/cli_discovery.py
+++ b/cli_discovery.py
@@ -1,0 +1,134 @@
+"""Machine discovery derived from the live argparse command definitions."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+DISCOVERY_SCHEMA_VERSION = 1
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_value(item) for item in value]
+    return str(value)
+
+
+def _subparsers_action(parser: argparse.ArgumentParser) -> argparse.Action:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise ValueError("parser has no subcommands")
+
+
+def _command_summaries(action: argparse.Action) -> dict[str, str]:
+    return {
+        str(choice.dest): str(choice.help or "")
+        for choice in getattr(action, "_choices_actions", [])
+    }
+
+
+def _value_type(action: argparse.Action) -> str:
+    if action.nargs == 0 and isinstance(action.const, bool):
+        return "boolean"
+    if action.type is not None:
+        return str(getattr(action.type, "__name__", action.type))
+    if action.choices:
+        first = next(iter(action.choices), "")
+        return type(first).__name__ if first != "" else "string"
+    return "string"
+
+
+def _argument_schema(action: argparse.Action) -> dict[str, Any]:
+    positional = not action.option_strings
+    repeatable = action.__class__.__name__ in {"_AppendAction", "_AppendConstAction"}
+    nargs = 1 if action.nargs is None else action.nargs
+    return {
+        "name": str(action.dest),
+        "kind": "positional" if positional else "option",
+        "flags": list(action.option_strings),
+        "value_type": _value_type(action),
+        "required": bool(action.required),
+        "repeatable": repeatable,
+        "nargs": _json_value(nargs),
+        "choices": (
+            [_json_value(item) for item in action.choices]
+            if action.choices is not None
+            else None
+        ),
+        "default": _json_value(action.default),
+        "help": str(action.help or ""),
+    }
+
+
+def command_schema(parser: argparse.ArgumentParser, command: str) -> dict[str, Any]:
+    """Return a stable machine schema for one live argparse subcommand."""
+
+    subparsers = _subparsers_action(parser)
+    choices = getattr(subparsers, "choices", {})
+    if command not in choices:
+        raise KeyError(command)
+    command_parser = choices[command]
+    summaries = _command_summaries(subparsers)
+    arguments = [
+        _argument_schema(action)
+        for action in command_parser._actions
+        if action.dest != "help"
+    ]
+    return {
+        "schema_version": DISCOVERY_SCHEMA_VERSION,
+        "type": "command_schema",
+        "command": command,
+        "description": summaries.get(command, ""),
+        "arguments": arguments,
+    }
+
+
+def capabilities(
+    parser: argparse.ArgumentParser,
+    *,
+    cli_version: str,
+    machine_output_commands: Sequence[str],
+    explicit_target_commands: Sequence[str],
+    result_schema_version: int,
+) -> dict[str, Any]:
+    """Return the command index and supported Agent-facing contracts."""
+
+    subparsers = _subparsers_action(parser)
+    choices = getattr(subparsers, "choices", {})
+    summaries = _command_summaries(subparsers)
+    machine_commands = set(machine_output_commands)
+    explicit_commands = set(explicit_target_commands)
+    discovery_commands = {"capabilities", "schema"}
+    commands = []
+    for name in sorted(choices):
+        action_dests = {
+            action.dest
+            for action in choices[name]._actions
+            if action.dest != "help"
+        }
+        commands.append(
+            {
+                "name": name,
+                "description": summaries.get(name, ""),
+                "machine_output": name in machine_commands or name in discovery_commands,
+                "supports_json": "output" in action_dests or name in discovery_commands,
+                "supports_strict_exit_codes": "strict_exit_codes" in action_dests,
+                "supports_non_interactive": "non_interactive" in action_dests,
+                "requires_explicit_target_in_agent_mode": name in explicit_commands,
+            }
+        )
+    return {
+        "schema_version": DISCOVERY_SCHEMA_VERSION,
+        "type": "capabilities",
+        "cli_version": str(cli_version),
+        "result_schema_version": int(result_schema_version),
+        "command_count": len(commands),
+        "commands": commands,
+    }

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -52,6 +52,10 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 只需关闭 target 回退时可单独使用 `--require-explicit-target`。默认模式保持现有 latest-manifest 和 submit-build 行为；`doctor / build` 不消费 manifest，不受显式 target 要求影响。
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
+机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
+
+Discovery schema 与核心结果 envelope 当前都使用 `schema_version=1`，但通过顶层 `type`（`capabilities` / `command_schema`）区分用途。
+
 - `gemini_translate_batch.py` 需要显式子命令；不带子命令会打印帮助并退出。
 - Batch 产物默认写到 `logs/batch_jobs/<package>/`。
 - `doctor` 只检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，不调用 Gemini，也不会写回 `.rpy`。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -152,7 +152,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 **上方内层 Tab**（`任务上下文` / `命令参考` / `任务记录`）：
 
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
-- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
+- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。Agent 还可通过 `capabilities` 和 `schema <command>` 直接读取当前 argparse 生成的机器命令索引与参数 schema，GUI 不复制维护另一份命令定义。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -86,6 +86,23 @@ python gemini_translate_batch.py status <manifest> --output json --non-interacti
 如果只想禁止 target 回退、但不需要声明完整非交互契约，可使用 `--require-explicit-target`。`doctor` 与 `build` 本来不消费 manifest，因此这两个命令在非交互模式下不要求 target。
 
 默认模式保持兼容：未传这两个新选项时，现有 latest-manifest 与 submit-build 回退仍然可用。Agent 应优先使用 `--output json --non-interactive --strict-exit-codes`，并始终显式传递同一 manifest。
+
+## 机器发现
+
+Agent 可在不加载项目配置、不读取 API Key、也不触发 workflow 的情况下查询当前 CLI：
+
+```powershell
+python gemini_translate_batch.py capabilities
+python gemini_translate_batch.py schema status
+```
+
+两个命令都直接向 stdout 输出 `schema_version=1` 的 JSON：
+
+- `capabilities` 返回 CLI 版本、结果契约版本、完整命令索引，以及每个命令是否支持 JSON、严格退出码、非交互和显式 target；
+- `schema <command>` 返回该命令当前的 positional/options、类型、required、repeatable、choices、默认值和帮助文本；
+- schema 直接从现行 argparse 定义生成，`--help` 仍是人类阅读的事实来源，不维护第二份手写命令表。
+
+没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪选项另行演进，不属于 discovery schema 的隐藏行为。
 没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
 
 ## 1. 安装核心依赖

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -34,6 +34,7 @@ import batch_cost_estimate
 import batch_non_chinese_rules
 import batch_submit_recovery
 import cli_contract
+import cli_discovery
 import doctor_recommendations as doctor_rec
 import keyword_glossary_merge
 import prompt_context
@@ -11014,6 +11015,20 @@ def build_arg_parser():
     repair_parser.add_argument('--context-before', type=int, default=2, help='How many prior nearby entries to include as context.')
     repair_parser.add_argument('--context-after', type=int, default=2, help='How many following nearby entries to include as context.')
     repair_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
+    subparsers.add_parser(
+        'capabilities',
+        help='Print machine-readable CLI capabilities and the command index.',
+    )
+    schema_parser = subparsers.add_parser(
+        'schema',
+        help='Print the machine-readable argparse schema for one command.',
+    )
+    schema_parser.add_argument(
+        'schema_command',
+        choices=sorted(subparsers.choices),
+        help='Command whose current argparse schema should be returned.',
+    )
+
 
     return parser
 
@@ -11041,6 +11056,22 @@ def dispatch_command(parser, args):
     if command is None:
         parser.print_help()
         return
+    if command == 'capabilities':
+        payload = cli_discovery.capabilities(
+            parser,
+            cli_version=__version__,
+            machine_output_commands=MACHINE_OUTPUT_COMMANDS,
+            explicit_target_commands=EXPLICIT_TARGET_COMMANDS,
+            result_schema_version=cli_contract.CLI_SCHEMA_VERSION,
+        )
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return payload
+
+    if command == 'schema':
+        payload = cli_discovery.command_schema(parser, args.schema_command)
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return payload
+
 
     if command in MACHINE_OUTPUT_COMMANDS:
         validate_machine_invocation(args)

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -1,0 +1,93 @@
+import contextlib
+import io
+import json
+import unittest
+from unittest import mock
+
+import cli_discovery
+import gemini_translate_batch as batch
+
+
+class CliDiscoveryTests(unittest.TestCase):
+    def test_capabilities_lists_live_commands_without_loading_project_config(self):
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch.legacy, "load_config") as load_config,
+            mock.patch.object(batch.legacy, "load_translator_settings") as load_settings,
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(["capabilities"])
+
+        payload = json.loads(stdout.getvalue())
+        names = {item["name"] for item in payload["commands"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["type"], "capabilities")
+        self.assertEqual(payload["command_count"], len(names))
+        self.assertIn("capabilities", names)
+        self.assertIn("schema", names)
+        self.assertNotIn("commands", names)
+        capabilities = {
+            item["name"]: item for item in payload["commands"]
+        }["capabilities"]
+        self.assertTrue(capabilities["machine_output"])
+        self.assertTrue(capabilities["supports_json"])
+        load_config.assert_not_called()
+        load_settings.assert_not_called()
+
+    def test_capabilities_derive_agent_support_from_current_parser(self):
+        parser = batch.build_arg_parser()
+
+        payload = cli_discovery.capabilities(
+            parser,
+            cli_version="test",
+            machine_output_commands=batch.MACHINE_OUTPUT_COMMANDS,
+            explicit_target_commands=batch.EXPLICIT_TARGET_COMMANDS,
+            result_schema_version=batch.cli_contract.CLI_SCHEMA_VERSION,
+        )
+
+        commands = {item["name"]: item for item in payload["commands"]}
+        self.assertTrue(commands["status"]["supports_json"])
+        self.assertTrue(commands["status"]["supports_strict_exit_codes"])
+        self.assertTrue(commands["status"]["supports_non_interactive"])
+        self.assertTrue(commands["status"]["requires_explicit_target_in_agent_mode"])
+        self.assertFalse(commands["build"]["requires_explicit_target_in_agent_mode"])
+        self.assertFalse(commands["split"]["supports_json"])
+
+    def test_schema_exports_live_argument_contract(self):
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            exit_code = batch.main(["schema", "status"])
+
+        payload = json.loads(stdout.getvalue())
+        arguments = {item["name"]: item for item in payload["arguments"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["type"], "command_schema")
+        self.assertEqual(payload["command"], "status")
+        self.assertEqual(arguments["target"]["kind"], "positional")
+        self.assertEqual(arguments["target"]["nargs"], "?")
+        self.assertEqual(arguments["output"]["choices"], ["text", "json"])
+        self.assertEqual(arguments["non_interactive"]["value_type"], "boolean")
+
+    def test_schema_preserves_required_and_repeatable_arguments(self):
+        parser = batch.build_arg_parser()
+
+        ingest = cli_discovery.command_schema(
+            parser,
+            "project-analysis-ingest-keywords",
+        )
+        structure = cli_discovery.command_schema(
+            parser,
+            "project-analysis-build-structure",
+        )
+
+        ingest_args = {item["name"]: item for item in ingest["arguments"]}
+        structure_args = {item["name"]: item for item in structure["arguments"]}
+        self.assertTrue(ingest_args["summary_jsonl"]["required"])
+        self.assertTrue(structure_args["script_root"]["repeatable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `capabilities` for a machine-readable CLI command index and Agent-facing feature flags
- add `schema <command>` to export the live argparse argument contract
- derive discovery output from the current parser instead of maintaining a second command table
- keep discovery config-free and side-effect-free
- document the discovery workflow for Agent, Batch, and GUI command references

## Design

`capabilities.commands` replaces a separate `commands` subcommand. `schema <command>` exposes positional/options, types, required/repeatable state, choices, defaults, and help text. Output trimming remains a later #276 stage.

## Validation

- targeted discovery/CLI contract tests — 28 passed
- `python -B tests/run_cli_tests.py -q` — 761 passed, 1 skipped
- `python scripts/run_quality_gates.py all`
- `git diff --check`

Part of #276.