### PR TITLE
Add Agent CLI output trimming

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -14,6 +14,7 @@ from typing import Any, TextIO
 
 
 CLI_SCHEMA_VERSION = 1
+_MISSING = object()
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -241,15 +242,56 @@ def error_envelope(
     }
 
 
-def write_json_envelope(envelope: Mapping[str, Any], stream: TextIO) -> None:
+def project_fields(
+    document: Mapping[str, Any],
+    field_paths: Sequence[str],
+) -> dict[str, Any]:
+    """Project a JSON object using dot-separated mapping paths.
+
+    Missing paths are omitted so callers can request optional fields across
+    workflow states without treating their absence as a command failure.
+    """
+
+    source = _json_compatible(dict(document))
+    projected: dict[str, Any] = {}
+    for raw_path in field_paths:
+        parts = [part.strip() for part in str(raw_path).split(".")]
+        if not parts or any(not part for part in parts):
+            raise ValueError(f"Invalid field path: {raw_path!r}")
+        value: Any = source
+        for part in parts:
+            if not isinstance(value, Mapping) or part not in value:
+                value = _MISSING
+                break
+            value = value[part]
+        if value is _MISSING:
+            continue
+        target = projected
+        for part in parts[:-1]:
+            existing = target.get(part)
+            if not isinstance(existing, dict):
+                existing = {}
+                target[part] = existing
+            target = existing
+        target[parts[-1]] = value
+    return projected
+
+
+def write_json_envelope(
+    envelope: Mapping[str, Any],
+    stream: TextIO,
+    *,
+    compact: bool = False,
+) -> None:
     """Write exactly one JSON document followed by a newline."""
 
     json.dump(
         _json_compatible(dict(envelope)),
         stream,
         ensure_ascii=False,
-        indent=2,
+        indent=None if compact else 2,
         sort_keys=True,
+        separators=(",", ":") if compact else None,
     )
     stream.write("\n")
     stream.flush()

--- a/cli_discovery.py
+++ b/cli_discovery.py
@@ -121,6 +121,9 @@ def capabilities(
                 "supports_json": "output" in action_dests or name in discovery_commands,
                 "supports_strict_exit_codes": "strict_exit_codes" in action_dests,
                 "supports_non_interactive": "non_interactive" in action_dests,
+                "supports_compact": "compact" in action_dests,
+                "supports_fields": "fields" in action_dests,
+                "supports_output_file": "output_file" in action_dests,
                 "requires_explicit_target_in_agent_mode": name in explicit_commands,
             }
         )

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -53,6 +53,9 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
+核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.safety_level` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。
+`capabilities / schema` 也支持这三个选项；它们原生输出 JSON，因此无需 `--output json`。
+
 
 Discovery schema 与核心结果 envelope 当前都使用 `schema_version=1`，但通过顶层 `type`（`capabilities` / `command_schema`）区分用途。
 

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -152,7 +152,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 **上方内层 Tab**（`任务上下文` / `命令参考` / `任务记录`）：
 
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
-- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。Agent 还可通过 `capabilities` 和 `schema <command>` 直接读取当前 argparse 生成的机器命令索引与参数 schema，GUI 不复制维护另一份命令定义。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
+- **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。机器结果还可用 `--compact`、`--fields` 和 `--output-file` 限制终端上下文或原子落盘。Agent 可通过 `capabilities` 和 `schema <command>` 直接读取当前 argparse 生成的机器命令索引、参数 schema 和这些能力标记，GUI 不复制维护另一份命令定义。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -87,7 +87,37 @@ python gemini_translate_batch.py status <manifest> --output json --non-interacti
 
 默认模式保持兼容：未传这两个新选项时，现有 latest-manifest 与 submit-build 回退仍然可用。Agent 应优先使用 `--output json --non-interactive --strict-exit-codes`，并始终显式传递同一 manifest。
 
+## 输出裁剪与文件输出
+
+七个核心 JSON 命令还支持三个可组合选项：
+
+```powershell
+python gemini_translate_batch.py status <manifest> --output json --compact
+python gemini_translate_batch.py check <manifest> --output json --fields command status result.check.safety_level artifacts.manifest
+python gemini_translate_batch.py status <manifest> --output json --output-file .\status.json
+```
+
+- `--compact` 移除缩进和多余空格，但仍输出一个以换行结尾的合法 JSON 文档；
+- `--fields` 使用点路径投影结果，保留嵌套结构；可一次传入多个路径、用逗号分隔，或重复传入该选项；
+- 请求的可选路径不存在时会被省略，命令不会因此失败；列表不支持按下标继续投影，应选择整个列表字段；
+- `--output-file` 将最终 JSON 原子写入指定路径，并保持 stdout 为空；父目录会按需创建；
+- 文件中的 `artifacts.output_file` 记录绝对输出路径，除非 `--fields` 主动将它裁掉；
+- 三个选项都必须显式配合 `--output json`，不会改变文本模式。
+
+字段投影只改变展示形状，不改变命令执行结果或严格退出码。例如 `check` 返回 `warn` 时，即使只输出 `status`，配合 `--strict-exit-codes` 仍退出 `3`。需要稳定 envelope 时不要使用 `--fields`；需要最小上下文时应至少选择 `command / ok / status / error` 以及当前动作所需的 `result`、`artifacts` 路径。
+
+`--output-file` 适合把结果交给后续脚本或避免终端上下文膨胀：
+
+```powershell
+python gemini_translate_batch.py check <manifest> `
+  --output json --non-interactive --strict-exit-codes `
+  --compact --output-file .\check-result.json
+```
+
+命令的业务退出码保持不变；调用方随后读取自己传入的文件路径。若文件无法创建或原子替换，命令失败并把诊断写入 stderr。
+
 ## 机器发现
+
 
 Agent 可在不加载项目配置、不读取 API Key、也不触发 workflow 的情况下查询当前 CLI：
 
@@ -100,9 +130,12 @@ python gemini_translate_batch.py schema status
 
 - `capabilities` 返回 CLI 版本、结果契约版本、完整命令索引，以及每个命令是否支持 JSON、严格退出码、非交互和显式 target；
 - `schema <command>` 返回该命令当前的 positional/options、类型、required、repeatable、choices、默认值和帮助文本；
+- `capabilities.commands` 也声明各命令是否支持 compact、字段投影和文件输出；`schema` 给出这些选项的实时 argparse 形状；
 - schema 直接从现行 argparse 定义生成，`--help` 仍是人类阅读的事实来源，不维护第二份手写命令表。
 
-没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪选项另行演进，不属于 discovery schema 的隐藏行为。
+`capabilities` 与 `schema` 本身就是 JSON 命令，也接受 `--compact / --fields / --output-file`，但不需要也不提供冗余的 `--output json`。
+
+没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪是公开参数，不存在 discovery schema 之外的隐藏 Agent 行为。
 没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式只承诺覆盖上面的七个核心命令；其他子命令以各自 `--help` 和落盘产物为准。
 
 ## 1. 安装核心依赖

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -20,6 +20,7 @@ if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
 from atomic_io import (
+    atomic_write,
     atomic_write_json,
     atomic_write_jsonl,
     atomic_write_many_lines,
@@ -10243,6 +10244,32 @@ def print_banner():
     print('=' * 60)
 
 
+def add_json_shaping_arguments(command_parser):
+    command_parser.add_argument(
+        '--compact',
+        action='store_true',
+        help='Emit JSON without indentation or extra spaces.',
+    )
+    command_parser.add_argument(
+        '--fields',
+        action='append',
+        nargs='+',
+        default=[],
+        metavar='PATH',
+        help=(
+            'Project JSON output to dot-separated field paths. May be repeated; '
+            'comma-separated paths are also accepted.'
+        ),
+    )
+    command_parser.add_argument(
+        '--output-file',
+        default='',
+        metavar='PATH',
+        help='Atomically write the final JSON document to PATH instead of stdout.',
+    )
+    return command_parser
+
+
 def add_machine_output_argument(command_parser):
     command_parser.add_argument(
         '--output',
@@ -10274,7 +10301,7 @@ def add_machine_output_argument(command_parser):
             'that consume a manifest.'
         ),
     )
-    return command_parser
+    return add_json_shaping_arguments(command_parser)
 
 
 def build_arg_parser():
@@ -11015,10 +11042,11 @@ def build_arg_parser():
     repair_parser.add_argument('--context-before', type=int, default=2, help='How many prior nearby entries to include as context.')
     repair_parser.add_argument('--context-after', type=int, default=2, help='How many following nearby entries to include as context.')
     repair_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
-    subparsers.add_parser(
+    capabilities_parser = subparsers.add_parser(
         'capabilities',
         help='Print machine-readable CLI capabilities and the command index.',
     )
+    add_json_shaping_arguments(capabilities_parser)
     schema_parser = subparsers.add_parser(
         'schema',
         help='Print the machine-readable argparse schema for one command.',
@@ -11028,6 +11056,7 @@ def build_arg_parser():
         choices=sorted(subparsers.choices),
         help='Command whose current argparse schema should be returned.',
     )
+    add_json_shaping_arguments(schema_parser)
 
 
     return parser
@@ -11064,12 +11093,12 @@ def dispatch_command(parser, args):
             explicit_target_commands=EXPLICIT_TARGET_COMMANDS,
             result_schema_version=cli_contract.CLI_SCHEMA_VERSION,
         )
-        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        _write_json_payload(payload, args)
         return payload
 
     if command == 'schema':
         payload = cli_discovery.command_schema(parser, args.schema_command)
-        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        _write_json_payload(payload, args)
         return payload
 
 
@@ -11700,6 +11729,47 @@ def _system_exit_message(exc):
     return 'Command stopped before producing a result.'
 
 
+def _machine_field_paths(args):
+    paths = []
+    for group in getattr(args, 'fields', []) or []:
+        values = group if isinstance(group, (list, tuple)) else [group]
+        for value in values:
+            paths.extend(
+                item.strip()
+                for item in str(value).split(',')
+                if item.strip()
+            )
+    return list(dict.fromkeys(paths))
+
+
+def _write_json_payload(document, args, *, record_output_artifact=False):
+    output_file = str(getattr(args, 'output_file', '') or '').strip()
+    payload = dict(document)
+    if output_file and record_output_artifact:
+        payload['artifacts'] = dict(payload.get('artifacts') or {})
+        payload['artifacts']['output_file'] = os.path.abspath(output_file)
+    field_paths = _machine_field_paths(args)
+    if field_paths:
+        payload = cli_contract.project_fields(payload, field_paths)
+
+    compact = bool(getattr(args, 'compact', False))
+    if output_file:
+        atomic_write(
+            output_file,
+            lambda stream: cli_contract.write_json_envelope(
+                payload,
+                stream,
+                compact=compact,
+            ),
+        )
+        return
+    cli_contract.write_json_envelope(payload, sys.stdout, compact=compact)
+
+
+def _write_machine_envelope(envelope, args):
+    _write_json_payload(envelope, args, record_output_artifact=True)
+
+
 def run_machine_command(parser, args):
     """Run one supported command with clean JSON stdout and text diagnostics."""
 
@@ -11752,7 +11822,7 @@ def run_machine_command(parser, args):
                 message=message,
                 details={'exit_code': legacy_exit_code},
             )
-        cli_contract.write_json_envelope(envelope, sys.stdout)
+        _write_machine_envelope(envelope, args)
         if args.strict_exit_codes:
             return cli_contract.strict_exit_code(envelope)
         return legacy_exit_code
@@ -11784,13 +11854,13 @@ def run_machine_command(parser, args):
                 message=message,
                 details={'exception_type': exception_type},
             )
-        cli_contract.write_json_envelope(envelope, sys.stdout)
+        _write_machine_envelope(envelope, args)
         if args.strict_exit_codes:
             return cli_contract.strict_exit_code(envelope)
         return 1
 
     _write_machine_diagnostics(diagnostics)
-    cli_contract.write_json_envelope(envelope, sys.stdout)
+    _write_machine_envelope(envelope, args)
     if args.strict_exit_codes:
         return cli_contract.strict_exit_code(envelope)
     return 0
@@ -11800,8 +11870,21 @@ def main(argv=None):
     parser = build_arg_parser()
     args = parser.parse_args(argv)
     output = getattr(args, 'output', 'text')
-    if getattr(args, 'strict_exit_codes', False) and output != 'json':
-        parser.error('--strict-exit-codes requires --output json')
+    json_only_options = []
+    if getattr(args, 'strict_exit_codes', False):
+        json_only_options.append('--strict-exit-codes')
+    if getattr(args, 'compact', False):
+        json_only_options.append('--compact')
+    if getattr(args, 'fields', None):
+        json_only_options.append('--fields')
+    if getattr(args, 'output_file', ''):
+        json_only_options.append('--output-file')
+    if (
+        json_only_options
+        and output != 'json'
+        and args.command not in {'capabilities', 'schema'}
+    ):
+        parser.error(f"{', '.join(json_only_options)} requires --output json")
     if output == 'json':
         if args.command not in MACHINE_OUTPUT_COMMANDS:
             cli_contract.write_json_envelope(

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -52,6 +52,44 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(json.loads(stream.getvalue()), envelope)
         self.assertTrue(stream.getvalue().endswith("\n"))
 
+    def test_write_json_envelope_supports_compact_serialization(self):
+        stream = io.StringIO()
+        envelope = cli_contract.success_envelope("status", status="pending")
+
+        cli_contract.write_json_envelope(envelope, stream, compact=True)
+
+        self.assertEqual(json.loads(stream.getvalue()), envelope)
+        self.assertNotIn("\n  ", stream.getvalue())
+        self.assertNotIn(": ", stream.getvalue())
+        self.assertTrue(stream.getvalue().endswith("\n"))
+
+    def test_project_fields_preserves_nested_shape_and_omits_missing_paths(self):
+        envelope = cli_contract.success_envelope(
+            "check",
+            status="warn",
+            result={"check": {"safety_level": "warn", "failure_items": 2}},
+            artifacts={"manifest": "manifest.json"},
+        )
+
+        projected = cli_contract.project_fields(
+            envelope,
+            [
+                "command",
+                "status",
+                "result.check.safety_level",
+                "artifacts.missing",
+            ],
+        )
+
+        self.assertEqual(
+            projected,
+            {
+                "command": "check",
+                "status": "warn",
+                "result": {"check": {"safety_level": "warn"}},
+            },
+        )
+
     def test_error_classification_exposes_stable_machine_actions(self):
         stale = cli_contract.classify_error(
             "Manifest or results changed after the last check.",

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -33,8 +33,28 @@ class CliDiscoveryTests(unittest.TestCase):
         }["capabilities"]
         self.assertTrue(capabilities["machine_output"])
         self.assertTrue(capabilities["supports_json"])
+        self.assertTrue(capabilities["supports_compact"])
+        self.assertTrue(capabilities["supports_fields"])
+        self.assertTrue(capabilities["supports_output_file"])
         load_config.assert_not_called()
         load_settings.assert_not_called()
+
+    def test_discovery_output_can_be_compacted_and_projected(self):
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            exit_code = batch.main(
+                [
+                    "capabilities",
+                    "--compact",
+                    "--fields",
+                    "type,command_count",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(set(json.loads(stdout.getvalue())), {"type", "command_count"})
+        self.assertNotIn(": ", stdout.getvalue())
 
     def test_capabilities_derive_agent_support_from_current_parser(self):
         parser = batch.build_arg_parser()
@@ -51,6 +71,9 @@ class CliDiscoveryTests(unittest.TestCase):
         self.assertTrue(commands["status"]["supports_json"])
         self.assertTrue(commands["status"]["supports_strict_exit_codes"])
         self.assertTrue(commands["status"]["supports_non_interactive"])
+        self.assertTrue(commands["status"]["supports_compact"])
+        self.assertTrue(commands["status"]["supports_fields"])
+        self.assertTrue(commands["status"]["supports_output_file"])
         self.assertTrue(commands["status"]["requires_explicit_target_in_agent_mode"])
         self.assertFalse(commands["build"]["requires_explicit_target_in_agent_mode"])
         self.assertFalse(commands["split"]["supports_json"])
@@ -70,6 +93,8 @@ class CliDiscoveryTests(unittest.TestCase):
         self.assertEqual(arguments["target"]["nargs"], "?")
         self.assertEqual(arguments["output"]["choices"], ["text", "json"])
         self.assertEqual(arguments["non_interactive"]["value_type"], "boolean")
+        self.assertTrue(arguments["fields"]["repeatable"])
+        self.assertEqual(arguments["fields"]["nargs"], "+")
 
     def test_schema_preserves_required_and_repeatable_arguments(self):
         parser = batch.build_arg_parser()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1,7 +1,9 @@
 import contextlib
 import io
 import json
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -28,6 +30,122 @@ class BatchCliContractTests(unittest.TestCase):
                 self.assertTrue(strict_invocation.require_explicit_target)
 
                 self.assertTrue(strict_args.strict_exit_codes)
+
+    def test_core_commands_expose_output_trimming_arguments(self):
+        parser = batch.build_arg_parser()
+
+        args = parser.parse_args(
+            [
+                "status",
+                "manifest.json",
+                "--output",
+                "json",
+                "--compact",
+                "--fields",
+                "status",
+                "result.job_state,artifacts.manifest",
+                "--output-file",
+                "result.json",
+            ]
+        )
+
+        self.assertTrue(args.compact)
+        self.assertEqual(
+            batch._machine_field_paths(args),
+            ["status", "result.job_state", "artifacts.manifest"],
+        )
+        self.assertEqual(args.output_file, "result.json")
+
+    def test_compact_fields_project_machine_stdout(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "job_state": "JOB_STATE_PENDING",
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--fields",
+                    "command,status,result.job_state,artifacts.manifest",
+                    "--compact",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {
+                "command": "status",
+                "status": "JOB_STATE_PENDING",
+                "result": {"job_state": "JOB_STATE_PENDING"},
+                "artifacts": {"manifest": "C:/jobs/demo/manifest.json"},
+            },
+        )
+        self.assertNotIn(": ", stdout.getvalue())
+    def test_field_projection_does_not_change_strict_exit_code(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "last_check_summary": {"safety_level": "warn"},
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "check",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--strict-exit-codes",
+                    "--fields",
+                    "status",
+                ]
+            )
+
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_NEEDS_ACTION)
+        self.assertEqual(json.loads(stdout.getvalue()), {"status": "warn"})
+
+    def test_output_file_is_atomic_and_leaves_stdout_empty(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "job_state": "JOB_STATE_SUCCEEDED",
+        }
+        stdout = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = Path(tmp) / "nested" / "status.json"
+            with (
+                mock.patch.object(batch, "dispatch_command", return_value=manifest),
+                contextlib.redirect_stdout(stdout),
+            ):
+                exit_code = batch.main(
+                    [
+                        "status",
+                        "manifest.json",
+                        "--output",
+                        "json",
+                        "--output-file",
+                        str(output_path),
+                    ]
+                )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(payload["status"], "JOB_STATE_SUCCEEDED")
+        self.assertEqual(payload["artifacts"]["output_file"], str(output_path))
 
     def test_non_interactive_requires_explicit_manifest_target(self):
         for command in sorted(batch.EXPLICIT_TARGET_COMMANDS):
@@ -479,6 +597,23 @@ class BatchCliContractTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("requires --output json", stderr.getvalue())
+
+    def test_output_trimming_options_require_json_output(self):
+        cases = (
+            ["doctor", "--compact"],
+            ["doctor", "--fields", "status"],
+            ["doctor", "--output-file", "result.json"],
+        )
+
+        for argv in cases:
+            with self.subTest(argv=argv):
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    with self.assertRaises(SystemExit) as raised:
+                        batch.main(argv)
+
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn("requires --output json", stderr.getvalue())
 
     def test_text_mode_preserves_human_stdout(self):
         stdout = io.StringIO()


### PR DESCRIPTION
## Summary

- add `--compact` for low-token JSON serialization
- add repeatable/comma-separated `--fields` projection with nested dot paths
- add atomic `--output-file` support that leaves stdout empty
- preserve semantic exit codes independently of projected output shape
- expose the same controls on the seven core JSON commands and `capabilities` / `schema`
- publish support flags through machine discovery and document the behavior for Agent, Batch, and GUI command references

## Behavior

Field projection omits unavailable optional paths and preserves nested object shape. File output creates parent directories, atomically replaces the destination, and records the absolute path in core result envelopes unless projected out. Discovery commands are already JSON-native, so their shaping options do not require `--output json`.

Text mode and workflow safety semantics remain unchanged.

## Validation

- targeted CLI contract/discovery tests — 36 passed
- `python -B tests/run_cli_tests.py -q` — 769 passed, 1 skipped
- `python scripts/run_quality_gates.py all`
- `git diff --check`

Part of #276.