### PR TITLE
Reuse CLI JSON contract in GUI workflows

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -12,7 +12,6 @@ from collections.abc import Mapping, Sequence
 from os import PathLike
 from typing import Any, TextIO
 
-
 CLI_SCHEMA_VERSION = 1
 _MISSING = object()
 
@@ -22,6 +21,40 @@ EXIT_NEEDS_ACTION = 3
 EXIT_BLOCKED = 4
 EXIT_INVALID_STATE = 5
 EXIT_RETRYABLE = 6
+
+
+def parse_result_envelope(text: str) -> dict[str, Any]:
+    """Parse and validate one versioned CLI result envelope."""
+
+    try:
+        document = json.loads(text)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("CLI output is not a valid JSON result envelope.") from exc
+    if not isinstance(document, Mapping):
+        raise ValueError("CLI result envelope must be a JSON object.")
+    if document.get("schema_version") != CLI_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported CLI result schema version: {document.get('schema_version')!r}."
+        )
+    if not isinstance(document.get("command"), str) or not document["command"]:
+        raise ValueError("CLI result envelope is missing command.")
+    if not isinstance(document.get("ok"), bool):
+        raise ValueError("CLI result envelope is missing boolean ok.")
+    if not isinstance(document.get("status"), str):
+        raise ValueError("CLI result envelope is missing status.")
+    for field in ("result", "artifacts"):
+        if not isinstance(document.get(field), Mapping):
+            raise ValueError(f"CLI result envelope field {field!r} must be an object.")
+    if not isinstance(document.get("warnings"), list):
+        raise ValueError("CLI result envelope field 'warnings' must be an array.")
+    error = document.get("error")
+    if document["ok"]:
+        if error is not None:
+            raise ValueError("Successful CLI result envelope must not contain an error.")
+    elif not isinstance(error, Mapping):
+        raise ValueError("Failed CLI result envelope must contain an error object.")
+    return dict(document)
+
 
 class MachineContractError(SystemExit):
     """Structured refusal raised by opt-in machine invocation guards."""
@@ -42,7 +75,6 @@ class MachineContractError(SystemExit):
         self.semantic_exit_code = int(semantic_exit_code)
         self.retryable = bool(retryable)
         self.details = dict(details or {})
-
 
 
 def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -12,6 +12,7 @@
 
 - 普通用户走「项目与环境 → 设置 → 检查 → 翻译 → 写回」；任务页保留当前操作和状态，完整日志、任务上下文与命令参考集中在「诊断与运行日志」。
 - 底层仍调用现有 CLI 脚本，不重写翻译核心：**批量翻译**走 `gemini_translate_batch.py`；**同步翻译**走 `gemini_translate.py`。
+- GUI 调用 Batch 的 `build / submit / status / download / check / apply` 时，使用版本化 JSON envelope 读取结果、状态、制品和错误；stdout 只承载结构化结果，stderr 的进度与诊断继续进入「运行日志」。旧版文本输出解析仅保留为兼容回退。
 - **开发与功能约定**：新能力须 CLI / GUI 同步交付，见根目录 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 - 配置仍用 `api_keys.json`、`translator_config.json`；批量写回以 CLI 的 `check -> apply` 安全合约为准，同步模式按脚本规则直接写回。
 - GUI 依赖在 `requirements-gui.txt`，不进入主 `requirements.txt`。**不装图形界面时，命令行工具可照常使用。**

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -11700,6 +11700,7 @@ def build_machine_success_envelope(command, value, args):
         status = str(check_summary.get('safety_level') or 'unknown')
     elif command == 'apply':
         result['apply'] = dict(manifest.get('apply_summary') or {})
+        result['apply']['next_split_manifest'] = manifest.get('next_split_manifest_path', '')
         status = 'applied' if manifest.get('applied_at') else 'completed'
 
     return cli_contract.success_envelope(

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -76,6 +76,7 @@ from PySide6.QtWidgets import (
     QToolButton,
 )
 from project_version import __version__
+import cli_contract
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
 from .responsive_layout import FlowButtonBar, ResponsiveActionPanel
@@ -112,7 +113,9 @@ from .check_report import (
     recheck_writeback_ready,
     running_writeback_summary,
     stale_writeback_summary,
+    summarize_apply_envelope,
     summarize_apply_output,
+    summarize_check_envelope,
     summarize_check_output,
     summarize_manifest_writeback,
 )
@@ -675,6 +678,7 @@ class MainWindow(QMainWindow):
 
         # Connect runner
         self.runner.line_ready.connect(self._on_cli_line_ready)
+        self.runner.stdout_line_ready.connect(self._on_cli_stdout_line_ready)
         self.runner.finished.connect(self._on_finished)
         self.runner.error.connect(self._on_runner_error)
 
@@ -10983,7 +10987,7 @@ class MainWindow(QMainWindow):
         self._set_task_running(True)
         self.runner.run(
             self.state.get_batch_script_path(),
-            ["apply", manifest_path],
+            ["apply", manifest_path, "--output", "json", "--non-interactive"],
         )
 
     def _on_apply_sync_translation(self) -> None:
@@ -11115,20 +11119,25 @@ class MainWindow(QMainWindow):
 
     # --- Runner callbacks ---
 
+    def _on_cli_stdout_line_ready(self, text: str):
+        if self._active_command in {"translation_workflow", "project_analysis_workflow"}:
+            self._workflow_step_output_lines.append(text)
+        elif self._active_command == "apply":
+            self._apply_output_lines.append(text)
+        elif self._active_command == "recheck":
+            self._recheck_output_lines.append(text)
+
     def _on_cli_line_ready(self, text: str):
         if self._active_command == "doctor":
             self._doctor_output_lines.append(text)
         elif self._active_command in {"translation_workflow", "project_analysis_workflow"}:
-            self._workflow_step_output_lines.append(text)
             self._workflow_progress = update_workflow_progress_from_line(
                 text,
                 self._workflow_progress,
             )
             self._schedule_progress_ui_flush()
-        elif self._active_command == "apply":
-            self._apply_output_lines.append(text)
-        elif self._active_command == "recheck":
-            self._recheck_output_lines.append(text)
+        elif self._active_command in {"apply", "recheck"}:
+            pass
         elif self._active_command == "probe":
             self._probe_output_lines.append(text)
         elif self._active_command == "compare_variants":
@@ -11446,12 +11455,24 @@ class MainWindow(QMainWindow):
                 already_applied = bool(manifest.get("applied_at"))
             except ValueError:
                 pass
-        summary = summarize_check_output(
-            output,
-            exit_code,
-            manifest_path=manifest_path,
-            already_applied=already_applied,
-        )
+        try:
+            envelope = cli_contract.parse_result_envelope(output)
+        except ValueError:
+            envelope = None
+        if envelope is not None:
+            summary = summarize_check_envelope(
+                envelope,
+                exit_code,
+                manifest_path=manifest_path,
+                already_applied=already_applied,
+            )
+        else:
+            summary = summarize_check_output(
+                output,
+                exit_code,
+                manifest_path=manifest_path,
+                already_applied=already_applied,
+            )
         self._set_writeback_summary(summary)
         self._refresh_diagnostics_context()
         if summary.status not in {"idle", "running", "stale"}:
@@ -11528,11 +11549,23 @@ class MainWindow(QMainWindow):
 
         if self._active_command == "apply":
             self._invalidate_manifest_caches(self._writeback_manifest_path or None)
-            summary = summarize_apply_output(
-                "\n".join(self._apply_output_lines),
-                exit_code,
-                manifest_path=self._writeback_manifest_path,
-            )
+            apply_output = "\n".join(self._apply_output_lines)
+            try:
+                envelope = cli_contract.parse_result_envelope(apply_output)
+            except ValueError:
+                envelope = None
+            if envelope is not None:
+                summary = summarize_apply_envelope(
+                    envelope,
+                    exit_code,
+                    manifest_path=self._writeback_manifest_path,
+                )
+            else:
+                summary = summarize_apply_output(
+                    apply_output,
+                    exit_code,
+                    manifest_path=self._writeback_manifest_path,
+                )
             self._set_writeback_summary(summary)
             self._refresh_diagnostics_context()
             if exit_code == 0:

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -500,6 +500,22 @@ _SETTINGS_LAZY_ATTR_TO_PAGE: dict[str, str] = {
 }
 
 
+def _workflow_output_updates_writeback(step_key: str, output: str) -> bool:
+    """Return whether a completed workflow step carries a check result."""
+
+    try:
+        envelope = cli_contract.parse_result_envelope(output)
+    except ValueError:
+        envelope = None
+    return bool(
+        (
+            envelope is not None
+            and envelope.get("command") == "check"
+            and envelope.get("status")
+        )
+        or step_key == "check-parent"
+    )
+
 class MainWindow(QMainWindow):
     def __init__(
         self,
@@ -12028,10 +12044,7 @@ class MainWindow(QMainWindow):
             if sync_candidates:
                 self._keyword_merge_candidates_path = sync_candidates
 
-        retry_parent = getattr(self._workflow, "retry_parent_manifest_path", "")
-        if "Safety status:" in step_output and (
-            step_key == "check-parent" or not retry_parent
-        ):
+        if _workflow_output_updates_writeback(step_key, step_output):
             self._update_writeback_from_check(step_output, exit_code, manifest_path)
         if self._uses_revision_writeback() and (
             "Preview JSONL:" in step_output or "Preview Markdown:" in step_output

--- a/gui_qt/batch_workflow_support.py
+++ b/gui_qt/batch_workflow_support.py
@@ -1,4 +1,5 @@
 """Shared Batch workflow helpers used by GUI and CLI argument planning."""
+
 from __future__ import annotations
 
 import json
@@ -62,6 +63,12 @@ def plan_unsubmitted_workflow_steps(manifest_path: str) -> list[str]:
     return ["submit", "status"]
 
 
+def machine_output_args(args: list[str]) -> list[str]:
+    """Request the shared non-interactive JSON result contract."""
+
+    return [*args, "--output", "json", "--non-interactive"]
+
+
 def build_submit_cli_args(
     manifest_path: str,
     submit_max_cost: float | None = None,
@@ -75,7 +82,7 @@ def build_submit_cli_args(
         args.append("--resume")
     if submit_max_cost is not None and submit_max_cost > 0:
         args.extend(["--max-cost", _format_max_cost(submit_max_cost)])
-    return args
+    return machine_output_args(args)
 
 
 def build_recover_submit_cli_args(manifest_path: str) -> list[str]:
@@ -184,6 +191,4 @@ def uncertain_submit_failure_message(output: str) -> str:
             "检测到输入文件已上传但尚未创建批量任务。"
             "请使用带 --resume 的 submit 继续创建任务，或使用 --force 重新开始。"
         )
-    return (
-        "提交被未完成状态拦截。请先恢复或确认上次提交，避免重复创建付费任务。"
-    )
+    return "提交被未完成状态拦截。请先恢复或确认上次提交，避免重复创建付费任务。"

--- a/gui_qt/check_report.py
+++ b/gui_qt/check_report.py
@@ -1,8 +1,10 @@
 """User-facing summaries for GUI check/apply commands."""
+
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
 
 from .summary_helpers import extend_facts_with_notices
 from .user_copy import format_manifest_path_fact, safety_level_label
@@ -78,6 +80,45 @@ def _format_check_finding(finding: str) -> str:
     if finding.startswith("[block] "):
         return f"[{safety_level_label('block')}] {finding[8:]}"
     return finding
+
+
+def summarize_check_envelope(
+    envelope: Mapping[str, object],
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+    already_applied: bool = False,
+) -> WritebackSummary:
+    """Build the GUI check summary from the shared CLI result envelope."""
+
+    if not envelope.get("ok"):
+        error = envelope.get("error")
+        message = error.get("message") if isinstance(error, Mapping) else ""
+        summary = summarize_check_output("", exit_code or 1, manifest_path=manifest_path)
+        if isinstance(message, str) and message.strip():
+            return replace(summary, message=message.strip())
+        return summary
+
+    result = envelope.get("result")
+    check = result.get("check") if isinstance(result, Mapping) else None
+    check_summary = dict(check) if isinstance(check, Mapping) else {}
+    check_summary.setdefault("safety_level", str(envelope.get("status") or ""))
+    manifest: dict[str, object] = {
+        "_manifest_path": manifest_path,
+        "last_check_summary": check_summary,
+    }
+    artifacts = envelope.get("artifacts")
+    if isinstance(artifacts, Mapping):
+        report_path = artifacts.get("check_report")
+        if isinstance(report_path, str) and report_path:
+            manifest["last_check_report_path"] = report_path
+    if already_applied:
+        manifest["applied_at"] = "structured_result"
+
+    summary = summarize_manifest_writeback(manifest)
+    if summary is not None:
+        return summary
+    return summarize_check_output("", exit_code, manifest_path=manifest_path)
 
 
 def summarize_check_output(
@@ -181,6 +222,40 @@ def summarize_check_output(
         can_apply=False,
         manifest_path=manifest_path,
     )
+
+
+def summarize_apply_envelope(
+    envelope: Mapping[str, object],
+    exit_code: int,
+    *,
+    manifest_path: str = "",
+) -> WritebackSummary:
+    """Build the GUI apply summary from the shared CLI result envelope."""
+
+    if not envelope.get("ok"):
+        error = envelope.get("error")
+        message = error.get("message") if isinstance(error, Mapping) else ""
+        summary = summarize_apply_output("", exit_code or 1, manifest_path=manifest_path)
+        if isinstance(message, str) and message.strip():
+            return replace(summary, message=message.strip())
+        return summary
+
+    result = envelope.get("result")
+    apply = result.get("apply") if isinstance(result, Mapping) else None
+    apply_summary = dict(apply) if isinstance(apply, Mapping) else {}
+    manifest: dict[str, object] = {
+        "_manifest_path": manifest_path,
+        "applied_at": "structured_result",
+        "apply_summary": apply_summary,
+    }
+    next_manifest = apply_summary.get("next_split_manifest")
+    if isinstance(next_manifest, str) and next_manifest:
+        manifest["next_split_manifest_path"] = next_manifest
+
+    summary = summarize_manifest_writeback(manifest)
+    if summary is not None:
+        return replace(summary, heading="翻译写回完成")
+    return summarize_apply_output("", exit_code, manifest_path=manifest_path)
 
 
 def summarize_apply_output(
@@ -304,9 +379,7 @@ def summarize_manifest_writeback(manifest: dict[str, object]) -> WritebackSummar
             reasons = safety_reasons.get(level)
             if isinstance(reasons, dict):
                 for name, count in sorted(reasons.items()):
-                    findings.append(
-                        f"[{safety_level_label(level)}] {name}: {count}"
-                    )
+                    findings.append(f"[{safety_level_label(level)}] {name}: {count}")
 
     if safety_text == "safe":
         return WritebackSummary(
@@ -362,10 +435,7 @@ def idle_writeback_summary_for_work_mode(mode) -> WritebackSummary:
     spec = work_mode_spec(mode)
     if not spec.supports_translation_writeback:
         if spec.mode == WorkMode.SYNC_TRANSLATION:
-            message = (
-                "同步翻译默认只生成差异预览；"
-                "确认预览后才会通过同步任务页写回。"
-            )
+            message = "同步翻译默认只生成差异预览；确认预览后才会通过同步任务页写回。"
         elif spec.mode == WorkMode.KEYWORD_EXTRACTION:
             message = "关键词模式只生成报告，不会修改游戏脚本。"
         elif spec.mode == WorkMode.REVISION:
@@ -375,8 +445,7 @@ def idle_writeback_summary_for_work_mode(mode) -> WritebackSummary:
             )
         elif spec.mode == WorkMode.SYNC_REVISION:
             message = (
-                "同步订正默认只出预览报告；请先在左侧「订正」生成预览，"
-                "再在结果区点击「写回订正」。"
+                "同步订正默认只出预览报告；请先在左侧「订正」生成预览，再在结果区点击「写回订正」。"
             )
         elif spec.mode == WorkMode.FINAL_REVIEW:
             message = (
@@ -427,7 +496,7 @@ def recheck_writeback_ready(
 
 
 def build_recheck_cli_args(manifest_path: str) -> list[str]:
-    return ["check", manifest_path]
+    return ["check", manifest_path, "--output", "json", "--non-interactive"]
 
 
 def running_writeback_summary(

--- a/gui_qt/cli_runner.py
+++ b/gui_qt/cli_runner.py
@@ -5,12 +5,13 @@ Wraps QProcess to invoke the existing batch CLI using argument lists only
 
 This keeps the GUI as a pure shell layer per the first version plan in #42.
 """
+
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
-from PySide6.QtCore import QProcess, QObject, Signal, QProcessEnvironment
+from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, Signal
 
 
 class CliRunner(QObject):
@@ -18,18 +19,23 @@ class CliRunner(QObject):
 
     Signals:
         line_ready(str): A decoded line of output (stdout or stderr).
+        stdout_line_ready(str): A decoded stdout line for structured consumers.
+        stderr_line_ready(str): A decoded stderr line for diagnostics.
         finished(int): Process exited with this code.
         error(str): Fatal error message.
     """
 
     line_ready = Signal(str)
+    stdout_line_ready = Signal(str)
+    stderr_line_ready = Signal(str)
     finished = Signal(int)
     error = Signal(str)
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
         self._proc: QProcess | None = None
-        self._pending_buffer = b""
+        self._stdout_pending_buffer = b""
+        self._stderr_pending_buffer = b""
 
     def run(self, script_path: str | Path, args: list[str]) -> None:
         """Start the CLI command.
@@ -49,7 +55,7 @@ class CliRunner(QObject):
         python_exe = sys.executable
 
         self._proc = QProcess(self)
-        self._proc.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        self._proc.setProcessChannelMode(QProcess.ProcessChannelMode.SeparateChannels)
 
         # Ensure UTF-8 on Windows
         env = QProcessEnvironment.systemEnvironment()
@@ -57,13 +63,15 @@ class CliRunner(QObject):
         env.insert("PYTHONUTF8", "1")
         self._proc.setProcessEnvironment(env)
 
-        self._proc.readyReadStandardOutput.connect(self._on_ready_read)
+        self._proc.readyReadStandardOutput.connect(self._on_stdout_ready)
+        self._proc.readyReadStandardError.connect(self._on_stderr_ready)
         self._proc.finished.connect(self._on_finished)
         self._proc.errorOccurred.connect(self._on_error)
 
         # Use list of arguments - never shell
         cmd_args = [str(script)] + args
-        self._pending_buffer = b""
+        self._stdout_pending_buffer = b""
+        self._stderr_pending_buffer = b""
 
         self.line_ready.emit(f"[GUI] 正在启动：{python_exe} {script} {' '.join(args)}\n")
         self._proc.start(python_exe, cmd_args)
@@ -74,10 +82,7 @@ class CliRunner(QObject):
 
     def is_running(self) -> bool:
         """Return True while a CLI subprocess is active."""
-        return (
-            self._proc is not None
-            and self._proc.state() == QProcess.ProcessState.Running
-        )
+        return self._proc is not None and self._proc.state() == QProcess.ProcessState.Running
 
     def kill(self) -> None:
         """Terminate the running process if any."""
@@ -86,51 +91,50 @@ class CliRunner(QObject):
             self._proc.kill()
             self._proc.waitForFinished(2000)
 
-    def _on_ready_read(self):
+    def _on_stdout_ready(self):
         if not self._proc:
             return
-        data = self._proc.readAllStandardOutput()
-        if not data:
+        self._stdout_pending_buffer = self._emit_complete_lines(
+            self._stdout_pending_buffer + bytes(self._proc.readAllStandardOutput()),
+            self.stdout_line_ready,
+        )
+
+    def _on_stderr_ready(self):
+        if not self._proc:
             return
-        self._pending_buffer += bytes(data)
+        self._stderr_pending_buffer = self._emit_complete_lines(
+            self._stderr_pending_buffer + bytes(self._proc.readAllStandardError()),
+            self.stderr_line_ready,
+        )
 
-        # Split on the earliest newline marker, including mixed line endings.
+    def _emit_complete_lines(self, buffer: bytes, channel_signal) -> bytes:
         while True:
-            idx_n = self._pending_buffer.find(b"\n")
-            idx_r = self._pending_buffer.find(b"\r")
-            candidates = [idx for idx in (idx_n, idx_r) if idx != -1]
-            if not candidates:
+            indexes = [idx for idx in (buffer.find(b"\n"), buffer.find(b"\r")) if idx != -1]
+            if not indexes:
                 break
-            pos = min(candidates)
-
-            line_bytes = self._pending_buffer[:pos]
-            if self._pending_buffer[pos:pos + 2] == b"\r\n":
-                self._pending_buffer = self._pending_buffer[pos + 2:]
-            else:
-                self._pending_buffer = self._pending_buffer[pos + 1:]
-
-            try:
-                line = line_bytes.decode("utf-8", errors="replace")
-            except Exception:
-                line = line_bytes.decode("utf-8", errors="replace")
-
+            pos = min(indexes)
+            line_bytes = buffer[:pos]
+            buffer = buffer[pos + (2 if buffer[pos : pos + 2] == b"\r\n" else 1) :]
+            line = line_bytes.decode("utf-8", errors="replace")
             if line:
+                channel_signal.emit(line)
                 self.line_ready.emit(line)
-
-        # Flush any remaining partial line on process end (handled in finished too)
+        return buffer
 
     def _on_finished(self, exit_code: int, exit_status: QProcess.ExitStatus):
         if self._proc is None:
             return
-        # Flush any leftover data
-        if self._pending_buffer:
-            try:
-                leftover = self._pending_buffer.decode("utf-8", errors="replace")
-                if leftover.strip():
-                    self.line_ready.emit(leftover.strip())
-            except Exception:
-                pass
-            self._pending_buffer = b""
+        for buffer_name, channel_signal in (
+            ("_stdout_pending_buffer", self.stdout_line_ready),
+            ("_stderr_pending_buffer", self.stderr_line_ready),
+        ):
+            buffer = getattr(self, buffer_name)
+            if buffer:
+                leftover = buffer.decode("utf-8", errors="replace").strip()
+                if leftover:
+                    channel_signal.emit(leftover)
+                    self.line_ready.emit(leftover)
+                setattr(self, buffer_name, b"")
 
         self.finished.emit(exit_code)
         self._proc = None

--- a/gui_qt/final_review_workflow.py
+++ b/gui_qt/final_review_workflow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Sequence
 
-from .batch_workflow_support import build_submit_cli_args
+from .batch_workflow_support import build_submit_cli_args, machine_output_args
 from .revision_report import summarize_revision_preview_output
 from .translation_workflow import (
     TERMINAL_FAILURE_STATES, WorkflowStep, WorkflowUpdate, extract_job_state,
@@ -142,6 +142,8 @@ class FinalReviewWorkflow:
             for finding_id in self.finding_ids:
                 args.extend(["--finding-id", finding_id])
             return args
+        if key in {"status", "download"}:
+            return machine_output_args([key, self.manifest_path])
         return [key, self.manifest_path]
 
     def _facts(self, extra=None):

--- a/gui_qt/keyword_workflow.py
+++ b/gui_qt/keyword_workflow.py
@@ -7,6 +7,7 @@ from .keyword_report import summarize_keyword_export_output
 from .batch_workflow_support import (
     build_recover_submit_cli_args,
     build_submit_cli_args,
+    machine_output_args,
     output_blocked_by_max_cost,
     output_blocked_by_uncertain_submit,
     plan_unsubmitted_workflow_steps,
@@ -239,6 +240,8 @@ class KeywordBatchWorkflow:
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
         if key == "recover-submit":
             return build_recover_submit_cli_args(self.manifest_path)
+        if key in {"status", "download"}:
+            return machine_output_args([key, self.manifest_path])
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/gui_qt/revision_workflow.py
+++ b/gui_qt/revision_workflow.py
@@ -7,6 +7,7 @@ from .revision_report import summarize_revision_preview_output
 from .batch_workflow_support import (
     build_recover_submit_cli_args,
     build_submit_cli_args,
+    machine_output_args,
     output_blocked_by_max_cost,
     output_blocked_by_uncertain_submit,
     plan_unsubmitted_workflow_steps,
@@ -242,6 +243,8 @@ class RevisionBatchWorkflow:
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
         if key == "recover-submit":
             return build_recover_submit_cli_args(self.manifest_path)
+        if key in {"status", "download"}:
+            return machine_output_args([key, self.manifest_path])
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/gui_qt/split_batch_workflow.py
+++ b/gui_qt/split_batch_workflow.py
@@ -1,7 +1,7 @@
 """GUI workflows for split batch package operations."""
 from __future__ import annotations
 
-from .batch_workflow_support import build_submit_cli_args
+from .batch_workflow_support import build_submit_cli_args, machine_output_args
 from .split_batch import SplitManifestEntry
 from .translation_workflow import WorkflowStep, WorkflowUpdate
 from .user_copy import format_manifest_path_fact
@@ -74,7 +74,7 @@ class SplitBatchQueueWorkflow:
         if self.action == "submit":
             args = build_submit_cli_args(self._current_path, self.submit_max_cost)
         else:
-            args = [self.action, self._current_path]
+            args = machine_output_args([self.action, self._current_path])
         return WorkflowStep(
             key=self.action,
             args=args,

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -3,10 +3,15 @@
 This module only plans and interprets CLI steps. The GUI still executes the
 existing command-line tool through ``CliRunner``.
 """
+
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import PurePosixPath, PureWindowsPath
+
+import cli_contract
 
 from .batch_workflow_support import (
     build_recover_submit_cli_args,
@@ -14,6 +19,7 @@ from .batch_workflow_support import (
     load_cost_estimate_facts_from_manifest,
     load_non_chinese_rules_facts_from_manifest,
     load_target_language_facts_from_manifest,
+    machine_output_args,
     output_blocked_by_max_cost,
     output_blocked_by_uncertain_submit,
     plan_unsubmitted_workflow_steps,
@@ -26,8 +32,6 @@ from .user_copy import (
     job_state_label,
     safety_level_label,
 )
-from pathlib import PurePosixPath, PureWindowsPath
-
 
 TERMINAL_FAILURE_STATES = {
     "JOB_STATE_FAILED",
@@ -71,22 +75,54 @@ def extract_created_package_path(output: str) -> str:
     return _extract_line_value(output, "Created batch package:")
 
 
+def _result_envelope(output: str) -> dict[str, object] | None:
+    try:
+        return cli_contract.parse_result_envelope(output)
+    except ValueError:
+        return None
+
+
 def extract_manifest_path(output: str) -> str:
+    envelope = _result_envelope(output)
+    artifacts = envelope.get("artifacts") if envelope else None
+    if isinstance(artifacts, Mapping):
+        manifest = artifacts.get("manifest")
+        if isinstance(manifest, str) and manifest.strip():
+            return manifest.strip()
     return _extract_line_value(output, "Manifest:")
 
 
 def extract_job_state(output: str) -> str:
+    envelope = _result_envelope(output)
+    if envelope:
+        status = envelope.get("status")
+        if isinstance(status, str):
+            return status.strip()
     return _extract_line_value(output, "State:")
 
 
 def extract_safety_status(output: str) -> str:
+    envelope = _result_envelope(output)
+    if envelope:
+        status = envelope.get("status")
+        if isinstance(status, str):
+            return status.strip()
     return _extract_line_value(output, "Safety status:")
+
+
+def extract_error_message(output: str) -> str:
+    envelope = _result_envelope(output)
+    error = envelope.get("error") if envelope else None
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if isinstance(message, str):
+            return message.strip()
+    return ""
 
 
 def output_has_quota_error(output: str) -> bool:
     return any(
-        marker in output
-        for marker in ("RESOURCE_EXHAUSTED", "429", "Quota/resource limit hit")
+        marker in output for marker in ("RESOURCE_EXHAUSTED", "429", "Quota/resource limit hit")
     )
 
 
@@ -95,7 +131,11 @@ def extract_suggested_split_command(output: str) -> str:
 
 
 def manifest_path_for_package(package_path: str) -> str:
-    if re.match(r"^[A-Za-z]:", package_path) or package_path.startswith("\\\\") or "\\" in package_path:
+    if (
+        re.match(r"^[A-Za-z]:", package_path)
+        or package_path.startswith("\\\\")
+        or "\\" in package_path
+    ):
         return str(PureWindowsPath(package_path) / "manifest.json")
     return str(PurePosixPath(package_path) / "manifest.json")
 
@@ -272,7 +312,8 @@ class TranslationWorkflow:
         return self._continue_or_finish()
 
     def _finish_failed_step(self, key: str, output: str) -> WorkflowUpdate:
-        message = f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。"
+        structured_error = extract_error_message(output)
+        message = structured_error or f"{STEP_TEXT[key][0]}没有正常完成，请查看下方原始输出。"
         extra_facts: list[str] = []
         if key in {"submit", "recover-submit"} and output_blocked_by_max_cost(output):
             message = (
@@ -282,7 +323,9 @@ class TranslationWorkflow:
             extra_facts.append("建议：检查高级设置中的提交成本上限，或先运行 split 拆包。")
         elif key in {"submit", "recover-submit"} and output_blocked_by_uncertain_submit(output):
             message = uncertain_submit_failure_message(output)
-            extra_facts.append("建议：在诊断与工具运行 recover-submit，或按提示使用 --resume / --force。")
+            extra_facts.append(
+                "建议：在诊断与工具运行 recover-submit，或按提示使用 --resume / --force。"
+            )
         elif key == "submit" and output_has_quota_error(output):
             message = (
                 "提交云端任务时命中配额或资源限制。当前批量包可能过大，"
@@ -301,9 +344,13 @@ class TranslationWorkflow:
         )
 
     def _finish_build(self, output: str) -> WorkflowUpdate:
+        manifest_path = extract_manifest_path(output)
         package_path = extract_created_package_path(output)
-        if not package_path:
-            if "No pending lines to translate." in output:
+        envelope = _result_envelope(output)
+        if not manifest_path and not package_path:
+            if (
+                envelope and envelope.get("status") == "no_work"
+            ) or "No pending lines to translate." in output:
                 self._pending_steps.clear()
                 return WorkflowUpdate(
                     status="done",
@@ -319,7 +366,7 @@ class TranslationWorkflow:
                 facts=[],
             )
 
-        self.manifest_path = manifest_path_for_package(package_path)
+        self.manifest_path = manifest_path or manifest_path_for_package(package_path)
         extra_facts = load_target_language_facts_from_manifest(self.manifest_path)
         extra_facts.extend(load_non_chinese_rules_facts_from_manifest(self.manifest_path))
         extra_facts.extend(load_cost_estimate_facts_from_manifest(self.manifest_path))
@@ -401,13 +448,17 @@ class TranslationWorkflow:
         if key == "merge-retry":
             return ["merge-retry", self.retry_parent_manifest_path, self.manifest_path]
         if key == "check-parent":
-            return ["check", self.retry_parent_manifest_path]
-        if key == "build" or not self.manifest_path:
+            return machine_output_args(["check", self.retry_parent_manifest_path])
+        if key == "build":
+            return machine_output_args([key])
+        if not self.manifest_path:
             return [key]
         if key == "submit":
             return build_submit_cli_args(self.manifest_path, self.submit_max_cost)
         if key == "recover-submit":
             return build_recover_submit_cli_args(self.manifest_path)
+        if key in {"status", "download", "check"}:
+            return machine_output_args([key, self.manifest_path])
         return [key, self.manifest_path]
 
     def _facts(self, extra_facts: list[str] | None = None) -> list[str]:

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -165,6 +165,22 @@ class CliContractTests(unittest.TestCase):
             cli_contract.EXIT_BLOCKED,
         )
 
+    def test_parse_result_envelope_accepts_shared_contract(self):
+        envelope = cli_contract.success_envelope(
+            "status",
+            status="JOB_STATE_RUNNING",
+        )
+
+        parsed = cli_contract.parse_result_envelope(json.dumps(envelope))
+
+        self.assertEqual(parsed, envelope)
+
+    def test_parse_result_envelope_rejects_unknown_or_incomplete_schema(self):
+        with self.assertRaises(ValueError):
+            cli_contract.parse_result_envelope('{"schema_version": 999}')
+        with self.assertRaises(ValueError):
+            cli_contract.parse_result_envelope("[]")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -451,16 +451,14 @@ class BatchCliContractTests(unittest.TestCase):
                 {"job_state": "JOB_STATE_FAILED"},
                 batch.cli_contract.EXIT_BLOCKED,
             ),
+            (
+                "submit",
+                {"job_state": "JOB_STATE_FAILED"},
+                batch.cli_contract.EXIT_BLOCKED,
+            ),
         )
 
         for command, manifest, expected_exit in cases:
-            (
-                (
-                    "submit",
-                    {"job_state": "JOB_STATE_FAILED"},
-                    batch.cli_contract.EXIT_BLOCKED,
-                ),
-            )
             with self.subTest(command=command):
                 stdout = io.StringIO()
                 manifest["_manifest_path"] = "C:/jobs/demo/manifest.json"

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -90,6 +90,7 @@ class BatchCliContractTests(unittest.TestCase):
             },
         )
         self.assertNotIn(": ", stdout.getvalue())
+
     def test_field_projection_does_not_change_strict_exit_code(self):
         manifest = {
             "_manifest_path": "C:/jobs/demo/manifest.json",
@@ -216,7 +217,6 @@ class BatchCliContractTests(unittest.TestCase):
         )
 
     def test_machine_result_builder_covers_manifest_workflow(self):
-
         args = SimpleNamespace(target="")
         base_manifest = {
             "_manifest_path": "C:/jobs/demo/manifest.json",
@@ -225,6 +225,7 @@ class BatchCliContractTests(unittest.TestCase):
             "summary": {"item_count": 2},
             "last_check_summary": {"safety_level": "safe"},
             "apply_summary": {"applied_lines": 2},
+            "next_split_manifest_path": "C:/jobs/part02/manifest.json",
             "applied_at": "2026-07-29T12:00:00",
         }
         expected_status = {
@@ -250,6 +251,11 @@ class BatchCliContractTests(unittest.TestCase):
                     envelope["artifacts"]["manifest"],
                     "C:/jobs/demo/manifest.json",
                 )
+                if command == "apply":
+                    self.assertEqual(
+                        envelope["result"]["apply"]["next_split_manifest"],
+                        "C:/jobs/part02/manifest.json",
+                    )
 
     def test_build_without_pending_work_does_not_load_latest_manifest(self):
         args = SimpleNamespace(target="")
@@ -379,9 +385,7 @@ class BatchCliContractTests(unittest.TestCase):
             contextlib.redirect_stdout(stdout),
             contextlib.redirect_stderr(stderr),
         ):
-            exit_code = batch.main(
-                ["status", "manifest.json", "--output", "json"]
-            )
+            exit_code = batch.main(["status", "manifest.json", "--output", "json"])
 
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 1)
@@ -429,9 +433,7 @@ class BatchCliContractTests(unittest.TestCase):
             mock.patch.object(batch, "dispatch_command", return_value=manifest),
             contextlib.redirect_stdout(stdout),
         ):
-            exit_code = batch.main(
-                ["check", "manifest.json", "--output", "json"]
-            )
+            exit_code = batch.main(["check", "manifest.json", "--output", "json"])
 
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 0)
@@ -453,10 +455,12 @@ class BatchCliContractTests(unittest.TestCase):
 
         for command, manifest, expected_exit in cases:
             (
-                "submit",
-                {"job_state": "JOB_STATE_FAILED"},
-                batch.cli_contract.EXIT_BLOCKED,
-            ),
+                (
+                    "submit",
+                    {"job_state": "JOB_STATE_FAILED"},
+                    batch.cli_contract.EXIT_BLOCKED,
+                ),
+            )
             with self.subTest(command=command):
                 stdout = io.StringIO()
                 manifest["_manifest_path"] = "C:/jobs/demo/manifest.json"
@@ -490,9 +494,7 @@ class BatchCliContractTests(unittest.TestCase):
             ),
             contextlib.redirect_stdout(stdout),
         ):
-            exit_code = batch.main(
-                ["doctor", "--output", "json", "--strict-exit-codes"]
-            )
+            exit_code = batch.main(["doctor", "--output", "json", "--strict-exit-codes"])
 
         self.assertEqual(exit_code, batch.cli_contract.EXIT_BLOCKED)
         self.assertEqual(json.loads(stdout.getvalue())["status"], "blocked")
@@ -511,9 +513,7 @@ class BatchCliContractTests(unittest.TestCase):
             contextlib.redirect_stderr(stderr),
         ):
             exit_code = batch.main(
-                [
-                    "status", "manifest.json", "--output", "json", "--strict-exit-codes"
-                ]
+                ["status", "manifest.json", "--output", "json", "--strict-exit-codes"]
             )
 
         payload = json.loads(stdout.getvalue())
@@ -540,9 +540,7 @@ class BatchCliContractTests(unittest.TestCase):
                     contextlib.redirect_stdout(stdout),
                 ):
                     exit_code = batch.main(
-                        [
-                            "apply", "manifest.json", "--output", "json", "--strict-exit-codes"
-                        ]
+                        ["apply", "manifest.json", "--output", "json", "--strict-exit-codes"]
                     )
 
                 payload = json.loads(stdout.getvalue())

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -19,7 +19,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
     def setUp(self):
         self.window = MainWindow.__new__(MainWindow)
 
-    def test_on_cli_line_ready_updates_workflow_progress_bar(self):
+    def test_cli_channels_keep_progress_out_of_structured_stdout(self):
         from gui_qt.workflow_progress import create_workflow_progress_state
 
         class FakeProgressBar:
@@ -59,7 +59,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
         self.window._on_cli_line_ready("[2/4] sync-key")
 
-        self.assertEqual(self.window._workflow_step_output_lines, ["[2/4] sync-key"])
+        self.assertEqual(self.window._workflow_step_output_lines, [])
         self.assertTrue(self.window.workflow_progress_bar.visible)
         self.assertEqual(self.window.workflow_progress_bar.range_values, (0, 4))
         self.assertEqual(self.window.workflow_progress_bar.value, 2)
@@ -67,6 +67,12 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(
             self.window.workflow_facts_label.text,
             "Manifest: C:/dummy/manifest.json\n当前请求：sync-key",
+        )
+
+        self.window._on_cli_stdout_line_ready('{"status":"completed"}')
+        self.assertEqual(
+            self.window._workflow_step_output_lines,
+            ['{"status":"completed"}'],
         )
 
     def test_clear_log_view_flushes_pending_buffer(self):
@@ -351,9 +357,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         return self.window.runner
 
     def test_bootstrap_rag_uses_skip_prepare(self):
-        runner = self._prepare_bootstrap_window(
-            {"batch": {"rag": {"enabled": True}}}
-        )
+        runner = self._prepare_bootstrap_window({"batch": {"rag": {"enabled": True}}})
 
         self.window._start_bootstrap_task("rag")
 
@@ -368,9 +372,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         )
 
     def test_bootstrap_source_index_uses_skip_prepare(self):
-        runner = self._prepare_bootstrap_window(
-            {"batch": {"source_index": {"enabled": True}}}
-        )
+        runner = self._prepare_bootstrap_window({"batch": {"source_index": {"enabled": True}}})
 
         self.window._start_bootstrap_task("source_index")
 
@@ -493,28 +495,37 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
             self.assertTrue(flags["enabled"])
             self.assertTrue(flags["inject_enabled"])
+
     def test_save_config_persists_context_storage_and_rolls_back_on_project_failure(self):
         from gui_qt.work_modes import WorkMode
 
         saved_configs = []
         config = {
             "sync": {"rag": {}},
-            "batch": {"rag": {"enabled": False}, "source_index": {"enabled": True}, "model": "gemini-3.1-flash-lite"},
+            "batch": {
+                "rag": {"enabled": False},
+                "source_index": {"enabled": True},
+                "model": "gemini-3.1-flash-lite",
+            },
         }
 
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+
             def normalize_game_root(self, path):
                 return Path("C:/Game/work"), False
+
             def load_translator_config(self):
                 return config
+
             def save_translator_config(self, saved_config):
                 saved_configs.append(copy.deepcopy(saved_config))
 
         class FakeCheckBox:
             def __init__(self, checked):
                 self._checked = checked
+
             def isChecked(self):
                 return self._checked
 
@@ -522,8 +533,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text="", data=""):
                 self._text = text
                 self._data = data
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return self._data
 
@@ -555,16 +568,16 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                     "project_analysis_inject_enabled": True,
                 },
             ),
-            mock.patch(
-                "project_context_settings.save_project_context_settings"
-            ) as save_project,
+            mock.patch("project_context_settings.save_project_context_settings") as save_project,
         ):
             saved = self.window._on_save_config()
 
         self.assertTrue(saved)
         self.assertEqual(len(saved_configs), 1)
         self.assertEqual(saved_configs[0]["context_storage"]["location"], "game")
-        self.assertEqual(saved_configs[0]["context_storage"]["game_dir_name"], "translation_context")
+        self.assertEqual(
+            saved_configs[0]["context_storage"]["game_dir_name"], "translation_context"
+        )
         save_project.assert_called_once_with(
             Path("C:/Game/work"),
             {
@@ -608,16 +621,20 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+
             def normalize_game_root(self, path):
                 return Path("C:/Game/work"), False
+
             def load_translator_config(self):
                 return config
+
             def save_translator_config(self, saved_config):
                 saved_configs.append(saved_config)
 
         class FakeCheckBox:
             def __init__(self, checked):
                 self._checked = checked
+
             def isChecked(self):
                 return self._checked
 
@@ -625,8 +642,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text="", data=""):
                 self._text = text
                 self._data = data
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return self._data
 
@@ -673,16 +692,20 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+
             def normalize_game_root(self, path):
                 return Path("C:/Game/work"), False
+
             def load_translator_config(self):
                 return config
+
             def save_translator_config(self, saved_config):
                 saved_configs.append(saved_config)
 
         class FakeCheckBox:
             def __init__(self, checked):
                 self._checked = checked
+
             def isChecked(self):
                 return self._checked
 
@@ -690,8 +713,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text="", data=""):
                 self._text = text
                 self._data = data
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return self._data
 
@@ -699,16 +724,20 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text):
                 self._text = text
                 self.focused = False
+
             def text(self):
                 return self._text
+
             def setFocus(self):
                 self.focused = True
 
         class FakeValue:
             def __init__(self, value):
                 self._value = value
+
             def value(self):
                 return self._value
+
             def setFocus(self):
                 pass
 
@@ -733,7 +762,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             "batch_temperature": FakeValue(0.4),
             "context_storage_game_dir_name": FakeText("custom_context"),
             "include_files": FakeText("chapter01.rpy\nchapter02.rpy"),
-            "prepare_unpack_command": FakeText("[\"python\", \"unpack.py\"]"),
+            "prepare_unpack_command": FakeText('["python", "unpack.py"]'),
             "batch_safety_settings": FakeText("relaxed_adult"),
             "batch_macro_setting": FakeText("Use a concise voice.\nKeep honorifics."),
             "batch_source_index_store_dir": FakeText("C:/ctx/source"),
@@ -761,7 +790,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.assertEqual(saved_config["include_files"], ["chapter01.rpy", "chapter02.rpy"])
         self.assertEqual(saved_config["prepare"]["unpack_command"], ["python", "unpack.py"])
         self.assertEqual(saved_config["batch"]["safety_settings"], "relaxed_adult")
-        self.assertEqual(saved_config["batch"]["macro_setting"], "Use a concise voice.\nKeep honorifics.")
+        self.assertEqual(
+            saved_config["batch"]["macro_setting"], "Use a concise voice.\nKeep honorifics."
+        )
         self.assertEqual(saved_config["batch"]["source_index"]["store_dir"], "C:/ctx/source")
 
     def test_save_config_validation_error_blocks_write(self):
@@ -776,14 +807,17 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/Game/work")
+
             def load_translator_config(self):
                 return config
+
             def save_translator_config(self, saved_config):
                 saved_configs.append(saved_config)
 
         class FakeCheckBox:
             def __init__(self, checked):
                 self._checked = checked
+
             def isChecked(self):
                 return self._checked
 
@@ -791,8 +825,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text="", data=""):
                 self._text = text
                 self._data = data
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return self._data
 
@@ -800,26 +836,31 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text):
                 self._text = text
                 self.focused = False
+
             def text(self):
                 return self._text
+
             def setFocus(self):
                 self.focused = True
 
         class FakeLabel:
             def __init__(self):
                 self.text = ""
+
             def setText(self, value):
                 self.text = value
 
         class FakeNav:
             def __init__(self):
                 self.row = None
+
             def setCurrentRow(self, row):
                 self.row = row
 
         class FakeStatusBar:
             def __init__(self):
                 self.messages = []
+
             def showMessage(self, text, timeout):
                 self.messages.append((text, timeout))
 
@@ -1130,7 +1171,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window.settings_stack = FakeStack()
         self.window._settings_nav_rows = {"workspace": 0, "project": 1}
         self.window._games_registry_panel = FakePanel()
-        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window.state = type(
+            "FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")}
+        )()
         self.window._task_running = False
         self.window._sync_settings_action_bar_enabled = lambda **_kwargs: None
 
@@ -1178,7 +1221,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window.settings_nav = FakeNav()
         self.window._settings_nav_rows = {"workspace": 0, "project": 1}
         self.window._games_registry_panel = FakePanel()
-        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window.state = type(
+            "FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")}
+        )()
         self.window._handling_config_tab_leave = False
         self.window._last_main_tab_index = 0
         self.window._refresh_api_status = lambda: None
@@ -1326,7 +1371,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             (),
             {"set_current_game_root": lambda self, _root: None},
         )()
-        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window.state = type(
+            "FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")}
+        )()
 
         with patch("gui_qt.app.QMessageBox", FakeMessageBox):
             result = self.window._on_registry_switch_project("C:/Game/work")
@@ -1389,7 +1436,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             (),
             {"set_current_game_root": lambda self, _root: None},
         )()
-        self.window.state = type("FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")})()
+        self.window.state = type(
+            "FakeState", (), {"get_game_root": lambda self: Path("C:/Game/work")}
+        )()
 
         with patch("gui_qt.app.QMessageBox", FakeMessageBox):
             result = self.window._on_registry_switch_project("C:/Game/work")
@@ -1519,8 +1568,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeCheckBox:
             def __init__(self):
                 self.checked = None
+
             def setChecked(self, value):
                 self.checked = value
+
             def isChecked(self):
                 return bool(self.checked)
 
@@ -1529,56 +1580,69 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 self.items = []
                 self.current_index = -1
                 self.current_data = ""
+
             def findText(self, text):
                 try:
                     return self.items.index((text, text))
                 except ValueError:
                     return -1
+
             def addItem(self, text, data=None):
                 self.items.append((text, text if data is None else data))
+
             def count(self):
                 return len(self.items)
+
             def setCurrentIndex(self, index):
                 self.current_index = index
                 if 0 <= index < len(self.items):
                     self.current_data = self.items[index][1]
+
             def findData(self, data):
                 for index, (_text, item_data) in enumerate(self.items):
                     if item_data == data:
                         return index
                 return -1
+
             def currentText(self):
                 if 0 <= self.current_index < len(self.items):
                     return self.items[self.current_index][0]
                 return ""
+
             def currentData(self):
                 return self.current_data
 
         class FakeValue:
             def __init__(self):
                 self.saved = None
+
             def setValue(self, value):
                 self.saved = value
+
             def value(self):
                 return self.saved
 
         class FakeText:
             def __init__(self):
                 self.saved = None
+
             def setText(self, value):
                 self.saved = value
+
             def text(self):
                 return self.saved or ""
 
         class FakeLabel:
             def __init__(self):
                 self.text = "stale"
+
             def setText(self, value):
                 self.text = value
 
         class FakeStatusBar:
             def __init__(self):
                 self.messages = []
+
             def showMessage(self, text, timeout):
                 self.messages.append((text, timeout))
 
@@ -1716,9 +1780,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
         from gui_qt.font_worker import FontInstallResult
 
-        self.window._on_recommended_fonts_downloaded(
-            FontInstallResult(False, error="network down")
-        )
+        self.window._on_recommended_fonts_downloaded(FontInstallResult(False, error="network down"))
 
         self.assertIsNone(self.window._font_install_worker)
         self.assertTrue(worker.deleted)
@@ -1758,8 +1820,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeCheckBox:
             def __init__(self):
                 self._checked = False
+
             def isChecked(self):
                 return self._checked
+
             def setChecked(self, checked):
                 self._checked = checked
 
@@ -1767,20 +1831,28 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text=""):
                 self._text = text
                 self._index = -1
+
             def findData(self, _data):
                 return 0
+
             def findText(self, _text):
                 return -1
+
             def setCurrentIndex(self, index):
                 self._index = index
+
             def addItem(self, text, _data=None):
                 self._text = text
+
             def count(self):
                 return 1
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return ""
+
             def setEnabled(self, _enabled):
                 pass
 
@@ -1817,8 +1889,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeCheckBox:
             def __init__(self):
                 self._checked = False
+
             def isChecked(self):
                 return self._checked
+
             def setChecked(self, checked):
                 self._checked = checked
 
@@ -1826,20 +1900,28 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, text=""):
                 self._text = text
                 self._index = -1
+
             def findData(self, _data):
                 return 0
+
             def findText(self, _text):
                 return -1
+
             def setCurrentIndex(self, index):
                 self._index = index
+
             def addItem(self, text, _data=None):
                 self._text = text
+
             def count(self):
                 return 1
+
             def currentText(self):
                 return self._text
+
             def currentData(self):
                 return ""
+
             def setEnabled(self, _enabled):
                 pass
 
@@ -2131,7 +2213,11 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window.timeline = self._fake_timeline()
 
         summary_calls = []
-        self.window._set_workflow_summary = lambda status, heading, message, facts=None: summary_calls.append((status, heading, message, facts))
+        self.window._set_workflow_summary = (
+            lambda status, heading, message, facts=None: summary_calls.append(
+                (status, heading, message, facts)
+            )
+        )
         self.window._refresh_diagnostics_context = MagicMock()
         self.window._refresh_writeback_from_latest_manifest = MagicMock()
         self.window._current_writeback_summary = lambda: type("Summary", (), {"status": "safe"})()
@@ -2141,8 +2227,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeStatusBar:
             def __init__(self):
                 self.messages = []
+
             def showMessage(self, text, timeout):
                 self.messages.append((text, timeout))
+
         status_bar = FakeStatusBar()
         self.window.statusBar = lambda: status_bar
 
@@ -2187,6 +2275,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeRunner:
             def __init__(self):
                 self.calls = []
+
             def run(self, script_path, args):
                 self.calls.append((script_path, args))
 
@@ -2207,14 +2296,20 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         self.window._append_log = lambda message: None
         self.window._set_task_running = lambda running: None
         summary_calls = []
-        self.window._set_workflow_summary = lambda status, heading, message, facts=None: summary_calls.append((status, heading, message, facts))
+        self.window._set_workflow_summary = (
+            lambda status, heading, message, facts=None: summary_calls.append(
+                (status, heading, message, facts)
+            )
+        )
 
         self.window._on_resume_translation()
 
         self.assertEqual(len(self.window.runner.calls), 1)
         script_path, args = self.window.runner.calls[0]
         self.assertEqual(script_path, Path("C:/tool/gemini_translate_batch.py"))
-        self.assertEqual(args, ["download", str(manifest_path)])
+        self.assertEqual(
+            args, ["download", str(manifest_path), "--output", "json", "--non-interactive"]
+        )
         self.assertEqual(summary_calls[-1][0], "running")
         self.assertTrue(self.window.timeline.visible)
         self.assertEqual(self.window.timeline.current_step_key, "download")
@@ -2247,6 +2342,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeStatusBar:
             def __init__(self):
                 self.messages = []
+
             def showMessage(self, text, timeout):
                 self.messages.append((text, timeout))
 
@@ -2267,7 +2363,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
         self.window._on_workflow_step_finished(0)
 
-        self.window._copy_keyword_reports_to_game_parent.assert_called_once_with("C:/dummy/manifest.json")
+        self.window._copy_keyword_reports_to_game_parent.assert_called_once_with(
+            "C:/dummy/manifest.json"
+        )
         self.window._refresh_writeback_from_latest_manifest.assert_called_once()
         self.window._set_writeback_summary.assert_not_called()
         self.assertIn("关键词提取完成", status_bar.messages[-1][0])
@@ -2300,10 +2398,13 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeStatusBar:
             def __init__(self):
                 self.messages = []
+
             def showMessage(self, text, timeout):
                 self.messages.append((text, timeout))
 
-        output = "Sync keyword run: C:/dummy/sync_keywords\nKeyword candidates: 2 deduped from 3 raw"
+        output = (
+            "Sync keyword run: C:/dummy/sync_keywords\nKeyword candidates: 2 deduped from 3 raw"
+        )
         self.window._workflow = FakeWorkflow()
         self.window._workflow_step_output_lines = output.splitlines()
         self.window._current_work_mode = lambda: WorkMode.SYNC_KEYWORD_EXTRACTION
@@ -2332,6 +2433,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeMessageBox:
             class Icon:
                 Warning = object()
+
             class ButtonRole:
                 AcceptRole = object()
                 DestructiveRole = object()
@@ -2342,22 +2444,30 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self, parent=None):
                 self._stay_btn = object()
                 self._buttons = []
+
             def setIcon(self, icon):
                 pass
+
             def setWindowTitle(self, title):
                 pass
+
             def setText(self, text):
                 pass
+
             def setInformativeText(self, text):
                 pass
+
             def addButton(self, text, role):
                 button = self._stay_btn if text == "留在设置页" else object()
                 self._buttons.append((text, button))
                 return button
+
             def setDefaultButton(self, button):
                 pass
+
             def exec(self):
                 FakeMessageBox.shown = True
+
             def clickedButton(self):
                 return self._stay_btn
 
@@ -2366,8 +2476,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 self.config_tab = config_tab
                 self.other_tab = other_tab
                 self.current_index = 1
+
             def widget(self, index):
                 return self.config_tab if index == 1 else self.other_tab
+
             def setCurrentIndex(self, index):
                 self.current_index = index
 
@@ -2413,8 +2525,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         class FakeState:
             def get_game_root(self):
                 return Path("C:/dummy/project")
+
             def get_latest_manifest_path_for_mode(self, game_root, mode):
                 return Path("C:/dummy/manifest.json")
+
             def load_resume_manifest(self, path, work_mode):
                 return {
                     "_manifest_path": str(path),
@@ -2430,6 +2544,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                         },
                     },
                 }
+
         self.window.state = FakeState()
 
         summaries = []
@@ -2471,9 +2586,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
         summaries = []
         split_refreshes = []
         self.window._set_writeback_summary = lambda summary: summaries.append(summary)
-        self.window._refresh_split_status_ui = (
-            lambda **kwargs: split_refreshes.append(kwargs)
-        )
+        self.window._refresh_split_status_ui = lambda **kwargs: split_refreshes.append(kwargs)
 
         self.window._refresh_writeback_from_latest_manifest()
 
@@ -2495,8 +2608,10 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             def __init__(self):
                 self.visible = True
                 self.enabled = True
+
             def setVisible(self, visible):
                 self.visible = visible
+
             def setEnabled(self, enabled):
                 self.enabled = enabled
 
@@ -2556,10 +2671,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 return None
 
         def load_manifest(path):
-            if (
-                path
-                and canonical_abs_path(path).lower() == expected_manifest_path
-            ):
+            if path and canonical_abs_path(path).lower() == expected_manifest_path:
                 return keyword_manifest
             return None
 
@@ -2600,10 +2712,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
                 return None
 
         def load_manifest(path):
-            if (
-                path
-                and canonical_abs_path(path).lower() == expected_manifest_path
-            ):
+            if path and canonical_abs_path(path).lower() == expected_manifest_path:
                 return keyword_manifest
             return None
 
@@ -2825,6 +2934,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             class FakeState:
                 def get_game_root(self):
                     return game_root
+
             self.window.state = FakeState()
 
             logged_messages = []
@@ -2836,7 +2946,9 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             self.assertTrue(target_dir.exists())
             self.assertTrue((target_dir / "keyword_candidates.md").exists())
             self.assertTrue((target_dir / "keyword_chunk_summaries.md").exists())
-            self.assertEqual((target_dir / "keyword_candidates.md").read_text(encoding="utf-8"), "candidates")
+            self.assertEqual(
+                (target_dir / "keyword_candidates.md").read_text(encoding="utf-8"), "candidates"
+            )
 
             self.assertTrue(any("已将关键词提取报告复制一份至" in msg for msg in logged_messages))
 
@@ -2856,20 +2968,22 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             class FakeState:
                 def get_game_root(self):
                     return game_root
+
             self.window.state = FakeState()
 
             logged_messages = []
             self.window._append_log = lambda msg: logged_messages.append(msg)
 
             self.window._copy_sync_keyword_reports_to_game_parent(
-                f"Sync keyword run: {sync_dir}\n"
-                "Keyword candidates: 2 deduped from 3 raw\n"
+                f"Sync keyword run: {sync_dir}\nKeyword candidates: 2 deduped from 3 raw\n"
             )
 
             target_dir = tmp_path / "Game" / "extracted_keywords"
             self.assertTrue((target_dir / "keyword_candidates.md").exists())
             self.assertTrue((target_dir / "keyword_chunk_summaries.md").exists())
-            self.assertEqual((target_dir / "keyword_candidates.md").read_text(encoding="utf-8"), "candidates")
+            self.assertEqual(
+                (target_dir / "keyword_candidates.md").read_text(encoding="utf-8"), "candidates"
+            )
             self.assertTrue(any("已将关键词提取报告复制一份至" in msg for msg in logged_messages))
 
     def test_sync_layout_sizes_skips_scrollable_doctor_labels(self):
@@ -2987,6 +3101,7 @@ class GuiAppConfigHelperTests(unittest.TestCase):
 
         # Switching into a mode without a prior session clears active completed snapshot.
         self.assertEqual(cleared, [True])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_app_config.py
+++ b/tests/test_gui_app_config.py
@@ -75,6 +75,24 @@ class GuiAppConfigHelperTests(unittest.TestCase):
             ['{"status":"completed"}'],
         )
 
+    def test_workflow_writeback_gate_accepts_json_check_envelope(self):
+        import json
+
+        import cli_contract
+        from gui_qt.app import _workflow_output_updates_writeback
+
+        output = json.dumps(cli_contract.success_envelope("check", status="safe"))
+
+        self.assertTrue(_workflow_output_updates_writeback("check", output))
+        self.assertTrue(
+            _workflow_output_updates_writeback(
+                "check-parent",
+                "Safety status: safe",
+            )
+        )
+        self.assertFalse(
+            _workflow_output_updates_writeback("check", "Safety status: safe")
+        )
     def test_clear_log_view_flushes_pending_buffer(self):
         class FakeLogView:
             def __init__(self):

--- a/tests/test_gui_batch_workflow_support.py
+++ b/tests/test_gui_batch_workflow_support.py
@@ -33,11 +33,19 @@ class GuiBatchWorkflowSupportTests(unittest.TestCase):
     def test_build_submit_cli_args_appends_max_cost(self):
         self.assertEqual(
             build_submit_cli_args("pkg/manifest.json"),
-            ["submit", "pkg/manifest.json"],
+            ["submit", "pkg/manifest.json", "--output", "json", "--non-interactive"],
         )
         self.assertEqual(
             build_submit_cli_args("pkg/manifest.json", 5),
-            ["submit", "pkg/manifest.json", "--max-cost", "5"],
+            [
+                "submit",
+                "pkg/manifest.json",
+                "--max-cost",
+                "5",
+                "--output",
+                "json",
+                "--non-interactive",
+            ],
         )
 
     def test_format_cost_estimate_facts(self):
@@ -102,7 +110,7 @@ class GuiBatchWorkflowSupportTests(unittest.TestCase):
             )
             self.assertEqual(
                 build_submit_cli_args(manifest_path),
-                ["submit", manifest_path, "--resume"],
+                ["submit", manifest_path, "--resume", "--output", "json", "--non-interactive"],
             )
 
     def test_plan_unsubmitted_workflow_steps_prefers_recover_submit(self):
@@ -140,7 +148,15 @@ class GuiBatchWorkflowSupportTests(unittest.TestCase):
 
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", r"C:\package\manifest.json", "--max-cost", "3.5"],
+            [
+                "submit",
+                r"C:\package\manifest.json",
+                "--max-cost",
+                "3.5",
+                "--output",
+                "json",
+                "--non-interactive",
+            ],
         )
 
     def test_load_non_chinese_rules_facts_from_manifest(self):

--- a/tests/test_gui_check_report.py
+++ b/tests/test_gui_check_report.py
@@ -6,7 +6,9 @@ from gui_qt.check_report import (
     idle_writeback_summary_for_work_mode,
     parse_check_output,
     recheck_writeback_ready,
+    summarize_apply_envelope,
     summarize_apply_output,
+    summarize_check_envelope,
     summarize_check_output,
     summarize_manifest_writeback,
 )
@@ -107,6 +109,50 @@ class GuiCheckReportTests(unittest.TestCase):
         self.assertEqual(summary.message.count("补译"), 1)
         self.assertIn("重新检查", summary.message)
         self.assertIn("可写回", summary.message)
+
+    def test_summarize_check_envelope_uses_structured_counts_and_reasons(self):
+        summary = summarize_check_envelope(
+            {
+                "ok": True,
+                "status": "warn",
+                "result": {
+                    "check": {
+                        "pending_files": 1,
+                        "pending_lines": 4,
+                        "failure_items": 2,
+                        "safety_reasons": {"warn": {"source_mismatch": 2}},
+                    }
+                },
+                "artifacts": {"check_report": r"C:\pkg\check.jsonl"},
+            },
+            exit_code=0,
+            manifest_path=r"C:\pkg\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "warn")
+        self.assertIn("1 个文件", "\n".join(summary.facts))
+        self.assertTrue(any("source_mismatch" in item for item in summary.findings))
+
+    def test_summarize_apply_envelope_uses_structured_result(self):
+        summary = summarize_apply_envelope(
+            {
+                "ok": True,
+                "status": "applied",
+                "result": {
+                    "apply": {
+                        "applied_files": 2,
+                        "applied_lines": 18,
+                        "next_split_manifest": r"C:\pkg\part02\manifest.json",
+                    }
+                },
+            },
+            exit_code=0,
+            manifest_path=r"C:\pkg\part01\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "applied")
+        self.assertIn("已写回 2 个文件", "\n".join(summary.facts))
+        self.assertIn("下一拆分包", "\n".join(summary.facts))
 
     def test_summarize_apply_output_marks_completed(self):
         summary = summarize_apply_output(
@@ -254,7 +300,7 @@ class GuiCheckReportTests(unittest.TestCase):
     def test_build_recheck_cli_args(self):
         self.assertEqual(
             build_recheck_cli_args(r"C:\pkg\manifest.json"),
-            ["check", r"C:\pkg\manifest.json"],
+            ["check", r"C:\pkg\manifest.json", "--output", "json", "--non-interactive"],
         )
 
     def test_recheck_writeback_ready_requires_batch_translation_and_manifest(self):

--- a/tests/test_gui_final_review_workflow.py
+++ b/tests/test_gui_final_review_workflow.py
@@ -1,4 +1,5 @@
 """GUI final-review workflow tests (#255 PR C)."""
+
 from __future__ import annotations
 
 import unittest
@@ -31,7 +32,6 @@ class FinalReviewWorkflowTests(unittest.TestCase):
         self.assertEqual(update.heading, "无法准备最终审校")
         self.assertIsNone(workflow.current_step())
 
-
     def test_succeeded_status_downloads_and_ingests_report(self):
         workflow = FinalReviewWorkflow(["status"], "C:/tmp/review/manifest.json")
         update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED")
@@ -53,19 +53,30 @@ class FinalReviewWorkflowTests(unittest.TestCase):
 
     def test_selected_findings_use_one_local_preview_step(self):
         workflow = FinalReviewWorkflow.create_revisions("C:/tmp/review/manifest.json", ["f1", "f2"])
-        self.assertEqual(workflow.current_step().args, [
-            "final-review-create-revisions", "C:/tmp/review/manifest.json",
-            "--finding-id", "f1", "--finding-id", "f2",
-        ])
-        output = "\n".join([
-            "Created final-review revision package: C:/tmp/revisions",
-            "Recoverable revision items: 2",
-            "Failure items: 0",
-            "Preview JSONL: C:/tmp/revisions/revision_preview.jsonl",
-        ])
+        self.assertEqual(
+            workflow.current_step().args,
+            [
+                "final-review-create-revisions",
+                "C:/tmp/review/manifest.json",
+                "--finding-id",
+                "f1",
+                "--finding-id",
+                "f2",
+            ],
+        )
+        output = "\n".join(
+            [
+                "Created final-review revision package: C:/tmp/revisions",
+                "Recoverable revision items: 2",
+                "Failure items: 0",
+                "Preview JSONL: C:/tmp/revisions/revision_preview.jsonl",
+            ]
+        )
         update = workflow.complete_current_step(0, output)
         self.assertEqual(update.heading, "订正预览已生成")
-        self.assertTrue(workflow.manifest_path.replace("\\", "/").endswith("revisions/manifest.json"))
+        self.assertTrue(
+            workflow.manifest_path.replace("\\", "/").endswith("revisions/manifest.json")
+        )
 
     def test_resume_final_review_manifest_uses_final_review_commands(self):
         workflow = resume_workflow(
@@ -74,7 +85,10 @@ class FinalReviewWorkflowTests(unittest.TestCase):
             {"mode": "final_review", "job_name": "jobs/1", "job_state": "JOB_STATE_RUNNING"},
         )
         self.assertIsInstance(workflow, FinalReviewWorkflow)
-        self.assertEqual(workflow.current_step().args, ["status", "C:/tmp/review/manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["status", "C:/tmp/review/manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_does_not_treat_missing_counts_as_complete(self):
         workflow = FinalReviewWorkflow.resume_manifest(
@@ -82,6 +96,7 @@ class FinalReviewWorkflowTests(unittest.TestCase):
             {"mode": "final_review", "summary": {"status_counts": {}}},
         )
         self.assertEqual(workflow.current_step().key, "final-review-resume")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_keyword_workflow.py
+++ b/tests/test_gui_keyword_workflow.py
@@ -32,7 +32,13 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
         self.assertEqual(update.status, "running")
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", "C:\\Games\\Example\\work\\logs\\batch_jobs\\kw1\\manifest.json"],
+            [
+                "submit",
+                "C:\\Games\\Example\\work\\logs\\batch_jobs\\kw1\\manifest.json",
+                "--output",
+                "json",
+                "--non-interactive",
+            ],
         )
 
     def test_build_without_source_lines_finishes_without_submitting(self):
@@ -68,7 +74,10 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
             {"job_name": ""},
         )
 
-        self.assertEqual(workflow.current_step().args, ["submit", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["submit", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_submitted_manifest_starts_from_status(self):
         workflow = KeywordBatchWorkflow.resume_manifest(
@@ -76,7 +85,10 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["status", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_succeeded_manifest_starts_from_download_and_export(self):
         manifest_path = r"C:\package\manifest.json"
@@ -85,7 +97,10 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example", "job_state": "JOB_STATE_SUCCEEDED"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["download", manifest_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", manifest_path, "--output", "json", "--non-interactive"],
+        )
         workflow.complete_current_step(0, "Saved results to: " + r"C:\package\results.jsonl" + "\n")
         self.assertEqual(workflow.current_step().args, ["export-keywords", manifest_path])
 
@@ -94,11 +109,18 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
 
         status_update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED\n")
         self.assertTrue(status_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["download", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
-        download_update = workflow.complete_current_step(0, "Saved results to: C:\\package\\results.jsonl\n")
+        download_update = workflow.complete_current_step(
+            0, "Saved results to: C:\\package\\results.jsonl\n"
+        )
         self.assertTrue(download_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["export-keywords", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args, ["export-keywords", "C:\\package\\manifest.json"]
+        )
 
         export_output = (
             "Keyword candidates: 3 deduped from 5 raw\n"
@@ -128,10 +150,8 @@ class GuiKeywordWorkflowTests(unittest.TestCase):
             "C:\\package\\manifest.json",
             {
                 "job_name": "batches/example",
-                "keyword_export": {
-                    "jsonl_path": "C:\\package\\keyword_candidates.jsonl"
-                }
-            }
+                "keyword_export": {"jsonl_path": "C:\\package\\keyword_candidates.jsonl"},
+            },
         )
         self.assertIsNone(workflow.current_step())
 

--- a/tests/test_gui_retry_workflow.py
+++ b/tests/test_gui_retry_workflow.py
@@ -49,19 +49,6 @@ class GuiRetryWorkflowTests(unittest.TestCase):
             ["submit", RETRY_PATH, "--max-cost", "4.5", "--output", "json", "--non-interactive"],
         )
 
-    def test_create_retry_followup_workflow_passes_submit_max_cost(self):
-        workflow = create_retry_followup_workflow(
-            RETRY_PATH,
-            _retry_manifest(),
-            PARENT_PATH,
-            submit_max_cost=4.5,
-        )
-
-        self.assertEqual(
-            workflow.current_step().args,
-            ["submit", RETRY_PATH, "--max-cost", "4.5", "--output", "json", "--non-interactive"],
-        )
-
     def test_describe_retry_followup_button_for_merge_step(self):
         label, tooltip = describe_retry_followup_button(
             RETRY_PATH,

--- a/tests/test_gui_retry_workflow.py
+++ b/tests/test_gui_retry_workflow.py
@@ -31,7 +31,10 @@ class GuiRetryWorkflowTests(unittest.TestCase):
         )
 
         self.assertEqual(workflow.restore_latest_manifest_path, PARENT_PATH)
-        self.assertEqual(workflow.current_step().args, ["submit", RETRY_PATH])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["submit", RETRY_PATH, "--output", "json", "--non-interactive"],
+        )
 
     def test_create_retry_followup_workflow_passes_submit_max_cost(self):
         workflow = create_retry_followup_workflow(
@@ -43,7 +46,7 @@ class GuiRetryWorkflowTests(unittest.TestCase):
 
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", RETRY_PATH, "--max-cost", "4.5"],
+            ["submit", RETRY_PATH, "--max-cost", "4.5", "--output", "json", "--non-interactive"],
         )
 
     def test_create_retry_followup_workflow_passes_submit_max_cost(self):
@@ -56,7 +59,7 @@ class GuiRetryWorkflowTests(unittest.TestCase):
 
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", RETRY_PATH, "--max-cost", "4.5"],
+            ["submit", RETRY_PATH, "--max-cost", "4.5", "--output", "json", "--non-interactive"],
         )
 
     def test_describe_retry_followup_button_for_merge_step(self):
@@ -121,7 +124,7 @@ class GuiRetryWorkflowTests(unittest.TestCase):
 
         self.assertIsNotNone(step)
         self.assertEqual(step.key, "status")
-        self.assertEqual(step.args, ["status", RETRY_PATH])
+        self.assertEqual(step.args, ["status", RETRY_PATH, "--output", "json", "--non-interactive"])
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_revision_workflow.py
+++ b/tests/test_gui_revision_workflow.py
@@ -41,7 +41,13 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
         self.assertEqual(update.status, "running")
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", "C:\\Games\\Example\\work\\logs\\batch_jobs\\rev1\\manifest.json"],
+            [
+                "submit",
+                "C:\\Games\\Example\\work\\logs\\batch_jobs\\rev1\\manifest.json",
+                "--output",
+                "json",
+                "--non-interactive",
+            ],
         )
 
     def test_build_without_source_lines_finishes_without_submitting(self):
@@ -77,7 +83,10 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
             {"job_name": ""},
         )
 
-        self.assertEqual(workflow.current_step().args, ["submit", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["submit", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_submitted_manifest_starts_from_status(self):
         workflow = RevisionBatchWorkflow.resume_manifest(
@@ -85,7 +94,10 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["status", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_succeeded_manifest_starts_from_download_and_preview(self):
         manifest_path = r"C:\package\manifest.json"
@@ -94,7 +106,10 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example", "job_state": "JOB_STATE_SUCCEEDED"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["download", manifest_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", manifest_path, "--output", "json", "--non-interactive"],
+        )
         workflow.complete_current_step(0, "Saved results to: " + r"C:\package\results.jsonl" + "\n")
         self.assertEqual(workflow.current_step().args, ["preview-revisions", manifest_path])
 
@@ -103,11 +118,18 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
 
         status_update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED\n")
         self.assertTrue(status_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["download", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
-        download_update = workflow.complete_current_step(0, "Saved results to: C:\\package\\results.jsonl\n")
+        download_update = workflow.complete_current_step(
+            0, "Saved results to: C:\\package\\results.jsonl\n"
+        )
         self.assertTrue(download_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["preview-revisions", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args, ["preview-revisions", "C:\\package\\manifest.json"]
+        )
 
         preview_update = workflow.complete_current_step(0, PREVIEW_OUTPUT)
         self.assertEqual(preview_update.status, "done")

--- a/tests/test_gui_split_batch.py
+++ b/tests/test_gui_split_batch.py
@@ -39,7 +39,9 @@ class GuiSplitBatchTests(unittest.TestCase):
             ),
         ]
 
-        self.assertEqual([entry.part_label for entry in entries], ["part01/03", "part02/03", "part03/03"])
+        self.assertEqual(
+            [entry.part_label for entry in entries], ["part01/03", "part02/03", "part03/03"]
+        )
         self.assertFalse(entries[0].selectable)
         self.assertEqual(entries[0].status_kind, "running")
         self.assertTrue(entries[1].selectable)
@@ -81,13 +83,17 @@ class GuiSplitBatchTests(unittest.TestCase):
         part1 = r"C:\pkg\part01_of_02\manifest.json"
         part2 = r"C:\pkg\part02_of_02\manifest.json"
         entries = [
-            entry_from_manifest(part1, {"split_index": 1, "split_total": 2, "job_name": "batches/one"}),
+            entry_from_manifest(
+                part1, {"split_index": 1, "split_total": 2, "job_name": "batches/one"}
+            ),
             entry_from_manifest(part2, {"split_index": 2, "split_total": 2, "job_name": ""}),
         ]
 
         workflow = SplitBatchQueueWorkflow.submit_remaining(entries, anchor_manifest_path=part1)
 
-        self.assertEqual(workflow.current_step().args, ["submit", part2])
+        self.assertEqual(
+            workflow.current_step().args, ["submit", part2, "--output", "json", "--non-interactive"]
+        )
         update = workflow.complete_current_step(0, "Manifest: ignored\n")
         self.assertEqual(update.status, "waiting")
         self.assertEqual(update.timeline_step_key, "status")
@@ -99,14 +105,21 @@ class GuiSplitBatchTests(unittest.TestCase):
         part2 = r"C:\pkg\part02_of_03\manifest.json"
         part3 = r"C:\pkg\part03_of_03\manifest.json"
         entries = [
-            entry_from_manifest(part1, {"split_index": 1, "split_total": 3, "job_name": "batches/one"}),
-            entry_from_manifest(part2, {"split_index": 2, "split_total": 3, "job_name": "batches/two", "applied_at": "x"}),
+            entry_from_manifest(
+                part1, {"split_index": 1, "split_total": 3, "job_name": "batches/one"}
+            ),
+            entry_from_manifest(
+                part2,
+                {"split_index": 2, "split_total": 3, "job_name": "batches/two", "applied_at": "x"},
+            ),
             entry_from_manifest(part3, {"split_index": 3, "split_total": 3, "job_name": ""}),
         ]
 
         workflow = SplitBatchQueueWorkflow.refresh_status(entries, anchor_manifest_path=part1)
 
-        self.assertEqual(workflow.current_step().args, ["status", part1])
+        self.assertEqual(
+            workflow.current_step().args, ["status", part1, "--output", "json", "--non-interactive"]
+        )
         update = workflow.complete_current_step(0, "State: JOB_STATE_RUNNING\n")
         self.assertEqual(update.status, "ready")
         self.assertIsNone(workflow.current_step())

--- a/tests/test_gui_translation_workflow.py
+++ b/tests/test_gui_translation_workflow.py
@@ -1,4 +1,7 @@
+import json
 import unittest
+
+import cli_contract
 
 from gui_qt.translation_workflow import (
     TranslationWorkflow,
@@ -36,17 +39,61 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
         self.assertEqual(extract_job_state("State: JOB_STATE_SUCCEEDED\n"), "JOB_STATE_SUCCEEDED")
         self.assertEqual(extract_safety_status("Safety status: safe\n"), "safe")
 
+    def test_extracts_shared_json_envelope_fields(self):
+        manifest_path = r"C:\pkg\manifest.json"
+        status_output = json.dumps(
+            cli_contract.success_envelope(
+                "status",
+                status="JOB_STATE_SUCCEEDED",
+                artifacts={"manifest": manifest_path},
+            )
+        )
+        check_output = json.dumps(
+            cli_contract.success_envelope(
+                "check",
+                status="safe",
+                artifacts={"manifest": manifest_path},
+            )
+        )
+
+        self.assertEqual(extract_job_state(status_output), "JOB_STATE_SUCCEEDED")
+        self.assertEqual(extract_safety_status(check_output), "safe")
+
+    def test_json_build_envelope_sets_manifest_without_parsing_console_copy(self):
+        manifest_path = r"C:\pkg\manifest.json"
+        workflow = TranslationWorkflow.start_new()
+        output = json.dumps(
+            cli_contract.success_envelope(
+                "build",
+                status="LOCAL_ONLY",
+                artifacts={"manifest": manifest_path},
+            )
+        )
+
+        update = workflow.complete_current_step(0, output)
+
+        self.assertTrue(update.should_continue)
+        self.assertEqual(workflow.manifest_path, manifest_path)
+
     def test_start_workflow_builds_then_submits_created_manifest(self):
         workflow = TranslationWorkflow.start_new()
 
-        self.assertEqual(workflow.current_step().args, ["build"])
+        self.assertEqual(
+            workflow.current_step().args, ["build", "--output", "json", "--non-interactive"]
+        )
         update = workflow.complete_current_step(0, BUILD_OUTPUT)
 
         self.assertTrue(update.should_continue)
         self.assertEqual(update.status, "running")
         self.assertEqual(
             workflow.current_step().args,
-            ["submit", "C:\\Games\\Example\\work\\logs\\batch_jobs\\job1\\manifest.json"],
+            [
+                "submit",
+                "C:\\Games\\Example\\work\\logs\\batch_jobs\\job1\\manifest.json",
+                "--output",
+                "json",
+                "--non-interactive",
+            ],
         )
 
     def test_build_without_pending_lines_finishes_without_submitting_stale_manifest(self):
@@ -73,7 +120,10 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
             {"job_name": ""},
         )
 
-        self.assertEqual(workflow.current_step().args, ["submit", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["submit", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_submitted_manifest_starts_from_status(self):
         workflow = TranslationWorkflow.resume_manifest(
@@ -81,7 +131,10 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["status", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
     def test_resume_safe_retry_manifest_merges_then_checks_parent(self):
         retry_path = r"C:\package\retry_parts\retry1\manifest.json"
@@ -99,7 +152,10 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
         self.assertEqual(workflow.current_step().args, ["merge-retry", parent_path, retry_path])
         update = workflow.complete_current_step(0, f"Merged retry results into: {parent_path}\n")
         self.assertTrue(update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["check", parent_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["check", parent_path, "--output", "json", "--non-interactive"],
+        )
         final = workflow.complete_current_step(0, "Safety status: safe\n")
         self.assertEqual(final.status, "done")
         self.assertEqual(workflow.manifest_path, parent_path)
@@ -116,9 +172,17 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
             },
         )
 
-        self.assertEqual(workflow.current_step().args, ["download", retry_path])
-        workflow.complete_current_step(0, r"Saved results to: C:\package\retry_parts\retry1\results.jsonl" + "\n")
-        self.assertEqual(workflow.current_step().args, ["check", retry_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", retry_path, "--output", "json", "--non-interactive"],
+        )
+        workflow.complete_current_step(
+            0, r"Saved results to: C:\package\retry_parts\retry1\results.jsonl" + "\n"
+        )
+        self.assertEqual(
+            workflow.current_step().args,
+            ["check", retry_path, "--output", "json", "--non-interactive"],
+        )
         update = workflow.complete_current_step(0, "Safety status: safe\n")
 
         self.assertTrue(update.should_continue)
@@ -143,20 +207,34 @@ class GuiTranslationWorkflowTests(unittest.TestCase):
             {"job_name": "batches/example", "job_state": "JOB_STATE_SUCCEEDED"},
         )
 
-        self.assertEqual(workflow.current_step().args, ["download", manifest_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", manifest_path, "--output", "json", "--non-interactive"],
+        )
         workflow.complete_current_step(0, "Saved results to: " + r"C:\package\results.jsonl" + "\n")
-        self.assertEqual(workflow.current_step().args, ["check", manifest_path])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["check", manifest_path, "--output", "json", "--non-interactive"],
+        )
 
     def test_status_succeeded_continues_to_download_and_check(self):
         workflow = TranslationWorkflow.resume_latest("C:\\package\\manifest.json")
 
         status_update = workflow.complete_current_step(0, "State: JOB_STATE_SUCCEEDED\n")
         self.assertTrue(status_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["download", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["download", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
-        download_update = workflow.complete_current_step(0, "Saved results to: C:\\package\\results.jsonl\n")
+        download_update = workflow.complete_current_step(
+            0, "Saved results to: C:\\package\\results.jsonl\n"
+        )
         self.assertTrue(download_update.should_continue)
-        self.assertEqual(workflow.current_step().args, ["check", "C:\\package\\manifest.json"])
+        self.assertEqual(
+            workflow.current_step().args,
+            ["check", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
+        )
 
         check_update = workflow.complete_current_step(0, "Safety status: safe\n")
         self.assertEqual(check_update.status, "done")

--- a/tests/test_gui_workflow_factory.py
+++ b/tests/test_gui_workflow_factory.py
@@ -19,7 +19,9 @@ class GuiWorkflowFactoryTests(unittest.TestCase):
         workflow = create_workflow(WorkMode.BATCH_TRANSLATION)
 
         self.assertIsInstance(workflow, TranslationWorkflow)
-        self.assertEqual(workflow.current_step().args, ["build"])
+        self.assertEqual(
+            workflow.current_step().args, ["build", "--output", "json", "--non-interactive"]
+        )
 
     def test_create_workflow_returns_sync_translation_workflow(self):
         workflow = create_workflow(WorkMode.SYNC_TRANSLATION)
@@ -78,7 +80,7 @@ class GuiWorkflowFactoryTests(unittest.TestCase):
         self.assertIsInstance(workflow, TranslationWorkflow)
         self.assertEqual(
             workflow.current_step().args,
-            ["status", "C:\\package\\manifest.json"],
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
         )
 
     def test_resume_workflow_returns_revision_resume(self):
@@ -91,7 +93,7 @@ class GuiWorkflowFactoryTests(unittest.TestCase):
         self.assertIsInstance(workflow, RevisionBatchWorkflow)
         self.assertEqual(
             workflow.current_step().args,
-            ["status", "C:\\package\\manifest.json"],
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
         )
 
     def test_resume_workflow_returns_none_for_sync_revision(self):
@@ -113,7 +115,7 @@ class GuiWorkflowFactoryTests(unittest.TestCase):
         self.assertIsInstance(workflow, KeywordBatchWorkflow)
         self.assertEqual(
             workflow.current_step().args,
-            ["status", "C:\\package\\manifest.json"],
+            ["status", "C:\\package\\manifest.json", "--output", "json", "--non-interactive"],
         )
 
     def test_validate_resume_manifest_accepts_keyword_extraction_mode(self):


### PR DESCRIPTION
## Summary

- make the GUI request the versioned JSON envelope for core Batch `build / submit / status / download / check / apply` steps
- separate CLI stdout from stderr so structured results stay parseable while progress and diagnostics remain visible in the GUI log
- reuse the shared result/error contract for workflow state, writeback summaries, artifacts, and errors, with legacy text parsing kept only as a compatibility fallback
- document the GUI/CLI contract boundary and extend regression coverage across translation, keyword, revision, final-review, retry, and split workflows

## Why

The GUI previously merged stdout and stderr, then recovered Batch state from English console lines. That duplicated CLI semantics and made status handling sensitive to human-facing copy. This change makes the shared CLI envelope the source of truth for both Agent-facing commands and GUI orchestration.

## Validation

- `python -B tests/run_gui_tests.py -q` — 891 passed
- `python -B tests/run_cli_tests.py -q` — 771 passed, 1 environment-dependent skip
- focused contract/GUI regression suite — 87 passed
- Ruff blocking checks — passed
- mypy scoped checks — passed
- `git diff --check` — passed
- `pip-audit` was retried twice; PyPI connections were reset before all lock files completed. Completed lock audits reported no known vulnerabilities.

Related to #276. This PR intentionally does not close the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent structured JSON results for batch translation, including status, artifacts, warnings, and errors.
  * GUI workflows now use machine-readable results for build, submit, check, status, download, and apply operations.
  * Apply results now include the next split manifest when available.
* **Bug Fixes**
  * Improved separation of progress logs from structured command output.
  * Added clearer error handling and retained legacy output parsing as a compatibility fallback.
* **Documentation**
  * Updated GUI workbench documentation to describe the structured output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->