### PR TITLE
Fix machine CLI contract regressions

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -9,11 +9,17 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from os import PathLike
-from typing import Any, TextIO
+from typing import Any, Iterator, TextIO
 
 CLI_SCHEMA_VERSION = 1
 _MISSING = object()
+_MACHINE_OUTPUT_ACTIVE: ContextVar[bool] = ContextVar(
+    "cli_machine_output_active",
+    default=False,
+)
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -21,6 +27,23 @@ EXIT_NEEDS_ACTION = 3
 EXIT_BLOCKED = 4
 EXIT_INVALID_STATE = 5
 EXIT_RETRYABLE = 6
+
+
+def machine_output_active() -> bool:
+    """Return whether the current call is executing a machine-output command."""
+
+    return _MACHINE_OUTPUT_ACTIVE.get()
+
+
+@contextmanager
+def machine_output_context() -> Iterator[None]:
+    """Mark nested core work as part of a machine-output CLI invocation."""
+
+    token = _MACHINE_OUTPUT_ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        _MACHINE_OUTPUT_ACTIVE.reset(token)
 
 
 def parse_result_envelope(text: str) -> dict[str, Any]:
@@ -287,9 +310,7 @@ def project_fields(
     source = _json_compatible(dict(document))
     projected: dict[str, Any] = {}
     for raw_path in field_paths:
-        parts = [part.strip() for part in str(raw_path).split(".")]
-        if not parts or any(not part for part in parts):
-            raise ValueError(f"Invalid field path: {raw_path!r}")
+        parts = field_path_parts(raw_path)
         value: Any = source
         for part in parts:
             if not isinstance(value, Mapping) or part not in value:
@@ -307,6 +328,15 @@ def project_fields(
             target = existing
         target[parts[-1]] = value
     return projected
+
+
+def field_path_parts(raw_path: Any) -> list[str]:
+    """Validate and split one dot-separated machine-output field path."""
+
+    parts = [part.strip() for part in str(raw_path).split(".")]
+    if not parts or any(not part for part in parts):
+        raise ValueError(f"Invalid field path: {raw_path!r}")
+    return parts
 
 
 def write_json_envelope(

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -32,7 +32,7 @@
 python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json --output json
 ```
 
-JSON 模式下 stdout 只包含结果文档，原有 banner、进度和诊断文本进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式、默认退出码以及非严格 JSON 的既有 `COMMAND_REFUSED / INTERNAL_ERROR` 分类保持兼容；仍须根据 `status` 判断是否可以继续写回。
+JSON 模式下 stdout 只包含结果文档，原有 banner、进度、prepare 子进程输出和诊断文本实时进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式和默认退出码保持兼容；仍须根据 `status` 判断是否可以继续写回。
 
 Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`1` 未分类内部错误，`2` 用法错误，`3` 需要处理（例如 `warn`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
 
@@ -53,7 +53,7 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
-核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.safety_level` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。
+核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.safety_level` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。
 `capabilities / schema` 也支持这三个选项；它们原生输出 JSON，因此无需 `--output json`。
 
 

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -12,7 +12,7 @@
 
 - 普通用户走「项目与环境 → 设置 → 检查 → 翻译 → 写回」；任务页保留当前操作和状态，完整日志、任务上下文与命令参考集中在「诊断与运行日志」。
 - 底层仍调用现有 CLI 脚本，不重写翻译核心：**批量翻译**走 `gemini_translate_batch.py`；**同步翻译**走 `gemini_translate.py`。
-- GUI 调用 Batch 的 `build / submit / status / download / check / apply` 时，使用版本化 JSON envelope 读取结果、状态、制品和错误；stdout 只承载结构化结果，stderr 的进度与诊断继续进入「运行日志」。旧版文本输出解析仅保留为兼容回退。
+- GUI 调用 Batch 的 `build / submit / status / download / check / apply` 时，使用版本化 JSON envelope 读取结果、状态、制品和错误；stdout 只承载结构化结果，stderr 的进度、prepare 子进程输出与诊断会实时进入「运行日志」。旧版文本输出解析仅保留为兼容回退。
 - **开发与功能约定**：新能力须 CLI / GUI 同步交付，见根目录 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 - 配置仍用 `api_keys.json`、`translator_config.json`；批量写回以 CLI 的 `check -> apply` 安全合约为准，同步模式按脚本规则直接写回。
 - GUI 依赖在 `requirements-gui.txt`，不进入主 `requirements.txt`。**不装图形界面时，命令行工具可照常使用。**

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -30,7 +30,7 @@ python gemini_translate_batch.py check <manifest> --output json
 python gemini_translate_batch.py apply <manifest> --output json
 ```
 
-JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning 和原有文本摘要会写入 stderr，完整 Batch 控制台日志仍会落盘。成功结果使用版本化 envelope：
+JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning、prepare 子进程输出和原有文本摘要会实时写入 stderr，完整 Batch 控制台日志仍会落盘。成功结果使用版本化 envelope：
 
 ```json
 {
@@ -65,7 +65,7 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning �
 | `5` | 输入、配置或状态已失效 | stale check、manifest/results 漂移、前置产物缺失 |
 | `6` | 远端临时错误，可稍后重试 | rate limit、quota、timeout、service unavailable |
 
-严格模式的错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容行为：拒绝类错误仍为 `COMMAND_REFUSED`，意外异常仍为 `INTERNAL_ERROR`，且不承诺 `semantic_exit_code`。
+严格模式的错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。Manifest 读取还会使用 `INVALID_MANIFEST_JSON`、`INVALID_MANIFEST_ENCODING`、`INVALID_MANIFEST_SHAPE` 或 `MANIFEST_UNREADABLE`；这些错误在严格模式下退出 `5`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容退出行为。
 
 
 ## 严格非交互与显式 manifest
@@ -100,6 +100,7 @@ python gemini_translate_batch.py status <manifest> --output json --output-file .
 - `--compact` 移除缩进和多余空格，但仍输出一个以换行结尾的合法 JSON 文档；
 - `--fields` 使用点路径投影结果，保留嵌套结构；可一次传入多个路径、用逗号分隔，或重复传入该选项；
 - 请求的可选路径不存在时会被省略，命令不会因此失败；列表不支持按下标继续投影，应选择整个列表字段；
+- 空路径、连续点等非法字段路径会在 workflow 执行前返回 `error.code=INVALID_FIELD_PATH` 和退出码 `2`；
 - `--output-file` 将最终 JSON 原子写入指定路径，并保持 stdout 为空；父目录会按需创建；
 - 文件中的 `artifacts.output_file` 记录绝对输出路径，除非 `--fields` 主动将它裁掉；
 - 三个选项都必须显式配合 `--output json`，不会改变文本模式。

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1851,8 +1851,47 @@ def remember_latest_manifest(manifest_path):
 
 def load_manifest(target=None):
     manifest_path = manifest_path_for_target(target)
-    with open(manifest_path, 'r', encoding='utf-8') as handle:
-        manifest = json.load(handle)
+    try:
+        with open(manifest_path, 'r', encoding='utf-8') as handle:
+            manifest = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise cli_contract.MachineContractError(
+            (
+                f'Manifest is not valid JSON: {manifest_path} '
+                f'(line {exc.lineno}, column {exc.colno}).'
+            ),
+            code_name='INVALID_MANIFEST_JSON',
+            suggested_action='rebuild_or_repair_manifest',
+            details={
+                'manifest_path': manifest_path,
+                'line': exc.lineno,
+                'column': exc.colno,
+            },
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise cli_contract.MachineContractError(
+            f'Manifest is not valid UTF-8: {manifest_path}.',
+            code_name='INVALID_MANIFEST_ENCODING',
+            suggested_action='rebuild_or_repair_manifest',
+            details={'manifest_path': manifest_path},
+        ) from exc
+    except OSError as exc:
+        raise cli_contract.MachineContractError(
+            f'Manifest could not be read: {manifest_path} ({exc}).',
+            code_name='MANIFEST_UNREADABLE',
+            suggested_action='inspect_manifest_permissions',
+            details={'manifest_path': manifest_path},
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise cli_contract.MachineContractError(
+            f'Manifest root must be a JSON object: {manifest_path}.',
+            code_name='INVALID_MANIFEST_SHAPE',
+            suggested_action='rebuild_or_repair_manifest',
+            details={
+                'manifest_path': manifest_path,
+                'actual_type': type(manifest).__name__,
+            },
+        )
     manifest['_manifest_path'] = manifest_path
     manifest['_package_dir'] = os.path.dirname(manifest_path)
     return manifest
@@ -11712,16 +11751,6 @@ def build_machine_success_envelope(command, value, args):
     )
 
 
-def _write_machine_diagnostics(buffer):
-    diagnostics = buffer.getvalue()
-    if not diagnostics:
-        return
-    sys.stderr.write(diagnostics)
-    if not diagnostics.endswith('\n'):
-        sys.stderr.write('\n')
-    sys.stderr.flush()
-
-
 def _system_exit_message(exc):
     if isinstance(exc.code, str) and exc.code.strip():
         return exc.code.strip()
@@ -11735,11 +11764,13 @@ def _machine_field_paths(args):
     for group in getattr(args, 'fields', []) or []:
         values = group if isinstance(group, (list, tuple)) else [group]
         for value in values:
-            paths.extend(
-                item.strip()
-                for item in str(value).split(',')
-                if item.strip()
-            )
+            raw_items = str(value).split(',')
+            if any(not item.strip() for item in raw_items):
+                raise ValueError(f'Invalid field path list: {value!r}')
+            for item in raw_items:
+                path = item.strip()
+                cli_contract.field_path_parts(path)
+                paths.append(path)
     return list(dict.fromkeys(paths))
 
 
@@ -11771,17 +11802,39 @@ def _write_machine_envelope(envelope, args):
     _write_json_payload(envelope, args, record_output_artifact=True)
 
 
+def _write_machine_usage_error(args, *, code, message, suggested_action):
+    """Write a usage error without reapplying invalid output projection."""
+
+    command = str(getattr(args, 'command', '') or '')
+    safe_args = copy.copy(args)
+    safe_args.fields = []
+    envelope = cli_contract.error_envelope(
+        command,
+        code=code,
+        message=message,
+        suggested_action=suggested_action,
+        details={'semantic_exit_code': cli_contract.EXIT_USAGE},
+    )
+    _write_json_payload(
+        envelope,
+        safe_args,
+        record_output_artifact=command in MACHINE_OUTPUT_COMMANDS,
+    )
+    return cli_contract.EXIT_USAGE
+
+
 def run_machine_command(parser, args):
     """Run one supported command with clean JSON stdout and text diagnostics."""
 
     command = str(args.command or '')
-    diagnostics = io.StringIO()
     try:
-        with contextlib.redirect_stdout(diagnostics):
+        with (
+            cli_contract.machine_output_context(),
+            contextlib.redirect_stdout(sys.stderr),
+        ):
             value = dispatch_command(parser, args)
             envelope = build_machine_success_envelope(command, value, args)
     except SystemExit as exc:
-        _write_machine_diagnostics(diagnostics)
         message = _system_exit_message(exc)
         legacy_exit_code = exc.code if isinstance(exc.code, int) and exc.code else 1
         if isinstance(exc, cli_contract.MachineContractError):
@@ -11828,7 +11881,6 @@ def run_machine_command(parser, args):
             return cli_contract.strict_exit_code(envelope)
         return legacy_exit_code
     except Exception as exc:
-        _write_machine_diagnostics(diagnostics)
         traceback.print_exc(file=sys.stderr)
         message = str(exc) or exc.__class__.__name__
         exception_type = exc.__class__.__name__
@@ -11860,7 +11912,6 @@ def run_machine_command(parser, args):
             return cli_contract.strict_exit_code(envelope)
         return 1
 
-    _write_machine_diagnostics(diagnostics)
     _write_machine_envelope(envelope, args)
     if args.strict_exit_codes:
         return cli_contract.strict_exit_code(envelope)
@@ -11886,6 +11937,18 @@ def main(argv=None):
         and args.command not in {'capabilities', 'schema'}
     ):
         parser.error(f"{', '.join(json_only_options)} requires --output json")
+    if getattr(args, 'fields', None):
+        try:
+            _machine_field_paths(args)
+        except ValueError as exc:
+            if output == 'json' or args.command in {'capabilities', 'schema'}:
+                return _write_machine_usage_error(
+                    args,
+                    code='INVALID_FIELD_PATH',
+                    message=str(exc),
+                    suggested_action='fix_field_path',
+                )
+            parser.error(str(exc))
     if output == 'json':
         if args.command not in MACHINE_OUTPUT_COMMANDS:
             cli_contract.write_json_envelope(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1850,6 +1850,13 @@ def remember_latest_manifest(manifest_path):
 
 
 def load_manifest(target=None):
+    """Load and validate a JSON manifest or raise a structured contract error.
+
+    Raises:
+        cli_contract.MachineContractError: If the manifest cannot be read as
+            UTF-8 JSON or its root value is not a JSON object.
+    """
+
     manifest_path = manifest_path_for_target(target)
     try:
         with open(manifest_path, 'r', encoding='utf-8') as handle:

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -90,6 +91,29 @@ class BatchCliContractTests(unittest.TestCase):
             },
         )
         self.assertNotIn(": ", stdout.getvalue())
+
+    def test_invalid_field_path_returns_structured_usage_error(self):
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--fields",
+                    "result..job_state",
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "INVALID_FIELD_PATH")
+        self.assertEqual(
+            payload["error"]["details"]["semantic_exit_code"],
+            batch.cli_contract.EXIT_USAGE,
+        )
 
     def test_field_projection_does_not_change_strict_exit_code(self):
         manifest = {
@@ -216,6 +240,43 @@ class BatchCliContractTests(unittest.TestCase):
             batch.cli_contract.EXIT_INVALID_STATE,
         )
 
+    def test_invalid_manifest_json_returns_invalid_state_error(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            manifest_path.write_text("{", encoding="utf-8")
+            with (
+                mock.patch.object(batch, "initialize_batch_logging"),
+                mock.patch.object(batch.legacy, "load_config"),
+                mock.patch.object(batch.legacy, "load_translator_settings"),
+                mock.patch.object(batch.legacy, "load_glossary"),
+                mock.patch.object(batch, "load_batch_settings"),
+                mock.patch.object(batch, "print_banner"),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                exit_code = batch.main(
+                    [
+                        "status",
+                        str(manifest_path),
+                        "--output",
+                        "json",
+                        "--non-interactive",
+                        "--strict-exit-codes",
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+        self.assertEqual(payload["error"]["code"], "INVALID_MANIFEST_JSON")
+        self.assertEqual(
+            payload["error"]["suggested_action"],
+            "rebuild_or_repair_manifest",
+        )
+        self.assertNotIn("Traceback", stderr.getvalue())
+
     def test_machine_result_builder_covers_manifest_workflow(self):
         args = SimpleNamespace(target="")
         base_manifest = {
@@ -304,6 +365,45 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertNotIn("banner", stdout.getvalue())
         self.assertIn("banner", stderr.getvalue())
         self.assertIn("doctor text", stderr.getvalue())
+
+    def test_machine_mode_routes_prepare_child_stdout_away_from_json(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as child_diagnostics:
+            def dispatch(_parser, _args):
+                self.assertTrue(batch.cli_contract.machine_output_active())
+                print("python progress")
+                ok = batch.legacy._run_prepare_command(
+                    [sys.executable, "-c", "print('child stdout')"],
+                    cwd=str(Path.cwd()),
+                    step_name="contract smoke",
+                )
+                self.assertTrue(ok)
+                return {}
+
+            with (
+                mock.patch.object(batch, "dispatch_command", side_effect=dispatch),
+                mock.patch.object(
+                    batch.legacy,
+                    "_machine_subprocess_diagnostic_stream",
+                    return_value=child_diagnostics,
+                ),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                exit_code = batch.main(["doctor", "--output", "json", "--compact"])
+
+            child_diagnostics.flush()
+            child_diagnostics.seek(0)
+            child_output = child_diagnostics.read()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["command"], "doctor")
+        self.assertNotIn("child stdout", stdout.getvalue())
+        self.assertIn("child stdout", child_output)
+        self.assertIn("python progress", stderr.getvalue())
 
     def test_check_json_exposes_safety_and_artifacts(self):
         manifest = {

--- a/tests/test_prepare_command_trust.py
+++ b/tests/test_prepare_command_trust.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import cli_contract
 import gemini_translate_batch as batch_mod
 import translator_runtime as runtime
 
@@ -150,6 +151,31 @@ class RunPrepareCommandTests(unittest.TestCase):
         printed = ' '.join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
         self.assertIn('cwd: /tmp/work', printed)
         self.assertIn('shell: False', printed)
+
+    def test_run_routes_child_output_to_stderr_in_machine_mode(self):
+        completed = mock.Mock(returncode=0)
+        diagnostics_stream = object()
+        with (
+            cli_contract.machine_output_context(),
+            mock.patch.object(runtime, 'PREP_ALLOW_SHELL_COMMANDS', False),
+            mock.patch.object(
+                runtime,
+                '_machine_subprocess_diagnostic_stream',
+                return_value=diagnostics_stream,
+            ),
+            mock.patch.object(runtime.subprocess, 'run', return_value=completed) as run_mock,
+            mock.patch('builtins.print'),
+        ):
+            ok = runtime._run_prepare_command(
+                ['python', 'tool.py'],
+                cwd='/tmp/work',
+                step_name='Custom RPA unpack',
+            )
+
+        self.assertTrue(ok)
+        _args, kwargs = run_mock.call_args
+        self.assertIs(kwargs['stdout'], diagnostics_stream)
+        self.assertIs(kwargs['stderr'], diagnostics_stream)
 
     def test_run_refuses_shell_string_without_opt_in(self):
         with (

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -33,6 +33,7 @@ def locked_runtime_state():
         yield
 
 from atomic_io import atomic_write_json, atomic_write_lines, file_sha256
+import cli_contract
 from gemini_model_catalog import (
     DEFAULT_GEMINI_EMBEDDING_MODEL,
     DEFAULT_GEMINI_TRANSLATION_MODEL,
@@ -2537,6 +2538,29 @@ def _render_prepare_command(command, variables):
     raise RuntimeError(f"Unsupported prepare command type: {type(command).__name__}")
 
 
+def _machine_subprocess_diagnostic_stream():
+    """Return an OS-backed stderr stream for child diagnostics in machine mode."""
+
+    if not cli_contract.machine_output_active():
+        return None
+    for stream in (sys.stderr, sys.__stderr__):
+        if stream is None:
+            continue
+        try:
+            stream.fileno()
+        except (AttributeError, io.UnsupportedOperation, OSError):
+            continue
+        return stream
+    return subprocess.DEVNULL
+
+
+def _machine_subprocess_output_kwargs():
+    stream = _machine_subprocess_diagnostic_stream()
+    if stream is None:
+        return {}
+    return {"stdout": stream, "stderr": stream}
+
+
 def _run_prepare_command(command, cwd, step_name):
     use_shell = prepare_command_uses_shell(command)
     if use_shell and not PREP_ALLOW_SHELL_COMMANDS:
@@ -2553,7 +2577,13 @@ def _run_prepare_command(command, cwd, step_name):
     print(f"[Prepare]   command: {shown}")
 
     try:
-        result = subprocess.run(command, cwd=cwd, shell=use_shell, check=False)
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            shell=use_shell,
+            check=False,
+            **_machine_subprocess_output_kwargs(),
+        )
     except Exception as e:
         print(f"[Prepare] {step_name} failed to start: {e}")
         return False


### PR DESCRIPTION
## Summary

Follow-up hardening for the machine-readable CLI contract delivered under #276:

- keep machine-mode stdout JSON-only while streaming Python diagnostics and prepare child-process output to stderr
- return structured manifest errors (`INVALID_MANIFEST_JSON`, `INVALID_MANIFEST_ENCODING`, `MANIFEST_UNREADABLE`, and `INVALID_MANIFEST_SHAPE`) with semantic invalid-state exits
- validate malformed `--fields` paths before dispatch and return `INVALID_FIELD_PATH` with usage exit code 2 instead of an uncaught traceback
- update CLI/GUI documentation and add regression coverage

## Root cause

Machine mode buffered Python stdout in `StringIO`, which neither intercepted inherited subprocess file descriptors nor exposed progress to the GUI until completion. Manifest decoding failures fell through to the generic internal-error classifier, while malformed field projections were validated only while writing the final envelope and could escape the machine error boundary.

## Validation

- `python -m unittest tests.test_cli_contract tests.test_gemini_translate_batch_cli_contract tests.test_prepare_command_trust` — 48 passed
- `python -B tests/run_cli_tests.py -q` — 775 passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 892 passed
- `python scripts/run_quality_gates.py all` — all blocking gates passed
- `git diff --check`
- real CLI smokes confirmed clean JSON stdout and strict exits 5 / 2 for malformed manifest / field path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved machine-readable JSON output with clean structured results on stdout and diagnostics routed to stderr.
  - Added clear, structured error responses for invalid manifests and field selections, including recovery guidance and consistent exit codes.
  - Enhanced handling of preparation-command output in JSON mode.

- **Documentation**
  - Updated CLI, GUI, and quickstart documentation to explain JSON output, logging, field selection, file output, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->