### PR TITLE
fix(registry): generic series discover and clearer refresh completion

### DIFF
--- a/docs/games_registry.md
+++ b/docs/games_registry.md
@@ -112,8 +112,8 @@ python games_registry.py discover
 
 # 从游戏目录或 .zip 复制整理为 Game_*/original/work/build 并登记
 python games_registry.py ingest --source path\to\game_or.zip
-python games_registry.py ingest --source game.zip --name "Glory Hounds"
-# → 磁盘目录 Game_GloryHounds，总表显示名 “Glory Hounds”；不移动源、不自动 bootstrap-work
+python games_registry.py ingest --source game.zip --name "Sample Title"
+# → 磁盘目录 Game_SampleTitle，总表显示名 “Sample Title”；不移动源、不自动 bootstrap-work
 
 # 快速刷新全部项目（默认：扫磁盘 + TL 行数，不跑 doctor）
 python games_registry.py refresh --all

--- a/docs/games_registry.md
+++ b/docs/games_registry.md
@@ -117,6 +117,10 @@ python games_registry.py ingest --source game.zip --name "Glory Hounds"
 
 # 快速刷新全部项目（默认：扫磁盘 + TL 行数，不跑 doctor）
 python games_registry.py refresh --all
+# 完成后会对比刷新前后状态（忽略仅更新的 last_refresh_at）。
+# GUI 总会弹出「刷新完成」汇报：
+# 无实质变化 → 仅说明没有新增变更，不提供同步 GAMES.md；
+# 有变化 → 汇报更新数量，并询问是否同步 GAMES.md。
 
 # 深度刷新单个项目（含 doctor，较慢）
 python games_registry.py refresh --project game_example --deep
@@ -264,7 +268,7 @@ python -m pytest tests/test_game_ingest.py tests/test_games_registry.py tests/te
 
 - 停止刷新只能在**项目之间**生效，无法打断单个项目正在进行的 doctor
 - 快速刷新对 layout 的判断是启发式的，不如深度模式准确
-- 「扫描新项目」只识别顶层 `Game_*` 与 `Game_Adastra_Universe/` 下已整理子目录；**未整理**的目录 / 压缩包请用「导入游戏…」或 `ingest`，不会被 discover 自动登记
+- 「扫描新项目」识别顶层 `Game_*`。若某个 `Game_*` 自身没有 `original` / `work` / `build`，但其直接子目录中有，则视为**系列容器**：只登记这些已整理子作品（路径形如 `Game_Series/Title`），不登记容器本身，也不登记无布局标记的资源子目录（术语表、备注等）。**未整理**的目录 / 压缩包请用「导入游戏…」或 `ingest`，不会被 discover 自动登记
 - `ingest` v1 仅支持目录与 `.zip`（复制、不移动）；不自动 bootstrap-work；目标 `Game_*` 已存在时需换游戏名称
 - 未勾选「打开时自动扫描」时，不会自动写入新发现的项目；需在「维护」中手动点「扫描新项目」或运行 `discover`
 - GUI 可改显示名称，但**不能**通过对话框变更项目路径（`path`）或移动磁盘目录

--- a/game_ingest.py
+++ b/game_ingest.py
@@ -88,10 +88,7 @@ def game_name_to_folder(game_name: str) -> str:
         return ""
     if slug in registry.WORKSPACE_SKIP_DIR_NAMES:
         return ""
-    folder = f"Game_{slug}"
-    if folder == registry.ADASTRA_UNIVERSE_DIR:
-        return ""
-    return folder
+    return f"Game_{slug}"
 
 
 def validate_game_name(game_name: str) -> str:

--- a/games_registry.py
+++ b/games_registry.py
@@ -1959,8 +1959,9 @@ _AUTO_PRESERVE_ON_REFRESH = frozenset(
         "last_batch_summary",
     }
 )
-# Wall-clock stamp only; always rewritten and not a user-visible status change.
-_AUTO_IGNORE_IN_REFRESH_COMPARE = frozenset({"last_refresh_at"})
+# Not user-visible content: wall-clock stamp and which scan mode last ran.
+# (lite→deep would otherwise always look "changed" solely because refresh_mode flips.)
+_AUTO_IGNORE_IN_REFRESH_COMPARE = frozenset({"last_refresh_at", "refresh_mode"})
 
 
 def snapshot_project_refresh_state(project: dict[str, Any] | None) -> str:
@@ -2019,6 +2020,15 @@ def _preserve_auto_fields_across_refresh(
     previous_auto: dict[str, Any] | None,
     new_auto: dict[str, Any],
 ) -> dict[str, Any]:
+    """Keep batch metadata across scan refresh.
+
+    ``scan_project_auto`` builds a fresh ``auto`` dict; without this merge,
+    ``record-batch`` fields would be wiped on every refresh. Non-empty values
+    from *previous_auto* for keys in ``_AUTO_PRESERVE_ON_REFRESH`` overwrite the
+    corresponding entries in *new_auto*. Missing keys, ``None``, and empty
+    strings in the previous snapshot are ignored so a blank previous value
+    cannot erase a newly written field.
+    """
     if not isinstance(previous_auto, dict):
         return new_auto
     for key in _AUTO_PRESERVE_ON_REFRESH:

--- a/games_registry.py
+++ b/games_registry.py
@@ -71,7 +71,8 @@ WORKSPACE_SKIP_DIR_NAMES = frozenset(
         "__pycache__",
     }
 )
-ADASTRA_UNIVERSE_DIR = "Game_Adastra_Universe"
+# Markers that identify an organized workspace game tree (ingest / series layout).
+WORKSPACE_LAYOUT_MARKERS = ("original", "work", "build")
 
 GAMES_MD_HEADER = """# 游戏状态总表
 
@@ -85,8 +86,8 @@ GAMES_MD_HEADER = """# 游戏状态总表
 
 本表只记录已经纳入整理结构的项目：
 
-- 顶层 `Game_*` 项目。
-- `Game_Adastra_Universe/` 下已经拆分整理的三部作品。
+- 顶层 `Game_*` 单作项目。
+- 系列容器 `Game_*` 下已整理的子作品（子目录含 `original` / `work` / `build` 之一）。
 
 暂不记录顶层压缩包、刚解压但尚未纳入 `Game_*` 结构的目录、工具链、SDK、课程 demo 或日志目录。
 
@@ -95,7 +96,7 @@ GAMES_MD_HEADER = """# 游戏状态总表
 - 游玩状态：`未玩` / `进行中` / `已玩完` / `弃置` / `待确认`
 - 翻译状态：`未开始` / `待提取` / `待反编译` / `待翻译` / `翻译中` / `待润色` / `已完成` / `待确认`
 - 当前版本：优先取 `build_info.json`（含 Ren'Py 常见的 `game/cache/build_info.json`）或 `options.rpy` 的 `config.version`。`script_version.txt` 是 Ren'Py 引擎版本，不作为游戏版本。
-- 术语提取：`glossary.json` / `macro_setting.md` / `extracted_keywords/` / 系列 `shared/` 术语表 / 对话提取批次，均记入备注。
+- 术语提取：`glossary.json` / `macro_setting.md` / `extracted_keywords/` / 系列共用术语表 / 对话提取批次，均记入备注。
 
 ## 项目状态
 
@@ -300,8 +301,52 @@ def source_site_name(raw: object) -> str:
     return hostname
 
 
+def has_workspace_layout_markers(path: Path) -> bool:
+    """True when *path* has at least one of original/ / work/ / build/."""
+    if not path.is_dir():
+        return False
+    return any((path / marker).is_dir() for marker in WORKSPACE_LAYOUT_MARKERS)
+
+
+def iter_series_member_dirs(container: Path) -> list[Path]:
+    """Immediate child dirs under *container* that look like organized games."""
+    if not container.is_dir():
+        return []
+    members: list[Path] = []
+    for child in sorted(container.iterdir(), key=lambda item: item.name.lower()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if has_workspace_layout_markers(child):
+            members.append(child)
+    return members
+
+
+def is_series_container_dir(path: Path) -> bool:
+    """True for a top-level Game_* that holds nested titles, not one game itself.
+
+    Rule (name-agnostic):
+    - the directory itself does **not** have original/work/build markers, and
+    - at least one direct child **does**.
+
+    Resource-only siblings (glossary, notes) under the same container are ignored
+    because they lack layout markers. If the Game_* root itself has markers, it
+    is treated as a single project even when it also has subfolders.
+    """
+    if not path.is_dir():
+        return False
+    if has_workspace_layout_markers(path):
+        return False
+    return bool(iter_series_member_dirs(path))
+
+
 def iter_workspace_project_paths(workspace_root: Path) -> list[str]:
-    """Return relative paths for workspace folders that look like game projects."""
+    """Return relative paths for workspace folders that look like game projects.
+
+    - Ordinary ``Game_*`` roots are registered as one project each.
+    - A ``Game_*`` root that is a series container (no layout markers of its own,
+      but children with original/work/build) contributes nested paths
+      ``Game_Series/Title`` instead of the container itself.
+    """
     paths: list[str] = []
     if not workspace_root.is_dir():
         return paths
@@ -309,14 +354,13 @@ def iter_workspace_project_paths(workspace_root: Path) -> list[str]:
     for child in sorted(workspace_root.iterdir(), key=lambda item: item.name.lower()):
         if not child.is_dir() or child.name in WORKSPACE_SKIP_DIR_NAMES:
             continue
-        if child.name.startswith("Game_") and child.name != ADASTRA_UNIVERSE_DIR:
+        if not child.name.startswith("Game_"):
+            continue
+        if is_series_container_dir(child):
+            for member in iter_series_member_dirs(child):
+                paths.append(f"{child.name}/{member.name}")
+        else:
             paths.append(child.name)
-
-    adastra_root = workspace_root / ADASTRA_UNIVERSE_DIR
-    if adastra_root.is_dir():
-        for child in sorted(adastra_root.iterdir(), key=lambda item: item.name.lower()):
-            if child.is_dir() and not child.name.startswith("."):
-                paths.append(f"{ADASTRA_UNIVERSE_DIR}/{child.name}")
     return paths
 
 
@@ -1906,6 +1950,86 @@ def update_project_manual_fields(
     return project
 
 
+# Batch metadata must survive scan refresh (record-batch writes these into auto).
+_AUTO_PRESERVE_ON_REFRESH = frozenset(
+    {
+        "last_batch_id",
+        "last_batch_manifest",
+        "last_batch_at",
+        "last_batch_summary",
+    }
+)
+# Wall-clock stamp only; always rewritten and not a user-visible status change.
+_AUTO_IGNORE_IN_REFRESH_COMPARE = frozenset({"last_refresh_at"})
+
+
+def snapshot_project_refresh_state(project: dict[str, Any] | None) -> str:
+    """Stable fingerprint of fields refresh is allowed to change (excl. timestamps)."""
+    if not isinstance(project, dict):
+        return ""
+    auto = project.get("auto") if isinstance(project.get("auto"), dict) else {}
+    auto_filtered = {
+        key: value
+        for key, value in auto.items()
+        if key not in _AUTO_IGNORE_IN_REFRESH_COMPARE
+    }
+    payload = {
+        "version": project.get("version"),
+        "version_source": project.get("version_source"),
+        "layout_status": project.get("layout_status"),
+        "translation_status": project.get("translation_status"),
+        "translation_status_source": project.get("translation_status_source"),
+        "engine": project.get("engine"),
+        "in_renpy_pipeline": project.get("in_renpy_pipeline"),
+        "auto": auto_filtered,
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def format_refresh_result_message(
+    *,
+    mode: str,
+    refreshed_count: int,
+    changed_count: int,
+    cancelled: bool = False,
+    total: int | None = None,
+    project_name: str | None = None,
+) -> str:
+    """User-facing refresh outcome: distinguish real status updates from no-ops."""
+    label = "深度" if mode == REFRESH_MODE_DEEP else "快速"
+    if cancelled:
+        total_text = total if total is not None else refreshed_count
+        base = f"{label}刷新已停止；已完成 {refreshed_count}/{total_text} 个项目"
+        if changed_count > 0:
+            return f"{base}；其中 {changed_count} 个有状态更新。"
+        return f"{base}。"
+    if project_name is not None:
+        if changed_count > 0:
+            return f"已{label}刷新项目 {project_name}；状态有更新。"
+        return f"已{label}刷新项目 {project_name}；与上次相比没有新增变更。"
+    if changed_count <= 0:
+        return f"已{label}刷新全部 {refreshed_count} 个项目；与上次相比没有新增变更。"
+    return (
+        f"已{label}刷新全部 {refreshed_count} 个项目；"
+        f"其中 {changed_count} 个状态有更新。"
+    )
+
+
+def _preserve_auto_fields_across_refresh(
+    previous_auto: dict[str, Any] | None,
+    new_auto: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(previous_auto, dict):
+        return new_auto
+    for key in _AUTO_PRESERVE_ON_REFRESH:
+        if key not in previous_auto:
+            continue
+        value = previous_auto.get(key)
+        if value not in (None, ""):
+            new_auto[key] = value
+    return new_auto
+
+
 def refresh_project(
     registry: dict[str, Any],
     project_id: str,
@@ -1918,8 +2042,9 @@ def refresh_project(
         return None
 
     deep = mode == REFRESH_MODE_DEEP
+    previous_auto = project.get("auto") if isinstance(project.get("auto"), dict) else {}
     auto = scan_project_auto(workspace_root, project, deep=deep)
-    project["auto"] = auto
+    project["auto"] = _preserve_auto_fields_across_refresh(previous_auto, auto)
 
     current_version = str(project.get("version") or "").strip()
     version_is_placeholder = current_version in {"", "待确认"}
@@ -1949,7 +2074,12 @@ def refresh_all(
     mode: str = REFRESH_MODE_LITE,
     on_progress: ProgressCallback | None = None,
     should_cancel: CancelCheck | None = None,
-) -> tuple[int, bool]:
+) -> tuple[int, bool, int]:
+    """Refresh every project.
+
+    Returns ``(completed_count, cancelled, changed_count)`` where *changed_count*
+    is how many projects had a real status/auto delta (excluding refresh time).
+    """
     projects = [
         project
         for project in registry.get("projects", [])
@@ -1957,18 +2087,33 @@ def refresh_all(
     ]
     total = len(projects)
     count = 0
+    changed_count = 0
     mode_label = "深度" if mode == REFRESH_MODE_DEEP else "快速"
     for index, project in enumerate(projects, start=1):
         if should_cancel and should_cancel():
-            registry["update_summary"] = f"{mode_label}刷新已停止；已完成 {count}/{total} 个项目"
-            return count, True
+            registry["update_summary"] = format_refresh_result_message(
+                mode=mode,
+                refreshed_count=count,
+                changed_count=changed_count,
+                cancelled=True,
+                total=total,
+            )
+            return count, True, changed_count
         project_id = str(project["id"])
         if on_progress is not None:
             on_progress(index, total, str(project.get("name") or project_id))
+        before = snapshot_project_refresh_state(project)
         refresh_project(registry, project_id, workspace_root=workspace_root, mode=mode)
+        after = snapshot_project_refresh_state(find_project(registry, project_id))
+        if before != after:
+            changed_count += 1
         count += 1
-    registry["update_summary"] = f"已{mode_label}刷新 {count} 个项目自动状态"
-    return count, False
+    registry["update_summary"] = format_refresh_result_message(
+        mode=mode,
+        refreshed_count=count,
+        changed_count=changed_count,
+    )
+    return count, False, changed_count
 
 
 def render_translation_status(project: dict[str, Any]) -> str:
@@ -2432,17 +2577,26 @@ def main(argv: list[str] | None = None) -> int:
             print(f"[{current}/{total}] {name}", flush=True)
 
         if args.all:
-            count, _cancelled = refresh_all(
+            count, _cancelled, changed_count = refresh_all(
                 registry,
                 workspace_root=workspace,
                 mode=mode,
                 on_progress=_cli_progress,
             )
             save_registry(registry_path, registry)
-            print(f"Refreshed {count} projects ({mode}) -> {registry_path}")
+            print(
+                format_refresh_result_message(
+                    mode=mode,
+                    refreshed_count=count,
+                    changed_count=changed_count,
+                )
+            )
+            print(f"-> {registry_path}")
         else:
             if mode == REFRESH_MODE_DEEP:
                 _cli_progress(1, 1, args.project_id)
+            existing = find_project(registry, args.project_id)
+            before = snapshot_project_refresh_state(existing)
             project = refresh_project(
                 registry,
                 args.project_id,
@@ -2453,7 +2607,19 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"Unknown project id: {args.project_id}", file=sys.stderr)
                 return 1
             save_registry(registry_path, registry)
-            print(f"Refreshed project {args.project_id} ({mode}) -> {registry_path}")
+            changed_count = (
+                0 if before == snapshot_project_refresh_state(project) else 1
+            )
+            name = str(project.get("name") or args.project_id)
+            print(
+                format_refresh_result_message(
+                    mode=mode,
+                    refreshed_count=1,
+                    changed_count=changed_count,
+                    project_name=name,
+                )
+            )
+            print(f"-> {registry_path}")
         return 0
 
     if args.command == "render-md":

--- a/gui_qt/games_registry_actions.py
+++ b/gui_qt/games_registry_actions.py
@@ -19,6 +19,8 @@ from games_registry import (
     default_games_md_path,
     discover_new_project_paths,
     empty_registry,
+    find_project,
+    format_refresh_result_message,
     import_from_games_md,
     load_registry,
     merge_discovered_projects,
@@ -30,6 +32,7 @@ from games_registry import (
     remove_project,
     save_registry,
     set_registry_preference,
+    snapshot_project_refresh_state,
     update_project_manual_fields,
     write_games_md,
 )
@@ -51,6 +54,9 @@ class RegistryActionResult:
     workspace_root: str = ""
     project_count: int = 0
     created_registry: bool = False
+    # Refresh-only: False when auto/status fingerprint matches the previous run.
+    # Callers should skip "sync GAMES.md?" when this is False.
+    status_changed: bool = True
 
 
 def _registry_file(workspace_root: Path) -> Path:
@@ -126,7 +132,7 @@ def refresh_registry_projects(
     label = _mode_label(mode)
 
     if refresh_everything:
-        count, cancelled = refresh_all(
+        count, cancelled, changed_count = refresh_all(
             data,
             workspace_root=workspace_root,
             mode=mode,
@@ -134,28 +140,37 @@ def refresh_registry_projects(
             should_cancel=should_cancel,
         )
         save_registry(registry_path, data)
+        message = str(data.get("update_summary") or "").strip() or format_refresh_result_message(
+            mode=mode,
+            refreshed_count=count,
+            changed_count=changed_count,
+            cancelled=cancelled,
+        )
         if cancelled:
             return RegistryActionResult(
                 False,
-                f"已停止{label}刷新，已完成 {count} 个项目。",
+                message,
                 cancelled=True,
+                status_changed=changed_count > 0,
             )
-        return RegistryActionResult(True, f"已{label}刷新全部 {count} 个项目。")
+        return RegistryActionResult(
+            True,
+            message,
+            status_changed=changed_count > 0,
+        )
 
     if not project_id:
         return RegistryActionResult(False, "未指定要刷新的项目。")
 
+    existing = find_project(data, project_id)
     if on_progress is not None:
-        project = next(
-            (item for item in data.get("projects", []) if item.get("id") == project_id),
-            None,
-        )
-        name = str((project or {}).get("name") or project_id)
+        name = str((existing or {}).get("name") or project_id)
         on_progress(1, 1, name)
 
     if should_cancel and should_cancel():
         return RegistryActionResult(False, "刷新已取消。", cancelled=True)
 
+    before = snapshot_project_refresh_state(existing)
     project = refresh_project(
         data,
         project_id,
@@ -166,16 +181,26 @@ def refresh_registry_projects(
         return RegistryActionResult(False, f"未找到项目：{project_id}")
     save_registry(registry_path, data)
 
+    name = str(project.get("name") or project_id)
+    changed_count = 0 if before == snapshot_project_refresh_state(project) else 1
     if should_cancel and should_cancel():
-        name = str(project.get("name") or project_id)
         return RegistryActionResult(
             False,
             f"已停止{label}刷新；项目 {name} 的结果已保存。",
             cancelled=True,
+            status_changed=changed_count > 0,
         )
 
-    name = str(project.get("name") or project_id)
-    return RegistryActionResult(True, f"已{label}刷新项目 {name}。")
+    return RegistryActionResult(
+        True,
+        format_refresh_result_message(
+            mode=mode,
+            refreshed_count=1,
+            changed_count=changed_count,
+            project_name=name,
+        ),
+        status_changed=changed_count > 0,
+    )
 
 
 def import_registry_from_games_md(
@@ -434,6 +459,51 @@ def prompt_render_games_md_after_refresh(
         parent,
         workspace_root,
         reason=f"{refresh_message}\n\n刷新结果已写入 games_registry.json。",
+    )
+
+
+def report_registry_refresh_completion(
+    parent: "QWidget | None",
+    workspace_root: Path,
+    *,
+    refresh_message: str,
+    status_changed: bool,
+) -> RegistryActionResult:
+    """Always show a refresh completion dialog; offer GAMES.md sync only if needed."""
+    from .widget_helpers import message_box_information, message_box_question
+
+    message = (refresh_message or "").strip() or "刷新已完成。"
+    if not status_changed:
+        message_box_information(
+            parent,
+            "刷新完成",
+            f"{message}\n\n总表自动状态与上次一致，无需同步 GAMES.md。",
+        )
+        return RegistryActionResult(True, message, status_changed=False)
+
+    reply = message_box_question(
+        parent,
+        "刷新完成",
+        f"{message}\n\n"
+        "结果已写入 games_registry.json。是否同步更新 GAMES.md？\n\n"
+        "说明：games_registry.json 是真源；同步会用 JSON 覆盖 GAMES.md 的表格区。",
+        yes_text="同步 GAMES.md",
+        no_text="完成",
+        default="yes",
+    )
+    if reply != "yes":
+        return RegistryActionResult(
+            True,
+            f"{message} 已跳过 GAMES.md 同步。".strip(),
+            status_changed=True,
+        )
+    render_result = render_registry_games_md(workspace_root)
+    combined = f"{message} {render_result.message}".strip()
+    return RegistryActionResult(
+        render_result.ok,
+        combined,
+        rendered_games_md=render_result.rendered_games_md,
+        status_changed=True,
     )
 
 

--- a/gui_qt/games_registry_panel.py
+++ b/gui_qt/games_registry_panel.py
@@ -1790,6 +1790,8 @@ class GamesRegistryPanel(QWidget):
         )
         if report.message:
             message = report.message
+        if not report.ok:
+            message_box_warning(self, "同步失败", message)
         self._status_label.setText(message)
 
     def _on_row_activated(self, row_index: int, _column: int) -> None:

--- a/gui_qt/games_registry_panel.py
+++ b/gui_qt/games_registry_panel.py
@@ -55,6 +55,7 @@ from .games_registry_actions import (
     discover_registry_projects,
     import_registry_from_games_md,
     prompt_render_games_md_after_refresh,
+    report_registry_refresh_completion,
     render_registry_games_md,
     save_registry_dialog_preference,
     save_registry_project_fields,
@@ -1781,13 +1782,14 @@ class GamesRegistryPanel(QWidget):
         if self._workspace_root is None:
             self._status_label.setText(message)
             return
-        render_result = prompt_render_games_md_after_refresh(
+        report = report_registry_refresh_completion(
             self,
             self._workspace_root,
-            message,
+            refresh_message=message,
+            status_changed=result.status_changed,
         )
-        if render_result.message:
-            message = f"{message} {render_result.message}".strip()
+        if report.message:
+            message = report.message
         self._status_label.setText(message)
 
     def _on_row_activated(self, row_index: int, _column: int) -> None:

--- a/tests/test_game_ingest.py
+++ b/tests/test_game_ingest.py
@@ -24,13 +24,13 @@ def _write_min_renpy_install(root: Path, *, title: str = "Demo") -> None:
 
 class GameIngestNamingTests(unittest.TestCase):
     def test_suggest_game_name_from_zip_stem(self):
-        path = Path("Glory Hounds-6.7.zip")
+        path = Path("Sample Title-1.0.zip")
         name = game_ingest.suggest_game_name(path)
         self.assertTrue(name)
         self.assertNotIn(".zip", name.lower())
 
     def test_game_name_to_folder_latin_words(self):
-        self.assertEqual(game_ingest.game_name_to_folder("Glory Hounds"), "Game_GloryHounds")
+        self.assertEqual(game_ingest.game_name_to_folder("Sample Title"), "Game_SampleTitle")
         self.assertEqual(game_ingest.game_name_to_folder("Custom Title"), "Game_CustomTitle")
 
     def test_game_name_to_folder_strips_existing_prefix(self):

--- a/tests/test_games_registry.py
+++ b/tests/test_games_registry.py
@@ -18,10 +18,10 @@ SAMPLE_MD = """# 游戏状态总表
 
 | 项目 | 路径 | 当前版本 | 目录状态 | 游玩状态 | 翻译状态 | 备注 / 下一步 |
 |---|---|---|---|---|---|---|
-| Glory Hounds | `Game_GloryHounds` | 6.7 | 已整理 | 待确认 | 已完成（6.7 增量） | 术语已提取。 |
-| Stranded | `Game_Stranded` | 0.4.0 | 已建 work | 待确认 | 未开始 | work 为空。 |
-| Stranded | `Game_Stranded` | 0.4.0 | duplicate | 待确认 | 未开始 | 应被去重。 |
-| Lookouts | `Game_Lookouts` | 1.3 | Unity 包 | 待确认 | 待确认 | 非 Ren'Py。 |
+| Example Pack | `Game_ExamplePack` | 6.7 | 已整理 | 待确认 | 已完成（6.7 增量） | 术语已提取。 |
+| Sample Title | `Game_SampleTitle` | 0.4.0 | 已建 work | 待确认 | 未开始 | work 为空。 |
+| Sample Title | `Game_SampleTitle` | 0.4.0 | duplicate | 待确认 | 未开始 | 应被去重。 |
+| Other Title | `Game_OtherTitle` | 1.3 | Unity 包 | 待确认 | 待确认 | 非 Ren'Py。 |
 """
 
 
@@ -30,7 +30,7 @@ class GamesRegistryTests(unittest.TestCase):
         projects = registry.parse_games_md_table(SAMPLE_MD)
         paths = [project["path"] for project in projects]
         self.assertEqual(len(projects), 3)
-        self.assertEqual(paths.count("Game_Stranded"), 1)
+        self.assertEqual(paths.count("Game_SampleTitle"), 1)
 
     def test_slugify_project_id_handles_nested_paths(self):
         self.assertEqual(
@@ -54,7 +54,7 @@ class GamesRegistryTests(unittest.TestCase):
             self.assertEqual(len(data["projects"]), 3)
             self.assertTrue(registry_path.is_file())
             loaded = registry.load_registry(registry_path)
-            self.assertEqual(loaded["projects"][0]["id"], "game_gloryhounds")
+            self.assertEqual(loaded["projects"][0]["id"], "game_examplepack")
 
     def test_normalize_translation_status_maps_unknown_to_default(self):
         self.assertEqual(registry.normalize_translation_status("  乱写状态  "), "待确认")
@@ -721,9 +721,9 @@ class GamesRegistryTests(unittest.TestCase):
                 {
                     "projects": [
                         {
-                            "id": "game_gloryhounds",
+                            "id": "game_examplepack",
                             "name": "Old Name",
-                            "path": "Game_GloryHounds",
+                            "path": "Game_ExamplePack",
                             "notes": "保留",
                             "auto": {"last_refresh_at": "2026-01-01T00:00:00+00:00"},
                         }
@@ -738,8 +738,8 @@ class GamesRegistryTests(unittest.TestCase):
                 merge=True,
             )
             by_path = {project["path"]: project for project in data["projects"]}
-            self.assertEqual(by_path["Game_GloryHounds"]["name"], "Glory Hounds")
-            self.assertEqual(by_path["Game_GloryHounds"]["auto"]["last_refresh_at"], "2026-01-01T00:00:00+00:00")
+            self.assertEqual(by_path["Game_ExamplePack"]["name"], "Example Pack")
+            self.assertEqual(by_path["Game_ExamplePack"]["auto"]["last_refresh_at"], "2026-01-01T00:00:00+00:00")
 
     def test_remove_project_and_manual_name_update(self):
         payload = {
@@ -1027,7 +1027,7 @@ class GamesRegistryTests(unittest.TestCase):
             self.assertEqual(by_path["Game_Keep"]["auto"]["marker"], 1)
             self.assertIn("Game_New", by_path)
             # SAMPLE_MD paths also merged
-            self.assertIn("Game_GloryHounds", by_path)
+            self.assertIn("Game_ExamplePack", by_path)
 
     def test_corrupt_registry_refuses_apply_and_preserves_file(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_games_registry.py
+++ b/tests/test_games_registry.py
@@ -34,8 +34,8 @@ class GamesRegistryTests(unittest.TestCase):
 
     def test_slugify_project_id_handles_nested_paths(self):
         self.assertEqual(
-            registry.slugify_project_id("Game_Adastra_Universe/Adastra", "Adastra"),
-            "game_adastra_universe_adastra",
+            registry.slugify_project_id("Game_SeriesPack/TitleA", "TitleA"),
+            "game_seriespack_titlea",
         )
 
     def test_import_from_games_md_writes_registry(self):
@@ -372,7 +372,7 @@ class GamesRegistryTests(unittest.TestCase):
                 return registry["projects"][0]
 
             with mock.patch.object(registry, "refresh_project", side_effect=fake_refresh):
-                count, cancelled = registry.refresh_all(
+                count, cancelled, changed_count = registry.refresh_all(
                     payload,
                     workspace_root=workspace,
                     should_cancel=lambda: len(calls) >= 1,
@@ -380,6 +380,7 @@ class GamesRegistryTests(unittest.TestCase):
 
             self.assertEqual(count, 1)
             self.assertTrue(cancelled)
+            self.assertEqual(changed_count, 0)
 
     def test_refresh_project_updates_auto_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -422,20 +423,130 @@ class GamesRegistryTests(unittest.TestCase):
                 {"待翻译", "待润色", "未开始", "待提取"},
             )
 
+    def test_refresh_preserves_batch_meta_and_reports_no_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            project_root = workspace / "Game_Example"
+            tl_dir = project_root / "work" / "game" / "tl" / "schinese"
+            tl_dir.mkdir(parents=True)
+            (tl_dir / "common.rpy").write_text(
+                '# line\n    new "hello"\n',
+                encoding="utf-8",
+            )
+            (project_root / "original" / "game").mkdir(parents=True)
+            payload = {
+                "workspace_root": workspace.as_posix(),
+                "projects": [
+                    {
+                        "id": "game_example",
+                        "name": "Example",
+                        "path": "Game_Example",
+                        "engine": "renpy",
+                        "in_renpy_pipeline": True,
+                        "translation_status_source": "scan",
+                        "translation_status": "",
+                        "auto": {
+                            "last_batch_id": "job_001",
+                            "last_batch_summary": "写回 2 文件",
+                        },
+                    }
+                ],
+            }
+            registry.refresh_project(payload, "game_example", workspace_root=workspace)
+            first = payload["projects"][0]
+            self.assertEqual(first["auto"]["last_batch_id"], "job_001")
+            self.assertEqual(first["auto"]["last_batch_summary"], "写回 2 文件")
+            before = registry.snapshot_project_refresh_state(first)
+            first_stamp = first["auto"]["last_refresh_at"]
+
+            registry.refresh_project(payload, "game_example", workspace_root=workspace)
+            second = payload["projects"][0]
+            self.assertEqual(second["auto"]["last_batch_id"], "job_001")
+            self.assertEqual(before, registry.snapshot_project_refresh_state(second))
+            # Timestamp always rewrites; may share the same second on fast machines.
+            self.assertTrue(second["auto"]["last_refresh_at"])
+            self.assertTrue(first_stamp)
+
+            count, cancelled, changed = registry.refresh_all(
+                payload,
+                workspace_root=workspace,
+            )
+            self.assertEqual((count, cancelled, changed), (1, False, 0))
+            self.assertIn("没有新增变更", payload["update_summary"])
+
+    def test_format_refresh_result_message_variants(self):
+        self.assertIn(
+            "没有新增变更",
+            registry.format_refresh_result_message(
+                mode=registry.REFRESH_MODE_LITE,
+                refreshed_count=3,
+                changed_count=0,
+            ),
+        )
+        self.assertIn(
+            "其中 2 个状态有更新",
+            registry.format_refresh_result_message(
+                mode=registry.REFRESH_MODE_DEEP,
+                refreshed_count=5,
+                changed_count=2,
+            ),
+        )
+        self.assertIn(
+            "没有新增变更",
+            registry.format_refresh_result_message(
+                mode=registry.REFRESH_MODE_LITE,
+                refreshed_count=1,
+                changed_count=0,
+                project_name="Example",
+            ),
+        )
+
     def test_iter_workspace_project_paths_finds_game_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)
             (workspace / "Game_Alpha").mkdir()
             (workspace / "Game_Beta").mkdir()
             (workspace / "renpy-translation-lab").mkdir()
-            adastra = workspace / "Game_Adastra_Universe" / "Adastra"
-            adastra.mkdir(parents=True)
+            # Single project that happens to have layout markers at root.
+            leaf = workspace / "Game_Leaf"
+            leaf.mkdir()
+            (leaf / "work").mkdir()
+            # Series container: no markers at root; members + resource-only siblings.
+            series = workspace / "Game_SeriesPack"
+            title_a = series / "TitleA"
+            title_a.mkdir(parents=True)
+            (title_a / "original").mkdir()
+            title_b = series / "TitleB"
+            title_b.mkdir(parents=True)
+            (title_b / "build").mkdir()
+            shared = series / "shared"
+            shared.mkdir()
+            (shared / "TERMS.md").write_text("# terms\n", encoding="utf-8")
+            bare = series / "notes_only"
+            bare.mkdir()
+            # Non-series Game_* that only has resource subdirs stays a single path.
+            alone = workspace / "Game_OnlyNotes"
+            alone.mkdir()
+            (alone / "docs").mkdir()
 
             paths = registry.iter_workspace_project_paths(workspace)
             self.assertEqual(
                 paths,
-                ["Game_Alpha", "Game_Beta", "Game_Adastra_Universe/Adastra"],
+                [
+                    "Game_Alpha",
+                    "Game_Beta",
+                    "Game_Leaf",
+                    "Game_OnlyNotes",
+                    "Game_SeriesPack/TitleA",
+                    "Game_SeriesPack/TitleB",
+                ],
             )
+            self.assertNotIn("Game_SeriesPack", paths)
+            self.assertNotIn("Game_SeriesPack/shared", paths)
+            self.assertNotIn("Game_SeriesPack/notes_only", paths)
+            self.assertTrue(registry.is_series_container_dir(series))
+            self.assertFalse(registry.is_series_container_dir(leaf))
+            self.assertFalse(registry.is_series_container_dir(alone))
 
     def test_merge_discovered_projects_adds_new_game_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_games_registry.py
+++ b/tests/test_games_registry.py
@@ -501,6 +501,95 @@ class GamesRegistryTests(unittest.TestCase):
             ),
         )
 
+    def test_snapshot_ignores_refresh_mode_and_timestamp(self):
+        project = {
+            "version": "1.0",
+            "version_source": "build_info",
+            "layout_status": "ready",
+            "translation_status": "待翻译",
+            "translation_status_source": "scan",
+            "engine": "renpy",
+            "in_renpy_pipeline": True,
+            "auto": {
+                "tl_rpy_files": 3,
+                "pending_tasks": 10,
+                "refresh_mode": registry.REFRESH_MODE_LITE,
+                "last_refresh_at": "2026-07-30T00:00:00+00:00",
+                "doctor_layout": "ready",
+                "doctor_mode": "existing_tl_only",
+            },
+        }
+        before = registry.snapshot_project_refresh_state(project)
+        project["auto"]["refresh_mode"] = registry.REFRESH_MODE_DEEP
+        project["auto"]["last_refresh_at"] = "2026-07-30T01:00:00+00:00"
+        after = registry.snapshot_project_refresh_state(project)
+        self.assertEqual(before, after)
+        project["auto"]["pending_tasks"] = 11
+        self.assertNotEqual(before, registry.snapshot_project_refresh_state(project))
+
+    def test_lite_then_deep_refresh_no_false_change_when_doctor_matches(self):
+        """Alternating scan modes must not report a change solely for refresh_mode."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            project_root = workspace / "Game_Example"
+            tl_dir = project_root / "work" / "game" / "tl" / "schinese"
+            tl_dir.mkdir(parents=True)
+            (tl_dir / "common.rpy").write_text(
+                '# line\n    new "hello"\n',
+                encoding="utf-8",
+            )
+            (project_root / "original" / "game").mkdir(parents=True)
+            payload = {
+                "workspace_root": workspace.as_posix(),
+                "projects": [
+                    {
+                        "id": "game_example",
+                        "name": "Example",
+                        "path": "Game_Example",
+                        "engine": "renpy",
+                        "in_renpy_pipeline": True,
+                        # Keep derivation source stable so only mode/stamp would flip.
+                        "translation_status_source": "manual",
+                        "translation_status": "待翻译",
+                    }
+                ],
+            }
+            registry.refresh_project(
+                payload,
+                "game_example",
+                workspace_root=workspace,
+                mode=registry.REFRESH_MODE_LITE,
+            )
+            auto = payload["projects"][0]["auto"]
+            layout = str(auto.get("doctor_layout") or "")
+            mode = str(auto.get("doctor_mode") or "")
+            before = registry.snapshot_project_refresh_state(payload["projects"][0])
+
+            with mock.patch.object(
+                registry,
+                "_doctor_layout_snapshot",
+                return_value=(layout, mode),
+            ):
+                registry.refresh_project(
+                    payload,
+                    "game_example",
+                    workspace_root=workspace,
+                    mode=registry.REFRESH_MODE_DEEP,
+                )
+            after = registry.snapshot_project_refresh_state(payload["projects"][0])
+            self.assertEqual(before, after)
+            self.assertEqual(
+                payload["projects"][0]["auto"]["refresh_mode"],
+                registry.REFRESH_MODE_DEEP,
+            )
+
+            count, cancelled, changed = registry.refresh_all(
+                payload,
+                workspace_root=workspace,
+                mode=registry.REFRESH_MODE_LITE,
+            )
+            self.assertEqual((count, cancelled, changed), (1, False, 0))
+
     def test_iter_workspace_project_paths_finds_game_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)

--- a/tests/test_gui_game_ingest_dialog.py
+++ b/tests/test_gui_game_ingest_dialog.py
@@ -33,14 +33,14 @@ class GuiGameIngestDialogTests(unittest.TestCase):
 
             dialog = GameIngestDialog(None, workspace_root=workspace)
             dialog._set_source(real_src)
-            dialog._name_edit.setText("Glory Hounds")
+            dialog._name_edit.setText("Sample Title")
             self._app.processEvents()
-            self.assertEqual(dialog._folder_preview.text(), "Game_GloryHounds")
+            self.assertEqual(dialog._folder_preview.text(), "Game_SampleTitle")
             # 将创建到 = workspace destination (native path), not the source path.
-            expected_dest = str(workspace.resolve() / "Game_GloryHounds")
+            expected_dest = str(workspace.resolve() / "Game_SampleTitle")
             self.assertEqual(dialog._path_preview.text(), expected_dest)
             self.assertTrue(
-                dialog._path_preview.text().endswith("Game_GloryHounds")
+                dialog._path_preview.text().endswith("Game_SampleTitle")
             )
             # Must not clip to bare drive letter only (the screenshot bug: "C:").
             self.assertNotEqual(dialog._path_preview.text().rstrip("/\\"), "C:")

--- a/tests/test_gui_games_registry_actions.py
+++ b/tests/test_gui_games_registry_actions.py
@@ -18,6 +18,7 @@ from gui_qt.games_registry_actions import (
     record_apply_batch_for_game_root,
     refresh_registry_projects,
     render_registry_games_md,
+    report_registry_refresh_completion,
     save_registry_dialog_preference,
     save_registry_project_fields,
 )
@@ -242,6 +243,50 @@ class GuiGamesRegistryActionsTests(unittest.TestCase):
             self.assertTrue(result.ok)
             data = registry.load_registry(workspace / registry.REGISTRY_FILENAME)
             self.assertTrue(data["preferences"]["auto_discover_on_open"])
+
+    def test_report_registry_refresh_completion_no_change_shows_info_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            self._write_registry(workspace, [])
+            with mock.patch(
+                "gui_qt.widget_helpers.message_box_information",
+            ) as info_mock, mock.patch(
+                "gui_qt.widget_helpers.message_box_question",
+            ) as question_mock:
+                result = report_registry_refresh_completion(
+                    None,
+                    workspace,
+                    refresh_message="已快速刷新全部 3 个项目；与上次相比没有新增变更。",
+                    status_changed=False,
+                )
+            self.assertTrue(result.ok)
+            self.assertFalse(result.status_changed)
+            self.assertIn("没有新增变更", result.message)
+            info_mock.assert_called_once()
+            self.assertEqual(info_mock.call_args.args[1], "刷新完成")
+            question_mock.assert_not_called()
+
+    def test_report_registry_refresh_completion_changed_offers_sync(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            self._write_registry(
+                workspace,
+                [{"id": "demo", "name": "Example", "path": "Game_Example"}],
+            )
+            with mock.patch(
+                "gui_qt.widget_helpers.message_box_question",
+                return_value="no",
+            ) as question_mock:
+                result = report_registry_refresh_completion(
+                    None,
+                    workspace,
+                    refresh_message="已快速刷新全部 1 个项目；其中 1 个状态有更新。",
+                    status_changed=True,
+                )
+            question_mock.assert_called_once()
+            self.assertEqual(question_mock.call_args.args[1], "刷新完成")
+            self.assertTrue(result.ok)
+            self.assertIn("跳过", result.message)
 
     def test_ingest_registry_project(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_gui_games_registry_dialog.py
+++ b/tests/test_gui_games_registry_dialog.py
@@ -279,6 +279,27 @@ class GuiGamesRegistryDialogTests(unittest.TestCase):
                 self.assertFalse(report_mock.call_args.kwargs.get("status_changed"))
             self.assertIn("没有新增变更", dialog._status_label.text())
 
+            with mock.patch(
+                "gui_qt.games_registry_panel.report_registry_refresh_completion",
+                return_value=RegistryActionResult(
+                    False,
+                    "已快速刷新项目 Example；状态有更新。 同步 GAMES.md 失败：disk full",
+                    status_changed=True,
+                ),
+            ), mock.patch(
+                "gui_qt.games_registry_panel.message_box_warning",
+            ) as warn_mock:
+                dialog._on_refresh_completed(
+                    RegistryActionResult(
+                        True,
+                        "已快速刷新项目 Example；状态有更新。",
+                        status_changed=True,
+                    )
+                )
+            warn_mock.assert_called_once()
+            self.assertEqual(warn_mock.call_args.args[1], "同步失败")
+            self.assertIn("同步 GAMES.md 失败", dialog._status_label.text())
+
     def test_refresh_keeps_table_enabled_for_scrolling(self):
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)

--- a/tests/test_gui_games_registry_dialog.py
+++ b/tests/test_gui_games_registry_dialog.py
@@ -242,13 +242,42 @@ class GuiGamesRegistryDialogTests(unittest.TestCase):
                 dialog._refresh_current_project()
                 start_mock.assert_called_once()
             with mock.patch(
-                "gui_qt.games_registry_panel.prompt_render_games_md_after_refresh",
-                return_value=RegistryActionResult(True, "已跳过 GAMES.md 同步。"),
-            ):
+                "gui_qt.games_registry_panel.report_registry_refresh_completion",
+                return_value=RegistryActionResult(
+                    True,
+                    "已快速刷新项目 Example；状态有更新。 已跳过 GAMES.md 同步。",
+                    status_changed=True,
+                ),
+            ) as report_mock:
                 dialog._on_refresh_completed(
-                    RegistryActionResult(True, "已快速刷新项目 Example。")
+                    RegistryActionResult(
+                        True,
+                        "已快速刷新项目 Example；状态有更新。",
+                        status_changed=True,
+                    )
                 )
+                report_mock.assert_called_once()
+                self.assertTrue(report_mock.call_args.kwargs.get("status_changed"))
             self.assertIn("已快速刷新项目 Example", dialog._status_label.text())
+
+            with mock.patch(
+                "gui_qt.games_registry_panel.report_registry_refresh_completion",
+                return_value=RegistryActionResult(
+                    True,
+                    "已快速刷新项目 Example；与上次相比没有新增变更。",
+                    status_changed=False,
+                ),
+            ) as report_mock:
+                dialog._on_refresh_completed(
+                    RegistryActionResult(
+                        True,
+                        "已快速刷新项目 Example；与上次相比没有新增变更。",
+                        status_changed=False,
+                    )
+                )
+                report_mock.assert_called_once()
+                self.assertFalse(report_mock.call_args.kwargs.get("status_changed"))
+            self.assertIn("没有新增变更", dialog._status_label.text())
 
     def test_refresh_keeps_table_enabled_for_scrolling(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Replace the hardcoded `Game_Adastra_Universe` discover special case with a **layout-based series container** rule: any top-level `Game_*` without `original`/`work`/`build` but with children that have those markers is treated as a series; resource-only siblings (e.g. glossary folders) are not registered.
- Refresh compares pre/post status fingerprints (ignoring `last_refresh_at`), reports **没有新增变更** vs **N 个状态有更新**, and preserves `last_batch_*` metadata across scan refresh.
- GUI always shows a **刷新完成** dialog; GAMES.md sync is offered only when status actually changed.

## Test plan
- [x] `python -m unittest tests.test_games_registry tests.test_gui_games_registry_actions tests.test_gui_games_registry_dialog -q`
- [ ] GUI: refresh all with no disk changes → completion dialog says 没有新增变更, no sync prompt
- [ ] GUI: refresh after changing a project → completion dialog offers 同步 GAMES.md / 完成
- [ ] Discover a series folder with nested titles + a resource-only sibling → only titled members registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved discovery of series-style game folders, registering organized titles while excluding containers and unorganized resources.
  - Refresh results now report how many projects changed and distinguish updates from no-op refreshes.
  - Added clearer refresh completion messages in the GUI.

- **Bug Fixes**
  - Refreshes preserve existing batch information.
  - The GUI no longer prompts to synchronize `GAMES.md` when no meaningful changes occurred.
  - Updated documentation to clarify discovery and import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->