### PR TITLE
Close out machine CLI contract for typed errors and output-file failures

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -54,6 +54,7 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
 核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.safety_level` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。
+输出文件会在 workflow 前进行可写性探测。若创建或原子替换失败，stderr 保留诊断，stdout 回退为未投影的 `OUTPUT_FILE_WRITE_FAILED` envelope；严格模式退出 `5`，兼容模式退出 `1`。必须同时读取 `error.details.workflow_started` 和 `command_completed`：分别区分 workflow 未启动、已启动但以错误结束、以及已成功完成后仅结果文件落盘失败；后两种状态都应按原命令可能已产生业务副作用处理。
 `capabilities / schema` 也支持这三个选项；它们原生输出 JSON，因此无需 `--output json`。
 
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -54,7 +54,7 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
 核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.safety_level` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。
-输出文件会在 workflow 前进行可写性探测。若创建或原子替换失败，stderr 保留诊断，stdout 回退为未投影的 `OUTPUT_FILE_WRITE_FAILED` envelope；严格模式退出 `5`，兼容模式退出 `1`。必须同时读取 `error.details.workflow_started` 和 `command_completed`：分别区分 workflow 未启动、已启动但以错误结束、以及已成功完成后仅结果文件落盘失败；后两种状态都应按原命令可能已产生业务副作用处理。
+输出文件会在 workflow 前进行可写性探测。若创建或原子替换失败，stderr 保留诊断，stdout 回退为未投影的 `OUTPUT_FILE_WRITE_FAILED` envelope；严格模式退出 `5`，兼容模式退出 `1`。必须同时读取 `error.details.workflow_started` 和 `error.details.command_completed`：分别区分 workflow 未启动、已启动但以错误结束、以及已成功完成后仅结果文件落盘失败；后两种状态都应按原命令可能已产生业务副作用处理。
 `capabilities / schema` 也支持这三个选项；它们原生输出 JSON，因此无需 `--output json`。
 
 

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -65,7 +65,9 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning、
 | `5` | 输入、配置或状态已失效 | stale check、manifest/results 漂移、前置产物缺失 |
 | `6` | 远端临时错误，可稍后重试 | rate limit、quota、timeout、service unavailable |
 
-严格模式的错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。Manifest 读取还会使用 `INVALID_MANIFEST_JSON`、`INVALID_MANIFEST_ENCODING`、`INVALID_MANIFEST_SHAPE` 或 `MANIFEST_UNREADABLE`；这些错误在严格模式下退出 `5`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容退出行为。
+严格模式的兜底错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。核心前置条件优先返回稳定错误码：manifest 读取与身份问题使用 `MANIFEST_NOT_FOUND`、`INVALID_MANIFEST_JSON`、`INVALID_MANIFEST_ENCODING`、`INVALID_MANIFEST_SHAPE`、`MANIFEST_UNREADABLE`、`INVALID_MANIFEST_PATH`、`MANIFEST_PROJECT_IDENTITY_MISSING`、`MANIFEST_PROJECT_MISMATCH`、`MANIFEST_MODE_MISMATCH` 或 `MANIFEST_PACKAGE_DIR_MISSING`；Batch 输入问题使用 `BATCH_INPUT_NOT_FOUND` 或 `INVALID_BATCH_INPUT_JSON`；apply 门禁使用 `APPLY_CHECK_REQUIRED`、`STALE_CHECK_CONTRACT`、`STALE_CHECK_FINGERPRINT` 或 `UNSAFE_CHECK_STATUS`。
+
+除 `UNSAFE_CHECK_STATUS` 按安全门禁退出 `4` 外，上述前置条件错误在严格模式下退出 `5`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容退出行为。
 
 
 ## 严格非交互与显式 manifest
@@ -115,7 +117,9 @@ python gemini_translate_batch.py check <manifest> `
   --compact --output-file .\check-result.json
 ```
 
-命令的业务退出码保持不变；调用方随后读取自己传入的文件路径。若文件无法创建或原子替换，命令失败并把诊断写入 stderr。
+成功写入时，命令的业务退出码保持不变；调用方随后读取自己传入的文件路径。CLI 会在 workflow 执行前探测明显不可写的目标，避免已知失败路径触发业务副作用。
+
+若文件无法创建或原子替换，诊断写入 stderr，完整的 `OUTPUT_FILE_WRITE_FAILED` envelope 改为回退到 stdout（不应用 `--fields` 投影）；严格模式退出 `5`，兼容模式退出 `1`。调用方必须同时检查 `error.details.workflow_started` 与 `command_completed`：前者为 `false` 表示前置探测失败、workflow 未执行；前者为 `true` 而后者为 `false` 表示 workflow 已启动但以错误结束；两者都为 `true` 表示 workflow 已成功完成后结果文件落盘失败，写操作可能已经生效。后两种情况可结合 `original_ok`、`original_status` 或 `original_error_code` 判断原命令结果。
 
 ## 机器发现
 

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -65,7 +65,7 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning、
 | `5` | 输入、配置或状态已失效 | stale check、manifest/results 漂移、前置产物缺失 |
 | `6` | 远端临时错误，可稍后重试 | rate limit、quota、timeout、service unavailable |
 
-严格模式的兜底错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。核心前置条件优先返回稳定错误码：manifest 读取与身份问题使用 `MANIFEST_NOT_FOUND`、`INVALID_MANIFEST_JSON`、`INVALID_MANIFEST_ENCODING`、`INVALID_MANIFEST_SHAPE`、`MANIFEST_UNREADABLE`、`INVALID_MANIFEST_PATH`、`MANIFEST_PROJECT_IDENTITY_MISSING`、`MANIFEST_PROJECT_MISMATCH`、`MANIFEST_MODE_MISMATCH` 或 `MANIFEST_PACKAGE_DIR_MISSING`；Batch 输入问题使用 `BATCH_INPUT_NOT_FOUND` 或 `INVALID_BATCH_INPUT_JSON`；apply 门禁使用 `APPLY_CHECK_REQUIRED`、`STALE_CHECK_CONTRACT`、`STALE_CHECK_FINGERPRINT` 或 `UNSAFE_CHECK_STATUS`。
+严格模式的兜底错误 envelope 可能使用 `STALE_STATE`、`PRECONDITION_FAILED`、`COMMAND_BLOCKED`、`REMOTE_RETRYABLE`、`COMMAND_REFUSED` 或 `INTERNAL_ERROR`。核心前置条件优先返回稳定错误码：manifest 读取与身份问题使用 `MANIFEST_NOT_FOUND`、`INVALID_MANIFEST_JSON`、`INVALID_MANIFEST_ENCODING`、`INVALID_MANIFEST_SHAPE`、`MANIFEST_UNREADABLE`、`INVALID_MANIFEST_PATH`、`MANIFEST_PROJECT_IDENTITY_MISSING`、`MANIFEST_PROJECT_MISMATCH`、`MANIFEST_MODE_MISMATCH` 或 `MANIFEST_PACKAGE_DIR_MISSING`；Batch 输入问题使用 `BATCH_INPUT_NOT_FOUND` 或 `INVALID_BATCH_INPUT_JSON`；apply 门禁使用 `APPLY_CHECK_REQUIRED`、`STALE_CHECK_CONTRACT`、`STALE_CHECK_FINGERPRINT` 或 `UNSAFE_CHECK_STATUS`；未知 `fail_apply_preflight` reason 回落到 `APPLY_PREFLIGHT_FAILED`。
 
 除 `UNSAFE_CHECK_STATUS` 按安全门禁退出 `4` 外，上述前置条件错误在严格模式下退出 `5`。同时读取 `retryable`、`suggested_action` 和权威的 `details.semantic_exit_code`，不要解析 `message` 文本。未启用严格模式时保持 schema v1 的兼容退出行为。
 
@@ -119,7 +119,7 @@ python gemini_translate_batch.py check <manifest> `
 
 成功写入时，命令的业务退出码保持不变；调用方随后读取自己传入的文件路径。CLI 会在 workflow 执行前探测明显不可写的目标，避免已知失败路径触发业务副作用。
 
-若文件无法创建或原子替换，诊断写入 stderr，完整的 `OUTPUT_FILE_WRITE_FAILED` envelope 改为回退到 stdout（不应用 `--fields` 投影）；严格模式退出 `5`，兼容模式退出 `1`。调用方必须同时检查 `error.details.workflow_started` 与 `command_completed`：前者为 `false` 表示前置探测失败、workflow 未执行；前者为 `true` 而后者为 `false` 表示 workflow 已启动但以错误结束；两者都为 `true` 表示 workflow 已成功完成后结果文件落盘失败，写操作可能已经生效。后两种情况可结合 `original_ok`、`original_status` 或 `original_error_code` 判断原命令结果。
+若文件无法创建或原子替换，诊断写入 stderr，完整的 `OUTPUT_FILE_WRITE_FAILED` envelope 改为回退到 stdout（不应用 `--fields` 投影）；严格模式退出 `5`，兼容模式退出 `1`。调用方必须同时检查 `error.details.workflow_started` 与 `error.details.command_completed`：前者为 `false` 表示前置探测失败、workflow 未执行；前者为 `true` 而后者为 `false` 表示 workflow 已启动但以错误结束；两者都为 `true` 表示 workflow 已成功完成后结果文件落盘失败，写操作可能已经生效。后两种情况可结合 `original_ok`、`original_status` 或 `original_error_code` 判断原命令结果。
 
 ## 机器发现
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 import time
 import tokenize
 import traceback
@@ -1061,7 +1062,12 @@ def _canonical_manifest_dir(value, field_name):
         return ''
     raw = value.strip()
     if not os.path.isabs(raw):
-        raise SystemExit(f'Manifest {field_name} must be an absolute path: {raw}')
+        raise cli_contract.MachineContractError(
+            f'Manifest {field_name} must be an absolute path: {raw}',
+            code_name='INVALID_MANIFEST_PATH',
+            suggested_action='rebuild_or_repair_manifest',
+            details={'field': field_name, 'path': raw},
+        )
     return _canonical_abs_path(raw)
 
 
@@ -1080,31 +1086,49 @@ def _infer_legacy_manifest_tl_dir(manifest):
             candidate = os.path.dirname(candidate)
         resolved = resolve_path_under_dir(candidate, rel_path, f'manifest file key {file_key}')
         if _normalized_abs_path(resolved) != _normalized_abs_path(path_value):
-            raise SystemExit(
-                f'Unsafe legacy manifest file path for {file_key}: '
-                'path escapes the inferred translation directory or does not match its file key.'
+            raise cli_contract.MachineContractError(
+                (
+                    f'Unsafe legacy manifest file path for {file_key}: '
+                    'path escapes the inferred translation directory or does not match its file key.'
+                ),
+                code_name='INVALID_MANIFEST_PATH',
+                suggested_action='rebuild_or_repair_manifest',
+                details={'field': f'files.{file_key}.path', 'path': path_value},
             )
         candidates.append(_canonical_abs_path(candidate))
     if not candidates:
         return ''
     first = candidates[0]
     if any(_normalized_abs_path(candidate) != _normalized_abs_path(first) for candidate in candidates[1:]):
-        raise SystemExit('Legacy manifest file paths do not share one translation directory.')
+        raise cli_contract.MachineContractError(
+            'Legacy manifest file paths do not share one translation directory.',
+            code_name='INVALID_MANIFEST_PATH',
+            suggested_action='rebuild_or_repair_manifest',
+            details={'field': 'files'},
+        )
     return first
 
 
 def manifest_project_identity(manifest):
     if not isinstance(manifest, dict):
-        raise SystemExit('Manifest project identity is missing; rebuild the batch package.')
+        raise cli_contract.MachineContractError(
+            'Manifest project identity is missing; rebuild the batch package.',
+            code_name='MANIFEST_PROJECT_IDENTITY_MISSING',
+            suggested_action='rebuild_batch_package',
+        )
     manifest_tl_dir = _canonical_manifest_dir(manifest.get('tl_dir'), 'tl_dir')
     identity_source = 'manifest'
     if not manifest_tl_dir:
         manifest_tl_dir = _infer_legacy_manifest_tl_dir(manifest)
         identity_source = 'legacy_file_paths'
     if not manifest_tl_dir:
-        raise SystemExit(
-            'Manifest project identity is missing and cannot be inferred from absolute file paths; '
-            'rebuild the batch package before check/apply.'
+        raise cli_contract.MachineContractError(
+            (
+                'Manifest project identity is missing and cannot be inferred from absolute file paths; '
+                'rebuild the batch package before check/apply.'
+            ),
+            code_name='MANIFEST_PROJECT_IDENTITY_MISSING',
+            suggested_action='rebuild_batch_package',
         )
     return {
         'base_dir': _canonical_manifest_dir(manifest.get('base_dir'), 'base_dir'),
@@ -1117,16 +1141,34 @@ def require_manifest_project_match(manifest, command_name):
     identity = manifest_project_identity(manifest)
     active_tl_dir = _canonical_abs_path(legacy.TL_DIR)
     if _normalized_abs_path(identity['tl_dir']) != _normalized_abs_path(active_tl_dir):
-        raise SystemExit(
-            f'{command_name} refused: manifest project does not match the active project '
-            f'(manifest tl_dir={identity["tl_dir"]}, active tl_dir={active_tl_dir}).'
+        raise cli_contract.MachineContractError(
+            (
+                f'{command_name} refused: manifest project does not match the active project '
+                f'(manifest tl_dir={identity["tl_dir"]}, active tl_dir={active_tl_dir}).'
+            ),
+            code_name='MANIFEST_PROJECT_MISMATCH',
+            suggested_action='select_matching_project_or_manifest',
+            details={
+                'command': command_name,
+                'manifest_tl_dir': identity['tl_dir'],
+                'active_tl_dir': active_tl_dir,
+            },
         )
     if identity['base_dir']:
         active_base_dir = _canonical_abs_path(legacy.BASE_DIR)
         if _normalized_abs_path(identity['base_dir']) != _normalized_abs_path(active_base_dir):
-            raise SystemExit(
-                f'{command_name} refused: manifest project does not match the active project '
-                f'(manifest base_dir={identity["base_dir"]}, active base_dir={active_base_dir}).'
+            raise cli_contract.MachineContractError(
+                (
+                    f'{command_name} refused: manifest project does not match the active project '
+                    f'(manifest base_dir={identity["base_dir"]}, active base_dir={active_base_dir}).'
+                ),
+                code_name='MANIFEST_PROJECT_MISMATCH',
+                suggested_action='select_matching_project_or_manifest',
+                details={
+                    'command': command_name,
+                    'manifest_base_dir': identity['base_dir'],
+                    'active_base_dir': active_base_dir,
+                },
             )
     return identity
 
@@ -1826,7 +1868,12 @@ def manifest_path_for_target(target):
             candidate = os.path.join(candidate, 'manifest.json')
         if os.path.isfile(candidate):
             return candidate
-        raise SystemExit(f'Manifest not found: {target}')
+        raise cli_contract.MachineContractError(
+            f'Manifest not found: {target}',
+            code_name='MANIFEST_NOT_FOUND',
+            suggested_action='pass_existing_manifest_path',
+            details={'target': str(target), 'resolved_path': candidate},
+        )
 
     if os.path.isfile(LATEST_MANIFEST_FILE):
         with open(LATEST_MANIFEST_FILE, 'r', encoding='utf-8') as handle:
@@ -1839,7 +1886,12 @@ def manifest_path_for_target(target):
         if 'manifest.json' in files:
             manifests.append(os.path.join(root, 'manifest.json'))
     if not manifests:
-        raise SystemExit('No batch manifest found.')
+        raise cli_contract.MachineContractError(
+            'No batch manifest found.',
+            code_name='MANIFEST_NOT_FOUND',
+            suggested_action='build_batch_package',
+            details={'search_directory': os.path.abspath(BATCH_JOBS_DIR)},
+        )
     manifests.sort(key=lambda path: os.path.getmtime(path), reverse=True)
     return manifests[0]
 
@@ -1912,9 +1964,18 @@ def manifest_mode(manifest):
 def require_manifest_mode(manifest, expected_mode, command_name):
     current_mode = manifest_mode(manifest)
     if current_mode != expected_mode:
-        raise SystemExit(
-            f'{command_name} only supports {expected_mode} manifests; '
-            f'this manifest is {current_mode}.'
+        raise cli_contract.MachineContractError(
+            (
+                f'{command_name} only supports {expected_mode} manifests; '
+                f'this manifest is {current_mode}.'
+            ),
+            code_name='MANIFEST_MODE_MISMATCH',
+            suggested_action='use_matching_workflow',
+            details={
+                'command': command_name,
+                'expected_mode': expected_mode,
+                'actual_mode': current_mode,
+            },
         )
 
 
@@ -2411,7 +2472,25 @@ def fail_apply_preflight(manifest, reason_code, message, current_fingerprint=Non
         current_fingerprint=current_fingerprint,
     )
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
-    raise SystemExit(f'{message} Report: {report_path}')
+    blocked = reason_code == 'unsafe_check_status'
+    raise cli_contract.MachineContractError(
+        f'{message} Report: {report_path}',
+        code_name={
+            'missing_check': 'APPLY_CHECK_REQUIRED',
+            'stale_check_contract': 'STALE_CHECK_CONTRACT',
+            'stale_check_fingerprint': 'STALE_CHECK_FINGERPRINT',
+            'unsafe_check_status': 'UNSAFE_CHECK_STATUS',
+        }.get(reason_code, 'APPLY_PREFLIGHT_FAILED'),
+        suggested_action='repair_results_or_run_check' if blocked else 'run_check_again',
+        semantic_exit_code=(
+            cli_contract.EXIT_BLOCKED if blocked else cli_contract.EXIT_INVALID_STATE
+        ),
+        details={
+            'reason_code': reason_code,
+            'report_path': report_path,
+            'current_fingerprint': current_fingerprint or {},
+        },
+    )
 
 
 def require_safe_check_for_apply(manifest):
@@ -2454,14 +2533,34 @@ def require_safe_check_for_apply(manifest):
 def load_request_rows(manifest):
     input_jsonl_path = manifest.get('input_jsonl_path')
     if not input_jsonl_path or not os.path.isfile(input_jsonl_path):
-        raise SystemExit(f"Input JSONL not found: {input_jsonl_path}")
+        raise cli_contract.MachineContractError(
+            f"Input JSONL not found: {input_jsonl_path}",
+            code_name='BATCH_INPUT_NOT_FOUND',
+            suggested_action='rebuild_batch_package',
+            details={'input_jsonl_path': input_jsonl_path or ''},
+        )
     rows = []
     with open(input_jsonl_path, 'r', encoding='utf-8') as handle:
-        for raw_line in handle:
+        for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
             if not line:
                 continue
-            rows.append(json.loads(line))
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise cli_contract.MachineContractError(
+                    (
+                        f'Batch input JSONL is not valid JSON: {input_jsonl_path} '
+                        f'(line {line_number}, column {exc.colno}).'
+                    ),
+                    code_name='INVALID_BATCH_INPUT_JSON',
+                    suggested_action='rebuild_batch_package',
+                    details={
+                        'input_jsonl_path': input_jsonl_path,
+                        'line': line_number,
+                        'column': exc.colno,
+                    },
+                ) from exc
     return rows
 
 
@@ -4980,13 +5079,23 @@ def ensure_manifest_cost_estimate(manifest):
         )
     except FileNotFoundError as exc:
         jsonl_path = manifest.get('input_jsonl_path') or ''
-        raise SystemExit(
-            f'Batch input JSONL not found: {jsonl_path or exc}'
+        raise cli_contract.MachineContractError(
+            f'Batch input JSONL not found: {jsonl_path or exc}',
+            code_name='BATCH_INPUT_NOT_FOUND',
+            suggested_action='rebuild_batch_package',
+            details={'input_jsonl_path': jsonl_path},
         ) from exc
     except json.JSONDecodeError as exc:
         jsonl_path = manifest.get('input_jsonl_path') or ''
-        raise SystemExit(
-            f'Batch input JSONL is not valid JSON: {jsonl_path} ({exc})'
+        raise cli_contract.MachineContractError(
+            f'Batch input JSONL is not valid JSON: {jsonl_path} ({exc})',
+            code_name='INVALID_BATCH_INPUT_JSON',
+            suggested_action='rebuild_batch_package',
+            details={
+                'input_jsonl_path': jsonl_path,
+                'line': exc.lineno,
+                'column': exc.colno,
+            },
         ) from exc
 
 
@@ -4997,7 +5106,11 @@ def _manifest_package_dir(manifest):
     manifest_path = manifest.get('_manifest_path')
     if manifest_path:
         return os.path.dirname(manifest_path)
-    raise SystemExit('Manifest package directory is missing.')
+    raise cli_contract.MachineContractError(
+        'Manifest package directory is missing.',
+        code_name='MANIFEST_PACKAGE_DIR_MISSING',
+        suggested_action='rebuild_or_repair_manifest',
+    )
 
 
 def _raise_uncertain_submit_blocked(uncertain_state):
@@ -11139,13 +11252,21 @@ def dispatch_command(parser, args):
             explicit_target_commands=EXPLICIT_TARGET_COMMANDS,
             result_schema_version=cli_contract.CLI_SCHEMA_VERSION,
         )
-        _write_json_payload(payload, args)
-        return payload
+        return _write_machine_document(
+            payload,
+            args,
+            command_completed=True,
+            workflow_started=True,
+        )
 
     if command == 'schema':
         payload = cli_discovery.command_schema(parser, args.schema_command)
-        _write_json_payload(payload, args)
-        return payload
+        return _write_machine_document(
+            payload,
+            args,
+            command_completed=True,
+            workflow_started=True,
+        )
 
 
     if command in MACHINE_OUTPUT_COMMANDS:
@@ -11805,8 +11926,134 @@ def _write_json_payload(document, args, *, record_output_artifact=False):
     cli_contract.write_json_envelope(payload, sys.stdout, compact=compact)
 
 
-def _write_machine_envelope(envelope, args):
-    _write_json_payload(envelope, args, record_output_artifact=True)
+def _is_output_file_failure(document):
+    error = document.get('error') if isinstance(document, dict) else None
+    return isinstance(error, dict) and error.get('code') == 'OUTPUT_FILE_WRITE_FAILED'
+
+
+def _output_file_failure_envelope(
+    args,
+    exc,
+    *,
+    workflow_started,
+    command_completed,
+    original_document=None,
+):
+    output_file = str(getattr(args, 'output_file', '') or '').strip()
+    details = {
+        'output_file': os.path.abspath(output_file) if output_file else '',
+        'exception_type': exc.__class__.__name__,
+        'reason': str(exc),
+        'command_completed': bool(command_completed),
+        'semantic_exit_code': cli_contract.EXIT_INVALID_STATE,
+        'workflow_started': bool(workflow_started),
+    }
+    if isinstance(original_document, dict):
+        if isinstance(original_document.get('status'), str):
+            details['original_status'] = original_document['status']
+        if isinstance(original_document.get('ok'), bool):
+            details['original_ok'] = original_document['ok']
+        original_error = original_document.get('error')
+        if isinstance(original_error, dict) and original_error.get('code'):
+            details['original_error_code'] = str(original_error['code'])
+    return cli_contract.error_envelope(
+        str(getattr(args, 'command', '') or ''),
+        code='OUTPUT_FILE_WRITE_FAILED',
+        message=f'Could not write JSON output file: {details["output_file"] or output_file}.',
+        suggested_action='choose_writable_output_path',
+        details=details,
+    )
+
+
+def _write_output_file_failure(
+    args,
+    exc,
+    *,
+    workflow_started,
+    command_completed,
+    original_document=None,
+):
+    envelope = _output_file_failure_envelope(
+        args,
+        exc,
+        command_completed=command_completed,
+        original_document=original_document,
+        workflow_started=workflow_started,
+    )
+    print(
+        f'Failed to write --output-file; returning structured error on stdout: {exc}',
+        file=sys.stderr,
+    )
+    fallback_args = copy.copy(args)
+    fallback_args.output_file = ''
+    fallback_args.fields = []
+    _write_json_payload(envelope, fallback_args)
+    return envelope
+
+
+def _write_machine_document(
+    document,
+    args,
+    *,
+    record_output_artifact=False,
+    command_completed=False,
+    workflow_started=False,
+):
+    """Write a document, falling back to stdout only for output-file failures."""
+
+    try:
+        _write_json_payload(
+            document,
+            args,
+            record_output_artifact=record_output_artifact,
+        )
+    except (OSError, ValueError) as exc:
+        if not str(getattr(args, 'output_file', '') or '').strip():
+            raise
+        return _write_output_file_failure(
+            args,
+            exc,
+            command_completed=command_completed,
+            original_document=document,
+            workflow_started=workflow_started,
+        )
+    return document
+
+
+def _preflight_output_file(args):
+    """Verify that an output target is writable before workflow side effects."""
+
+    output_file = str(getattr(args, 'output_file', '') or '').strip()
+    if not output_file:
+        return
+    target = os.path.abspath(output_file)
+    if os.path.isdir(target):
+        raise IsADirectoryError(f'Output path is a directory: {target}')
+    directory = os.path.dirname(target) or os.curdir
+    os.makedirs(directory, exist_ok=True)
+    fd, probe_path = tempfile.mkstemp(
+        prefix=f'.{os.path.basename(target)}.',
+        suffix='.probe.tmp',
+        dir=directory,
+    )
+    os.close(fd)
+    os.unlink(probe_path)
+
+
+def _output_file_failure_exit_code(args):
+    if getattr(args, 'strict_exit_codes', False):
+        return cli_contract.EXIT_INVALID_STATE
+    return 1
+
+
+def _write_machine_envelope(envelope, args, *, command_completed):
+    return _write_machine_document(
+        envelope,
+        args,
+        record_output_artifact=True,
+        command_completed=command_completed,
+        workflow_started=True,
+    )
 
 
 def _write_machine_usage_error(args, *, code, message, suggested_action):
@@ -11822,11 +12069,14 @@ def _write_machine_usage_error(args, *, code, message, suggested_action):
         suggested_action=suggested_action,
         details={'semantic_exit_code': cli_contract.EXIT_USAGE},
     )
-    _write_json_payload(
+    emitted = _write_machine_document(
         envelope,
         safe_args,
         record_output_artifact=command in MACHINE_OUTPUT_COMMANDS,
+        command_completed=False,
     )
+    if _is_output_file_failure(emitted):
+        return _output_file_failure_exit_code(args)
     return cli_contract.EXIT_USAGE
 
 
@@ -11883,9 +12133,11 @@ def run_machine_command(parser, args):
                 message=message,
                 details={'exit_code': legacy_exit_code},
             )
-        _write_machine_envelope(envelope, args)
+        emitted = _write_machine_envelope(envelope, args, command_completed=False)
+        if _is_output_file_failure(emitted):
+            return _output_file_failure_exit_code(args)
         if args.strict_exit_codes:
-            return cli_contract.strict_exit_code(envelope)
+            return cli_contract.strict_exit_code(emitted)
         return legacy_exit_code
     except Exception as exc:
         traceback.print_exc(file=sys.stderr)
@@ -11914,14 +12166,18 @@ def run_machine_command(parser, args):
                 message=message,
                 details={'exception_type': exception_type},
             )
-        _write_machine_envelope(envelope, args)
+        emitted = _write_machine_envelope(envelope, args, command_completed=False)
+        if _is_output_file_failure(emitted):
+            return _output_file_failure_exit_code(args)
         if args.strict_exit_codes:
-            return cli_contract.strict_exit_code(envelope)
+            return cli_contract.strict_exit_code(emitted)
         return 1
 
-    _write_machine_envelope(envelope, args)
+    emitted = _write_machine_envelope(envelope, args, command_completed=True)
+    if _is_output_file_failure(emitted):
+        return _output_file_failure_exit_code(args)
     if args.strict_exit_codes:
-        return cli_contract.strict_exit_code(envelope)
+        return cli_contract.strict_exit_code(emitted)
     return 0
 
 
@@ -11956,19 +12212,32 @@ def main(argv=None):
                     suggested_action='fix_field_path',
                 )
             parser.error(str(exc))
-    if output == 'json':
-        if args.command not in MACHINE_OUTPUT_COMMANDS:
-            cli_contract.write_json_envelope(
-                cli_contract.error_envelope(
-                    str(args.command or ''),
-                    code='OUTPUT_NOT_SUPPORTED',
-                    message='JSON output is not supported for this command.',
-                ),
-                sys.stdout,
+    if output == 'json' and args.command not in MACHINE_OUTPUT_COMMANDS:
+        cli_contract.write_json_envelope(
+            cli_contract.error_envelope(
+                str(args.command or ''),
+                code='OUTPUT_NOT_SUPPORTED',
+                message='JSON output is not supported for this command.',
+            ),
+            sys.stdout,
+        )
+        return 2
+    if getattr(args, 'output_file', ''):
+        try:
+            _preflight_output_file(args)
+        except (OSError, ValueError) as exc:
+            _write_output_file_failure(
+                args,
+                exc,
+                command_completed=False,
+                workflow_started=False,
             )
-            return 2
+            return _output_file_failure_exit_code(args)
+    if output == 'json':
         return run_machine_command(parser, args)
-    dispatch_command(parser, args)
+    result = dispatch_command(parser, args)
+    if args.command in {'capabilities', 'schema'} and _is_output_file_failure(result):
+        return _output_file_failure_exit_code(args)
     return 0
 
 

--- a/gui_qt/cli_runner.py
+++ b/gui_qt/cli_runner.py
@@ -124,6 +124,9 @@ class CliRunner(QObject):
     def _on_finished(self, exit_code: int, exit_status: QProcess.ExitStatus):
         if self._proc is None:
             return
+        # QProcess may still hold final bytes when finished is delivered.
+        self._on_stdout_ready()
+        self._on_stderr_ready()
         for buffer_name, channel_signal in (
             ("_stdout_pending_buffer", self.stdout_line_ready),
             ("_stderr_pending_buffer", self.stderr_line_ready),

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -205,7 +206,7 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertFalse(payload["error"]["details"]["command_completed"])
         self.assertEqual(
             payload["error"]["details"]["output_file"],
-            str(output_path.resolve()),
+            os.path.abspath(str(output_path)),
         )
         self.assertNotIn("Traceback", stderr.getvalue())
         dispatch.assert_not_called()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -172,6 +172,110 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertEqual(payload["status"], "JOB_STATE_SUCCEEDED")
         self.assertEqual(payload["artifacts"]["output_file"], str(output_path))
 
+
+    def test_output_file_preflight_failure_is_structured_before_dispatch(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            blocking_file = Path(tmp) / "not-a-directory"
+            blocking_file.write_text("occupied", encoding="utf-8")
+            output_path = blocking_file / "status.json"
+            with (
+                mock.patch.object(batch, "dispatch_command") as dispatch,
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                exit_code = batch.main(
+                    [
+                        "status",
+                        "manifest.json",
+                        "--output",
+                        "json",
+                        "--strict-exit-codes",
+                        "--output-file",
+                        str(output_path),
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+        self.assertFalse(payload["error"]["details"]["workflow_started"])
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_WRITE_FAILED")
+        self.assertFalse(payload["error"]["details"]["command_completed"])
+        self.assertEqual(
+            payload["error"]["details"]["output_file"],
+            str(output_path.resolve()),
+        )
+        self.assertNotIn("Traceback", stderr.getvalue())
+        dispatch.assert_not_called()
+
+    def test_output_file_write_race_reports_completed_command_on_stdout(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "job_state": "JOB_STATE_SUCCEEDED",
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "_preflight_output_file"),
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            mock.patch.object(
+                batch,
+                "atomic_write",
+                side_effect=PermissionError("target became read-only"),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--strict-exit-codes",
+                    "--output-file",
+                    "status.json",
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        details = payload["error"]["details"]
+        self.assertTrue(details["workflow_started"])
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_WRITE_FAILED")
+        self.assertTrue(details["command_completed"])
+        self.assertTrue(details["original_ok"])
+        self.assertEqual(details["original_status"], "JOB_STATE_SUCCEEDED")
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_discovery_output_file_failure_returns_nonzero_and_json_stdout(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "_preflight_output_file"),
+            mock.patch.object(
+                batch,
+                "atomic_write",
+                side_effect=PermissionError("target became read-only"),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                ["capabilities", "--output-file", "capabilities.json"]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_WRITE_FAILED")
+        self.assertTrue(payload["error"]["details"]["command_completed"])
+        self.assertTrue(payload["error"]["details"]["workflow_started"])
+        self.assertNotIn("Traceback", stderr.getvalue())
+
     def test_non_interactive_requires_explicit_manifest_target(self):
         for command in sorted(batch.EXPLICIT_TARGET_COMMANDS):
             with self.subTest(command=command):
@@ -277,6 +381,95 @@ class BatchCliContractTests(unittest.TestCase):
         )
         self.assertNotIn("Traceback", stderr.getvalue())
 
+
+    def test_core_preconditions_raise_typed_contract_errors(self):
+        with self.assertRaises(batch.cli_contract.MachineContractError) as path_error:
+            batch._canonical_manifest_dir("relative/tl", "tl_dir")
+        self.assertEqual(path_error.exception.code_name, "INVALID_MANIFEST_PATH")
+
+        with (
+            mock.patch.object(
+                batch,
+                "manifest_project_identity",
+                return_value={
+                    "tl_dir": "C:/different/tl",
+                    "base_dir": "",
+                    "source": "manifest",
+                },
+            ),
+            mock.patch.object(batch.legacy, "TL_DIR", "C:/active/tl"),
+            self.assertRaises(batch.cli_contract.MachineContractError) as project_error,
+        ):
+            batch.require_manifest_project_match({}, "apply")
+        self.assertEqual(
+            project_error.exception.code_name,
+            "MANIFEST_PROJECT_MISMATCH",
+        )
+        self.assertEqual(
+            project_error.exception.semantic_exit_code,
+            batch.cli_contract.EXIT_INVALID_STATE,
+        )
+
+        decode_error = json.JSONDecodeError("invalid", "{", 0)
+        with (
+            mock.patch.object(batch, "load_json_file", return_value={}),
+            mock.patch.object(
+                batch.batch_cost_estimate,
+                "attach_cost_estimate_to_manifest",
+                side_effect=decode_error,
+            ),
+            self.assertRaises(batch.cli_contract.MachineContractError) as jsonl_error,
+        ):
+            batch.ensure_manifest_cost_estimate({"input_jsonl_path": "input.jsonl"})
+        self.assertEqual(jsonl_error.exception.code_name, "INVALID_BATCH_INPUT_JSON")
+
+        with (
+            mock.patch.object(
+                batch,
+                "write_apply_failure_report",
+                return_value="C:/jobs/demo/apply_failure_report.json",
+            ),
+            mock.patch.object(batch, "save_manifest"),
+            self.assertRaises(batch.cli_contract.MachineContractError) as apply_error,
+        ):
+            batch.fail_apply_preflight(
+                {},
+                "unsafe_check_status",
+                "Last check is not safe.",
+            )
+        self.assertEqual(apply_error.exception.code_name, "UNSAFE_CHECK_STATUS")
+        self.assertEqual(
+            apply_error.exception.semantic_exit_code,
+            batch.cli_contract.EXIT_BLOCKED,
+        )
+
+    def test_typed_core_error_bypasses_message_classifier_in_machine_mode(self):
+        stdout = io.StringIO()
+
+        def dispatch(_parser, _args):
+            return batch._canonical_manifest_dir("relative/tl", "tl_dir")
+
+        with (
+            mock.patch.object(batch, "dispatch_command", side_effect=dispatch),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "manifest.json",
+                    "--output",
+                    "json",
+                    "--strict-exit-codes",
+                ]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_INVALID_STATE)
+        self.assertEqual(payload["error"]["code"], "INVALID_MANIFEST_PATH")
+        self.assertEqual(
+            payload["error"]["suggested_action"],
+            "rebuild_or_repair_manifest",
+        )
     def test_machine_result_builder_covers_manifest_workflow(self):
         args = SimpleNamespace(target="")
         base_manifest = {

--- a/tests/test_gui_cli_runner.py
+++ b/tests/test_gui_cli_runner.py
@@ -1,8 +1,20 @@
+"""Channel buffering and finished-drain behavior for Gui CLI runner."""
+from __future__ import annotations
+
 import unittest
 
-from PySide6.QtCore import QProcess
+from tests import gui_test_support
 
-from gui_qt.cli_runner import CliRunner
+try:
+    from PySide6.QtCore import QProcess
+
+    from gui_qt.cli_runner import CliRunner
+except ImportError as exc:
+    CliRunner = None  # type: ignore[assignment,misc]
+    QProcess = None  # type: ignore[assignment,misc]
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
 
 
 class _FakeProcess:
@@ -17,6 +29,7 @@ class _FakeProcess:
         return self.stderr_chunks.pop(0) if self.stderr_chunks else b""
 
 
+@gui_test_support.skip_unless_gui(CliRunner is None, IMPORT_ERROR)
 class CliRunnerChannelTests(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
@@ -43,7 +56,10 @@ class CliRunnerChannelTests(unittest.TestCase):
 
         self.assertEqual(self.stdout_lines, ['{', '  "ok": true', '}'])
         self.assertEqual(self.stderr_lines, ['progress 1', 'partial diagnostic'])
-        self.assertEqual(self.all_lines, self.stdout_lines[:-1] + ['progress 1', '}','partial diagnostic'])
+        self.assertEqual(
+            self.all_lines,
+            self.stdout_lines[:-1] + ['progress 1', '}', 'partial diagnostic'],
+        )
         self.assertEqual(self.finished_codes, [0])
         self.assertIsNone(self.runner._proc)
 

--- a/tests/test_gui_cli_runner.py
+++ b/tests/test_gui_cli_runner.py
@@ -1,0 +1,64 @@
+import unittest
+
+from PySide6.QtCore import QProcess
+
+from gui_qt.cli_runner import CliRunner
+
+
+class _FakeProcess:
+    def __init__(self, *, stdout=(), stderr=()):
+        self.stdout_chunks = list(stdout)
+        self.stderr_chunks = list(stderr)
+
+    def readAllStandardOutput(self):
+        return self.stdout_chunks.pop(0) if self.stdout_chunks else b""
+
+    def readAllStandardError(self):
+        return self.stderr_chunks.pop(0) if self.stderr_chunks else b""
+
+
+class CliRunnerChannelTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+        self.stdout_lines = []
+        self.stderr_lines = []
+        self.all_lines = []
+        self.finished_codes = []
+        self.runner.stdout_line_ready.connect(self.stdout_lines.append)
+        self.runner.stderr_line_ready.connect(self.stderr_lines.append)
+        self.runner.line_ready.connect(self.all_lines.append)
+        self.runner.finished.connect(self.finished_codes.append)
+
+    def test_channels_stay_separate_across_chunks_and_final_tail(self):
+        self.runner._proc = _FakeProcess(
+            stdout=(b'{\r', b'\n  "ok": true\r\n', b'}'),
+            stderr=(b'progress 1\r\npartial diagnostic',),
+        )
+
+        self.runner._on_stdout_ready()
+        self.runner._on_stdout_ready()
+        self.runner._on_stdout_ready()
+        self.runner._on_stderr_ready()
+        self.runner._on_finished(0, QProcess.ExitStatus.NormalExit)
+
+        self.assertEqual(self.stdout_lines, ['{', '  "ok": true', '}'])
+        self.assertEqual(self.stderr_lines, ['progress 1', 'partial diagnostic'])
+        self.assertEqual(self.all_lines, self.stdout_lines[:-1] + ['progress 1', '}','partial diagnostic'])
+        self.assertEqual(self.finished_codes, [0])
+        self.assertIsNone(self.runner._proc)
+
+    def test_finished_drains_unread_process_bytes_before_flushing(self):
+        self.runner._proc = _FakeProcess(
+            stdout=(b'{"status":"completed"}',),
+            stderr=(b'final diagnostic',),
+        )
+
+        self.runner._on_finished(7, QProcess.ExitStatus.NormalExit)
+
+        self.assertEqual(self.stdout_lines, ['{"status":"completed"}'])
+        self.assertEqual(self.stderr_lines, ['final diagnostic'])
+        self.assertEqual(self.finished_codes, [7])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Stabilize core Batch machine-mode precondition failures with stable error codes (manifest path/identity/mode/package, batch input, apply gate) so callers do not need to parse English messages.
- Harden `--output-file` failure handling: preflight writability before workflow side effects; on write/replace failure return a full `OUTPUT_FILE_WRITE_FAILED` envelope on stdout (no field projection) with `workflow_started` / `command_completed` so agents can distinguish preflight failure vs post-success disk failure.
- Drain remaining QProcess stdout/stderr in the GUI CLI runner on process finish so final machine envelopes and diagnostics are not dropped, with unit coverage.

## Test plan
- [x] `python -m unittest tests.test_gemini_translate_batch_cli_contract`
- [x] `python -m unittest tests.test_gui_cli_runner`
- [ ] `python -B tests/run_cli_tests.py -q`
- [ ] `python -B tests/run_gui_tests.py -q`
- [ ] Confirm machine JSON docs and quickstart/batch workflow wording match the new error codes and output-file contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured JSON error responses for validation, input, and pre-flight failures.
  * Improved `--output-file` failure handling with fallback stdout envelopes, diagnostics, and clear workflow status details.
  * Added strict-mode exit code guidance for output and precondition failures.

* **Bug Fixes**
  * Ensured final buffered CLI stdout and stderr content is processed before completion is reported.

* **Documentation**
  * Expanded guidance for interpreting error codes, retry actions, workflow status, and command results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->