### PR TITLE
Add project-scoped model usage ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ outputs/
 batch_runs/
 artifacts/
 downloads/
+translation_usage/
 *.log
 *.tmp
 *.bak

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ python -m gui_qt
 | 安装与配置 | [setup.md](docs/setup.md) |
 | GUI 工作台 | [gui_workbench.md](docs/gui_workbench.md) |
 | Batch 与写回安全 | [batch_workflows.md](docs/batch_workflows.md) |
+| 实际模型用量账本 | [model_usage_ledger.md](docs/model_usage_ledger.md) |
 | RAG / 索引 / Story Memory | [context_systems.md](docs/context_systems.md) |
 | 边界、安全与烟测 | [project_notes.md](docs/project_notes.md) |
 | 项目沿革 | [project_history.md](docs/project_history.md) |

--- a/atomic_io.py
+++ b/atomic_io.py
@@ -12,6 +12,9 @@ import os
 import shutil
 import stat
 import tempfile
+import time
+import uuid
+from contextlib import contextmanager
 from typing import Any, Callable, Iterable, TextIO
 
 
@@ -25,6 +28,88 @@ def file_sha256(path: str | os.PathLike[str], *, chunk_size: int = 1024 * 1024) 
 
 def sha256_text(text: str, *, encoding: str = "utf-8") -> str:
     return hashlib.sha256(text.encode(encoding)).hexdigest()
+
+
+class AtomicFileLockTimeoutError(TimeoutError):
+    """Raised when a same-directory exclusive file lock cannot be acquired."""
+
+
+@contextmanager
+def exclusive_file_lock(
+    lock_path: str | os.PathLike[str],
+    *,
+    timeout: float = 30.0,
+    poll_interval: float = 0.01,
+    stale_after: float = 300.0,
+):
+    """Serialize cooperating writers with an exclusive same-directory lock file.
+
+    The lock uses atomic ``O_EXCL`` creation so it works on Windows and POSIX.
+    A token prevents one owner from deleting a replacement lock, and abandoned
+    regular lock files are recovered after ``stale_after`` seconds.
+    """
+    target = os.path.abspath(os.fspath(lock_path))
+    directory = os.path.dirname(target) or "."
+    os.makedirs(directory, exist_ok=True)
+    token = uuid.uuid4().hex
+    owner = {
+        "pid": os.getpid(),
+        "token": token,
+        "created_at": time.time(),
+    }
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    delay = max(0.001, float(poll_interval))
+
+    while True:
+        try:
+            fd = os.open(target, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            try:
+                lock_stat = os.lstat(target)
+            except FileNotFoundError:
+                continue
+            if not stat.S_ISREG(lock_stat.st_mode):
+                raise OSError(f"File lock path is not a regular file: {target}")
+            age = max(0.0, time.time() - lock_stat.st_mtime)
+            if stale_after >= 0 and age >= float(stale_after):
+                try:
+                    os.unlink(target)
+                except FileNotFoundError:
+                    pass
+                continue
+            if time.monotonic() >= deadline:
+                raise AtomicFileLockTimeoutError(
+                    f"Timed out waiting for file lock: {target}"
+                )
+            time.sleep(delay)
+            continue
+
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(owner, handle, ensure_ascii=False)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            try:
+                os.unlink(target)
+            except OSError:
+                pass
+            raise
+        break
+
+    try:
+        yield owner
+    finally:
+        try:
+            with open(target, "r", encoding="utf-8") as handle:
+                current = json.load(handle)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            current = {}
+        if isinstance(current, dict) and current.get("token") == token:
+            try:
+                os.unlink(target)
+            except FileNotFoundError:
+                pass
 
 
 def atomic_write(

--- a/batch_cost_estimate.py
+++ b/batch_cost_estimate.py
@@ -112,6 +112,49 @@ def resolve_model_pricing(model_name, pricing_config):
     return best_rates
 
 
+def _coerce_nonnegative_int(value):
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def estimate_usage_cost(
+    model_name,
+    *,
+    prompt_tokens,
+    output_tokens,
+    pricing_config,
+):
+    """Estimate one recorded response from normalized actual token counts.
+
+    Returns ``None`` when pricing or a token counter required by a non-zero
+    rate is unknown. This keeps unknown usage distinct from a real zero cost.
+    """
+    model_rates = resolve_model_pricing(model_name, pricing_config)
+    if not isinstance(model_rates, dict):
+        return None
+    input_rate = _coerce_positive_float(model_rates.get('input_per_million'), 0.0)
+    output_rate = _coerce_positive_float(model_rates.get('output_per_million'), 0.0)
+    if not input_rate and not output_rate:
+        return None
+
+    input_count = _coerce_nonnegative_int(prompt_tokens)
+    output_count = _coerce_nonnegative_int(output_tokens)
+    if input_rate and input_count is None:
+        return None
+    if output_rate and output_count is None:
+        return None
+    estimate = (
+        (float(input_count or 0) * input_rate)
+        + (float(output_count or 0) * output_rate)
+    ) / 1_000_000
+    return round(estimate, 8)
+
+
 def iter_request_text_parts(request_payload):
     request = request_payload.get('request') if isinstance(request_payload, dict) else None
     if not isinstance(request, dict):

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
 ### 现行：Batch、上下文与检查
 
 - [Batch 工作流与安全检查](batch_workflows.md)：`build → apply`、订正、最终审校 campaign、关键词、identity v2、A/B、golden corpus。
+- [实际模型用量账本](model_usage_ledger.md)：按当前项目、任务、阶段、provider 与模型归集 Batch / 同步实际调用，并说明离线补录、成本和未知值语义。
 - [上下文系统](context_systems.md)：RAG、原文索引、Story Memory、store 路径与 benchmark。
 - [环境检查智能建议机制](doctor_recommendations.md)：建议等级、必需/可选并列、workflow_state。
 - [环境检查状态矩阵](doctor_states_matrix.md)：layout / pending / 上下文派生字段与决策漏斗（开发对照）。
@@ -76,6 +77,7 @@
 | 工具全局 | `translator_config.json`、`api_keys.json` | `game_root`、模型、chunk、SDK、RAG/索引的**默认** |
 | **当前项目** | `<work>/project_context_settings.json` | 是否启用批量 RAG、原文索引、build 时暖库 |
 | 项目资产 | `<work>/glossary.json`、`macro_setting.md` 等 | 术语、口吻 |
+| 项目运行状态 | `<work>/translation_usage/usage_ledger.json` | 实际模型调用的本地用量账本（不要提交） |
 | 工作区总表 | 工作区根 `games_registry.json` | 多游戏进度（非 lab 仓库内默认） |
 
 ## 维护约定

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -70,6 +70,23 @@ Discovery schema 与核心结果 envelope 当前都使用 `schema_version=1`，�
 - `apply` 写回前会再次校验当前源文本；如果 apply 阶段发现漂移，会拒绝写回并在包目录写入 `apply_failure_report.json` / `failures.jsonl`。
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包。
 
+## 实际模型用量
+
+Batch 下载、同步关键词/订正、普通同步翻译、repair、probe、A/B 与项目分析会把 provider 返回的实际 usage metadata 汇总到当前项目的本地账本。该旁路统计不改变 Batch 状态，也不放宽 `check -> apply` 写回门禁。
+
+```powershell
+python gemini_translate_batch.py usage-import logs/batch_jobs/<package>/manifest.json
+python gemini_translate_batch.py usage-report
+python gemini_translate_batch.py usage-report --provider gemini --group-by task,stage,model --json
+```
+
+- `usage-import` 只读取已下载结果，可重复执行；不会联网或重新调用模型。
+- retry / split 使用 provider response identity 和结果 fingerprint 幂等去重；合并 retry 后会展开原始结果 lineage，不把本地合成行算作新调用。
+- token 或 cost 未返回时保持未知，不会显示成 0；估算成本与 provider 报告的实际成本分列。
+- 账本按 `game_root` 隔离，默认写到 `<game_root>/translation_usage/usage_ledger.json`。
+
+完整字段、过滤器、成本与隐私语义见 [实际模型用量账本](model_usage_ledger.md)。
+
 ## 订正流程
 
 订正模式扫描已有 `old/new` / TL 注释译文，先生成预览，显式 apply 后才写回当前译文行：

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -155,6 +155,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
 - **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。机器结果还可用 `--compact`、`--fields` 和 `--output-file` 限制终端上下文或原子落盘。Agent 可通过 `capabilities` 和 `schema <command>` 直接读取当前 argparse 生成的机器命令索引、参数 schema 和这些能力标记，GUI 不复制维护另一份命令定义。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
+- **实际模型用量**：任务上下文显示当前项目累计调用、已知 token、未知记录数、最近运行及可用成本摘要；命令参考提供 `usage-import` 和 `usage-report`。缺失 usage 不显示成 0，完整字段与成本语义见 [实际模型用量账本](model_usage_ledger.md)。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。
 

--- a/docs/model_usage_ledger.md
+++ b/docs/model_usage_ledger.md
@@ -12,11 +12,13 @@
 <game_root>/translation_usage/usage_ledger.json
 ```
 
-文件中的 `project.game_root` 是规范化绝对路径，`project.project_id` 是该路径的 SHA-256 identity。读取和写入都会核对 identity，不允许把两个游戏项目的记录混入同一文件。写入使用同目录临时文件和原子替换；GUI 只读取该公共账本，不维护第二份统计状态。
+文件中的 `project.game_root` 是规范化绝对路径，`project.project_id` 是该路径的 SHA-256 identity。读取和写入都会核对 identity，不允许把两个游戏项目的记录混入同一文件。写入使用同目录文件锁序列化 load/merge/write，再经 `atomic_io` 临时文件与原子替换落盘；GUI 只读取该公共账本，不维护第二份统计状态。
+
+当前实现仍是单个 JSON 数组，没有 prune/archive。对中小规模项目足够，但不要把它当作最终存储形态；超大账本时写入与查询成本会随记录数增长。
 
 账本包含逐响应记录，主要字段为：
 
-- `operation_id` / `run_id` / `manifest_id`
+- `operation_id` / `run_id` / `manifest_id`（同步预览的 `operation_id` 与当次 `run_id` 对齐，按 run 区分，不按 project 折叠）
 - `task_mode`：`translation`、`revision`、`keyword`、`repair`、`analysis`
 - `stage`：例如 `batch_translation`、`sync_revision`、`compare_variants`、`label`、`route`、`brief`
 - `provider` / `model` / `thinking_level` / `execution_mode`
@@ -34,7 +36,7 @@
 |---|---|---|
 | Gemini Batch | `download` 得到或复用完整 `results.jsonl` 后 | 只读取本地结果，不重新调用 API |
 | 同步关键词 / 订正 | 同步 `results.jsonl` 原子落盘后 | Gemini 与 LiteLLM 使用同一导入器 |
-| 普通同步翻译 | 每个成功响应返回后 | 即使后续 JSON 解析或译文校验失败，已发生的调用仍会记录 |
+| 普通同步翻译 | 预览 run 内内存缓冲，结束时一次写入 | 成功响应先入缓冲；`finally` 统一 flush，因此中途校验失败仍会保留已发生的调用 |
 | repair / probe / A/B | 每个成功响应返回后 | 分别归入 `repair` 或 `analysis` 阶段 |
 | Project Analysis | label、route、brief 成功响应后 | map-reduce 通过 stage-aware recorder 复用同一核心接口 |
 

--- a/docs/model_usage_ledger.md
+++ b/docs/model_usage_ledger.md
@@ -1,0 +1,112 @@
+# 实际模型用量账本
+
+文档地图：[docs/README.md](README.md)
+
+实际模型用量账本把 Batch、同步 Gemini、LiteLLM 及分析流程返回的 usage metadata 归一到当前游戏项目。它只增加旁路统计，不改变翻译、检查、预览或写回语义；Batch 仍必须遵守 `check -> apply` 合约。
+
+## 项目隔离与文件位置
+
+每个 `game_root` 使用自己的账本：
+
+```text
+<game_root>/translation_usage/usage_ledger.json
+```
+
+文件中的 `project.game_root` 是规范化绝对路径，`project.project_id` 是该路径的 SHA-256 identity。读取和写入都会核对 identity，不允许把两个游戏项目的记录混入同一文件。写入使用同目录临时文件和原子替换；GUI 只读取该公共账本，不维护第二份统计状态。
+
+账本包含逐响应记录，主要字段为：
+
+- `operation_id` / `run_id` / `manifest_id`
+- `task_mode`：`translation`、`revision`、`keyword`、`repair`、`analysis`
+- `stage`：例如 `batch_translation`、`sync_revision`、`compare_variants`、`label`、`route`、`brief`
+- `provider` / `model` / `thinking_level` / `execution_mode`
+- `calls`
+- `prompt_tokens` / `completion_tokens` / `total_tokens` / `thoughts_tokens` / `cached_tokens`
+- `provider_usage`：provider 返回的原始 usage 摘要，不保存响应正文
+- `estimated_cost` 与 `actual_cost`
+- `recorded_at` / `dedupe_key` / 响应与来源 identity
+
+缺失 token 或 cost 保持 `null`。聚合报告同时给出 `*_known_records` 与 `*_unknown_records`，不会把未知值伪造成 0。
+
+## 数据来源与自动记录
+
+| 路径 | 记录时点 | 说明 |
+|---|---|---|
+| Gemini Batch | `download` 得到或复用完整 `results.jsonl` 后 | 只读取本地结果，不重新调用 API |
+| 同步关键词 / 订正 | 同步 `results.jsonl` 原子落盘后 | Gemini 与 LiteLLM 使用同一导入器 |
+| 普通同步翻译 | 每个成功响应返回后 | 即使后续 JSON 解析或译文校验失败，已发生的调用仍会记录 |
+| repair / probe / A/B | 每个成功响应返回后 | 分别归入 `repair` 或 `analysis` 阶段 |
+| Project Analysis | label、route、brief 成功响应后 | map-reduce 通过 stage-aware recorder 复用同一核心接口 |
+
+自动记录失败只产生警告，不会把一次已经安全完成的下载、翻译或分析改成失败。需要排查或补录时使用显式 CLI。
+
+### 幂等与 retry / split
+
+有 provider response id 时，去重键优先绑定该 identity；没有 id 时使用 provider、model、请求行 key 与响应摘要 fingerprint。重复执行 `download` 或 `usage-import` 不会重复累计同一响应。
+
+`split` 子包和完整包之间复制同一响应时会命中同一去重键。`merge-retry` 会先导入已验证的 parent 与 retry 原始结果；之后对已合并 manifest 执行 `usage-import` 时，也会展开到原始结果 lineage，不把本地合成行当作新的 provider 调用。实际重新发出的 retry / repair 请求仍是新的计费调用，应单独记录。
+
+## CLI
+
+### 离线导入
+
+```powershell
+python gemini_translate_batch.py usage-import C:\path\to\manifest.json
+```
+
+省略 target 时沿用现有 latest-manifest 规则。该命令只读取 manifest 与已经落盘的结果；不会创建 client、提交任务或请求 provider。
+
+机器可读摘要：
+
+```powershell
+python gemini_translate_batch.py usage-import C:\path\to\manifest.json --json
+```
+
+输出包含扫描行数、候选记录数、新增/重复记录数、账本路径及当前项目聚合报告。
+
+### 查询与聚合
+
+```powershell
+python gemini_translate_batch.py usage-report
+python gemini_translate_batch.py usage-report --task revision --provider gemini
+python gemini_translate_batch.py usage-report --stage brief --model gemini-3.1-flash-lite
+python gemini_translate_batch.py usage-report --group-by task,stage,provider,model --json
+```
+
+可用过滤器：
+
+- `--task`
+- `--stage`
+- `--provider`
+- `--model`
+
+`--group-by` 支持 `task`、`stage`、`provider`、`model`、`run`、`operation`、`execution`，默认按 task / stage / provider / model 分组。`usage-import` / `usage-report` 的机器输出开关是独立的 `--json`；它们是只读/本地账本命令，不使用 Batch workflow 的 `--output json` envelope。
+
+## GUI
+
+「诊断与运行日志」的任务上下文会显示：
+
+- 当前项目累计调用数和已知 total token
+- token 不完整时的未知记录数
+- 最近一次运行的 task / stage / provider / model 与 token 摘要
+- 存在时的估算成本和 provider 报告成本
+
+命令参考提供「导入当前结果用量」与「查看项目模型用量」。切换 `game_root` 后读取新的项目账本；账本 mtime 参与刷新键，因此同一任务记录下新增用量也会刷新。
+
+## 成本语义
+
+成本字段严格区分：
+
+- `estimated_cost`：使用当前配置价格表和已知 token 计算，`estimated_cost_basis=configured_pricing`；只是估算，不是 provider 账单。
+- `actual_cost`：只有 usage 或响应 metadata 明确给出 cost 时才记录，并保留 `actual_cost_source`。
+- 没有匹配价格、缺少必要 token 或 provider 未返回 cost 时，值为未知，不显示 0 成本。
+
+当前 `batch.pricing` 是 Batch 估算价格表，因此自动导入的 Batch 响应可以生成估算成本；同步路径不会擅自把 Batch 费率当作同步账单。Project Analysis 延续其现有配置费率估算，但仍标记为 estimate。
+
+## 隐私与版本控制
+
+账本保存 provider usage 摘要、模型/阶段 identity 和响应 fingerprint，不保存 prompt、译文或完整响应正文。它仍属于项目本地运行数据；不要把真实游戏项目账本、Batch 结果或日志提交到公开仓库。
+
+## 设计来源
+
+provider-neutral tracker、按阶段归因与跨续跑增量合并的方向参考了 [BigDawnGhost/wenyi](https://github.com/BigDawnGhost/wenyi)（MIT License）的设计思路。本实现依据本项目现有 manifest、同步 backend、GUI 与安全写回边界独立编写，没有复制 Wenyi 源代码或实质性代码片段。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,7 @@
 
 - `glossary.example.json` -> `<game_root>/glossary.json`
 - `macro_setting.example.md` -> `<game_root>/macro_setting.md`
+- 模型调用后会生成 `<game_root>/translation_usage/usage_ledger.json`，这是按项目隔离的本地运行状态，不应提交；详见 [实际模型用量账本](model_usage_ledger.md)。
 
 这些文件通常包含 API key、本地游戏路径、项目私有术语或剧情设定，不应提交到公开仓库。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -5570,7 +5570,6 @@ def import_manifest_usage_best_effort(manifest, result_path=None):
     except (
         OSError,
         ValueError,
-        SystemExit,
         model_usage_ledger.UsageLedgerError,
     ) as exc:
         print(f'Warning: Model usage ledger import failed: {exc}')

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -39,6 +39,7 @@ import cli_contract
 import cli_discovery
 import doctor_recommendations as doctor_rec
 import keyword_glossary_merge
+import model_usage_ledger
 import prompt_context
 import translation_ab_experiment
 import story_memory
@@ -4977,6 +4978,9 @@ def merge_retry_results(parent_target, retry_target):
     if missing_retry_rows:
         raise SystemExit(f'Retry result is missing rows for chunks: {sorted(missing_retry_rows)[:5]}')
 
+    import_manifest_usage_best_effort(parent_manifest)
+    import_manifest_usage_best_effort(retry_manifest, result_path=retry_result_path)
+
     direct_retry_keys = []
     partial_chunks_by_parent = {}
     for chunk in retry_chunks:
@@ -5413,6 +5417,7 @@ def download_results(target=None, force=False):
     expected_sha = manifest.get('result_jsonl_sha256')
     if os.path.isfile(result_path) and not force:
         if result_artifact_is_complete(result_path, expected_sha):
+            import_manifest_usage_best_effort(manifest)
             print(f'Result file already exists: {result_path}')
             return result_path
         print(
@@ -5441,6 +5446,7 @@ def download_results(target=None, force=False):
     manifest['downloaded_at'] = datetime.now().isoformat(timespec='seconds')
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
 
+    import_manifest_usage_best_effort(manifest)
     print(f'Saved results to: {result_path}')
     return result_path
 
@@ -5497,12 +5503,127 @@ def extract_usage_metadata(response_payload):
 def summarize_usage_metadata(usage_metadata):
     if not isinstance(usage_metadata, dict):
         return {}
-    summary = {}
-    for key in ('promptTokenCount', 'thoughtsTokenCount', 'candidatesTokenCount', 'totalTokenCount'):
-        value = usage_metadata.get(key)
-        if value is not None:
-            summary[key] = value
-    return summary
+    return dict(usage_metadata)
+
+
+def import_manifest_usage(manifest, result_path=None):
+    """Offline-import real provider result sources for one manifest lineage.
+
+    A merged retry file can contain locally synthesized rows. For that state,
+    import the original parent result plus each retry result instead of treating
+    the merged JSONL as another provider call.
+    """
+    pricing_config = batch_cost_estimate.load_pricing_config(
+        _read_translator_config_object()
+    )
+    sources = []
+    if result_path:
+        sources.append((manifest, result_path))
+    else:
+        merge_history = manifest.get('retry_merge_history')
+        if isinstance(merge_history, list) and merge_history:
+            first = merge_history[0] if isinstance(merge_history[0], dict) else {}
+            parent_result = first.get('previous_result_jsonl_path')
+            if parent_result:
+                sources.append((manifest, parent_result))
+            for entry in merge_history:
+                if not isinstance(entry, dict):
+                    continue
+                retry_manifest_path = entry.get('retry_manifest')
+                if not retry_manifest_path:
+                    continue
+                retry_manifest = load_manifest(retry_manifest_path)
+                retry_result = (
+                    entry.get('retry_result_jsonl_path')
+                    or resolve_manifest_result_path(retry_manifest)
+                )
+                sources.append((retry_manifest, retry_result))
+        if not sources:
+            sources.append((manifest, resolve_manifest_result_path(manifest)))
+
+    summaries = [
+        model_usage_ledger.import_manifest_results(
+            source_manifest,
+            result_path=source_result,
+            pricing_config=pricing_config,
+        )
+        for source_manifest, source_result in sources
+    ]
+    last = summaries[-1]
+    combined = {
+        **last,
+        'result_path': last.get('result_path') if len(summaries) == 1 else '',
+        'result_paths': [item.get('result_path') for item in summaries],
+    }
+    for key in (
+        'scanned_rows', 'candidate_records', 'skipped_rows',
+        'inserted_records', 'duplicate_records',
+    ):
+        combined[key] = sum(int(item.get(key) or 0) for item in summaries)
+    return combined
+
+
+def import_manifest_usage_best_effort(manifest, result_path=None):
+    """Record auxiliary usage without changing the translation/result workflow."""
+    try:
+        return import_manifest_usage(manifest, result_path=result_path)
+    except (
+        OSError,
+        ValueError,
+        SystemExit,
+        model_usage_ledger.UsageLedgerError,
+    ) as exc:
+        print(f'Warning: Model usage ledger import failed: {exc}')
+        return {
+            'inserted_records': 0,
+            'duplicate_records': 0,
+            'error': str(exc),
+        }
+
+
+def record_generation_usage_best_effort(
+    *,
+    task_mode,
+    stage,
+    result,
+    operation_id,
+    run_id,
+    source_key,
+    thinking_level='',
+    source=None,
+    pricing_config=None,
+):
+    """Record one successful synchronous response without failing its caller."""
+    if not legacy.BASE_DIR:
+        return {
+            'inserted_records': 0,
+            'duplicate_records': 0,
+            'error': 'game_root is unset',
+        }
+    try:
+        return model_usage_ledger.record_generation_usage(
+            game_root=legacy.BASE_DIR,
+            task_mode=task_mode,
+            stage=stage,
+            provider=str(result.get('provider') or SYNC_BACKEND or 'unknown'),
+            model=str(result.get('model') or SYNC_MODEL or BATCH_MODEL or 'unknown'),
+            usage_metadata=result.get('usage_metadata') or {},
+            response_payload=result.get('response_payload') or {},
+            operation_id=operation_id,
+            run_id=run_id,
+            thinking_level=thinking_level,
+            execution_mode=str(result.get('execution_mode') or 'sync'),
+            source_key=source_key,
+            source=source or {},
+            pricing_config=pricing_config,
+        )
+    except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
+        print(f'Warning: Model usage ledger record failed: {exc}')
+        return {
+            'inserted_records': 0,
+            'duplicate_records': 0,
+            'error': str(exc),
+        }
 
 
 def bump_counter(bucket, name, amount=1):
@@ -7157,6 +7278,13 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
     if not sample:
         raise SystemExit('No request rows available for the requested probe range.')
 
+    usage_run_id = model_usage_ledger.new_run_id('probe')
+    usage_operation_id = (
+        'probe-manifest-'
+        + hashlib.sha256(
+            str(manifest.get('_manifest_path') or '').encode('utf-8')
+        ).hexdigest()[:20]
+    )
     client = create_batch_client(api_key_index=api_key_index)
     summary = {
         'sample_count': len(sample),
@@ -7205,6 +7333,22 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
         except Exception as exc:
             summary['request_errors'] += 1
             parse_error = str(exc)
+        else:
+            record_generation_usage_best_effort(
+                task_mode='analysis',
+                stage='probe',
+                result=_sync_result_to_dict(result),
+                operation_id=usage_operation_id,
+                run_id=usage_run_id,
+                source_key=str(key),
+                thinking_level=str((manifest.get('settings') or {}).get('thinking_level') or ''),
+                source={
+                    'kind': 'probe_response',
+                    'manifest_path': str(manifest.get('_manifest_path') or ''),
+                    'row_key': str(key),
+                    'sample_index': index,
+                },
+            )
         if response_text:
             try:
                 payload = parse_json_payload(response_text)
@@ -8808,6 +8952,7 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
     manifest['result_jsonl_path'] = result_path
     manifest['result_jsonl_sha256'] = content_sha
     save_manifest(manifest, update_latest=False)
+    import_manifest_usage_best_effort(manifest)
     return manifest
 
 
@@ -9058,6 +9203,11 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
     run_dir = os.path.join(REPAIR_RUNS_DIR, f'{timestamp}_{report_stem}')
     os.makedirs(run_dir, exist_ok=True)
 
+    usage_run_id = f'repair-{os.path.basename(run_dir)}'
+    usage_operation_id = (
+        'repair-report-'
+        + hashlib.sha256(os.path.abspath(report_path).encode('utf-8')).hexdigest()[:20]
+    )
     request_log_path = os.path.join(run_dir, 'repair_requests.jsonl')
     result_log_path = os.path.join(run_dir, 'repair_results.jsonl')
     failure_log_path = os.path.join(run_dir, 'repair_failures.jsonl')
@@ -9147,6 +9297,23 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                 }
             )
             continue
+
+        record_generation_usage_best_effort(
+            task_mode='repair',
+            stage='repair',
+            result=response_data,
+            operation_id=usage_operation_id,
+            run_id=usage_run_id,
+            source_key=str(job.get('key') or index),
+            thinking_level=BATCH_THINKING_LEVEL,
+            source={
+                'kind': 'repair_response',
+                'report_path': os.path.abspath(report_path),
+                'run_dir': os.path.abspath(run_dir),
+                'job_key': str(job.get('key') or ''),
+                'request_index': index,
+            },
+        )
 
         if response_text:
             try:
@@ -10888,6 +11055,41 @@ def build_arg_parser():
         help='Manifest path or package dir. Defaults to latest package.',
     )
 
+    usage_import_parser = subparsers.add_parser(
+        'usage-import',
+        help='Offline-import provider usage from an existing results.jsonl into the project ledger.',
+    )
+    usage_import_parser.add_argument(
+        'target',
+        nargs='?',
+        default='',
+        help='Manifest path or package dir. Defaults to latest package.',
+    )
+    usage_import_parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Print a machine-readable JSON import summary.',
+    )
+
+    usage_report_parser = subparsers.add_parser(
+        'usage-report',
+        help='Report actual recorded model usage for the current project.',
+    )
+    usage_report_parser.add_argument('--task', default='', help='Filter by task mode.')
+    usage_report_parser.add_argument('--stage', default='', help='Filter by pipeline stage.')
+    usage_report_parser.add_argument('--provider', default='', help='Filter by provider.')
+    usage_report_parser.add_argument('--model', default='', help='Filter by model.')
+    usage_report_parser.add_argument(
+        '--group-by',
+        default='task,stage,provider,model',
+        help='Comma-separated grouping fields: task, stage, provider, model, run, operation, execution.',
+    )
+    usage_report_parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Print a machine-readable JSON report.',
+    )
+
     status_parser = subparsers.add_parser('status', help='Refresh and show batch job status.')
     add_machine_output_argument(status_parser)
     status_parser.add_argument(
@@ -11370,9 +11572,6 @@ def dispatch_command(parser, args):
         'project-analysis-publish',
         'project-analysis-unpublish',
     }:
-        import contextlib
-        import io
-
         from project_analysis import (
             ProjectAnalysisError,
             collect_project_analysis_status,
@@ -11425,6 +11624,12 @@ def dispatch_command(parser, args):
                 model = (
                     getattr(args, 'model', '') or PROJECT_ANALYSIS_MODEL or BATCH_MODEL or SYNC_MODEL
                 )
+                analysis_usage_run_id = model_usage_ledger.new_run_id('project-analysis')
+                analysis_usage_operation_id = (
+                    'project-analysis-'
+                    + hashlib.sha256(str(legacy.BASE_DIR or '').encode('utf-8')).hexdigest()[:20]
+                )
+
 
                 def _generate(request: SyncGenerationRequest):
                     # Reuse production sync path (Gemini / LiteLLM).
@@ -11455,6 +11660,27 @@ def dispatch_command(parser, args):
                     batch_cost_estimate.resolve_model_pricing(model, pricing_config) or {}
                 )
 
+                def _record_project_analysis_usage(event):
+                    result = event.get('result')
+                    if result is None:
+                        return
+                    record_generation_usage_best_effort(
+                        task_mode='analysis',
+                        stage=str(event.get('stage') or 'project_analysis'),
+                        result=_sync_result_to_dict(result),
+                        operation_id=analysis_usage_operation_id,
+                        run_id=analysis_usage_run_id,
+                        source_key=str(event.get('artifact_id') or ''),
+                        thinking_level=PROJECT_ANALYSIS_THINKING_LEVEL,
+                        source={
+                            'kind': 'project_analysis_response',
+                            'store_dir': str(store_dir or ''),
+                            'artifact_id': str(event.get('artifact_id') or ''),
+                            'stage': str(event.get('stage') or ''),
+                        },
+                        pricing_config=pricing_config,
+                    )
+
                 def _project_analysis_progress(event):
                     print(
                         "PROJECT_ANALYSIS_PROGRESS "
@@ -11479,6 +11705,7 @@ def dispatch_command(parser, args):
                     provider=SYNC_BACKEND or 'gemini',
                     model=model,
                     progress=_project_analysis_progress,
+                    usage_recorder=_record_project_analysis_usage,
                     pricing={
                         "currency": pricing_config.get("currency") or "USD",
                         "input_per_million": model_rates.get("input_per_million") or 0.0,
@@ -11569,6 +11796,55 @@ def dispatch_command(parser, args):
             raise SystemExit(f'Project analysis error: {exc}') from exc
 
     initialize_batch_logging()
+    if command in {'usage-import', 'usage-report'}:
+        as_json = bool(getattr(args, 'json', False))
+
+        def _run_usage_command():
+            legacy.load_config(require_api_key=False)
+            legacy.load_translator_settings(persist_corrected_game_root=False)
+            load_batch_settings()
+            if command == 'usage-import':
+                manifest = load_manifest(getattr(args, 'target', '') or None)
+                result = import_manifest_usage(manifest)
+                result['report'] = model_usage_ledger.query_usage(result['game_root'])
+                return result
+            if not legacy.BASE_DIR:
+                raise model_usage_ledger.UsageLedgerError(
+                    'game_root is required for usage-report'
+                )
+            return model_usage_ledger.query_usage(
+                legacy.BASE_DIR,
+                task=getattr(args, 'task', '') or '',
+                stage=getattr(args, 'stage', '') or '',
+                provider=getattr(args, 'provider', '') or '',
+                model=getattr(args, 'model', '') or '',
+                group_by=getattr(args, 'group_by', '') or '',
+            )
+
+        try:
+            if as_json:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    result = _run_usage_command()
+                print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+                return result
+            result = _run_usage_command()
+            if command == 'usage-import':
+                print('Model usage import:')
+                result_paths = result.get('result_paths') or [result.get('result_path')]
+                for result_path in result_paths:
+                    if result_path:
+                        print(f"- result: {result_path}")
+                print(f"- scanned rows: {int(result.get('scanned_rows') or 0)}")
+                print(f"- inserted records: {int(result.get('inserted_records') or 0)}")
+                print(f"- duplicate records: {int(result.get('duplicate_records') or 0)}")
+                print(f"- ledger: {result.get('ledger_path') or ''}")
+            else:
+                for line in model_usage_ledger.format_usage_report(result):
+                    print(line)
+            return result
+        except model_usage_ledger.UsageLedgerError as exc:
+            raise SystemExit(f'Model usage ledger error: {exc}') from exc
+
     legacy.load_config()
     legacy.load_translator_settings()
     legacy.load_glossary()

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -77,6 +77,7 @@ from PySide6.QtWidgets import (
 )
 from project_version import __version__
 import cli_contract
+import model_usage_ledger
 
 from .path_utils import canonical_abs_path, normalize_context_storage_location
 from .responsive_layout import FlowButtonBar, ResponsiveActionPanel
@@ -6418,17 +6419,31 @@ class MainWindow(QMainWindow):
     ) -> None:
         spec = work_mode_spec(self._current_work_mode())
         running = self.kill_btn.isEnabled()
+        game_root = self.state.get_game_root()
+        usage_ledger_path = ""
+        if game_root is not None:
+            try:
+                usage_ledger_path = model_usage_ledger.usage_ledger_path(game_root)
+            except model_usage_ledger.UsageLedgerError:
+                usage_ledger_path = ""
+        usage_ledger_mtime = self._diagnostics_manifest_mtime_ns(
+            usage_ledger_path or None
+        )
         if spec.mode == WorkMode.SYNC_TRANSLATION:
             input_key = (
                 "sync",
                 str(self.state.get_sync_script_path()),
                 sys.executable,
+                str(game_root or ""),
+                usage_ledger_mtime,
                 running,
             )
             if not force and self._diagnostics_refresh_input_key == input_key:
                 return
             context = sync_diagnostics_context(
                 sync_script_path=str(self.state.get_sync_script_path()),
+                batch_script_path=str(self.state.get_batch_script_path()),
+                game_root=str(game_root or ""),
                 python_exe=sys.executable,
             )
             self._set_diagnostics_context(context)
@@ -6444,7 +6459,6 @@ class MainWindow(QMainWindow):
             return
 
         uses_batch_manifest = spec.manifest_mode is not None
-        game_root = self.state.get_game_root()
         latest_manifest = latest_manifest_path
         if latest_manifest is None and uses_batch_manifest and game_root is not None:
             latest_manifest = self.state.get_latest_manifest_path_for_mode(
@@ -6470,6 +6484,7 @@ class MainWindow(QMainWindow):
             str(self.state.get_logs_dir()),
             submit_max_cost,
             running,
+            usage_ledger_mtime,
         )
         if not force and self._diagnostics_refresh_input_key == input_key:
             # Inputs unchanged since last tab visit — skip disk/widget rebuild.
@@ -6487,6 +6502,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=submit_max_cost,
+            game_root=str(game_root or ""),
         )
         self._set_diagnostics_context(context)
         self._diagnostics_refresh_input_key = input_key

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -6314,6 +6314,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=self._submit_max_cost_from_config(),
+            game_root=str(self.state.get_game_root() or ""),
         )
         merged_context = DiagnosticsContext(
             status=str(merge_summary["status"]),
@@ -10577,6 +10578,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=self._submit_max_cost_from_config(),
+            game_root=str(self.state.get_game_root() or ""),
         )
         self._set_diagnostics_context(
             probe_summary_to_diagnostics_context(
@@ -10631,6 +10633,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=self._submit_max_cost_from_config(),
+            game_root=str(self.state.get_game_root() or ""),
         )
         self._set_diagnostics_context(
             ab_experiment_summary_to_diagnostics_context(
@@ -10680,6 +10683,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=self._submit_max_cost_from_config(),
+            game_root=str(self.state.get_game_root() or ""),
         )
         self._set_diagnostics_context(
             split_summary_to_diagnostics_context(
@@ -10898,6 +10902,7 @@ class MainWindow(QMainWindow):
             logs_dir=str(self.state.get_logs_dir()),
             python_exe=sys.executable,
             submit_max_cost=self._submit_max_cost_from_config(),
+            game_root=str(self.state.get_game_root() or ""),
         )
         self._set_diagnostics_context(
             repair_summary_to_diagnostics_context(
@@ -11651,6 +11656,7 @@ class MainWindow(QMainWindow):
                 logs_dir=str(self.state.get_logs_dir()),
                 python_exe=sys.executable,
                 submit_max_cost=self._submit_max_cost_from_config(),
+                game_root=str(self.state.get_game_root() or ""),
             )
             self._set_diagnostics_context(
                 probe_summary_to_diagnostics_context(probe_summary, base_context)
@@ -11682,6 +11688,7 @@ class MainWindow(QMainWindow):
                 logs_dir=str(self.state.get_logs_dir()),
                 python_exe=sys.executable,
                 submit_max_cost=self._submit_max_cost_from_config(),
+                game_root=str(self.state.get_game_root() or ""),
             )
             self._set_diagnostics_context(
                 ab_experiment_summary_to_diagnostics_context(ab_summary, base_context)
@@ -11723,6 +11730,7 @@ class MainWindow(QMainWindow):
                 logs_dir=str(self.state.get_logs_dir()),
                 python_exe=sys.executable,
                 submit_max_cost=self._submit_max_cost_from_config(),
+                game_root=str(self.state.get_game_root() or ""),
             )
             self._set_diagnostics_context(
                 split_summary_to_diagnostics_context(split_summary, base_context)
@@ -11772,6 +11780,7 @@ class MainWindow(QMainWindow):
                 logs_dir=str(self.state.get_logs_dir()),
                 python_exe=sys.executable,
                 submit_max_cost=self._submit_max_cost_from_config(),
+                game_root=str(self.state.get_game_root() or ""),
             )
             self._set_diagnostics_context(
                 repair_summary_to_diagnostics_context(parsed, base_context)

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
+import model_usage_ledger
 from keyword_glossary_merge import build_merge_keywords_cli_command
 
 from .batch_workflow_support import (
@@ -19,6 +20,7 @@ from .batch_workflow_support import (
     load_uncertain_submit_facts_from_manifest,
 )
 from .user_copy import (
+    format_usage_ledger_facts,
     format_job_fact,
     format_job_state_fact,
     format_manifest_path_fact,
@@ -570,6 +572,25 @@ def build_cli_commands(
         )
     )
 
+    commands.extend(
+        [
+            DiagnosticsCommand(
+                label="导入当前结果用量",
+                command=format_cli_command(
+                    python_exe,
+                    batch_script_path,
+                    ["usage-import", manifest_path],
+                ),
+            ),
+            DiagnosticsCommand(
+                label="查看项目模型用量",
+                command=format_cli_command(
+                    python_exe, batch_script_path, ["usage-report"]
+                ),
+            ),
+        ]
+    )
+
     return commands
 
 
@@ -798,12 +819,42 @@ def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> lis
     return facts
 
 
-def idle_diagnostics_context() -> DiagnosticsContext:
+def _project_usage_facts(game_root: str | None) -> list[str]:
+    if not game_root:
+        return []
+    try:
+        return format_usage_ledger_facts(model_usage_ledger.query_usage(game_root))
+    except (OSError, ValueError, model_usage_ledger.UsageLedgerError):
+        return []
+
+
+def _usage_report_command(
+    batch_script_path: str,
+    python_exe: str,
+) -> list[DiagnosticsCommand]:
+    if not batch_script_path:
+        return []
+    return [
+        DiagnosticsCommand(
+            label="查看项目模型用量",
+            command=format_cli_command(
+                python_exe, batch_script_path, ["usage-report"]
+            ),
+        )
+    ]
+
+
+def idle_diagnostics_context(
+    *,
+    game_root: str | None = None,
+    batch_script_path: str = "",
+    python_exe: str = "python",
+) -> DiagnosticsContext:
     return DiagnosticsContext(
         status="idle",
         heading="暂无任务上下文",
         message="开始任务后，这里会显示任务记录、翻译包、云端任务和可复制命令。",
-        facts=[],
+        facts=_project_usage_facts(game_root),
         paths=[],
         commands=[],
         manifest_json_preview="",
@@ -813,16 +864,20 @@ def idle_diagnostics_context() -> DiagnosticsContext:
 def sync_diagnostics_context(
     *,
     sync_script_path: str,
+    batch_script_path: str = "",
+    game_root: str | None = None,
     python_exe: str = "python",
 ) -> DiagnosticsContext:
     command = format_cli_command(python_exe, sync_script_path, [])
+    commands = [DiagnosticsCommand(label="同步翻译", command=command)]
+    commands.extend(_usage_report_command(batch_script_path, python_exe))
     return DiagnosticsContext(
         status="ready",
         heading="同步翻译上下文",
         message="同步模式不生成批量任务记录；以下为可手动运行的同步命令。",
-        facts=[],
+        facts=_project_usage_facts(game_root),
         paths=[],
-        commands=[DiagnosticsCommand(label="同步翻译", command=command)],
+        commands=commands,
         manifest_json_preview="",
     )
 
@@ -836,11 +891,16 @@ def build_diagnostics_context(
     python_exe: str = "python",
     path_exists: Callable[[str], bool] | None = None,
     submit_max_cost: float | None = None,
+    game_root: str | None = None,
 ) -> DiagnosticsContext:
     exists = path_exists or _default_path_exists
 
     if not latest_manifest_path and not manifest:
-        return idle_diagnostics_context()
+        return idle_diagnostics_context(
+            game_root=game_root,
+            batch_script_path=batch_script_path,
+            python_exe=python_exe,
+        )
 
     manifest_path = ""
     if manifest:
@@ -856,12 +916,16 @@ def build_diagnostics_context(
                 status="warning",
                 heading="无法读取任务记录",
                 message="找到了任务记录路径，但内容未能加载。请查看下方原始日志。",
-                facts=[format_manifest_path_fact(manifest_path)],
+                facts=[format_manifest_path_fact(manifest_path)] + _project_usage_facts(game_root),
                 paths=[],
                 commands=[],
                 manifest_json_preview="",
             )
-        return idle_diagnostics_context()
+        return idle_diagnostics_context(
+            game_root=game_root,
+            batch_script_path=batch_script_path,
+            python_exe=python_exe,
+        )
 
     package_dir = resolve_package_dir(manifest_path, manifest)
     facts = build_manifest_facts(manifest, manifest_path)
@@ -870,6 +934,8 @@ def build_diagnostics_context(
     if exists(latest_pointer):
         facts.append(f"最近任务指针：{latest_pointer}")
 
+    effective_game_root = game_root or str(manifest.get("base_dir") or "")
+    facts.extend(_project_usage_facts(effective_game_root))
     paths = collect_existing_report_paths(package_dir, manifest, path_exists=exists)
     commands = build_cli_commands(
         python_exe=python_exe,

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -20,6 +20,8 @@ from .batch_workflow_support import (
     load_uncertain_submit_facts_from_manifest,
 )
 from .user_copy import (
+    USAGE_LEDGER_COPY,
+    format_notice_fact,
     format_usage_ledger_facts,
     format_job_fact,
     format_job_state_fact,
@@ -825,7 +827,7 @@ def _project_usage_facts(game_root: str | None) -> list[str]:
     try:
         return format_usage_ledger_facts(model_usage_ledger.query_usage(game_root))
     except (OSError, ValueError, model_usage_ledger.UsageLedgerError):
-        return []
+        return [format_notice_fact(USAGE_LEDGER_COPY["load_error"])]
 
 
 def _usage_report_command(

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -307,6 +307,26 @@ def build_cli_commands(
             ),
         ),
     ]
+    # Keep usage commands ahead of mode-specific early returns so revision /
+    # keyword / retry packages expose the same import/report actions.
+    commands.extend(
+        [
+            DiagnosticsCommand(
+                label="导入当前结果用量",
+                command=format_cli_command(
+                    python_exe,
+                    batch_script_path,
+                    ["usage-import", manifest_path],
+                ),
+            ),
+            DiagnosticsCommand(
+                label="查看项目模型用量",
+                command=format_cli_command(
+                    python_exe, batch_script_path, ["usage-report"]
+                ),
+            ),
+        ]
+    )
 
     mode = manifest.get("mode")
     mode_text = mode.strip() if isinstance(mode, str) else ""
@@ -574,25 +594,6 @@ def build_cli_commands(
         )
     )
 
-    commands.extend(
-        [
-            DiagnosticsCommand(
-                label="导入当前结果用量",
-                command=format_cli_command(
-                    python_exe,
-                    batch_script_path,
-                    ["usage-import", manifest_path],
-                ),
-            ),
-            DiagnosticsCommand(
-                label="查看项目模型用量",
-                command=format_cli_command(
-                    python_exe, batch_script_path, ["usage-report"]
-                ),
-            ),
-        ]
-    )
-
     return commands
 
 
@@ -858,7 +859,7 @@ def idle_diagnostics_context(
         message="开始任务后，这里会显示任务记录、翻译包、云端任务和可复制命令。",
         facts=_project_usage_facts(game_root),
         paths=[],
-        commands=[],
+        commands=_usage_report_command(batch_script_path, python_exe),
         manifest_json_preview="",
     )
 
@@ -918,7 +919,10 @@ def build_diagnostics_context(
                 status="warning",
                 heading="无法读取任务记录",
                 message="找到了任务记录路径，但内容未能加载。请查看下方原始日志。",
-                facts=[format_manifest_path_fact(manifest_path)] + _project_usage_facts(game_root),
+                facts=[
+                    format_manifest_path_fact(manifest_path),
+                    *_project_usage_facts(game_root),
+                ],
                 paths=[],
                 commands=[],
                 manifest_json_preview="",

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -40,6 +40,14 @@ CONTEXT_LIBRARY_COPY = {
     ),
 }
 
+USAGE_LEDGER_COPY = {
+    "empty": "模型用量：当前项目暂无实际响应记录",
+    "total": "模型用量",
+    "recent": "最近一次运行",
+    "estimated_cost": "估算成本（非 provider 账单）",
+    "actual_cost": "Provider 报告成本",
+}
+
 PROJECT_ANALYSIS_COPY = {
     "start": "开始分析",
     "generate": "生成项目摘要",
@@ -280,6 +288,67 @@ def format_job_state_fact(state: str) -> str:
 
 def format_safety_fact(level: str, *, prefix: str = "检查结果") -> str:
     return f"{prefix}：{safety_level_label(level)}"
+
+
+def _format_usage_cost_values(metric: Any) -> str:
+    if not isinstance(metric, dict):
+        return ""
+    values = metric.get("values")
+    if not isinstance(values, dict) or not values:
+        return ""
+    return "、".join(
+        f"{float(value):.6f} {currency}"
+        for currency, value in sorted(values.items())
+    )
+
+
+def format_usage_ledger_facts(report: Any) -> list[str]:
+    """Render the shared usage report for the diagnostics facts list."""
+    if not isinstance(report, dict):
+        return []
+    totals = report.get("totals")
+    if not isinstance(totals, dict):
+        return []
+    records = int(totals.get("records") or 0)
+    if records <= 0:
+        return [USAGE_LEDGER_COPY["empty"]]
+
+    calls = int(totals.get("calls") or 0)
+    total_tokens = totals.get("total_tokens")
+    unknown_tokens = int(totals.get("total_tokens_unknown_records") or 0)
+    if total_tokens is None:
+        token_text = "token 数未知"
+    else:
+        token_text = f"{int(total_tokens):,} token"
+        if unknown_tokens:
+            token_text += f"；另有 {unknown_tokens} 条记录未知"
+    facts = [
+        f"{USAGE_LEDGER_COPY['total']}：累计 {calls} 次调用；{token_text}",
+    ]
+
+    recent = report.get("recent_run")
+    if isinstance(recent, dict):
+        recent_totals = recent.get("totals")
+        recent_totals = recent_totals if isinstance(recent_totals, dict) else {}
+        recent_tokens = recent_totals.get("total_tokens")
+        recent_token_text = (
+            "token 数未知" if recent_tokens is None else f"{int(recent_tokens):,} token"
+        )
+        dimensions = " / ".join(
+            ", ".join(str(value) for value in recent.get(key) or [])
+            for key in ("task_modes", "stages", "providers", "models")
+        )
+        facts.append(
+            f"{USAGE_LEDGER_COPY['recent']}：{dimensions or '未知'}；{recent_token_text}"
+        )
+
+    estimated = _format_usage_cost_values(totals.get("estimated_cost"))
+    if estimated:
+        facts.append(f"{USAGE_LEDGER_COPY['estimated_cost']}：{estimated}")
+    actual = _format_usage_cost_values(totals.get("actual_cost"))
+    if actual:
+        facts.append(f"{USAGE_LEDGER_COPY['actual_cost']}：{actual}")
+    return facts
 
 
 def format_notice_fact(text: str) -> str:

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -42,6 +42,7 @@ CONTEXT_LIBRARY_COPY = {
 
 USAGE_LEDGER_COPY = {
     "empty": "模型用量：当前项目暂无实际响应记录",
+    "load_error": "模型用量账本读取失败，统计暂不可用",
     "total": "模型用量",
     "recent": "最近一次运行",
     "estimated_cost": "估算成本（非 provider 账单）",

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -23,18 +23,26 @@ class LiteLLMCapabilityError(LiteLLMBackendError):
 
 
 def _serialize_response(response: Any) -> Mapping[str, Any]:
+    payload: Dict[str, Any] | None = None
     if isinstance(response, Mapping):
-        return dict(response)
-    for method_name in ("model_dump", "to_dict"):
-        method = getattr(response, method_name, None)
-        if callable(method):
-            payload = method()
-            if isinstance(payload, Mapping):
-                return dict(payload)
-    raise LiteLLMBackendError(
-        f"LiteLLM returned unsupported response type: {type(response).__name__}",
-        category="invalid_response",
-    )
+        payload = dict(response)
+    else:
+        for method_name in ("model_dump", "to_dict"):
+            method = getattr(response, method_name, None)
+            if callable(method):
+                serialized = method()
+                if isinstance(serialized, Mapping):
+                    payload = dict(serialized)
+                    break
+    if payload is None:
+        raise LiteLLMBackendError(
+            f"LiteLLM returned unsupported response type: {type(response).__name__}",
+            category="invalid_response",
+        )
+    hidden = getattr(response, "_hidden_params", None)
+    if isinstance(hidden, Mapping) and "_hidden_params" not in payload:
+        payload["_hidden_params"] = dict(hidden)
+    return payload
 
 
 def _instruction_text(value: Any) -> str:

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
+
+import atomic_io
+import batch_cost_estimate
 
 SCHEMA_VERSION = 1
 USAGE_DIRECTORY_NAME = "translation_usage"
@@ -293,57 +295,6 @@ def extract_actual_cost(
     return None, None, None
 
 
-def resolve_model_pricing(
-    model: str,
-    pricing_config: Mapping[str, Any] | None,
-) -> Mapping[str, Any] | None:
-    config = dict(pricing_config or {})
-    models = config.get("models")
-    if not isinstance(models, Mapping):
-        return None
-    normalized = str(model or "").strip()
-    rates = models.get(normalized)
-    if isinstance(rates, Mapping):
-        return rates
-    best = ""
-    best_rates = None
-    for candidate, candidate_rates in models.items():
-        if (
-            isinstance(candidate, str)
-            and normalized.startswith(candidate)
-            and len(candidate) > len(best)
-            and isinstance(candidate_rates, Mapping)
-        ):
-            best = candidate
-            best_rates = candidate_rates
-    return best_rates
-
-
-def estimate_cost_from_usage(
-    normalized_usage: Mapping[str, Any],
-    model_rates: Mapping[str, Any] | None,
-) -> float | None:
-    rates = dict(model_rates or {})
-    input_rate = _nonnegative_float(rates.get("input_per_million"))
-    output_rate = _nonnegative_float(rates.get("output_per_million"))
-    if input_rate is None and output_rate is None:
-        return None
-    if not (input_rate or output_rate):
-        return None
-
-    prompt = _nonnegative_int(normalized_usage.get("prompt_tokens"))
-    output = _nonnegative_int(normalized_usage.get("billable_output_tokens"))
-    if input_rate and prompt is None:
-        return None
-    if output_rate and output is None:
-        return None
-    estimate = (
-        (float(prompt or 0) * float(input_rate or 0.0))
-        + (float(output or 0) * float(output_rate or 0.0))
-    ) / 1_000_000
-    return round(estimate, 8)
-
-
 def _dedupe_key(
     *,
     project_id: str,
@@ -410,16 +361,25 @@ def build_usage_record(
         usage_metadata=raw_usage,
     )
 
-    rates = resolve_model_pricing(model_name, pricing_config)
+    pricing = dict(pricing_config or {})
     computed_estimate = (
         _nonnegative_float(estimated_cost)
         if estimated_cost is not None
-        else estimate_cost_from_usage(normalized, rates)
+        else batch_cost_estimate.estimate_usage_cost(
+            model_name,
+            prompt_tokens=normalized["prompt_tokens"],
+            output_tokens=normalized["billable_output_tokens"],
+            pricing_config=pricing,
+        )
     )
+    estimate_basis = None
+    if computed_estimate is not None:
+        estimate_basis = (
+            "caller_supplied" if estimated_cost is not None else "configured_pricing"
+        )
     actual_cost, actual_currency, actual_source = extract_actual_cost(
         raw_usage, response_payload
     )
-    pricing = dict(pricing_config or {})
     estimate_currency = (
         str(estimated_cost_currency or pricing.get("currency") or "").strip() or None
     )
@@ -447,9 +407,7 @@ def build_usage_record(
         "provider_usage": raw_usage,
         "estimated_cost": computed_estimate,
         "estimated_cost_currency": estimate_currency if computed_estimate is not None else None,
-        "estimated_cost_basis": (
-            "configured_pricing" if computed_estimate is not None else None
-        ),
+        "estimated_cost_basis": estimate_basis,
         "actual_cost": actual_cost,
         "actual_cost_currency": actual_currency if actual_cost is not None else None,
         "actual_cost_source": actual_source,
@@ -485,6 +443,7 @@ class UsageLedger:
                 "Usage ledger path must stay inside the selected game_root"
             )
         self.path = candidate_path
+        self.lock_path = f"{candidate_path}.lock"
 
     def _empty_payload(self) -> dict[str, Any]:
         now = utc_now_iso()
@@ -527,34 +486,32 @@ class UsageLedger:
         game_root = self.project["game_root"]
         if not os.path.isdir(game_root):
             raise UsageLedgerError(f"game_root does not exist: {game_root}")
-        parent = os.path.dirname(self.path)
-        os.makedirs(parent, exist_ok=True)
-        tmp_path = ""
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=parent,
-                prefix=f".{USAGE_LEDGER_FILENAME}.",
-                suffix=".tmp",
-                delete=False,
-            ) as handle:
-                tmp_path = handle.name
-                json.dump(payload, handle, ensure_ascii=False, indent=2)
-                handle.write("\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp_path, self.path)
+            atomic_io.atomic_write_json(
+                self.path,
+                payload,
+                ensure_ascii=False,
+                indent=2,
+            )
         except OSError as exc:
             raise UsageLedgerError(f"Could not write usage ledger {self.path}: {exc}") from exc
-        finally:
-            if tmp_path and os.path.exists(tmp_path):
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
 
     def add_records(self, records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+        game_root = self.project["game_root"]
+        if not os.path.isdir(game_root):
+            raise UsageLedgerError(f"game_root does not exist: {game_root}")
+        try:
+            with atomic_io.exclusive_file_lock(self.lock_path):
+                return self._add_records_unlocked(records)
+        except OSError as exc:
+            raise UsageLedgerError(
+                f"Could not lock usage ledger {self.path}: {exc}"
+            ) from exc
+
+    def _add_records_unlocked(
+        self,
+        records: Iterable[Mapping[str, Any]],
+    ) -> dict[str, Any]:
         payload = self.load()
         stored = list(payload.get("records") or [])
         existing = {

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -1,0 +1,1001 @@
+"""Project-scoped, provider-neutral model usage ledger.
+
+The ledger stores usage summaries only. Response text is used to derive a
+stable deduplication fingerprint but is never persisted in the ledger.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+SCHEMA_VERSION = 1
+USAGE_DIRECTORY_NAME = "translation_usage"
+USAGE_LEDGER_FILENAME = "usage_ledger.json"
+
+TASK_MODE_ALIASES = {
+    "translation": "translation",
+    "revision": "revision",
+    "revisions": "revision",
+    "keyword": "keyword",
+    "keywords": "keyword",
+    "keyword_extraction": "keyword",
+    "repair": "repair",
+    "analysis": "analysis",
+    "final_review": "analysis",
+    "project_analysis": "analysis",
+    "probe": "analysis",
+    "compare_variants": "analysis",
+}
+
+GROUP_FIELD_ALIASES = {
+    "task": "task_mode",
+    "task_mode": "task_mode",
+    "stage": "stage",
+    "provider": "provider",
+    "model": "model",
+    "run": "run_id",
+    "run_id": "run_id",
+    "operation": "operation_id",
+    "operation_id": "operation_id",
+    "execution": "execution_mode",
+    "execution_mode": "execution_mode",
+}
+
+TOKEN_FIELDS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "thoughts_tokens",
+    "cached_tokens",
+)
+
+
+class UsageLedgerError(RuntimeError):
+    """Raised when a usage ledger cannot be read, validated, or written."""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def canonical_game_root(game_root: str | os.PathLike[str] | None) -> str:
+    if not game_root:
+        raise UsageLedgerError("game_root is required for the model usage ledger")
+    raw = os.fspath(game_root)
+    try:
+        return str(Path(raw).expanduser().resolve(strict=False))
+    except OSError:
+        return os.path.abspath(raw)
+
+
+def project_identity(game_root: str | os.PathLike[str] | None) -> dict[str, str]:
+    canonical = canonical_game_root(game_root)
+    normalized = os.path.normcase(canonical)
+    return {
+        "game_root": canonical,
+        "project_id": hashlib.sha256(normalized.encode("utf-8")).hexdigest(),
+    }
+
+
+def usage_ledger_path(game_root: str | os.PathLike[str] | None) -> str:
+    root = canonical_game_root(game_root)
+    return os.path.join(root, USAGE_DIRECTORY_NAME, USAGE_LEDGER_FILENAME)
+
+
+def new_run_id(prefix: str) -> str:
+    clean = "".join(char if char.isalnum() or char in "-_" else "-" for char in prefix)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{clean or 'usage'}-{stamp}-{uuid.uuid4().hex[:12]}"
+
+
+def normalize_task_mode(value: Any) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_")
+    return TASK_MODE_ALIASES.get(normalized, normalized or "analysis")
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _json_safe_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    normalized = _json_safe(dict(value))
+    return normalized if isinstance(normalized, dict) else {}
+
+
+def _canonical_json_digest(value: Any) -> str:
+    payload = json.dumps(
+        _json_safe(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def extract_provider_usage(response_payload: Any) -> dict[str, Any]:
+    """Extract a provider usage mapping without assuming Gemini or OpenAI casing."""
+    payload = response_payload if isinstance(response_payload, Mapping) else {}
+    nested = payload.get("response")
+    if isinstance(nested, Mapping):
+        payload = nested
+    for key in ("usageMetadata", "usage_metadata", "usage"):
+        usage = payload.get(key)
+        if isinstance(usage, Mapping):
+            return _json_safe_mapping(usage)
+    return {}
+
+
+def extract_response_id(response_payload: Any) -> str:
+    payload = response_payload if isinstance(response_payload, Mapping) else {}
+    candidates = [payload]
+    nested = payload.get("response")
+    if isinstance(nested, Mapping):
+        candidates.insert(0, nested)
+    for candidate in candidates:
+        for key in ("responseId", "response_id", "id", "request_id"):
+            value = candidate.get(key)
+            if isinstance(value, (str, int)) and str(value).strip():
+                return str(value).strip()
+    return ""
+
+
+def _nested_value(mapping: Mapping[str, Any], path: Sequence[str]) -> Any:
+    value: Any = mapping
+    for key in path:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _first_int(mapping: Mapping[str, Any], paths: Iterable[Sequence[str]]) -> int | None:
+    for path in paths:
+        parsed = _nonnegative_int(_nested_value(mapping, path))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def normalize_usage_metadata(usage_metadata: Mapping[str, Any] | None) -> dict[str, int | bool | None]:
+    """Normalize Gemini, LiteLLM/OpenAI, and generic token counters.
+
+    Missing values remain ``None``. ``total_tokens`` is derived only when the
+    available component counters make that derivation unambiguous.
+    """
+    usage = dict(usage_metadata or {})
+    prompt = _first_int(
+        usage,
+        (
+            ("promptTokenCount",),
+            ("prompt_token_count",),
+            ("prompt_tokens",),
+            ("input_tokens",),
+            ("inputTokenCount",),
+        ),
+    )
+    completion = _first_int(
+        usage,
+        (
+            ("candidatesTokenCount",),
+            ("candidates_token_count",),
+            ("completion_tokens",),
+            ("output_tokens",),
+            ("outputTokenCount",),
+        ),
+    )
+    thoughts = _first_int(
+        usage,
+        (
+            ("thoughtsTokenCount",),
+            ("thoughts_token_count",),
+            ("thoughts_tokens",),
+            ("reasoning_tokens",),
+            ("completion_tokens_details", "reasoning_tokens"),
+            ("output_tokens_details", "reasoning_tokens"),
+        ),
+    )
+    cached = _first_int(
+        usage,
+        (
+            ("cachedContentTokenCount",),
+            ("cached_content_token_count",),
+            ("cached_tokens",),
+            ("cache_read_input_tokens",),
+            ("prompt_tokens_details", "cached_tokens"),
+            ("input_tokens_details", "cached_tokens"),
+        ),
+    )
+    total = _first_int(
+        usage,
+        (
+            ("totalTokenCount",),
+            ("total_token_count",),
+            ("total_tokens",),
+        ),
+    )
+    total_derived = False
+    if total is None and prompt is not None and completion is not None:
+        total = prompt + completion
+        if "candidatesTokenCount" in usage and thoughts is not None:
+            total += thoughts
+        total_derived = True
+
+    billable_output = None
+    if total is not None and prompt is not None:
+        billable_output = max(0, total - prompt)
+    elif completion is not None:
+        billable_output = completion
+        if "candidatesTokenCount" in usage and thoughts is not None:
+            billable_output += thoughts
+
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+        "thoughts_tokens": thoughts,
+        "cached_tokens": cached,
+        "billable_output_tokens": billable_output,
+        "total_tokens_derived": total_derived,
+    }
+
+
+def _nonnegative_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if parsed < 0 or parsed != parsed or parsed in (float("inf"), float("-inf")):
+        return None
+    return parsed
+
+
+def extract_actual_cost(
+    usage_metadata: Mapping[str, Any] | None,
+    response_payload: Any = None,
+) -> tuple[float | None, str | None, str | None]:
+    usage = dict(usage_metadata or {})
+    for key in ("actual_cost", "total_cost", "response_cost", "cost"):
+        parsed = _nonnegative_float(usage.get(key))
+        if parsed is not None:
+            currency = usage.get("cost_currency") or usage.get("currency")
+            return parsed, str(currency).strip() or None, f"usage.{key}"
+
+    payload = response_payload if isinstance(response_payload, Mapping) else {}
+    hidden = payload.get("_hidden_params")
+    if isinstance(hidden, Mapping):
+        parsed = _nonnegative_float(hidden.get("response_cost"))
+        if parsed is not None:
+            currency = hidden.get("response_cost_currency") or hidden.get("currency") or "USD"
+            return parsed, str(currency).strip() or None, "_hidden_params.response_cost"
+    return None, None, None
+
+
+def resolve_model_pricing(
+    model: str,
+    pricing_config: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    config = dict(pricing_config or {})
+    models = config.get("models")
+    if not isinstance(models, Mapping):
+        return None
+    normalized = str(model or "").strip()
+    rates = models.get(normalized)
+    if isinstance(rates, Mapping):
+        return rates
+    best = ""
+    best_rates = None
+    for candidate, candidate_rates in models.items():
+        if (
+            isinstance(candidate, str)
+            and normalized.startswith(candidate)
+            and len(candidate) > len(best)
+            and isinstance(candidate_rates, Mapping)
+        ):
+            best = candidate
+            best_rates = candidate_rates
+    return best_rates
+
+
+def estimate_cost_from_usage(
+    normalized_usage: Mapping[str, Any],
+    model_rates: Mapping[str, Any] | None,
+) -> float | None:
+    rates = dict(model_rates or {})
+    input_rate = _nonnegative_float(rates.get("input_per_million"))
+    output_rate = _nonnegative_float(rates.get("output_per_million"))
+    if input_rate is None and output_rate is None:
+        return None
+    if not (input_rate or output_rate):
+        return None
+
+    prompt = _nonnegative_int(normalized_usage.get("prompt_tokens"))
+    output = _nonnegative_int(normalized_usage.get("billable_output_tokens"))
+    if input_rate and prompt is None:
+        return None
+    if output_rate and output is None:
+        return None
+    estimate = (
+        (float(prompt or 0) * float(input_rate or 0.0))
+        + (float(output or 0) * float(output_rate or 0.0))
+    ) / 1_000_000
+    return round(estimate, 8)
+
+
+def _dedupe_key(
+    *,
+    project_id: str,
+    provider: str,
+    model: str,
+    response_payload: Any,
+    response_id: str,
+    run_id: str,
+    source_key: str,
+    usage_metadata: Mapping[str, Any],
+) -> str:
+    if response_id:
+        identity = f"response:{provider}:{model}:{response_id}"
+    elif response_payload:
+        identity = (
+            f"payload:{provider}:{model}:{source_key}:"
+            f"{_canonical_json_digest(response_payload)}"
+        )
+    else:
+        identity = (
+            f"call:{provider}:{model}:{run_id}:{source_key}:"
+            f"{_canonical_json_digest(usage_metadata)}"
+        )
+    return hashlib.sha256(f"{project_id}:{identity}".encode("utf-8")).hexdigest()
+
+
+def build_usage_record(
+    *,
+    game_root: str | os.PathLike[str],
+    task_mode: str,
+    stage: str,
+    provider: str,
+    model: str,
+    usage_metadata: Mapping[str, Any] | None,
+    response_payload: Any = None,
+    operation_id: str = "",
+    run_id: str = "",
+    manifest_id: str = "",
+    thinking_level: str = "",
+    execution_mode: str = "",
+    source_key: str = "",
+    source: Mapping[str, Any] | None = None,
+    pricing_config: Mapping[str, Any] | None = None,
+    estimated_cost: float | None = None,
+    estimated_cost_currency: str = "",
+    dedupe_key: str = "",
+    recorded_at: str = "",
+) -> dict[str, Any]:
+    identity = project_identity(game_root)
+    raw_usage = _json_safe_mapping(usage_metadata)
+    normalized = normalize_usage_metadata(raw_usage)
+    response_id = extract_response_id(response_payload)
+    provider_name = str(provider or "").strip().lower() or "unknown"
+    model_name = str(model or "").strip() or "unknown"
+    run_identity = str(run_id or "").strip() or new_run_id("usage")
+    key = str(dedupe_key or "").strip() or _dedupe_key(
+        project_id=identity["project_id"],
+        provider=provider_name,
+        model=model_name,
+        response_payload=response_payload,
+        response_id=response_id,
+        run_id=run_identity,
+        source_key=str(source_key or ""),
+        usage_metadata=raw_usage,
+    )
+
+    rates = resolve_model_pricing(model_name, pricing_config)
+    computed_estimate = (
+        _nonnegative_float(estimated_cost)
+        if estimated_cost is not None
+        else estimate_cost_from_usage(normalized, rates)
+    )
+    actual_cost, actual_currency, actual_source = extract_actual_cost(
+        raw_usage, response_payload
+    )
+    pricing = dict(pricing_config or {})
+    estimate_currency = (
+        str(estimated_cost_currency or pricing.get("currency") or "").strip() or None
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dedupe_key": key,
+        "project": identity,
+        "operation_id": str(operation_id or "").strip() or None,
+        "run_id": run_identity,
+        "manifest_id": str(manifest_id or "").strip() or None,
+        "task_mode": normalize_task_mode(task_mode),
+        "stage": str(stage or "").strip() or "unknown",
+        "provider": provider_name,
+        "model": model_name,
+        "thinking_level": str(thinking_level or "").strip() or None,
+        "execution_mode": str(execution_mode or "").strip() or None,
+        "calls": 1,
+        "prompt_tokens": normalized["prompt_tokens"],
+        "completion_tokens": normalized["completion_tokens"],
+        "total_tokens": normalized["total_tokens"],
+        "thoughts_tokens": normalized["thoughts_tokens"],
+        "cached_tokens": normalized["cached_tokens"],
+        "total_tokens_derived": bool(normalized["total_tokens_derived"]),
+        "provider_usage": raw_usage,
+        "estimated_cost": computed_estimate,
+        "estimated_cost_currency": estimate_currency if computed_estimate is not None else None,
+        "estimated_cost_basis": (
+            "configured_pricing" if computed_estimate is not None else None
+        ),
+        "actual_cost": actual_cost,
+        "actual_cost_currency": actual_currency if actual_cost is not None else None,
+        "actual_cost_source": actual_source,
+        "response_id": response_id or None,
+        "recorded_at": str(recorded_at or "").strip() or utc_now_iso(),
+        "source": _json_safe_mapping(source),
+    }
+
+
+class UsageLedger:
+    """Atomic JSON usage store bound to exactly one canonical game root."""
+
+    def __init__(
+        self,
+        game_root: str | os.PathLike[str],
+        *,
+        path: str | os.PathLike[str] | None = None,
+    ) -> None:
+        self.project = project_identity(game_root)
+        candidate_path = os.path.abspath(
+            os.fspath(path) if path is not None else usage_ledger_path(game_root)
+        )
+        try:
+            common_root = os.path.commonpath(
+                [self.project["game_root"], candidate_path]
+            )
+        except ValueError as exc:
+            raise UsageLedgerError(
+                "Usage ledger path must stay inside the selected game_root"
+            ) from exc
+        if os.path.normcase(common_root) != os.path.normcase(self.project["game_root"]):
+            raise UsageLedgerError(
+                "Usage ledger path must stay inside the selected game_root"
+            )
+        self.path = candidate_path
+
+    def _empty_payload(self) -> dict[str, Any]:
+        now = utc_now_iso()
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "project": dict(self.project),
+            "created_at": now,
+            "updated_at": now,
+            "records": [],
+        }
+
+    def load(self) -> dict[str, Any]:
+        if not os.path.isfile(self.path):
+            return self._empty_payload()
+        try:
+            with open(self.path, "r", encoding="utf-8-sig") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise UsageLedgerError(f"Could not read usage ledger {self.path}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise UsageLedgerError(f"Usage ledger root must be an object: {self.path}")
+        if int(payload.get("schema_version") or 0) != SCHEMA_VERSION:
+            raise UsageLedgerError(
+                f"Unsupported usage ledger schema_version in {self.path}: "
+                f"{payload.get('schema_version')!r}"
+            )
+        stored_project = payload.get("project")
+        if not isinstance(stored_project, Mapping):
+            raise UsageLedgerError(f"Usage ledger project identity is missing: {self.path}")
+        if stored_project.get("project_id") != self.project["project_id"]:
+            raise UsageLedgerError(
+                "Usage ledger project identity does not match the selected game_root"
+            )
+        records = payload.get("records")
+        if not isinstance(records, list) or any(not isinstance(row, dict) for row in records):
+            raise UsageLedgerError(f"Usage ledger records must be an array: {self.path}")
+        return payload
+
+    def _write(self, payload: Mapping[str, Any]) -> None:
+        game_root = self.project["game_root"]
+        if not os.path.isdir(game_root):
+            raise UsageLedgerError(f"game_root does not exist: {game_root}")
+        parent = os.path.dirname(self.path)
+        os.makedirs(parent, exist_ok=True)
+        tmp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=parent,
+                prefix=f".{USAGE_LEDGER_FILENAME}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                tmp_path = handle.name
+                json.dump(payload, handle, ensure_ascii=False, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.path)
+        except OSError as exc:
+            raise UsageLedgerError(f"Could not write usage ledger {self.path}: {exc}") from exc
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    def add_records(self, records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+        payload = self.load()
+        stored = list(payload.get("records") or [])
+        existing = {
+            str(record.get("dedupe_key") or "")
+            for record in stored
+            if record.get("dedupe_key")
+        }
+        inserted = 0
+        duplicates = 0
+        for raw in records:
+            record = _json_safe_mapping(raw)
+            record_project = record.get("project")
+            if not isinstance(record_project, Mapping):
+                raise UsageLedgerError("Usage record project identity is missing")
+            if record_project.get("project_id") != self.project["project_id"]:
+                raise UsageLedgerError("Refusing to mix usage records from different projects")
+            key = str(record.get("dedupe_key") or "").strip()
+            if not key:
+                raise UsageLedgerError("Usage record dedupe_key is missing")
+            if key in existing:
+                duplicates += 1
+                continue
+            existing.add(key)
+            stored.append(record)
+            inserted += 1
+        if inserted:
+            payload["records"] = stored
+            payload["project"] = dict(self.project)
+            payload["updated_at"] = utc_now_iso()
+            self._write(payload)
+        return {
+            "ledger_path": self.path,
+            "inserted_records": inserted,
+            "duplicate_records": duplicates,
+            "total_records": len(stored),
+        }
+
+
+def _manifest_task_and_stage(manifest: Mapping[str, Any]) -> tuple[str, str]:
+    manifest_mode = str(manifest.get("mode") or "translation").strip().lower()
+    task_mode = normalize_task_mode(manifest_mode)
+    execution = str(
+        manifest.get("execution_mode") or manifest.get("execution") or "batch"
+    ).strip().lower()
+    if manifest_mode == "final_review":
+        stage = "final_review"
+    else:
+        stage = f"{execution}_{task_mode}"
+    return task_mode, stage
+
+
+def _manifest_identity(manifest: Mapping[str, Any]) -> tuple[str, str, str]:
+    manifest_path = str(manifest.get("_manifest_path") or "").strip()
+    parent_ref = str(
+        manifest.get("retry_of_manifest")
+        or manifest.get("split_from_manifest")
+        or manifest_path
+    ).strip()
+    operation_seed = parent_ref or str(manifest.get("created_at") or "")
+    operation_id = (
+        "manifest-operation-"
+        + hashlib.sha256(operation_seed.encode("utf-8")).hexdigest()[:20]
+    )
+    run_label = str(
+        manifest.get("job_name")
+        or manifest.get("result_file_name")
+        or manifest.get("display_name")
+        or ""
+    ).strip()
+    if not run_label:
+        run_label = os.path.basename(os.path.dirname(manifest_path)) if manifest_path else ""
+    if not run_label:
+        run_label = new_run_id("manifest")
+    manifest_id = (
+        "manifest-" + hashlib.sha256(manifest_path.encode("utf-8")).hexdigest()[:20]
+        if manifest_path
+        else ""
+    )
+    return operation_id, run_label, manifest_id
+
+
+def import_manifest_results(
+    manifest: Mapping[str, Any],
+    *,
+    result_path: str | os.PathLike[str] | None = None,
+    pricing_config: Mapping[str, Any] | None = None,
+    ledger: UsageLedger | None = None,
+) -> dict[str, Any]:
+    """Offline-import usage metadata from a downloaded/sync result JSONL."""
+    game_root = str(manifest.get("base_dir") or "").strip()
+    if not game_root:
+        raise UsageLedgerError("Manifest base_dir/game_root is missing")
+    raw_result_path = (
+        os.fspath(result_path)
+        if result_path is not None
+        else str(manifest.get("result_jsonl_path") or "")
+    )
+    if not raw_result_path:
+        raise UsageLedgerError("Result JSONL path is missing")
+    path = os.path.abspath(raw_result_path)
+    if not os.path.isfile(path):
+        raise UsageLedgerError(f"Result JSONL not found: {path}")
+
+    task_mode, stage = _manifest_task_and_stage(manifest)
+    operation_id, run_id, manifest_id = _manifest_identity(manifest)
+    execution = str(
+        manifest.get("execution_mode") or manifest.get("execution") or "batch"
+    ).strip().lower()
+    settings = manifest.get("settings")
+    settings = settings if isinstance(settings, Mapping) else {}
+    thinking_level = str(settings.get("thinking_level") or "")
+    default_provider = str(manifest.get("provider") or "").strip().lower()
+    if not default_provider:
+        default_provider = "gemini" if execution == "batch" else "unknown"
+    default_model = str(
+        manifest.get("model") or manifest.get("batch_model") or ""
+    ).strip()
+    effective_pricing = pricing_config if execution == "batch" else None
+
+    candidates: list[dict[str, Any]] = []
+    scanned_rows = 0
+    skipped_rows = 0
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for row_index, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                scanned_rows += 1
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise UsageLedgerError(
+                        f"Invalid result JSON at {path}:{row_index}: {exc}"
+                    ) from exc
+                if not isinstance(row, Mapping):
+                    skipped_rows += 1
+                    continue
+                response_payload = row.get("response_payload")
+                if not isinstance(response_payload, Mapping):
+                    response_payload = row.get("response")
+                if not isinstance(response_payload, Mapping):
+                    response_payload = {}
+                usage = row.get("usage_metadata")
+                if not isinstance(usage, Mapping):
+                    usage = extract_provider_usage(response_payload)
+                if row.get("error") and not response_payload and not usage:
+                    skipped_rows += 1
+                    continue
+                if not response_payload and not usage:
+                    skipped_rows += 1
+                    continue
+                row_key = str(row.get("key") or row.get("custom_id") or row_index)
+                candidates.append(
+                    build_usage_record(
+                        game_root=game_root,
+                        task_mode=task_mode,
+                        stage=str(row.get("pipeline_stage") or stage),
+                        provider=str(row.get("provider") or default_provider),
+                        model=str(row.get("model") or default_model),
+                        usage_metadata=usage,
+                        response_payload=response_payload,
+                        operation_id=operation_id,
+                        run_id=run_id,
+                        manifest_id=manifest_id,
+                        thinking_level=thinking_level,
+                        execution_mode=str(row.get("execution_mode") or execution),
+                        source_key=row_key,
+                        source={
+                            "kind": "manifest_results",
+                            "manifest_path": str(manifest.get("_manifest_path") or ""),
+                            "result_path": path,
+                            "row_key": row_key,
+                            "row_index": row_index,
+                        },
+                        pricing_config=effective_pricing,
+                    )
+                )
+    except OSError as exc:
+        raise UsageLedgerError(f"Could not read result JSONL {path}: {exc}") from exc
+
+    store = ledger or UsageLedger(game_root)
+    write_summary = store.add_records(candidates)
+    return {
+        **write_summary,
+        "game_root": canonical_game_root(game_root),
+        "result_path": path,
+        "scanned_rows": scanned_rows,
+        "candidate_records": len(candidates),
+        "skipped_rows": skipped_rows,
+    }
+
+
+def record_generation_usage(
+    *,
+    game_root: str | os.PathLike[str],
+    task_mode: str,
+    stage: str,
+    provider: str,
+    model: str,
+    usage_metadata: Mapping[str, Any] | None,
+    response_payload: Any = None,
+    operation_id: str = "",
+    run_id: str = "",
+    thinking_level: str = "",
+    execution_mode: str = "sync",
+    source_key: str = "",
+    source: Mapping[str, Any] | None = None,
+    pricing_config: Mapping[str, Any] | None = None,
+    ledger: UsageLedger | None = None,
+) -> dict[str, Any]:
+    record = build_usage_record(
+        game_root=game_root,
+        task_mode=task_mode,
+        stage=stage,
+        provider=provider,
+        model=model,
+        usage_metadata=usage_metadata,
+        response_payload=response_payload,
+        operation_id=operation_id,
+        run_id=run_id,
+        thinking_level=thinking_level,
+        execution_mode=execution_mode,
+        source_key=source_key,
+        source=source,
+        pricing_config=pricing_config,
+    )
+    store = ledger or UsageLedger(game_root)
+    return store.add_records([record])
+
+
+def normalize_group_by(group_by: Sequence[str] | str | None) -> tuple[str, ...]:
+    raw = (
+        [part.strip() for part in group_by.split(",")]
+        if isinstance(group_by, str)
+        else list(group_by or [])
+    )
+    if not raw:
+        raw = ["task", "stage", "provider", "model"]
+    fields: list[str] = []
+    for value in raw:
+        normalized = GROUP_FIELD_ALIASES.get(str(value).strip().lower())
+        if not normalized:
+            raise UsageLedgerError(f"Unsupported usage group field: {value}")
+        if normalized not in fields:
+            fields.append(normalized)
+    return tuple(fields)
+
+
+def _aggregate_cost(records: Sequence[Mapping[str, Any]], prefix: str) -> dict[str, Any]:
+    values: dict[str, float] = {}
+    known = 0
+    for record in records:
+        cost = _nonnegative_float(record.get(f"{prefix}_cost"))
+        if cost is None:
+            continue
+        currency = str(record.get(f"{prefix}_cost_currency") or "unknown")
+        values[currency] = values.get(currency, 0.0) + cost
+        known += 1
+    return {
+        "values": {
+            currency: round(value, 8)
+            for currency, value in sorted(values.items())
+        },
+        "known_records": known,
+        "unknown_records": len(records) - known,
+    }
+
+
+def aggregate_usage_records(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, Any] = {
+        "records": len(records),
+        "calls": sum(
+            int(record.get("calls") or 0)
+            for record in records
+            if _nonnegative_int(record.get("calls")) is not None
+        ),
+    }
+    for field in TOKEN_FIELDS:
+        values = [
+            parsed
+            for record in records
+            if (parsed := _nonnegative_int(record.get(field))) is not None
+        ]
+        totals[field] = sum(values) if values else None
+        totals[f"{field}_known_records"] = len(values)
+        totals[f"{field}_unknown_records"] = len(records) - len(values)
+    totals["estimated_cost"] = _aggregate_cost(records, "estimated")
+    totals["actual_cost"] = _aggregate_cost(records, "actual")
+    return totals
+
+
+def _record_matches(record: Mapping[str, Any], field: str, expected: str) -> bool:
+    actual = str(record.get(field) or "")
+    if field in {"provider", "task_mode", "stage", "execution_mode"}:
+        return actual.lower() == expected.lower()
+    return actual == expected
+
+
+def query_usage(
+    game_root: str | os.PathLike[str],
+    *,
+    task: str = "",
+    stage: str = "",
+    provider: str = "",
+    model: str = "",
+    group_by: Sequence[str] | str | None = None,
+    ledger: UsageLedger | None = None,
+) -> dict[str, Any]:
+    store = ledger or UsageLedger(game_root)
+    payload = store.load()
+    records: list[dict[str, Any]] = list(payload.get("records") or [])
+    filters = {
+        "task_mode": normalize_task_mode(task) if task else "",
+        "stage": str(stage or "").strip(),
+        "provider": str(provider or "").strip(),
+        "model": str(model or "").strip(),
+    }
+    filtered = [
+        record
+        for record in records
+        if all(
+            not expected or _record_matches(record, field, expected)
+            for field, expected in filters.items()
+        )
+    ]
+    group_fields = normalize_group_by(group_by)
+    buckets: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+    for record in filtered:
+        key = tuple(str(record.get(field) or "unknown") for field in group_fields)
+        buckets.setdefault(key, []).append(record)
+    groups = []
+    for key, rows in sorted(buckets.items(), key=lambda item: item[0]):
+        group = {field: value for field, value in zip(group_fields, key)}
+        group["totals"] = aggregate_usage_records(rows)
+        groups.append(group)
+
+    recent_run = None
+    if filtered:
+        latest = max(filtered, key=lambda row: str(row.get("recorded_at") or ""))
+        latest_run_id = str(latest.get("run_id") or "")
+        recent_rows = [
+            row for row in filtered if str(row.get("run_id") or "") == latest_run_id
+        ]
+        recent_run = {
+            "run_id": latest_run_id or None,
+            "recorded_at": latest.get("recorded_at"),
+            "task_modes": sorted(
+                {str(row.get("task_mode") or "unknown") for row in recent_rows}
+            ),
+            "stages": sorted(
+                {str(row.get("stage") or "unknown") for row in recent_rows}
+            ),
+            "providers": sorted(
+                {str(row.get("provider") or "unknown") for row in recent_rows}
+            ),
+            "models": sorted(
+                {str(row.get("model") or "unknown") for row in recent_rows}
+            ),
+            "totals": aggregate_usage_records(recent_rows),
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "project": dict(store.project),
+        "ledger_path": store.path,
+        "filters": {key: value for key, value in filters.items() if value},
+        "group_by": list(group_fields),
+        "totals": aggregate_usage_records(filtered),
+        "groups": groups,
+        "recent_run": recent_run,
+    }
+
+
+def _format_token_metric(totals: Mapping[str, Any], field: str) -> str:
+    value = totals.get(field)
+    unknown = int(totals.get(f"{field}_unknown_records") or 0)
+    text = "unknown" if value is None else f"{int(value):,}"
+    if unknown:
+        text += f" ({unknown} record(s) unknown)"
+    return text
+
+
+def _format_cost_metric(metric: Mapping[str, Any]) -> str:
+    values = metric.get("values") if isinstance(metric, Mapping) else {}
+    unknown = int(metric.get("unknown_records") or 0) if isinstance(metric, Mapping) else 0
+    if isinstance(values, Mapping) and values:
+        text = ", ".join(
+            f"{float(value):.6f} {currency}"
+            for currency, value in values.items()
+        )
+    else:
+        text = "unknown"
+    if unknown:
+        text += f" ({unknown} record(s) unknown)"
+    return text
+
+
+def format_usage_report(report: Mapping[str, Any]) -> list[str]:
+    totals = report.get("totals") if isinstance(report.get("totals"), Mapping) else {}
+    project = report.get("project") if isinstance(report.get("project"), Mapping) else {}
+    lines = [
+        "Model usage ledger:",
+        f"- Project: {project.get('game_root') or '(unknown)'}",
+        f"- Ledger: {report.get('ledger_path') or '(unknown)'}",
+        f"- Records / calls: {int(totals.get('records') or 0)} / {int(totals.get('calls') or 0)}",
+        f"- Prompt tokens: {_format_token_metric(totals, 'prompt_tokens')}",
+        f"- Completion tokens: {_format_token_metric(totals, 'completion_tokens')}",
+        f"- Total tokens: {_format_token_metric(totals, 'total_tokens')}",
+        f"- Thoughts tokens: {_format_token_metric(totals, 'thoughts_tokens')}",
+        f"- Cached tokens: {_format_token_metric(totals, 'cached_tokens')}",
+        (
+            "- Estimated cost (configured pricing, not provider billing): "
+            + _format_cost_metric(totals.get("estimated_cost") or {})
+        ),
+        (
+            "- Actual cost (provider reported only): "
+            + _format_cost_metric(totals.get("actual_cost") or {})
+        ),
+    ]
+    groups = report.get("groups")
+    if isinstance(groups, list) and groups:
+        lines.append("Groups:")
+        group_fields = report.get("group_by") or []
+        for group in groups:
+            if not isinstance(group, Mapping):
+                continue
+            label = " / ".join(str(group.get(field) or "unknown") for field in group_fields)
+            group_totals = group.get("totals") if isinstance(group.get("totals"), Mapping) else {}
+            lines.append(
+                f"- {label}: {int(group_totals.get('calls') or 0)} call(s), "
+                f"{_format_token_metric(group_totals, 'total_tokens')} total tokens"
+            )
+    recent = report.get("recent_run")
+    if isinstance(recent, Mapping):
+        recent_totals = (
+            recent.get("totals") if isinstance(recent.get("totals"), Mapping) else {}
+        )
+        lines.append(
+            "- Recent run: "
+            f"{recent.get('run_id') or '(unknown)'}; "
+            f"{int(recent_totals.get('calls') or 0)} call(s); "
+            f"{_format_token_metric(recent_totals, 'total_tokens')} total tokens"
+        )
+    return lines

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -283,15 +283,23 @@ def extract_actual_cost(
         parsed = _nonnegative_float(usage.get(key))
         if parsed is not None:
             currency = usage.get("cost_currency") or usage.get("currency")
-            return parsed, str(currency).strip() or None, f"usage.{key}"
+            return parsed, str(currency or "").strip() or None, f"usage.{key}"
 
     payload = response_payload if isinstance(response_payload, Mapping) else {}
     hidden = payload.get("_hidden_params")
     if isinstance(hidden, Mapping):
         parsed = _nonnegative_float(hidden.get("response_cost"))
         if parsed is not None:
-            currency = hidden.get("response_cost_currency") or hidden.get("currency") or "USD"
-            return parsed, str(currency).strip() or None, "_hidden_params.response_cost"
+            currency = (
+                hidden.get("response_cost_currency")
+                or hidden.get("currency")
+                or "USD"
+            )
+            return (
+                parsed,
+                str(currency or "").strip() or None,
+                "_hidden_params.response_cost",
+            )
     return None, None, None
 
 
@@ -465,7 +473,14 @@ class UsageLedger:
             raise UsageLedgerError(f"Could not read usage ledger {self.path}: {exc}") from exc
         if not isinstance(payload, dict):
             raise UsageLedgerError(f"Usage ledger root must be an object: {self.path}")
-        if int(payload.get("schema_version") or 0) != SCHEMA_VERSION:
+        try:
+            schema_version = int(payload.get("schema_version") or 0)
+        except (TypeError, ValueError) as exc:
+            raise UsageLedgerError(
+                f"Unsupported usage ledger schema_version in {self.path}: "
+                f"{payload.get('schema_version')!r}"
+            ) from exc
+        if schema_version != SCHEMA_VERSION:
             raise UsageLedgerError(
                 f"Unsupported usage ledger schema_version in {self.path}: "
                 f"{payload.get('schema_version')!r}"

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -574,14 +574,18 @@ def run_mapreduce_drafts(
         stage_usage["output_tokens"] += output_tokens
         stage_usage["total_tokens"] += total_tokens
         if usage_recorder is not None:
-            usage_recorder(
-                {
-                    "stage": stage,
-                    "artifact_id": current_request["artifact_id"],
-                    "result": result,
-                    "usage_metadata": metadata,
-                }
-            )
+            try:
+                usage_recorder(
+                    {
+                        "stage": stage,
+                        "artifact_id": current_request["artifact_id"],
+                        "result": result,
+                        "usage_metadata": metadata,
+                    }
+                )
+            except Exception:
+                # Accounting must never abort generation after tokens were spent.
+                pass
         return result
 
     def _emit_progress(stage: str, completed: int, total: int, action: str) -> None:

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -500,6 +500,7 @@ def run_mapreduce_drafts(
     provider: str = "",
     model: str = "",
     progress: Callable[[Mapping[str, Any]], None] | None = None,
+    usage_recorder: Callable[[Mapping[str, Any]], None] | None = None,
     pricing: Mapping[str, Any] | None = None,
     analysis_inputs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -513,6 +514,8 @@ def run_mapreduce_drafts(
     ``completed``, ``total``, ``action``, and a ``usage`` mapping. ``pricing`` may
     provide ``currency``, ``input_per_million``, and ``output_per_million``; the
     final progress event, return value, and manifest then include estimated cost.
+    ``usage_recorder`` receives each successful response together with its
+    stage and artifact id so callers can persist provider-neutral usage.
     """
     if generate is None:
         if backend is None:
@@ -544,11 +547,17 @@ def run_mapreduce_drafts(
     def _tracked_generate(request: SyncGenerationRequest) -> SyncGenerationResult:
         result = raw_generate(request)
         metadata = dict(getattr(result, "usage_metadata", None) or {})
-        input_tokens = _usage_int(metadata, "prompt_token_count", "prompt_tokens", "input_tokens")
-        output_tokens = _usage_int(
-            metadata, "candidates_token_count", "completion_tokens", "output_tokens"
+        input_tokens = _usage_int(
+            metadata, "promptTokenCount", "prompt_token_count", "prompt_tokens", "input_tokens"
         )
-        total_tokens = _usage_int(metadata, "total_token_count", "total_tokens")
+        output_tokens = _usage_int(
+            metadata,
+            "candidatesTokenCount", "candidates_token_count",
+            "completion_tokens", "output_tokens",
+        )
+        total_tokens = _usage_int(
+            metadata, "totalTokenCount", "total_token_count", "total_tokens"
+        )
         if not total_tokens:
             total_tokens = input_tokens + output_tokens
         usage_summary["requests"] += 1
@@ -564,6 +573,15 @@ def run_mapreduce_drafts(
         stage_usage["input_tokens"] += input_tokens
         stage_usage["output_tokens"] += output_tokens
         stage_usage["total_tokens"] += total_tokens
+        if usage_recorder is not None:
+            usage_recorder(
+                {
+                    "stage": stage,
+                    "artifact_id": current_request["artifact_id"],
+                    "result": result,
+                    "usage_metadata": metadata,
+                }
+            )
         return result
 
     def _emit_progress(stage: str, completed: int, total: int, action: str) -> None:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -19,6 +19,16 @@ class AtomicIoHelperTests(unittest.TestCase):
             self.assertEqual(path.read_text(encoding='utf-8'), 'new\n')
             self.assertEqual(list(Path(tmp).glob('*.tmp')), [])
 
+    def test_exclusive_file_lock_serializes_and_releases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_path = Path(tmp) / 'demo.lock'
+            with atomic_io.exclusive_file_lock(lock_path, timeout=1.0):
+                self.assertTrue(lock_path.is_file())
+                with self.assertRaises(atomic_io.AtomicFileLockTimeoutError):
+                    with atomic_io.exclusive_file_lock(lock_path, timeout=0.05):
+                        pass
+            self.assertFalse(lock_path.exists())
+
     def test_atomic_write_preserves_original_when_replace_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / 'data.json'

--- a/tests/test_batch_cost_estimate.py
+++ b/tests/test_batch_cost_estimate.py
@@ -50,6 +50,42 @@ class BatchCostEstimateTests(unittest.TestCase):
         self.assertTrue(batch_cost_estimate.cost_estimate_exceeds_max(estimate, 10))
         self.assertFalse(batch_cost_estimate.cost_estimate_exceeds_max(estimate, 12.5))
 
+    def test_estimate_usage_cost_reuses_shared_pricing(self):
+        pricing = {
+            'currency': 'USD',
+            'models': {
+                'gemini-test': {
+                    'input_per_million': 1.0,
+                    'output_per_million': 2.0,
+                }
+            },
+        }
+        self.assertEqual(
+            batch_cost_estimate.estimate_usage_cost(
+                'gemini-test',
+                prompt_tokens=1_000_000,
+                output_tokens=500_000,
+                pricing_config=pricing,
+            ),
+            2.0,
+        )
+        self.assertIsNone(
+            batch_cost_estimate.estimate_usage_cost(
+                'unknown-model',
+                prompt_tokens=10,
+                output_tokens=5,
+                pricing_config=pricing,
+            )
+        )
+        self.assertIsNone(
+            batch_cost_estimate.estimate_usage_cost(
+                'gemini-test',
+                prompt_tokens=None,
+                output_tokens=5,
+                pricing_config=pricing,
+            )
+        )
+
     def test_estimate_final_review_uses_unit_or_request_count(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             jsonl_path = os.path.join(tmp_dir, 'requests.jsonl')

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -232,6 +232,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertNotIn("写回翻译（仅可写回）", by_label)
         self.assertIn(parent_path, by_label["合并补译结果"])
         self.assertIn(retry_path, by_label["合并补译结果"])
+        self.assertIn("usage-import", by_label["导入当前结果用量"])
+        self.assertIn("usage-report", by_label["查看项目模型用量"])
 
     def test_revision_manifest_commands_use_revision_apply_flow(self):
         manifest_path = r"C:\logs\batch_jobs\rev1\manifest.json"
@@ -249,6 +251,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertNotIn("写回翻译（仅可写回）", by_label)
         self.assertIn("preview-revisions", by_label["预览订正结果"])
         self.assertIn("apply-revisions", by_label["写回订正（预览确认后）"])
+        self.assertIn("usage-import", by_label["导入当前结果用量"])
+        self.assertIn("usage-report", by_label["查看项目模型用量"])
 
     def test_local_final_review_candidates_omit_cloud_submit(self):
         commands = build_cli_commands(
@@ -292,6 +296,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertNotIn("检查翻译结果", by_label)
         self.assertNotIn("写回翻译（仅可写回）", by_label)
         self.assertIn("export-keywords", by_label["导出关键词报告"])
+        self.assertIn("usage-import", by_label["导入当前结果用量"])
+        self.assertIn("usage-report", by_label["查看项目模型用量"])
         self.assertIn(manifest_path, by_label["导出关键词报告"])
 
     def test_keyword_manifest_with_export_includes_merge_glossary_commands(self):
@@ -324,7 +330,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
             logs_dir=r"C:\logs\batch_jobs",
         )
         self.assertEqual(context.status, idle_diagnostics_context().status)
-        self.assertEqual(context.commands, [])
+        command_labels = [command.label for command in context.commands]
+        self.assertEqual(command_labels, ["查看项目模型用量"])
 
     def test_build_diagnostics_context_idle_when_latest_path_suppressed(self):
         context = build_diagnostics_context(

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -391,6 +391,9 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertTrue(any("最近检查：可写回" in fact for fact in context.facts))
         self.assertTrue(any(entry.label == "批量请求" for entry in context.paths))
         self.assertTrue(context.commands)
+        command_labels = {entry.label for entry in context.commands}
+        self.assertIn("导入当前结果用量", command_labels)
+        self.assertIn("查看项目模型用量", command_labels)
         self.assertIn('"mode": "translation"', context.manifest_json_preview)
 
     def test_build_diagnostics_context_warns_when_latest_differs(self):

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -48,6 +48,31 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "stop")
         self.assertEqual(result.usage_metadata["prompt_tokens"], 8)
 
+    def test_preserves_provider_reported_cost_from_hidden_params(self):
+        class Response:
+            _hidden_params = {
+                "response_cost": 0.00125,
+                "response_cost_currency": "USD",
+            }
+
+            def model_dump(self):
+                return {
+                    "choices": [{
+                        "message": {"content": "ok"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 8, "completion_tokens": 6},
+                }
+
+        backend = LiteLLMSyncBackend(completion=lambda **kwargs: Response())
+        result = backend.generate(
+            SyncGenerationRequest("openai/test", "hello")
+        )
+
+        self.assertEqual(
+            result.response_payload["_hidden_params"]["response_cost"], 0.00125
+        )
+
     def test_uses_json_object_for_deepseek(self):
         calls = []
 

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -197,6 +197,65 @@ class ModelUsageLedgerTests(unittest.TestCase):
             self.assertEqual(record["actual_cost_source"], "_hidden_params.response_cost")
             self.assertEqual(record["stage"], "sync_keyword")
 
+    def test_usage_response_cost_without_currency_stays_unknown_currency(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            result_path = self._write_jsonl(
+                package,
+                [
+                    {
+                        "key": "kw-cost-only",
+                        "provider": "litellm",
+                        "model": "openai/test-model",
+                        "execution_mode": "sync",
+                        "usage_metadata": {
+                            "prompt_tokens": 4,
+                            "completion_tokens": 2,
+                            "total_tokens": 6,
+                            "response_cost": 0.42,
+                        },
+                        "response": {"id": "chatcmpl-cost-only"},
+                    }
+                ],
+            )
+            manifest = self._manifest(
+                game_root,
+                result_path,
+                mode="keyword_extraction",
+                execution="sync",
+                provider="litellm",
+                model="openai/test-model",
+            )
+
+            usage.import_manifest_results(manifest, result_path=result_path)
+            record = usage.UsageLedger(game_root).load()["records"][0]
+            report = usage.query_usage(game_root)
+
+            self.assertEqual(record["actual_cost"], 0.42)
+            self.assertIsNone(record["actual_cost_currency"])
+            self.assertEqual(record["actual_cost_source"], "usage.response_cost")
+            # Missing currency buckets under "unknown", never the literal "None".
+            self.assertEqual(
+                report["totals"]["actual_cost"]["values"],
+                {"unknown": 0.42},
+            )
+            self.assertNotIn("None", report["totals"]["actual_cost"]["values"])
+
+    def test_non_numeric_schema_version_raises_usage_ledger_error(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            ledger = usage.UsageLedger(game_root)
+            os.makedirs(os.path.dirname(ledger.path), exist_ok=True)
+            with open(ledger.path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "schema_version": "x",
+                        "project": ledger.project,
+                        "records": [],
+                    },
+                    handle,
+                )
+            with self.assertRaises(usage.UsageLedgerError):
+                ledger.load()
+
     def test_missing_usage_stays_unknown_instead_of_zero(self):
         with tempfile.TemporaryDirectory() as game_root:
             usage.record_generation_usage(

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -3,7 +3,10 @@ import io
 import json
 import os
 import tempfile
+import threading
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import gemini_translate_batch as batch
@@ -217,6 +220,45 @@ class ModelUsageLedgerTests(unittest.TestCase):
             self.assertEqual(report["totals"]["total_tokens_unknown_records"], 1)
             self.assertEqual(report["totals"]["estimated_cost"]["values"], {})
             self.assertEqual(report["totals"]["actual_cost"]["values"], {})
+
+    def test_concurrent_writers_keep_both_records(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            barrier = threading.Barrier(2)
+            original_load = usage.UsageLedger.load
+
+            def slow_load(ledger):
+                payload = original_load(ledger)
+                time.sleep(0.05)
+                return payload
+
+            def write_record(index):
+                barrier.wait()
+                return usage.record_generation_usage(
+                    game_root=game_root,
+                    task_mode="translation",
+                    stage="sync_translation",
+                    provider="gemini",
+                    model="gemini-test",
+                    usage_metadata={"totalTokenCount": index + 1},
+                    response_payload={"responseId": f"concurrent-{index}"},
+                    operation_id="concurrent-operation",
+                    run_id="concurrent-run",
+                    source_key=f"record-{index}",
+                )
+
+            with (
+                mock.patch.object(usage.UsageLedger, "load", slow_load),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                results = list(executor.map(write_record, range(2)))
+
+            report = usage.query_usage(game_root)
+            ledger = usage.UsageLedger(game_root)
+
+            self.assertEqual(sum(row["inserted_records"] for row in results), 2)
+            self.assertEqual(report["totals"]["records"], 2)
+            self.assertEqual(report["totals"]["total_tokens"], 3)
+            self.assertFalse(os.path.exists(ledger.lock_path))
 
     def test_project_identity_prevents_cross_root_mixing(self):
         with tempfile.TemporaryDirectory() as first_root, tempfile.TemporaryDirectory() as second_root:
@@ -627,6 +669,84 @@ class ModelUsageLedgerTests(unittest.TestCase):
 
             self.assertTrue(any("累计 1 次调用" in fact for fact in context.facts))
             self.assertTrue(any("12 token" in fact for fact in context.facts))
+
+    def test_gui_diagnostics_surfaces_corrupt_ledger(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            ledger_path = usage.usage_ledger_path(game_root)
+            os.makedirs(os.path.dirname(ledger_path), exist_ok=True)
+            with open(ledger_path, "w", encoding="utf-8") as handle:
+                handle.write("{not-json")
+
+            context = build_diagnostics_context(
+                latest_manifest_path=None,
+                manifest=None,
+                batch_script_path="gemini_translate_batch.py",
+                logs_dir="logs",
+                game_root=game_root,
+            )
+
+            self.assertTrue(
+                any("模型用量账本读取失败" in fact for fact in context.facts)
+            )
+
+    def test_sync_path_buffers_records_until_flush(self):
+        import translator_runtime as runtime
+        from sync_model_backend import SyncGenerationResult, SYNC_EXECUTION_MODE
+
+        with tempfile.TemporaryDirectory() as game_root:
+            previous_base = runtime.BASE_DIR
+            previous_backend = runtime.SYNC_BACKEND
+            runtime.BASE_DIR = game_root
+            runtime.SYNC_BACKEND = "litellm"
+            usage_buffer = []
+            fake_result = SyncGenerationResult(
+                provider="litellm",
+                model="provider/model",
+                execution_mode=SYNC_EXECUTION_MODE,
+                response_payload={"id": "buffered-1"},
+                response_text='[{"id":"a","translation":"你好"}]',
+                finish_reason="stop",
+                usage_metadata={"totalTokenCount": 7},
+            )
+            fake_backend = mock.Mock()
+            fake_backend.generate.return_value = fake_result
+            try:
+                with mock.patch(
+                    "litellm_sync_backend.LiteLLMSyncBackend",
+                    return_value=fake_backend,
+                ), mock.patch.object(
+                    runtime, "get_current_model", return_value="provider/model"
+                ):
+                    runtime.call_gemini_sdk(
+                        "prompt",
+                        [{"id": "a", "text": "Hello"}],
+                        usage_run_id="sync-run-1",
+                        usage_buffer=usage_buffer,
+                        usage_operation_id="sync-run-1",
+                    )
+                self.assertEqual(len(usage_buffer), 1)
+                self.assertFalse(os.path.exists(usage.usage_ledger_path(game_root)))
+
+                usage.UsageLedger(game_root).add_records(usage_buffer)
+                report = usage.query_usage(game_root)
+                self.assertEqual(report["totals"]["records"], 1)
+                self.assertEqual(report["totals"]["total_tokens"], 7)
+                self.assertEqual(
+                    usage.UsageLedger(game_root).load()["records"][0]["operation_id"],
+                    "sync-run-1",
+                )
+            finally:
+                runtime.BASE_DIR = previous_base
+                runtime.SYNC_BACKEND = previous_backend
+
+    def test_import_best_effort_does_not_swallow_system_exit(self):
+        with self.assertRaises(SystemExit):
+            with mock.patch.object(
+                batch,
+                "import_manifest_usage",
+                side_effect=SystemExit("contract failure"),
+            ):
+                batch.import_manifest_usage_best_effort({"_manifest_path": "x"})
 
 
 if __name__ == "__main__":

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -1,0 +1,633 @@
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import gemini_translate_batch as batch
+import model_usage_ledger as usage
+from gui_qt.diagnostics_context import build_diagnostics_context
+from sync_model_backend import SYNC_EXECUTION_MODE, SyncGenerationResult
+
+
+class ModelUsageLedgerTests(unittest.TestCase):
+    def _write_jsonl(self, directory, rows):
+        path = os.path.join(directory, "results.jsonl")
+        with open(path, "w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        return path
+
+    def _manifest(
+        self,
+        game_root,
+        result_path,
+        *,
+        mode="translation",
+        execution="batch",
+        provider="",
+        model="gemini-test",
+    ):
+        package_dir = os.path.dirname(result_path)
+        return {
+            "_manifest_path": os.path.join(package_dir, "manifest.json"),
+            "_package_dir": package_dir,
+            "mode": mode,
+            "execution": execution,
+            "provider": provider,
+            "model": model if execution == "sync" else "",
+            "batch_model": model,
+            "base_dir": game_root,
+            "tl_dir": os.path.join(game_root, "game", "tl", "schinese"),
+            "display_name": f"{mode}-fixture",
+            "result_jsonl_path": result_path,
+            "settings": {"thinking_level": "minimal"},
+        }
+
+    def test_batch_gemini_import_is_offline_idempotent_and_keeps_raw_usage(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            result_path = self._write_jsonl(
+                package,
+                [
+                    {
+                        "key": "chunk-1",
+                        "response": {
+                            "responseId": "gemini-response-1",
+                            "usageMetadata": {
+                                "promptTokenCount": 100,
+                                "candidatesTokenCount": 40,
+                                "thoughtsTokenCount": 10,
+                                "cachedContentTokenCount": 20,
+                                "totalTokenCount": 150,
+                            },
+                        },
+                    }
+                ],
+            )
+            manifest = self._manifest(game_root, result_path)
+            pricing = {
+                "currency": "USD",
+                "models": {
+                    "gemini-test": {
+                        "input_per_million": 1.0,
+                        "output_per_million": 2.0,
+                    }
+                },
+            }
+
+            first = usage.import_manifest_results(
+                manifest, result_path=result_path, pricing_config=pricing
+            )
+            second = usage.import_manifest_results(
+                manifest, result_path=result_path, pricing_config=pricing
+            )
+            report = usage.query_usage(game_root)
+            record = usage.UsageLedger(game_root).load()["records"][0]
+
+            self.assertEqual(first["inserted_records"], 1)
+            self.assertEqual(second["inserted_records"], 0)
+            self.assertEqual(second["duplicate_records"], 1)
+            self.assertEqual(report["totals"]["calls"], 1)
+            self.assertEqual(report["totals"]["prompt_tokens"], 100)
+            self.assertEqual(report["totals"]["completion_tokens"], 40)
+            self.assertEqual(report["totals"]["thoughts_tokens"], 10)
+            self.assertEqual(report["totals"]["cached_tokens"], 20)
+            self.assertEqual(report["totals"]["total_tokens"], 150)
+            self.assertEqual(
+                report["totals"]["estimated_cost"]["values"]["USD"],
+                0.0002,
+            )
+            self.assertEqual(report["totals"]["actual_cost"]["values"], {})
+            self.assertEqual(
+                record["provider_usage"]["cachedContentTokenCount"], 20
+            )
+            self.assertEqual(record["task_mode"], "translation")
+            self.assertEqual(record["stage"], "batch_translation")
+            self.assertTrue(os.path.isfile(usage.usage_ledger_path(game_root)))
+
+    def test_sync_gemini_fixture_maps_revision_stage(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            result_path = self._write_jsonl(
+                package,
+                [
+                    {
+                        "key": "rv-1",
+                        "provider": "gemini",
+                        "model": "gemini-sync",
+                        "execution_mode": "sync",
+                        "usage_metadata": {
+                            "promptTokenCount": 25,
+                            "candidatesTokenCount": 5,
+                            "totalTokenCount": 30,
+                        },
+                        "response": {"responseId": "gemini-sync-response-1"},
+                    }
+                ],
+            )
+            manifest = self._manifest(
+                game_root,
+                result_path,
+                mode="revision",
+                execution="sync",
+                provider="gemini",
+                model="gemini-sync",
+            )
+
+            summary = usage.import_manifest_results(manifest, result_path=result_path)
+            report = usage.query_usage(game_root, task="revision", provider="gemini")
+            record = usage.UsageLedger(game_root).load()["records"][0]
+
+            self.assertEqual(summary["inserted_records"], 1)
+            self.assertEqual(report["totals"]["total_tokens"], 30)
+            self.assertEqual(record["task_mode"], "revision")
+            self.assertEqual(record["stage"], "sync_revision")
+            self.assertEqual(record["execution_mode"], "sync")
+
+    def test_litellm_fixture_maps_snake_case_cache_reasoning_and_actual_cost(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            result_path = self._write_jsonl(
+                package,
+                [
+                    {
+                        "key": "kw-1",
+                        "provider": "litellm",
+                        "model": "openai/test-model",
+                        "execution_mode": "sync",
+                        "usage_metadata": {
+                            "prompt_tokens": 8,
+                            "completion_tokens": 4,
+                            "total_tokens": 12,
+                            "prompt_tokens_details": {"cached_tokens": 3},
+                            "completion_tokens_details": {"reasoning_tokens": 2},
+                        },
+                        "response": {
+                            "id": "chatcmpl-fixture-1",
+                            "_hidden_params": {"response_cost": 0.00125},
+                        },
+                    }
+                ],
+            )
+            manifest = self._manifest(
+                game_root,
+                result_path,
+                mode="keyword_extraction",
+                execution="sync",
+                provider="litellm",
+                model="openai/test-model",
+            )
+
+            usage.import_manifest_results(manifest, result_path=result_path)
+            report = usage.query_usage(game_root, task="keyword", provider="litellm")
+            record = usage.UsageLedger(game_root).load()["records"][0]
+
+            self.assertEqual(report["totals"]["prompt_tokens"], 8)
+            self.assertEqual(report["totals"]["completion_tokens"], 4)
+            self.assertEqual(report["totals"]["thoughts_tokens"], 2)
+            self.assertEqual(report["totals"]["cached_tokens"], 3)
+            self.assertEqual(
+                report["totals"]["actual_cost"]["values"]["USD"],
+                0.00125,
+            )
+            self.assertIsNone(record["estimated_cost"])
+            self.assertEqual(record["actual_cost_source"], "_hidden_params.response_cost")
+            self.assertEqual(record["stage"], "sync_keyword")
+
+    def test_missing_usage_stays_unknown_instead_of_zero(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            usage.record_generation_usage(
+                game_root=game_root,
+                task_mode="repair",
+                stage="repair",
+                provider="gemini",
+                model="gemini-test",
+                usage_metadata={},
+                response_payload={"responseId": "unknown-usage-1"},
+                operation_id="repair-operation",
+                run_id="repair-run",
+                source_key="repair-1",
+            )
+            report = usage.query_usage(game_root)
+
+            self.assertEqual(report["totals"]["calls"], 1)
+            self.assertIsNone(report["totals"]["prompt_tokens"])
+            self.assertIsNone(report["totals"]["completion_tokens"])
+            self.assertIsNone(report["totals"]["total_tokens"])
+            self.assertEqual(report["totals"]["total_tokens_unknown_records"], 1)
+            self.assertEqual(report["totals"]["estimated_cost"]["values"], {})
+            self.assertEqual(report["totals"]["actual_cost"]["values"], {})
+
+    def test_project_identity_prevents_cross_root_mixing(self):
+        with tempfile.TemporaryDirectory() as first_root, tempfile.TemporaryDirectory() as second_root:
+            first = usage.record_generation_usage(
+                game_root=first_root,
+                task_mode="analysis",
+                stage="label",
+                provider="gemini",
+                model="gemini-test",
+                usage_metadata={"totalTokenCount": 7},
+                response_payload={"responseId": "same-provider-id"},
+                run_id="analysis-1",
+                source_key="label-a",
+            )
+            second = usage.record_generation_usage(
+                game_root=second_root,
+                task_mode="analysis",
+                stage="label",
+                provider="gemini",
+                model="gemini-test",
+                usage_metadata={"totalTokenCount": 7},
+                response_payload={"responseId": "same-provider-id"},
+                run_id="analysis-1",
+                source_key="label-a",
+            )
+
+            self.assertEqual(first["inserted_records"], 1)
+            self.assertEqual(second["inserted_records"], 1)
+            with self.assertRaises(usage.UsageLedgerError):
+                usage.UsageLedger(
+                    second_root,
+                    path=usage.usage_ledger_path(first_root),
+                ).load()
+
+    def test_same_provider_response_id_from_different_models_stays_distinct(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            for model in ("provider/model-a", "provider/model-b"):
+                usage.record_generation_usage(
+                    game_root=game_root,
+                    task_mode="translation",
+                    stage="sync_translation",
+                    provider="litellm",
+                    model=model,
+                    usage_metadata={"total_tokens": 5},
+                    response_payload={"id": "shared-fixture-id"},
+                    run_id="shared-id-run",
+                    source_key=model,
+                )
+
+            report = usage.query_usage(game_root, provider="litellm")
+
+            self.assertEqual(report["totals"]["calls"], 2)
+            self.assertEqual(report["totals"]["total_tokens"], 10)
+
+    def test_report_filters_and_groups_by_task_stage_provider_model(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            for response_id, task, stage, provider, model, tokens in (
+                ("r1", "translation", "batch_translation", "gemini", "m1", 10),
+                ("r2", "analysis", "brief", "litellm", "m2", 20),
+            ):
+                usage.record_generation_usage(
+                    game_root=game_root,
+                    task_mode=task,
+                    stage=stage,
+                    provider=provider,
+                    model=model,
+                    usage_metadata={"total_tokens": tokens},
+                    response_payload={"id": response_id},
+                    run_id=f"run-{response_id}",
+                    source_key=response_id,
+                )
+
+            all_report = usage.query_usage(game_root)
+            filtered = usage.query_usage(
+                game_root,
+                task="analysis",
+                stage="brief",
+                provider="litellm",
+                model="m2",
+            )
+
+            self.assertEqual(len(all_report["groups"]), 2)
+            self.assertEqual(filtered["totals"]["records"], 1)
+            self.assertEqual(filtered["totals"]["total_tokens"], 20)
+            self.assertEqual(filtered["groups"][0]["task_mode"], "analysis")
+
+    def test_retry_merge_import_expands_original_result_lineage(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            parent_dir = os.path.join(package, "parent")
+            retry_dir = os.path.join(package, "retry")
+            os.makedirs(parent_dir)
+            os.makedirs(retry_dir)
+            parent_result = self._write_jsonl(
+                parent_dir,
+                [
+                    {
+                        "key": "chunk-1",
+                        "response": {
+                            "responseId": "parent-response",
+                            "usageMetadata": {"totalTokenCount": 10},
+                        },
+                    }
+                ],
+            )
+            retry_result = self._write_jsonl(
+                retry_dir,
+                [
+                    {
+                        "key": "chunk-2",
+                        "response": {
+                            "responseId": "retry-response",
+                            "usageMetadata": {"totalTokenCount": 20},
+                        },
+                    }
+                ],
+            )
+            retry_manifest = self._manifest(game_root, retry_result)
+            retry_manifest_path = os.path.join(retry_dir, "manifest.json")
+            retry_manifest["_manifest_path"] = retry_manifest_path
+            with open(retry_manifest_path, "w", encoding="utf-8") as handle:
+                json.dump(retry_manifest, handle)
+
+            parent_manifest = self._manifest(game_root, os.path.join(parent_dir, "merged.jsonl"))
+            parent_manifest["retry_merge_history"] = [
+                {
+                    "previous_result_jsonl_path": parent_result,
+                    "retry_manifest": retry_manifest_path,
+                    "retry_result_jsonl_path": retry_result,
+                }
+            ]
+
+            with mock.patch.object(
+                batch, "_read_translator_config_object", return_value={}
+            ):
+                first = batch.import_manifest_usage(parent_manifest)
+                second = batch.import_manifest_usage(parent_manifest)
+            report = usage.query_usage(game_root)
+
+            self.assertEqual(first["inserted_records"], 2)
+            self.assertEqual(first["result_path"], "")
+            self.assertEqual(first["result_paths"], [parent_result, retry_result])
+            self.assertEqual(second["inserted_records"], 0)
+            self.assertEqual(second["duplicate_records"], 2)
+            self.assertEqual(report["totals"]["calls"], 2)
+            self.assertEqual(report["totals"]["total_tokens"], 30)
+
+    def test_probe_records_only_successful_provider_responses(self):
+        with tempfile.TemporaryDirectory() as package:
+            manifest = {
+                "_manifest_path": os.path.join(package, "manifest.json"),
+                "_package_dir": package,
+                "batch_model": "gemini-test",
+                "settings": {"thinking_level": "minimal"},
+                "chunks": [{"key": "chunk-1", "items": [{"id": "item-1"}]}],
+            }
+            request_rows = [
+                {
+                    "key": "chunk-1",
+                    "request": {"contents": [], "generation_config": {}},
+                }
+            ]
+            response_text = json.dumps(
+                [{"id": "item-1", "translation": "译文"}], ensure_ascii=False
+            )
+            success = SyncGenerationResult(
+                provider="gemini",
+                model="gemini-test",
+                execution_mode=SYNC_EXECUTION_MODE,
+                response_payload={"responseId": "probe-response"},
+                response_text=response_text,
+                finish_reason="STOP",
+                usage_metadata={"totalTokenCount": 9},
+            )
+
+            class SuccessBackend:
+                def __init__(self, *_args, **_kwargs):
+                    pass
+
+                def generate(self, _request):
+                    return success
+
+            with (
+                mock.patch.object(batch, "load_manifest", return_value=manifest),
+                mock.patch.object(batch, "load_request_rows", return_value=request_rows),
+                mock.patch.object(batch, "create_batch_client", return_value=object()),
+                mock.patch.object(batch, "GeminiSyncBackend", SuccessBackend),
+                mock.patch.object(
+                    batch, "record_generation_usage_best_effort"
+                ) as recorder,
+            ):
+                success_summary = batch.probe_requests("unused", limit=1)
+
+            self.assertEqual(success_summary["request_errors"], 0)
+            self.assertEqual(success_summary["parse_ok"], 1)
+            recorder.assert_called_once()
+            self.assertEqual(recorder.call_args.kwargs["stage"], "probe")
+
+            class FailingBackend:
+                def __init__(self, *_args, **_kwargs):
+                    pass
+
+                def generate(self, _request):
+                    raise RuntimeError("provider failed")
+
+            with (
+                mock.patch.object(batch, "load_manifest", return_value=manifest),
+                mock.patch.object(batch, "load_request_rows", return_value=request_rows),
+                mock.patch.object(batch, "create_batch_client", return_value=object()),
+                mock.patch.object(batch, "GeminiSyncBackend", FailingBackend),
+                mock.patch.object(
+                    batch, "record_generation_usage_best_effort"
+                ) as failed_recorder,
+            ):
+                failed_summary = batch.probe_requests("unused", limit=1)
+
+            self.assertEqual(failed_summary["request_errors"], 1)
+            failed_recorder.assert_not_called()
+
+    def test_repair_records_only_successful_provider_responses(self):
+        with tempfile.TemporaryDirectory() as package:
+            report_path = os.path.join(package, "remaining.jsonl")
+            job = {
+                "key": "repair-1",
+                "file_path": "script.rpy",
+                "items": [
+                    {
+                        "id": "item-1",
+                        "line": 1,
+                        "text": "Hello",
+                        "start": 0,
+                        "end": 7,
+                        "prefix": "",
+                        "quote": '"',
+                    }
+                ],
+            }
+            response_text = json.dumps(
+                [{"id": "item-1", "translation": "译文"}], ensure_ascii=False
+            )
+            response = {
+                "provider": "gemini",
+                "model": "gemini-test",
+                "execution_mode": "sync",
+                "response_payload": {"responseId": "repair-response"},
+                "response_text": response_text,
+                "finish_reason": "STOP",
+                "usage_metadata": {"totalTokenCount": 12},
+            }
+
+            common_patches = (
+                mock.patch.object(
+                    batch, "load_repair_report_items", return_value=[{"line": 1}]
+                ),
+                mock.patch.object(
+                    batch, "build_repair_jobs", return_value=([job], [])
+                ),
+                mock.patch.object(
+                    batch,
+                    "build_repair_request",
+                    return_value={"key": "repair-1", "request": {}},
+                ),
+                mock.patch.object(batch, "REPAIR_RUNS_DIR", package),
+                mock.patch.object(batch, "STORY_MEMORY_ENABLED", False),
+                mock.patch.object(
+                    batch.legacy,
+                    "validate_translation",
+                    return_value=(False, "fixture validation failure"),
+                ),
+            )
+            with contextlib.ExitStack() as stack:
+                for patcher in common_patches:
+                    stack.enter_context(patcher)
+                stack.enter_context(
+                    mock.patch.object(batch, "run_sync_request", return_value=response)
+                )
+                recorder = stack.enter_context(mock.patch.object(
+                    batch, "record_generation_usage_best_effort"
+                ))
+                success_summary = batch.repair_remaining_items(report_path)
+
+            self.assertEqual(success_summary["request_errors"], 0)
+            recorder.assert_called_once()
+            self.assertEqual(recorder.call_args.kwargs["stage"], "repair")
+
+            common_failure_patches = (
+                mock.patch.object(
+                    batch, "load_repair_report_items", return_value=[{"line": 1}]
+                ),
+                mock.patch.object(
+                    batch, "build_repair_jobs", return_value=([job], [])
+                ),
+                mock.patch.object(
+                    batch,
+                    "build_repair_request",
+                    return_value={"key": "repair-1", "request": {}},
+                ),
+                mock.patch.object(batch, "REPAIR_RUNS_DIR", package),
+                mock.patch.object(batch, "STORY_MEMORY_ENABLED", False),
+            )
+            with contextlib.ExitStack() as stack:
+                for patcher in common_failure_patches:
+                    stack.enter_context(patcher)
+                stack.enter_context(mock.patch.object(
+                    batch, "run_sync_request", side_effect=RuntimeError("provider failed")
+                ))
+                failed_recorder = stack.enter_context(mock.patch.object(
+                    batch, "record_generation_usage_best_effort"
+                ))
+                failed_summary = batch.repair_remaining_items(report_path)
+
+            self.assertEqual(failed_summary["request_errors"], 1)
+            failed_recorder.assert_not_called()
+
+
+    def test_cli_parser_exposes_json_filters_and_import_target(self):
+        report_args = batch.build_arg_parser().parse_args(
+            [
+                "usage-report",
+                "--task",
+                "translation",
+                "--provider",
+                "gemini",
+                "--group-by",
+                "provider,model",
+                "--json",
+            ]
+        )
+        import_args = batch.build_arg_parser().parse_args(
+            ["usage-import", "C:/pkg/manifest.json", "--json"]
+        )
+
+        self.assertEqual(report_args.command, "usage-report")
+        self.assertTrue(report_args.json)
+        self.assertEqual(report_args.group_by, "provider,model")
+        self.assertEqual(import_args.target, "C:/pkg/manifest.json")
+        self.assertTrue(import_args.json)
+
+    def test_usage_import_json_dispatch_is_offline_and_machine_readable(self):
+        with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
+            result_path = self._write_jsonl(
+                package,
+                [
+                    {
+                        "key": "chunk-1",
+                        "response": {
+                            "responseId": "offline-cli-response",
+                            "usageMetadata": {"totalTokenCount": 17},
+                        },
+                    }
+                ],
+            )
+            manifest = self._manifest(game_root, result_path)
+            parser = batch.build_arg_parser()
+            args = parser.parse_args(
+                ["usage-import", manifest["_manifest_path"], "--json"]
+            )
+            output = io.StringIO()
+            previous_base_dir = batch.legacy.BASE_DIR
+            batch.legacy.BASE_DIR = ""
+            try:
+                with (
+                    mock.patch.object(batch, "initialize_batch_logging"),
+                    mock.patch.object(batch.legacy, "load_config"),
+                    mock.patch.object(batch.legacy, "load_translator_settings"),
+                    mock.patch.object(batch, "load_batch_settings"),
+                    mock.patch.object(batch, "load_manifest", return_value=manifest),
+                    mock.patch.object(
+                        batch, "_read_translator_config_object", return_value={}
+                    ),
+                    mock.patch.object(
+                        batch,
+                        "create_batch_client",
+                        side_effect=AssertionError("usage-import must stay offline"),
+                    ),
+                    contextlib.redirect_stdout(output),
+                ):
+                    returned = batch.dispatch_command(parser, args)
+            finally:
+                batch.legacy.BASE_DIR = previous_base_dir
+
+            payload = json.loads(output.getvalue())
+            self.assertEqual(payload["inserted_records"], 1)
+            self.assertEqual(payload["report"]["totals"]["calls"], 1)
+            self.assertEqual(returned["report"]["totals"]["total_tokens"], 17)
+
+
+    def test_gui_diagnostics_wraps_public_project_summary(self):
+        with tempfile.TemporaryDirectory() as game_root:
+            usage.record_generation_usage(
+                game_root=game_root,
+                task_mode="translation",
+                stage="sync_translation",
+                provider="litellm",
+                model="provider/model",
+                usage_metadata={"prompt_tokens": 9, "completion_tokens": 3, "total_tokens": 12},
+                response_payload={"id": "gui-summary-1"},
+                run_id="gui-run",
+                source_key="gui-1",
+            )
+
+            context = build_diagnostics_context(
+                latest_manifest_path=None,
+                manifest=None,
+                batch_script_path="gemini_translate_batch.py",
+                logs_dir="logs",
+                game_root=game_root,
+            )
+
+            self.assertTrue(any("累计 1 次调用" in fact for fact in context.facts))
+            self.assertTrue(any("12 token" in fact for fact in context.facts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -94,6 +94,32 @@ class MapReduceTests(unittest.TestCase):
             with_ids = [r for r in labels if r.get("evidence_item_ids")]
             self.assertTrue(with_ids)
 
+    def test_usage_recorder_failure_does_not_abort_generation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "pa")
+            gen.ingest_keyword_summaries(str(KEYWORDS), store_dir=store_dir)
+            gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=str(FIXTURE_DIR),
+                script_roots=[str(FIXTURE_DIR)],
+                entry_labels=["start"],
+            )
+            backend = FakeBackend()
+
+            def boom(_event):
+                raise RuntimeError("ledger unavailable")
+
+            result = llm.run_mapreduce_drafts(
+                store_dir=store_dir,
+                backend=backend,
+                config={"model": "fake-model"},
+                force=True,
+                usage_recorder=boom,
+            )
+            self.assertGreaterEqual(result["labels_refined"], 1)
+            self.assertGreaterEqual(result["routes_refined"], 1)
+            self.assertGreater(len(backend.calls), 0)
+
     def test_optional_inputs_are_prompted_persisted_and_invalidate_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = os.path.join(tmp, "pa")

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -65,16 +65,23 @@ class MapReduceTests(unittest.TestCase):
                 entry_labels=["start"],
             )
             backend = FakeBackend()
+            usage_events = []
             result = llm.run_mapreduce_drafts(
                 store_dir=store_dir,
                 backend=backend,
                 config={"model": "fake-model"},
                 force=True,
+                usage_recorder=usage_events.append,
             )
             self.assertGreaterEqual(result["labels_refined"], 1)
             self.assertGreaterEqual(result["routes_refined"], 1)
             self.assertGreater(len(backend.calls), 0)
             self.assertEqual(result["prompt_schema_version"], llm.PROMPT_SCHEMA_VERSION)
+            self.assertEqual(len(usage_events), len(backend.calls))
+            self.assertTrue({"label", "route", "brief"}.issubset(
+                {event["stage"] for event in usage_events}
+            ))
+            self.assertTrue(all("result" in event for event in usage_events))
 
             store = pa.ProjectAnalysisStore(store_dir)
             labels = store.load_summaries(pa.KIND_LABEL)

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -100,7 +100,7 @@ class SyncTranslationPreviewTests(unittest.TestCase):
                 "prefix": "",
             }
 
-            def translate_batch(batch, replacements, usage_run_id=""):
+            def translate_batch(batch, replacements, usage_run_id="", **_kwargs):
                 replacements.setdefault(0, []).append((4, 11, "你好", "", '"'))
                 return [batch[0]["progress_entry"]]
 

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -100,7 +100,7 @@ class SyncTranslationPreviewTests(unittest.TestCase):
                 "prefix": "",
             }
 
-            def translate_batch(batch, replacements):
+            def translate_batch(batch, replacements, usage_run_id=""):
                 replacements.setdefault(0, []).append((4, 11, "你好", "", '"'))
                 return [batch[0]["progress_entry"]]
 

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -254,6 +254,52 @@ class TranslationAbExperimentTests(unittest.TestCase):
             self.assertEqual(translations['baseline'][SAMPLE_ITEM_ID], '你好')
             self.assertEqual(translations['story_memory'][SAMPLE_ITEM_ID], '你好')
 
+    def test_run_translation_ab_experiment_usage_ledger_error_does_not_fail_variant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            loaded['base_dir'] = tmp
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+
+            def fake_sync_runner(request_payload, model_name, api_key_index=None):
+                return {
+                    'response_text': _full_chunk_translations(),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {'total_tokens': 12},
+                }
+
+            with mock.patch.object(
+                ab_mod.model_usage_ledger,
+                'record_generation_usage',
+                side_effect=TypeError('unexpected usage shape'),
+            ):
+                summary = ab_mod.run_translation_ab_experiment(
+                    loaded,
+                    variants,
+                    limit=1,
+                    offset=0,
+                    output_dir=os.path.join(tmp, 'experiment'),
+                    dry_run=False,
+                    sync_runner=fake_sync_runner,
+                )
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                row = json.loads(handle.readline())
+            errors = {
+                variant['name']: variant.get('error', '') for variant in row['variants']
+            }
+            self.assertEqual(errors['baseline'], '')
+            self.assertEqual(errors['story_memory'], '')
+            translations = {
+                variant['name']: variant['translations'] for variant in row['variants']
+            }
+            self.assertEqual(translations['baseline'][SAMPLE_ITEM_ID], '你好')
+
     def test_run_translation_ab_experiment_records_variant_sync_errors(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest_path = os.path.join(tmp, 'manifest.json')

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -221,6 +221,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 json.dump(manifest, handle, ensure_ascii=False, indent=2)
 
             loaded = batch_mod.load_manifest(manifest_path)
+            loaded['base_dir'] = tmp
             variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
             calls = []
 
@@ -232,16 +233,21 @@ class TranslationAbExperimentTests(unittest.TestCase):
                     'usage_metadata': {'total_tokens': 12},
                 }
 
-            summary = ab_mod.run_translation_ab_experiment(
-                loaded,
-                variants,
-                limit=1,
-                offset=0,
-                output_dir=os.path.join(tmp, 'experiment'),
-                dry_run=False,
-                sync_runner=fake_sync_runner,
-            )
+            with mock.patch.object(
+                ab_mod.model_usage_ledger, 'record_generation_usage'
+            ) as usage_recorder:
+                summary = ab_mod.run_translation_ab_experiment(
+                    loaded,
+                    variants,
+                    limit=1,
+                    offset=0,
+                    output_dir=os.path.join(tmp, 'experiment'),
+                    dry_run=False,
+                    sync_runner=fake_sync_runner,
+                )
             self.assertEqual(len(calls), 2)
+            self.assertEqual(usage_recorder.call_count, 2)
+            self.assertEqual(usage_recorder.call_args.kwargs['game_root'], tmp)
             with open(summary['results_path'], 'r', encoding='utf-8') as handle:
                 row = json.loads(handle.readline())
             translations = {variant['name']: variant['translations'] for variant in row['variants']}
@@ -258,6 +264,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 json.dump(manifest, handle, ensure_ascii=False, indent=2)
 
             loaded = batch_mod.load_manifest(manifest_path)
+            loaded['base_dir'] = tmp
             variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
             call_count = {'value': 0}
 
@@ -271,16 +278,20 @@ class TranslationAbExperimentTests(unittest.TestCase):
                     }
                 raise RuntimeError('sync failed')
 
-            summary = ab_mod.run_translation_ab_experiment(
-                loaded,
-                variants,
-                limit=1,
-                offset=0,
-                output_dir=os.path.join(tmp, 'experiment'),
-                dry_run=False,
-                sync_runner=flaky_sync_runner,
-            )
+            with mock.patch.object(
+                ab_mod.model_usage_ledger, 'record_generation_usage'
+            ) as usage_recorder:
+                summary = ab_mod.run_translation_ab_experiment(
+                    loaded,
+                    variants,
+                    limit=1,
+                    offset=0,
+                    output_dir=os.path.join(tmp, 'experiment'),
+                    dry_run=False,
+                    sync_runner=flaky_sync_runner,
+                )
             self.assertTrue(os.path.isfile(summary['report_path']))
+            usage_recorder.assert_called_once()
             with open(summary['results_path'], 'r', encoding='utf-8') as handle:
                 row = json.loads(handle.readline())
             self.assertEqual(len(row['variants']), 2)

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -568,7 +568,8 @@ def run_variant_for_chunk(
                         'variant': variant_name,
                     },
                 )
-            except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
+            except Exception as exc:
+                # Accounting must not turn a successful variant into a failure.
                 usage_context.setdefault('errors', []).append(str(exc))
         translations, parse_error = extract_translation_map(
             response.get('response_text') or '',

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import os
 import re
@@ -11,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Callable
 
+import model_usage_ledger
 import story_memory
 import translator_runtime as legacy
 
@@ -106,6 +108,7 @@ def summarize_variant_settings() -> dict:
         'macro_setting_preview': _macro_preview(batch_mod.BATCH_MACRO_SETTING),
         'temperature': batch_mod.BATCH_TEMPERATURE,
         'max_output_tokens': batch_mod.BATCH_MAX_OUTPUT_TOKENS,
+        'thinking_level': batch_mod.BATCH_THINKING_LEVEL,
     }
 
 
@@ -525,6 +528,7 @@ def run_variant_for_chunk(
     api_key_index: int | None = None,
     dry_run: bool = False,
     sync_runner: Callable[..., dict] | None = None,
+    usage_context: dict | None = None,
 ) -> VariantRunResult:
     model_name = model_override.strip() or settings.get('model') or _batch().BATCH_MODEL
     try:
@@ -540,6 +544,32 @@ def run_variant_for_chunk(
 
         runner = sync_runner or _batch().run_sync_request
         response = runner(request_payload, model_name, api_key_index=api_key_index)
+        game_root = str((usage_context or {}).get('game_root') or legacy.BASE_DIR or '')
+        if usage_context and game_root:
+            try:
+                model_usage_ledger.record_generation_usage(
+                    game_root=game_root,
+                    task_mode='analysis',
+                    stage='compare_variants',
+                    provider=str(response.get('provider') or _batch().SYNC_BACKEND or 'unknown'),
+                    model=str(response.get('model') or model_name),
+                    usage_metadata=response.get('usage_metadata') or {},
+                    response_payload=response.get('response_payload') or {},
+                    operation_id=str(usage_context.get('operation_id') or ''),
+                    run_id=str(usage_context.get('run_id') or ''),
+                    thinking_level=str(settings.get('thinking_level') or ''),
+                    execution_mode=str(response.get('execution_mode') or 'sync'),
+                    source_key=f"{chunk.get('key') or ''}:{variant_name}",
+                    source={
+                        'kind': 'translation_ab_response',
+                        'manifest_path': str(usage_context.get('manifest_path') or ''),
+                        'output_dir': str(usage_context.get('output_dir') or ''),
+                        'chunk_key': str(chunk.get('key') or ''),
+                        'variant': variant_name,
+                    },
+                )
+            except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
+                usage_context.setdefault('errors', []).append(str(exc))
         translations, parse_error = extract_translation_map(
             response.get('response_text') or '',
             enriched.get('items') or [],
@@ -581,6 +611,18 @@ def run_translation_ab_experiment(
         slug = batch_mod.guess_project_slug()
         output_dir = create_experiment_output_dir(f'{slug}_ab')
 
+    manifest_path = str(manifest.get('_manifest_path') or '')
+    usage_context = {
+        'operation_id': (
+            'compare-variants-manifest-'
+            + hashlib.sha256(manifest_path.encode('utf-8')).hexdigest()[:20]
+        ),
+        'run_id': f'compare-variants-{os.path.basename(output_dir)}',
+        'manifest_path': manifest_path,
+        'output_dir': os.path.abspath(output_dir),
+        'game_root': str(manifest.get('base_dir') or legacy.BASE_DIR or ''),
+        'errors': [],
+    }
     chunk_results: list[ChunkExperimentResult] = [
         ChunkExperimentResult(
             chunk_key=str(chunk.get('key') or ''),
@@ -603,6 +645,7 @@ def run_translation_ab_experiment(
                             api_key_index=api_key_index,
                             dry_run=dry_run,
                             sync_runner=sync_runner,
+                            usage_context=usage_context,
                         )
                     )
     except Exception as exc:
@@ -636,4 +679,6 @@ def run_translation_ab_experiment(
     }
     if experiment_error:
         result['experiment_error'] = experiment_error
+    if usage_context.get('errors'):
+        result['usage_ledger_errors'] = list(usage_context['errors'])
     return result

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -4146,7 +4146,13 @@ def normalize_result_items(payload):
     )
 
 
-def call_gemini_sdk(prompt, items, usage_run_id=''):
+def call_gemini_sdk(
+    prompt,
+    items,
+    usage_run_id='',
+    usage_buffer=None,
+    usage_operation_id='',
+):
     """Calls the explicitly configured synchronous backend."""
     model_name = get_current_model()
     generation_config = {
@@ -4182,8 +4188,7 @@ def call_gemini_sdk(prompt, items, usage_run_id=''):
     if usage_run_id and BASE_DIR:
         item_ids = [str(item.get('id') or '') for item in items]
         try:
-            project_id = model_usage_ledger.project_identity(BASE_DIR)['project_id']
-            model_usage_ledger.record_generation_usage(
+            record = model_usage_ledger.build_usage_record(
                 game_root=BASE_DIR,
                 task_mode='translation',
                 stage='sync_translation',
@@ -4191,7 +4196,7 @@ def call_gemini_sdk(prompt, items, usage_run_id=''):
                 model=result.model,
                 usage_metadata=result.usage_metadata,
                 response_payload=result.response_payload,
-                operation_id=f'sync-translation-{project_id[:20]}',
+                operation_id=usage_operation_id or usage_run_id,
                 run_id=usage_run_id,
                 execution_mode=result.execution_mode,
                 source_key='|'.join(item_ids),
@@ -4200,6 +4205,10 @@ def call_gemini_sdk(prompt, items, usage_run_id=''):
                     'item_ids': item_ids,
                 },
             )
+            if usage_buffer is not None:
+                usage_buffer.append(record)
+            else:
+                model_usage_ledger.UsageLedger(BASE_DIR).add_records([record])
         except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
             print(
                 f'Warning: Model usage ledger record failed: {exc}',
@@ -4220,7 +4229,13 @@ def call_gemini_sdk(prompt, items, usage_run_id=''):
     detail = f" ({'; '.join(diagnostics)})" if diagnostics else ""
     raise ValueError(f"Invalid response from API. Missing structured text{detail}.")
 
-def process_batch(batch, replacements, usage_run_id=''):
+def process_batch(
+    batch,
+    replacements,
+    usage_run_id='',
+    usage_buffer=None,
+    usage_operation_id='',
+):
     glossary_hits = retrieve_sync_glossary_hits(batch) if SYNC_RAG_ENABLED else []
     history_hits, rag_stats = retrieve_sync_history_hits(batch) if SYNC_RAG_ENABLED else ([], {})
     story_hits = retrieve_sync_story_hits(batch) if SYNC_STORY_MEMORY_ENABLED else None
@@ -4234,7 +4249,13 @@ def process_batch(batch, replacements, usage_run_id=''):
     )
 
     # Call API (SDK handles connection details)
-    results = call_gemini_sdk(prompt, batch, usage_run_id=usage_run_id)
+    results = call_gemini_sdk(
+        prompt,
+        batch,
+        usage_run_id=usage_run_id,
+        usage_buffer=usage_buffer,
+        usage_operation_id=usage_operation_id,
+    )
 
     if not isinstance(results, list):
         raise RuntimeError(f"API returned {type(results)} instead of list")
@@ -4277,7 +4298,14 @@ def process_batch(batch, replacements, usage_run_id=''):
     return valid_progress_entries
 
 
-def process_batch_with_retry(batch, replacements, retry_depth=0, usage_run_id=''):
+def process_batch_with_retry(
+    batch,
+    replacements,
+    retry_depth=0,
+    usage_run_id='',
+    usage_buffer=None,
+    usage_operation_id='',
+):
     if retry_depth >= 5:
         log_failure(batch, "Max retry depth reached")
         return []
@@ -4289,7 +4317,13 @@ def process_batch_with_retry(batch, replacements, retry_depth=0, usage_run_id=''
             # Respect rate limits
             time.sleep(get_random_delay())
 
-            return process_batch(batch, replacements, usage_run_id=usage_run_id)
+            return process_batch(
+                batch,
+                replacements,
+                usage_run_id=usage_run_id,
+                usage_buffer=usage_buffer,
+                usage_operation_id=usage_operation_id,
+            )
 
         except Exception as e:
             error_str = str(e)
@@ -4342,10 +4376,14 @@ def process_batch_with_retry(batch, replacements, retry_depth=0, usage_run_id=''
         r1 = process_batch_with_retry(
             batch[:mid], replacements, retry_depth + 1,
             usage_run_id=usage_run_id,
+            usage_buffer=usage_buffer,
+            usage_operation_id=usage_operation_id,
         )
         r2 = process_batch_with_retry(
             batch[mid:], replacements, retry_depth + 1,
             usage_run_id=usage_run_id,
+            usage_buffer=usage_buffer,
+            usage_operation_id=usage_operation_id,
         )
         return r1 + r2
 
@@ -4895,6 +4933,9 @@ def run_translation(*, prepare=False):
     print(f"Sync backend: {SYNC_BACKEND}")
     print(f"Models: {MODELS}")
     usage_run_id = model_usage_ledger.new_run_id('sync-translation')
+    # One preview invocation is one operation; do not collapse all runs by project_id.
+    usage_operation_id = usage_run_id
+    usage_buffer: list = []
     if SYNC_BACKEND == "gemini":
         print(f"Gemini API Keys Loaded: {len(API_KEYS)}")
     else:
@@ -4905,113 +4946,131 @@ def run_translation(*, prepare=False):
     print(f"Progress log: {PROGRESS_LOG}")
     print("=" * 60)
 
-    if prepare:
-        run_prepare_steps()
-    elif PREP_ENABLED:
-        print("Prepare step skipped in preview mode; use --prepare explicitly if needed.")
-    if not os.path.isdir(TL_DIR):
-        print("WARNING: TL_DIR does not exist in preview mode.")
+    try:
+        if prepare:
+            run_prepare_steps()
+        elif PREP_ENABLED:
+            print("Prepare step skipped in preview mode; use --prepare explicitly if needed.")
+        if not os.path.isdir(TL_DIR):
+            print("WARNING: TL_DIR does not exist in preview mode.")
 
-    files_to_process = []
-    for root, _, files in os.walk(TL_DIR):
-        for filename in files:
-            if not filename.endswith(".rpy"):
-                continue
-            file_path = os.path.join(root, filename)
-            relative_path = _normalize_rel_path(os.path.relpath(file_path, TL_DIR))
-            if INCLUDE_FILES or INCLUDE_PREFIXES:
-                allowed = bool(INCLUDE_FILES and relative_path in INCLUDE_FILES)
-                if not allowed and INCLUDE_PREFIXES:
-                    allowed = any(relative_path.startswith(prefix) for prefix in INCLUDE_PREFIXES)
-                if not allowed:
+        files_to_process = []
+        for root, _, files in os.walk(TL_DIR):
+            for filename in files:
+                if not filename.endswith(".rpy"):
                     continue
-            files_to_process.append(file_path)
-    files_to_process.sort(key=lambda value: os.path.normcase(os.path.abspath(value)))
-    print(f"Found {len(files_to_process)} files.")
+                file_path = os.path.join(root, filename)
+                relative_path = _normalize_rel_path(os.path.relpath(file_path, TL_DIR))
+                if INCLUDE_FILES or INCLUDE_PREFIXES:
+                    allowed = bool(INCLUDE_FILES and relative_path in INCLUDE_FILES)
+                    if not allowed and INCLUDE_PREFIXES:
+                        allowed = any(relative_path.startswith(prefix) for prefix in INCLUDE_PREFIXES)
+                    if not allowed:
+                        continue
+                files_to_process.append(file_path)
+        files_to_process.sort(key=lambda value: os.path.normcase(os.path.abspath(value)))
+        print(f"Found {len(files_to_process)} files.")
 
-    global_progress = _upgrade_legacy_progress_keys(load_progress(), files_to_process)
-    preview_files = []
-    for file_path in files_to_process:
-        filename = os.path.basename(file_path)
-        progress_key = _progress_key_for_path(file_path)
-        print(f"\nProcessing: {filename}")
-        source_sha256 = file_sha256(file_path)
-        with open(file_path, "r", encoding="utf-8-sig") as handle:
-            lines = handle.readlines()
+        global_progress = _upgrade_legacy_progress_keys(load_progress(), files_to_process)
+        preview_files = []
+        for file_path in files_to_process:
+            filename = os.path.basename(file_path)
+            progress_key = _progress_key_for_path(file_path)
+            print(f"\nProcessing: {filename}")
+            source_sha256 = file_sha256(file_path)
+            with open(file_path, "r", encoding="utf-8-sig") as handle:
+                lines = handle.readlines()
 
-        completed_entries = set(_normalize_progress_entries(global_progress.get(progress_key, [])))
-        tasks = []
-        for task in collect_tasks(lines):
-            if is_non_translatable(task["text"]):
-                continue
-            progress_entry = task.get("progress_entry") or _progress_entry_for_task(task)
-            if progress_entry in completed_entries or _progress_line_entry(task["line"]) in completed_entries:
-                if not FORCE_RETRANSLATE_ENGLISH or not is_english_like(task["text"]):
+            completed_entries = set(_normalize_progress_entries(global_progress.get(progress_key, [])))
+            tasks = []
+            for task in collect_tasks(lines):
+                if is_non_translatable(task["text"]):
                     continue
-            task["id"] = translation_core.build_identity_v2(
-                progress_key,
-                task.get("block_name", "_global"),
-                task.get("block_index", 0),
-                task.get("source_for_id") or task["text"],
-                block_occurrence=task.get("block_occurrence", 1),
-            )
-            task["progress_entry"] = _progress_entry_for_task(task)
-            task["file_rel_path"] = progress_key
-            tasks.append(task)
+                progress_entry = task.get("progress_entry") or _progress_entry_for_task(task)
+                if progress_entry in completed_entries or _progress_line_entry(task["line"]) in completed_entries:
+                    if not FORCE_RETRANSLATE_ENGLISH or not is_english_like(task["text"]):
+                        continue
+                task["id"] = translation_core.build_identity_v2(
+                    progress_key,
+                    task.get("block_name", "_global"),
+                    task.get("block_index", 0),
+                    task.get("source_for_id") or task["text"],
+                    block_occurrence=task.get("block_occurrence", 1),
+                )
+                task["progress_entry"] = _progress_entry_for_task(task)
+                task["file_rel_path"] = progress_key
+                tasks.append(task)
 
-        if not tasks:
-            print("  No new lines to translate.")
-            continue
-        print(f"  Found {len(tasks)} lines to translate.")
+            if not tasks:
+                print("  No new lines to translate.")
+                continue
+            print(f"  Found {len(tasks)} lines to translate.")
 
-        replacements = {}
-        successful_entries = []
-        batch = []
-        current_batch_chars = 0
-        for task in tasks:
-            task_len = len(task["text"])
-            if batch and (
-                len(batch) >= MAX_ITEMS or current_batch_chars + task_len > MAX_CHARS
-            ):
+            replacements = {}
+            successful_entries = []
+            batch = []
+            current_batch_chars = 0
+            for task in tasks:
+                task_len = len(task["text"])
+                if batch and (
+                    len(batch) >= MAX_ITEMS or current_batch_chars + task_len > MAX_CHARS
+                ):
+                    successful_entries.extend(process_batch_with_retry(
+                        batch,
+                        replacements,
+                        usage_run_id=usage_run_id,
+                        usage_buffer=usage_buffer,
+                        usage_operation_id=usage_operation_id,
+                    ))
+                    batch = []
+                    current_batch_chars = 0
+                batch.append(task)
+                current_batch_chars += task_len
+            if batch:
                 successful_entries.extend(process_batch_with_retry(
-                    batch, replacements, usage_run_id=usage_run_id,
+                    batch,
+                    replacements,
+                    usage_run_id=usage_run_id,
+                    usage_buffer=usage_buffer,
+                    usage_operation_id=usage_operation_id,
                 ))
-                batch = []
-                current_batch_chars = 0
-            batch.append(task)
-            current_batch_chars += task_len
-        if batch:
-            successful_entries.extend(process_batch_with_retry(
-                batch, replacements, usage_run_id=usage_run_id,
-            ))
 
-        if replacements:
-            normalized_entries = _normalize_progress_entries(successful_entries)
-            preview_lines = render_replacement_lines(lines, replacements)
-            preview_files.append(
-                {
-                    "relative_path": progress_key,
-                    "source_text": "".join(lines),
-                    "source_sha256": source_sha256,
-                    "preview_text": "".join(preview_lines),
-                    "progress_entries": normalized_entries,
-                    "translated_items": len(normalized_entries),
-                }
-            )
-        print(f"  Previewed {filename}.")
+            if replacements:
+                normalized_entries = _normalize_progress_entries(successful_entries)
+                preview_lines = render_replacement_lines(lines, replacements)
+                preview_files.append(
+                    {
+                        "relative_path": progress_key,
+                        "source_text": "".join(lines),
+                        "source_sha256": source_sha256,
+                        "preview_text": "".join(preview_lines),
+                        "progress_entries": normalized_entries,
+                        "translated_items": len(normalized_entries),
+                    }
+                )
+            print(f"  Previewed {filename}.")
 
-    manifest_path, manifest = sync_translation_preview.create_sync_preview(
-        log_dir=LOG_DIR,
-        project_root=BASE_DIR,
-        tl_dir=TL_DIR,
-        files=preview_files,
-    )
-    report_path = os.path.join(os.path.dirname(manifest_path), "preview.diff")
-    summary = manifest.get("summary") or {}
-    print(f"Sync preview manifest: {manifest_path}")
-    print(f"Sync preview report: {report_path}")
-    print(f"Preview files: {int(summary.get('files_changed') or 0)}")
-    print(f"Preview translations: {int(summary.get('translated_items') or 0)}")
-    print("Preview status: safe")
-    print("No project scripts were modified. Review the diff, then run with --apply MANIFEST.")
-    return manifest_path
+        manifest_path, manifest = sync_translation_preview.create_sync_preview(
+            log_dir=LOG_DIR,
+            project_root=BASE_DIR,
+            tl_dir=TL_DIR,
+            files=preview_files,
+        )
+        report_path = os.path.join(os.path.dirname(manifest_path), "preview.diff")
+        summary = manifest.get("summary") or {}
+        print(f"Sync preview manifest: {manifest_path}")
+        print(f"Sync preview report: {report_path}")
+        print(f"Preview files: {int(summary.get('files_changed') or 0)}")
+        print(f"Preview translations: {int(summary.get('translated_items') or 0)}")
+        print("Preview status: safe")
+        print("No project scripts were modified. Review the diff, then run with --apply MANIFEST.")
+        return manifest_path
+    finally:
+        if usage_buffer and BASE_DIR:
+            try:
+                model_usage_ledger.UsageLedger(BASE_DIR).add_records(usage_buffer)
+            except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
+                print(
+                    f'Warning: Model usage ledger flush failed: {exc}',
+                    flush=True,
+                )

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -51,6 +51,7 @@ from rpa_safety import (
     member_output_size,
     read_bounded_compressed_index,
 )
+import model_usage_ledger
 import prompt_context
 import story_memory
 import sync_translation_preview
@@ -4145,7 +4146,7 @@ def normalize_result_items(payload):
     )
 
 
-def call_gemini_sdk(prompt, items):
+def call_gemini_sdk(prompt, items, usage_run_id=''):
     """Calls the explicitly configured synchronous backend."""
     model_name = get_current_model()
     generation_config = {
@@ -4170,12 +4171,40 @@ def call_gemini_sdk(prompt, items):
             serialize_response=serialize_unknown,
             extract_text=extract_text_from_response_payload,
             extract_finish_reason=extract_finish_reason,
+            extract_usage=model_usage_ledger.extract_provider_usage,
         )
         result = backend.generate(SyncGenerationRequest(
             model=model_name,
             contents=prompt,
             config=generation_config,
         ))
+
+    if usage_run_id and BASE_DIR:
+        item_ids = [str(item.get('id') or '') for item in items]
+        try:
+            project_id = model_usage_ledger.project_identity(BASE_DIR)['project_id']
+            model_usage_ledger.record_generation_usage(
+                game_root=BASE_DIR,
+                task_mode='translation',
+                stage='sync_translation',
+                provider=result.provider,
+                model=result.model,
+                usage_metadata=result.usage_metadata,
+                response_payload=result.response_payload,
+                operation_id=f'sync-translation-{project_id[:20]}',
+                run_id=usage_run_id,
+                execution_mode=result.execution_mode,
+                source_key='|'.join(item_ids),
+                source={
+                    'kind': 'sync_translation_response',
+                    'item_ids': item_ids,
+                },
+            )
+        except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
+            print(
+                f'Warning: Model usage ledger record failed: {exc}',
+                flush=True,
+            )
 
     if result.parsed is not None:
         return normalize_result_items(serialize_unknown(result.parsed))
@@ -4191,7 +4220,7 @@ def call_gemini_sdk(prompt, items):
     detail = f" ({'; '.join(diagnostics)})" if diagnostics else ""
     raise ValueError(f"Invalid response from API. Missing structured text{detail}.")
 
-def process_batch(batch, replacements):
+def process_batch(batch, replacements, usage_run_id=''):
     glossary_hits = retrieve_sync_glossary_hits(batch) if SYNC_RAG_ENABLED else []
     history_hits, rag_stats = retrieve_sync_history_hits(batch) if SYNC_RAG_ENABLED else ([], {})
     story_hits = retrieve_sync_story_hits(batch) if SYNC_STORY_MEMORY_ENABLED else None
@@ -4205,7 +4234,7 @@ def process_batch(batch, replacements):
     )
 
     # Call API (SDK handles connection details)
-    results = call_gemini_sdk(prompt, batch)
+    results = call_gemini_sdk(prompt, batch, usage_run_id=usage_run_id)
 
     if not isinstance(results, list):
         raise RuntimeError(f"API returned {type(results)} instead of list")
@@ -4248,7 +4277,7 @@ def process_batch(batch, replacements):
     return valid_progress_entries
 
 
-def process_batch_with_retry(batch, replacements, retry_depth=0):
+def process_batch_with_retry(batch, replacements, retry_depth=0, usage_run_id=''):
     if retry_depth >= 5:
         log_failure(batch, "Max retry depth reached")
         return []
@@ -4260,7 +4289,7 @@ def process_batch_with_retry(batch, replacements, retry_depth=0):
             # Respect rate limits
             time.sleep(get_random_delay())
 
-            return process_batch(batch, replacements)
+            return process_batch(batch, replacements, usage_run_id=usage_run_id)
 
         except Exception as e:
             error_str = str(e)
@@ -4310,8 +4339,14 @@ def process_batch_with_retry(batch, replacements, retry_depth=0):
     if len(batch) > 1:
         print("  > Splitting batch...", flush=True)
         mid = len(batch) // 2
-        r1 = process_batch_with_retry(batch[:mid], replacements, retry_depth + 1)
-        r2 = process_batch_with_retry(batch[mid:], replacements, retry_depth + 1)
+        r1 = process_batch_with_retry(
+            batch[:mid], replacements, retry_depth + 1,
+            usage_run_id=usage_run_id,
+        )
+        r2 = process_batch_with_retry(
+            batch[mid:], replacements, retry_depth + 1,
+            usage_run_id=usage_run_id,
+        )
         return r1 + r2
 
     log_failure(batch, f"Failed after retries: {error_str}")
@@ -4859,6 +4894,7 @@ def run_translation(*, prepare=False):
     print("Synchronous Translator Preview (Ren'Py)")
     print(f"Sync backend: {SYNC_BACKEND}")
     print(f"Models: {MODELS}")
+    usage_run_id = model_usage_ledger.new_run_id('sync-translation')
     if SYNC_BACKEND == "gemini":
         print(f"Gemini API Keys Loaded: {len(API_KEYS)}")
     else:
@@ -4937,13 +4973,17 @@ def run_translation(*, prepare=False):
             if batch and (
                 len(batch) >= MAX_ITEMS or current_batch_chars + task_len > MAX_CHARS
             ):
-                successful_entries.extend(process_batch_with_retry(batch, replacements))
+                successful_entries.extend(process_batch_with_retry(
+                    batch, replacements, usage_run_id=usage_run_id,
+                ))
                 batch = []
                 current_batch_chars = 0
             batch.append(task)
             current_batch_chars += task_len
         if batch:
-            successful_entries.extend(process_batch_with_retry(batch, replacements))
+            successful_entries.extend(process_batch_with_retry(
+                batch, replacements, usage_run_id=usage_run_id,
+            ))
 
         if replacements:
             normalized_entries = _normalize_progress_entries(successful_entries)


### PR DESCRIPTION
## Summary

- add an atomic, project-scoped, provider-neutral usage ledger for offline Batch results and successful sync, repair, probe, A/B, and project-analysis responses
- preserve Gemini and LiteLLM/OpenAI raw usage while normalizing token fields, provider-reported cost, optional configured estimates, project isolation, and retry/resume/split idempotency
- add filtered/grouped human and JSON CLI reports, GUI current-project/recent-run summaries, user copy, docs, and conceptual attribution to Wenyi's MIT-licensed design

## Validation

- `python -m unittest tests.test_model_usage_ledger tests.test_atomic_io tests.test_batch_repair tests.test_translation_ab_experiment tests.test_project_analysis_llm tests.test_litellm_sync_backend tests.test_sync_translation_preview tests.test_gui_diagnostics_context` — 139 passed, 1 skipped
- `python -B tests/run_cli_tests.py -q` — 800 passed, 1 skipped
- `python -B tests/run_gui_tests.py -q` — 894 passed
- `python scripts/run_quality_gates.py all` — all blocking gates passed
- all 33 tracked Markdown local links resolve
- `git diff --check`

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a project-level model usage ledger that records token usage, estimated costs, and provider-reported costs.
  * Added `usage-import` and `usage-report` commands with filtering, grouping, and JSON output.
  * Added usage tracking across batch translation, previews, repairs, probes, analysis, and A/B experiments.
  * Added model usage summaries to the GUI diagnostics view.

* **Bug Fixes**
  * Preserved provider-reported cost details in generated results.
  * Added safe concurrent ledger updates and duplicate prevention.

* **Documentation**
  * Documented ledger storage, reporting, privacy, and usage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->