### PR TITLE
Implement Ren'Py P2 adapter writeback plan

### DIFF
--- a/docs/engine_adapter.md
+++ b/docs/engine_adapter.md
@@ -2,10 +2,11 @@
 
 文档地图：[docs/README.md](README.md)
 
-当前已交付 #265 的 P1：同步翻译预览与普通 Batch translation build 通过同一个
-`RenPyAdapter` 发现 `.rpy`、构建候选清单并提取 `TranslationUnit`。这一阶段是只读
-扫描迁移，不改变现有命令、配置、manifest v1/v2、identity v2、终端文案或
-`check -> apply` 写回合同。
+当前已交付 #265 的 P1 与 P2：同步翻译预览、普通 Batch translation build，以及
+revision preview/apply 通过 `RenPyAdapter` 的 relocation、validation 和声明式
+writeback plan；公共层重新校验 plan 后，仍由既有 workflow 执行 check→apply、路径
+约束、事务恢复和 atomic write。P2 不改变现有命令、配置、manifest v1/v2、identity
+v2 或终端文案合同。
 
 ## 当前边界
 
@@ -14,12 +15,17 @@
 | `engine_adapters/contracts.py` | engine-neutral protocol、capability、candidate、occurrence、validation / writeback 的版本化信封 |
 | `engine_adapters/renpy.py` | Ren'Py 项目发现、`.rpy` inventory、分类、source marker、speaker、translate block / occurrence / ordinal、只读 occurrence 提取 |
 | `engine_adapters/coverage.py` | 独立校验 inventory invariant、生成稳定 digest、导出 coverage/review package、导入并校验人工或 Agent review |
+| `engine_adapters/writeback.py` | 公共 plan schema、source snapshot、相对路径、文件 hash、span、重叠和 plan digest 校验；只在内存中渲染，不持有 writer |
 | `translation_core.py` | 唯一的 `TranslationUnit` / `ModelResult` 核心模型；adapter 不创建第二套翻译单元 |
-| sync / Batch workflow | 模型调用、prompt、progress、manifest、preview/check/apply、RAG / Source Index 回灌 |
+| sync / Batch / revision workflow | 模型调用、prompt、progress、manifest、preview/check/apply、RAG / Source Index 回灌；atomic writer 仍在 workflow/common 层 |
 
-P1 的 `relocate_occurrences()`、`validate_translation()` 与
-`build_writeback_plan()` 明确 fail closed；Ren'Py 重定位、格式校验和声明式写回属于
-P2。revision、keyword、Project Analysis 与 Final Review 的扫描入口在 P1 保持原状。
+P2 的 `relocate_occurrences()` 先按 identity v2，再按 source/context evidence 做唯一
+重定位；无法唯一定位时返回 `common.locator.unresolved`。`validate_translation()`
+输出版本化 `ValidationResult`，`build_writeback_plan()` 只产生
+`text_span_replace` 操作。公共消费者会在 check 和 apply 的二次源重读后再次校验
+source snapshot、文件 hash、半开 span、非重叠、相对路径和 plan digest；adapter 没有
+文件写入权限。keyword、Project Analysis 与 Final Review 的独立扫描入口不在本阶段
+扩大范围。
 
 ## 扫描与等价性
 

--- a/docs/engine_adapter.md
+++ b/docs/engine_adapter.md
@@ -20,8 +20,9 @@ v2 或终端文案合同。
 | sync / Batch / revision workflow | 模型调用、prompt、progress、manifest、preview/check/apply、RAG / Source Index 回灌；atomic writer 仍在 workflow/common 层 |
 
 P2 的 `relocate_occurrences()` 先按 identity v2，再在同一 localization 文件内按
-source/context evidence 做唯一重定位；无法唯一定位时返回
-`common.locator.unresolved`。`validate_translation()`
+source/context evidence 做唯一重定位；content evidence 还需达到最低结构分
+（`CONTENT_EVIDENCE_MIN_SCORE`，默认 150，排除仅“同文件+同原文”的弱匹配），
+同分并列时仍返回 `common.locator.unresolved`。`validate_translation()`
 输出版本化 `ValidationResult`，`build_writeback_plan()` 只产生
 `text_span_replace` 操作。公共消费者会在 check 和 apply 的二次源重读后再次校验
 source snapshot、文件 hash、半开 span、非重叠、相对路径和 plan digest；adapter 没有

--- a/docs/engine_adapter.md
+++ b/docs/engine_adapter.md
@@ -21,7 +21,7 @@ v2 或终端文案合同。
 
 P2 的 `relocate_occurrences()` 先按 identity v2，再在同一 localization 文件内按
 source/context evidence 做唯一重定位；content evidence 还需达到最低结构分
-（`CONTENT_EVIDENCE_MIN_SCORE`，默认 150，排除仅“同文件+同原文”的弱匹配），
+（`CONTENT_EVIDENCE_MIN_SCORE`，默认 140，排除仅“同文件+同原文”的 125 分弱匹配），
 同分并列时仍返回 `common.locator.unresolved`。`validate_translation()`
 输出版本化 `ValidationResult`，`build_writeback_plan()` 只产生
 `text_span_replace` 操作。公共消费者会在 check 和 apply 的二次源重读后再次校验

--- a/docs/engine_adapter.md
+++ b/docs/engine_adapter.md
@@ -19,8 +19,9 @@ v2 或终端文案合同。
 | `translation_core.py` | 唯一的 `TranslationUnit` / `ModelResult` 核心模型；adapter 不创建第二套翻译单元 |
 | sync / Batch / revision workflow | 模型调用、prompt、progress、manifest、preview/check/apply、RAG / Source Index 回灌；atomic writer 仍在 workflow/common 层 |
 
-P2 的 `relocate_occurrences()` 先按 identity v2，再按 source/context evidence 做唯一
-重定位；无法唯一定位时返回 `common.locator.unresolved`。`validate_translation()`
+P2 的 `relocate_occurrences()` 先按 identity v2，再在同一 localization 文件内按
+source/context evidence 做唯一重定位；无法唯一定位时返回
+`common.locator.unresolved`。`validate_translation()`
 输出版本化 `ValidationResult`，`build_writeback_plan()` 只产生
 `text_span_replace` 操作。公共消费者会在 check 和 apply 的二次源重读后再次校验
 source snapshot、文件 hash、半开 span、非重叠、相对路径和 plan digest；adapter 没有

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -255,7 +255,7 @@ build -> submit -> status -> download -> check
 
 ### 同步翻译
 
-在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
+在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；若部分文件未通过 adapter 写回计划校验，GUI 显示「部分完成」警告，只允许写回 manifest 中其余已生成的安全预览。用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
 
 #### LiteLLM 同步替代边界
 

--- a/docs/plans/engine_adapter_contract.md
+++ b/docs/plans/engine_adapter_contract.md
@@ -342,9 +342,9 @@ P0/P1 不向现有 manifest v1/v2 序列化 occurrence 信封，因此 manifest 
   缩小重定位候选，但不能只凭 hint 跳过 identity/source 校验。
 
 identity v2 未命中时，Ren'Py content-evidence fallback 仅在同一 `file_rel_path`
-内打分；最高分必须唯一且达到 `CONTENT_EVIDENCE_MIN_SCORE`（当前 150，排除仅
-“同文件+同原文”的弱匹配 125）。同分并列或低于最低分均返回
-`common.locator.unresolved`，不得 fail-open 写回。
+内打分；最高分必须唯一且达到 `CONTENT_EVIDENCE_MIN_SCORE`（当前 140，排除仅
+“同文件+同原文”的弱匹配 125；典型 stale-block 唯一回落约 140+）。同分并列或
+低于最低分均返回 `common.locator.unresolved`，不得 fail-open 写回。
 
 `source_marker_kind` 为 `comment`、`old_new` 或 `direct_source`。公共层只做 JSON
 schema/version/size 检查，把 locator 原样交回同一 engine adapter；不得读取或校验

--- a/docs/plans/engine_adapter_contract.md
+++ b/docs/plans/engine_adapter_contract.md
@@ -341,6 +341,11 @@ P0/P1 不向现有 manifest v1/v2 序列化 occurrence 信封，因此 manifest 
 - 三者都只是 adapter-private relocation hint，不是公共业务坐标。adapter 可以用它们
   缩小重定位候选，但不能只凭 hint 跳过 identity/source 校验。
 
+identity v2 未命中时，Ren'Py content-evidence fallback 仅在同一 `file_rel_path`
+内打分；最高分必须唯一且达到 `CONTENT_EVIDENCE_MIN_SCORE`（当前 150，排除仅
+“同文件+同原文”的弱匹配 125）。同分并列或低于最低分均返回
+`common.locator.unresolved`，不得 fail-open 写回。
+
 `source_marker_kind` 为 `comment`、`old_new` 或 `direct_source`。公共层只做 JSON
 schema/version/size 检查，把 locator 原样交回同一 engine adapter；不得读取或校验
 Ren'Py hint 字段作业务判断。

--- a/docs/plans/engine_adapter_contract.md
+++ b/docs/plans/engine_adapter_contract.md
@@ -2,7 +2,8 @@
 
 > 状态：#265 / #285 的 P0 设计基线；#265 P1 已按本文合同实现只读
 > `RenPyAdapter`、coverage/review 产物，并迁移 sync 与普通 Batch translation
-> build 的扫描入口。P2 的 relocation / validation / writeback plan 尚未实现。
+> build 的扫描入口；#265 P2 已实现 Ren'Py relocation、validation、声明式
+> writeback plan 及 sync/Batch/revision 的公共 plan 消费。
 > 当前实现说明见 [Ren'Py Engine Adapter 与覆盖审计](../engine_adapter.md)。
 
 ## 1. 范围与硬性边界
@@ -70,8 +71,8 @@ pair collector 就宣称 revision/repair 已统一。
 | scan | sync：`run_translation() -> collect_tasks() -> collect_tasks_with_progress()`；Batch build：`create_batch_package() -> collect_pending_file_jobs() -> collect_tasks_with_progress()`。 | tokenizer/AST heuristic 识别字符串；translation file 中保护 `old`、keyword argument、Character display name 与 voice 行。宽泛解析异常当前会跳过。 |
 | build | sync：task -> `process_batch_with_retry() -> process_batch()`；Batch：file jobs -> `build_chunks()` -> `translation_core.units_from_items()` -> request JSONL + manifest v2。 | prompt/result 是公共语义；文件、block、source marker、speaker、span 是 Ren'Py 语义。Batch manifest 仍为 `manifest_version=2`、`core_schema_version=2`。 |
 | relocate | `collect_result_actions()` / `collect_revision_actions()` 调用 `relocate_v2_chunk_items()`；后者按文件调用 `scan_all_translation_units()` 并用 item `id` 更新 `line/start/end`。 | 仅 manifest v2 使用 identity relocation。v1 保持旧定位与后续 source validation 行为。sync preview 不做 item relocation，而以 whole-file snapshot/hash 拒绝漂移。 |
-| validate | sync：`process_batch() -> validate_translation()`；Batch：`collect_result_actions() -> validate_translation()`，随后 `validate_result_replacements()` / `validate_replacements_for_lines()` 校验 live token 与 expected source。 | `validate_translation()` 当前混合公共规则（空译文、保留词、目标语言 heuristic）和 Ren'Py 规则（tag/field/percent token）。source snapshot、项目匹配和路径约束属于公共安全层。 |
-| render | sync preview 与 Batch/revision apply 都调用 `translator_runtime.render_replacement_lines()`；它经 `quote_with()` 保留 prefix/quote 并转义字符串。 | 当前 renderer 是 Ren'Py 字符串字面量语义。`commit_replacements()` 和 Batch apply 再交给 `atomic_io` 写入。 |
+| validate | sync：`process_batch()` 后由 `RenPyAdapter.validate_translation()` 重检；Batch/revision：collect 的 source validation 后构建 adapter `ValidationResult`。 | adapter 输出稳定 reason codes；公共 plan consumer 继续负责 source snapshot、项目匹配、路径约束和 check safety。 |
+| render | sync preview、Batch apply、revision apply 都先构建 adapter `WritebackPlan`，再由 `engine_adapters.writeback.render_writeback_plan()` 在内存中拼接最终 fragment。 | adapter 负责 Ren'Py prefix/quote/escape；common 不二次渲染，最后仍由现有 `atomic_write_many_lines()` 写入。 |
 | check | `check_results() -> require_manifest_project_match() -> collect_result_actions(validate_sources=True) -> attach_check_contract()`。 | `CHECK_CONTRACT_VERSION=2`；fingerprint 绑定 manifest target shape、结果文件、项目 identity 和设置；reason codes 聚合为 `safe/warn/block`。 |
 | apply | `apply_results()` 先恢复 transaction、要求最近一次 `safe` check，再重新收集结果、重新读取源文件和二次 source validation；之后 render 全部目标文件并用 `atomic_write_many_lines()` 事务写入。 | `--force` 只放宽“已经 apply”防重 guard，不绕过 stale check、project/source validation 或 `block`。 |
 | sync apply | `apply_sync_translation_preview() -> sync_translation_preview.apply_sync_preview()`；先验证 project/TL identity、manifest/report/artifact fingerprint 和每个源文件 hash，再一次性原子写入。 | sync 没有 Batch check 命令，但 preview manifest 自带独立、不可变的 source/proposed snapshot 合同。 |
@@ -125,7 +126,7 @@ adapter 可以在 P1 继续提供现有 `progress_entry` 兼容值，但 progres
 
 | 路径 | 当前扫描 / 消费方式 | P0 判断 |
 |---|---|---|
-| revision | `collect_revision_file_jobs() -> collect_translation_entries_from_lines()`；后者再用 `build_identity_v2_by_span() -> scan_all_translation_units(mode=revision)` 绑定 identity v2。preview/apply 继续走 source validation、Ren'Py renderer 和原子写回。 | 已译 occurrence 提取与 translation pending 扫描相邻但不同；P1 不抢先迁移，P2 与 relocation/validation/writeback plan 一起收敛。 |
+| revision | `collect_revision_file_jobs() -> collect_translation_entries_from_lines()`；后者再用 `build_identity_v2_by_span() -> scan_all_translation_units(mode=revision)` 绑定 identity v2。preview/apply 继续走 source validation、adapter plan 和原子写回。 | 已译 occurrence 提取与 translation pending 扫描仍相邻但不同；P2 只收敛 relocation/validation/writeback，不把 keyword/Project Analysis 扩进本阶段。 |
 | keyword | `collect_keyword_file_jobs() -> collect_repair_entries_from_lines()`，同时合并 source/translation pair 与 `legacy.collect_tasks()`。输出 glossary candidates，不写 `.rpy`。 | P1 保持原状；以后消费 candidate inventory 的“可分析文本投影”，不能把关键词任务等同翻译覆盖。 |
 | Project Analysis | `project_analysis_generate.build_structure_drafts()` 调用 `project_analysis_routes.discover_script_files()` 扫 source `.rpy` 且跳过 `tl/`，再调用 `project_analysis_routes.build_route_graph()` 解析 label/jump/call/menu；content fingerprint 与 lineage 存在自己的 store。 | 保留独立剧情结构 parser。后续只把 fresh coverage digest/review status 作为 publish upstream gate；不把全部 UI 文本注入分析 prompt。 |
 | Final Review | `create_final_review_package()` 以 `collect_pending_file_jobs()` 判断 pending，以 `collect_revision_file_jobs()` 取得已译 pairs；`evaluate_readiness()` 当前主要依赖 pending=0 与 review items>0，snapshot/context digest 冻结翻译与上下文。 | P1 保持原状；后续把 coverage dependency 加进 readiness 与 snapshot/upstream digest，不能只凭已识别 pending=0 宣称完成。 |
@@ -139,7 +140,7 @@ adapter 可以在 P1 继续提供现有 `progress_entry` 兼容值，但 progres
 | `TranslationUnit`、`ModelResult`、prompt、response normalization | `translation_core.py` | 继续作为唯一翻译核心模型；不得创建 engine-specific 第二套 unit。 |
 | adapter protocol、engine-neutral envelope/schema | 建议新增 `engine_adapters/contracts.py`（P1） | 可以依赖 `translation_core`；`translation_core` 不反向依赖 adapter，避免循环。 |
 | candidate/report/review、digest、freshness、review policy | 建议新增 `engine_adapters/coverage.py`（P1） | 公共层生成并校验 artifacts；adapter 只提供候选和分类证据。 |
-| project / manifest identity、check fingerprint、最近一次 safe check | common/workflow 层；P2 可从 Batch 中提取共享 helper | adapter 不得决定是否允许 apply。 |
+| project / manifest identity、check fingerprint、最近一次 safe check | common/workflow 层；P2 通过 adapter plan gate 接入现有 Batch/sync/revision 门禁 | adapter 不得决定是否允许 apply。 |
 | target path containment、source snapshot re-read、plan 越界/重叠检查 | common writeback safety 层 | adapter locator 对公共层保持 opaque；writeback operation 必须另带公共层可校验的相对 target。 |
 | atomic transaction、recovery、failure report、apply state | `atomic_io.py` 与 workflow 层 | adapter 不获得 writer、file handle、callback 或任意路径写权限。 |
 | progress、CLI/GUI orchestration、model/provider、RAG/Source Index 回灌 | 现有 workflow/common 模块 | 都是 adapter 的 consumer，不属于引擎解析合同。 |
@@ -757,9 +758,9 @@ AND unresolved_findings == 0
 
 | 路径 | P1 首阶段 | 后续边界 |
 |---|---|---|
-| sync translation preview build | 经 `RenPyAdapter` 的 discover/inventory/audit/extract 取得与当前完全等价的 units；保持 CLI/GUI/preview artifact 不变。新 coverage artifacts 只读，不启用 gate。 | P2 用 adapter validation/writeback plan，但 sync project/source/atomic apply 仍由 common 层执行。 |
+| sync translation preview build | 经 `RenPyAdapter` 的 discover/inventory/audit/extract 取得与当前完全等价的 units；保持 CLI/GUI/preview artifact 不变。 | P2 preview manifest 保存单文件 plan；apply 在首笔写入前用 source artifact 重建并重检 plan，project/source/atomic apply 仍由 common 层执行。 |
 | Batch translation build | 与 sync 共用同一 adapter extraction；legacy item/manifest v2 shape、chunk/prompt/RAG 行为不变。 | P2 check 消费 adapter validation/plan；最近一次 safe check、fingerprint 与 apply re-read 保持公共层。 |
-| revision | P1 保持 `collect_revision_file_jobs()` 原状，避免把已译 pair/writeback 迁移偷带进扫描阶段。 | P2 与 relocation、validation、render/writeback plan 一次收敛；preview/apply 安全语义不得分叉。 |
+| revision | 保持 `collect_revision_file_jobs()` 的 pair 扫描边界，不把 Project Analysis/keyword 迁移偷带进来。 | P2 preview/apply 均在 source revalidation 后消费 adapter plan；不安全时拒绝写回。 |
 | keyword | P1 保持现有 repair-entry scan 与输出。 | adapter inventory 稳定后再消费 analysis projection；仍只输出 glossary candidates。 |
 | Project Analysis | P1 保持独立 route parser 和现有 publish 行为，不消费全部 occurrence。 | 后续将 fresh coverage/review digest 加入 publish gate 与 lineage upstream dependency；只消费 analysis projection digest。 |
 | Final Review | P1 保持当前 pending/revision scan、readiness 和 snapshot shape。 | 后续 readiness 必须验证 coverage gate；coverage/review digest 纳入 snapshot/upstream dependency。 |

--- a/docs/plans/engine_adapter_contract.md
+++ b/docs/plans/engine_adapter_contract.md
@@ -448,6 +448,11 @@ v1 只允许 common 层实现并注册的 operation kinds。Ren'Py 首个 kind �
 - common 层在第一笔写入前再次读取全部文件并复核；
 - 全部通过后才生成 rendered files 并交给 `atomic_write_many_lines()`。
 
+- `expected_fragment_sha256` 是 common consumer 对 live raw span 的校验；
+- `expected_text_digest` 绑定 adapter 已解码的源文本与 operation/plan payload，
+  但 common 层保持 engine-neutral，不重新解析 Ren'Py 字符串 literal；adapter
+  构建 plan 时必须从同一已验证 occurrence 生成该 digest。
+
 `apply --force` 不得跳过 plan freshness、source snapshot、coverage gate、`block`
 validation 或公共安全检查。
 

--- a/engine_adapters/__init__.py
+++ b/engine_adapters/__init__.py
@@ -10,6 +10,11 @@ from .contracts import (
     OCCURRENCE_SCHEMA_VERSION,
     VALIDATION_SCHEMA_VERSION,
     WRITEBACK_PLAN_SCHEMA_VERSION,
+    RelocationResult,
+    ValidatedTranslation,
+    ValidationResult,
+    WritebackOperation,
+    WritebackPlan,
     Candidate,
     CandidateInventory,
     EngineAdapter,
@@ -33,6 +38,12 @@ from .coverage import (
     validate_coverage_report_freshness,
     validate_review_record,
 )
+from .writeback import (
+    WritebackPlanError,
+    render_writeback_plan,
+    source_snapshot_fingerprint,
+    validate_writeback_plan,
+)
 from .renpy import (
     ADAPTER_VERSION as RENPY_ADAPTER_VERSION,
     RenPyAdapter,
@@ -51,6 +62,11 @@ __all__ = [
     "RENPY_ADAPTER_VERSION",
     "VALIDATION_SCHEMA_VERSION",
     "WRITEBACK_PLAN_SCHEMA_VERSION",
+    "RelocationResult",
+    "ValidatedTranslation",
+    "ValidationResult",
+    "WritebackOperation",
+    "WritebackPlan",
     "Candidate",
     "CandidateInventory",
     "CoverageFreshness",
@@ -72,6 +88,10 @@ __all__ = [
     "build_translation_snapshot",
     "export_coverage_package",
     "load_review_record",
+    "WritebackPlanError",
+    "render_writeback_plan",
+    "source_snapshot_fingerprint",
+    "validate_writeback_plan",
     "validate_coverage_report_freshness",
     "validate_review_record",
 ]

--- a/engine_adapters/contracts.py
+++ b/engine_adapters/contracts.py
@@ -291,6 +291,13 @@ class ValidatedTranslation:
 
 @dataclass(frozen=True)
 class WritebackOperation:
+    """Declarative replacement emitted by an engine adapter.
+
+    ``expected_fragment_sha256`` is the common consumer's live raw-span guard.
+    ``expected_text_digest`` binds the adapter-decoded source text into the
+    operation and plan digests; the engine-neutral consumer deliberately does
+    not decode engine-specific literals a second time.
+    """
     operation_id: str
     kind: str
     occurrence_id: str

--- a/engine_adapters/contracts.py
+++ b/engine_adapters/contracts.py
@@ -1,9 +1,8 @@
 """Versioned, engine-neutral contracts for localization adapters.
 
-P1 introduces read-only discovery, inventory, audit, and extraction.  The
-validation, relocation, and writeback data classes are defined here so future
-stages extend one protocol, but no P1 implementation is allowed to write game
-files.
+P1 introduced read-only discovery, inventory, audit, and extraction.  P2 adds
+relocation, engine validation, and declarative writeback plans while keeping
+all project/manifest checks and actual file writes in common workflow code.
 """
 
 from __future__ import annotations
@@ -105,6 +104,8 @@ class ProjectDiscovery:
     source_documents: tuple[SourceDocument, ...]
     localization_mode: LocalizationMode
     catalog_provenance: Mapping[str, Any] = field(default_factory=dict)
+    coverage_digest: str = ""
+    coverage_review_digest: str = ""
 
     def document_by_path(self) -> dict[str, SourceDocument]:
         return {document.file_rel_path: document for document in self.source_documents}
@@ -247,6 +248,13 @@ class RelocationResult:
     unresolved_occurrence_ids: tuple[str, ...] = ()
     diagnostics: tuple[Mapping[str, Any], ...] = ()
 
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "occurrences": [occurrence.to_dict() for occurrence in self.occurrences],
+            "unresolved_occurrence_ids": list(self.unresolved_occurrence_ids),
+            "diagnostics": [dict(item) for item in self.diagnostics],
+        }
+
 
 @dataclass(frozen=True)
 class ValidationResult:
@@ -259,6 +267,19 @@ class ValidationResult:
     translation_digest: str
     normalized_translation: str | None = None
     validation_schema_version: int = VALIDATION_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "validation_schema_version": self.validation_schema_version,
+            "occurrence_id": self.occurrence_id,
+            "engine": self.engine,
+            "status": self.status,
+            "reason_codes": list(self.reason_codes),
+            "diagnostics": [dict(item) for item in self.diagnostics],
+            "source_constraints_digest": self.source_constraints_digest,
+            "translation_digest": self.translation_digest,
+            "normalized_translation": self.normalized_translation,
+        }
 
 
 @dataclass(frozen=True)
@@ -284,6 +305,23 @@ class WritebackOperation:
     replacement_fragment: str
     validation_digest: str
 
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "operation_id": self.operation_id,
+            "kind": self.kind,
+            "occurrence_id": self.occurrence_id,
+            "target_root": self.target_root,
+            "target_rel_path": self.target_rel_path,
+            "expected_file_sha256": self.expected_file_sha256,
+            "line": self.line,
+            "start_col": self.start_col,
+            "end_col": self.end_col,
+            "expected_fragment_sha256": self.expected_fragment_sha256,
+            "expected_text_digest": self.expected_text_digest,
+            "replacement_fragment": self.replacement_fragment,
+            "validation_digest": self.validation_digest,
+        }
+
 
 @dataclass(frozen=True)
 class WritebackPlan:
@@ -296,6 +334,19 @@ class WritebackPlan:
     operations: tuple[WritebackOperation, ...]
     plan_digest: str
     writeback_plan_schema_version: int = WRITEBACK_PLAN_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "writeback_plan_schema_version": self.writeback_plan_schema_version,
+            "engine": self.engine,
+            "adapter_version": self.adapter_version,
+            "project_identity_digest": self.project_identity_digest,
+            "source_snapshot_fingerprint": self.source_snapshot_fingerprint,
+            "coverage_digest": self.coverage_digest,
+            "coverage_review_digest": self.coverage_review_digest,
+            "operations": [operation.to_dict() for operation in self.operations],
+            "plan_digest": self.plan_digest,
+        }
 
 
 @runtime_checkable
@@ -338,8 +389,8 @@ class EngineAdapter(Protocol):
     ) -> RelocationResult:
         """Relocate occurrences against live sources (P2).
 
-        P1 implementations must fail closed with ``NotImplementedError``
-        rather than returning empty success results.
+        Unsupported adapters must fail closed rather than returning an empty
+        success result.
         """
         ...
 
@@ -350,8 +401,7 @@ class EngineAdapter(Protocol):
     ) -> ValidationResult:
         """Validate translated text for engine format rules (P2).
 
-        P1 implementations must fail closed with ``NotImplementedError``
-        rather than returning empty success results.
+        Unsupported adapters must fail closed rather than returning a pass.
         """
         ...
 
@@ -363,8 +413,7 @@ class EngineAdapter(Protocol):
     ) -> WritebackPlan:
         """Build a declarative writeback plan (P2).
 
-        P1 implementations must fail closed with ``NotImplementedError``
-        rather than returning empty success results. Adapters never receive
+        Unsupported adapters must fail closed. Adapters never receive
         arbitrary file-write authority.
         """
         ...

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -58,8 +58,9 @@ from .writeback import source_snapshot_fingerprint
 ADAPTER_VERSION = "1.1.0"
 LOCATOR_SCHEMA_VERSION = 1
 # Same-file + same-source alone scores 125. Content-evidence matches must also
-# share at least one structural signal (speaker / block / marker / fingerprint).
-CONTENT_EVIDENCE_MIN_SCORE = 150
+# clear this floor so bare unique-string hits without structural signals fail closed.
+# Typical unique stale-block fallback scores 140+ (shared block_occurrence / speaker).
+CONTENT_EVIDENCE_MIN_SCORE = 140
 
 
 @dataclass(frozen=True)

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -10,7 +10,8 @@ the legacy scanners' broad exception handlers become coverage claims.
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from collections import Counter
+from dataclasses import dataclass, replace
 import hashlib
 import io
 import os
@@ -25,6 +26,8 @@ import translation_core
 from .contracts import (
     CONTENT_FINGERPRINT_SCHEMA_VERSION,
     ENGINE_ADAPTER_PROTOCOL_VERSION,
+    VALIDATION_SCHEMA_VERSION,
+    WRITEBACK_PLAN_SCHEMA_VERSION,
     Candidate,
     CandidateInventory,
     CoverageReportDraft,
@@ -39,6 +42,7 @@ from .contracts import (
     SourceDocument,
     ValidatedTranslation,
     ValidationResult,
+    WritebackOperation,
     WritebackPlan,
 )
 from .coverage import (
@@ -50,7 +54,7 @@ from .coverage import (
 )
 
 
-ADAPTER_VERSION = "1.0.0"
+ADAPTER_VERSION = "1.1.0"
 LOCATOR_SCHEMA_VERSION = 1
 
 
@@ -127,10 +131,11 @@ def _normalize_fingerprint_text(value: str) -> str:
 
 
 class RenPyAdapter:
-    """P1 Ren'Py adapter.
+    """P2 Ren'Py adapter with read-only relocation and writeback planning.
 
     The adapter can read only the project/localization roots supplied to
-    :meth:`discover_project`.  P2 protocol methods intentionally fail closed.
+    :meth:`discover_project`.  It returns declarative data only; common
+    workflow code retains project, manifest, and atomic write authority.
     """
 
     protocol_version = ENGINE_ADAPTER_PROTOCOL_VERSION
@@ -158,8 +163,8 @@ class RenPyAdapter:
             selected_localization_mode=LocalizationMode.HYBRID,
             source_inventory=True,
             native_catalog=True,
-            relocation=False,
-            declarative_writeback=(),
+            relocation=True,
+            declarative_writeback=("text_span_replace",),
             native_catalog_required_for_writeback=True,
         )
 
@@ -175,7 +180,11 @@ class RenPyAdapter:
                     "collect_tasks_with_progress",
                     "scan_all_translation_units",
                 ],
-                "p1_writeback": False,
+                "p2_relocation": True,
+                "p2_validation": True,
+                "p2_writeback_plan": True,
+                "validation_schema_version": VALIDATION_SCHEMA_VERSION,
+                "writeback_plan_schema_version": WRITEBACK_PLAN_SCHEMA_VERSION,
             }
         )
 
@@ -1248,20 +1257,351 @@ class RenPyAdapter:
             )
         return tuple(occurrences)
 
+    @staticmethod
+    def _source_snapshot_fingerprint(source_documents: Sequence[SourceDocument]) -> str:
+        return digest_json([
+            document.manifest_entry()
+            for document in sorted(source_documents, key=lambda item: item.file_rel_path)
+        ])
+
+    @classmethod
+    def _project_with_live_sources(
+        cls,
+        project: ProjectDiscovery,
+        live_sources: Sequence[SourceDocument],
+    ) -> ProjectDiscovery:
+        documents = tuple(sorted(live_sources, key=lambda item: item.file_rel_path))
+        source_fingerprint = cls._source_snapshot_fingerprint(documents)
+        project_snapshot_fingerprint = digest_json(
+            {
+                "engine": project.engine,
+                "localization_mode": project.localization_mode.value,
+                "target_language": project.target_language,
+                "source_fingerprint": source_fingerprint,
+            }
+        )
+        return replace(
+            project,
+            source_documents=documents,
+            source_fingerprint=source_fingerprint,
+            project_snapshot_fingerprint=project_snapshot_fingerprint,
+        )
+
+    @staticmethod
+    def _content_fingerprint(document: SourceDocument, unit: translation_core.TranslationUnit) -> str:
+        lines = document.lines()
+        before = lines[unit.line - 1].strip() if unit.line > 0 else ""
+        after = lines[unit.line + 1].strip() if unit.line + 1 < len(lines) else ""
+        return digest_json(
+            {
+                "schema_version": CONTENT_FINGERPRINT_SCHEMA_VERSION,
+                "source": _normalize_fingerprint_text(unit.source_text),
+                "speaker_id": _normalize_fingerprint_text(unit.speaker_id),
+                "speaker_name": _normalize_fingerprint_text(unit.speaker_name),
+                "before": _normalize_fingerprint_text(before),
+                "after": _normalize_fingerprint_text(after),
+            }
+        )
+
+    @staticmethod
+    def _token_counters(legacy: ModuleType, text: str) -> dict[str, Counter[str]]:
+        return {
+            "tag": Counter(legacy.RENPY_TAG_RE.findall(text or "")),
+            "field": Counter(legacy.RENPY_FIELD_RE.findall(text or "")),
+            "percent": Counter(legacy.PERCENT_FORMAT_TOKEN_RE.findall(text or "")),
+        }
+
+    @staticmethod
+    def _counter_payload(counter: Counter[str]) -> dict[str, int]:
+        return {key: counter[key] for key in sorted(counter)}
+
+    @staticmethod
+    def _render_literal(
+        legacy: ModuleType,
+        translated_text: str,
+        prefix: str,
+        quote: str,
+    ) -> str:
+        normalized = translated_text
+        if getattr(legacy, "USE_TRANSLATION_MEMORY", False):
+            normalized = legacy.apply_normalization(normalized)
+        quote = str(quote or '"')
+        quote_char = quote[0]
+        escapes = getattr(
+            legacy,
+            "SPECIAL_ESCAPES",
+            (
+                ("\\\\", "\\\\\\\\"),
+                ('"', '\\"'),
+                ("\\a", "\\\\a"),
+                ("\\b", "\\\\b"),
+                ("\\f", "\\\\f"),
+                ("\\n", "\\\\n"),
+                ("\\r", "\\\\r"),
+                ("\\t", "\\\\t"),
+                ("\\v", "\\\\v"),
+            ),
+        )
+        escaped = str(normalized)
+        for old, new in escapes:
+            if old == quote_char:
+                continue
+            escaped = escaped.replace(old, new)
+        escaped = escaped.replace(quote_char, "\\" + quote_char)
+        return f"{prefix or ''}{quote}{escaped}{quote}"
+
+    @staticmethod
+    def _literal_at_span(line: str, start: int, end: int) -> tuple[str, str] | None:
+        try:
+            tokens = tokenize.generate_tokens(io.StringIO(line).readline)
+            for token in tokens:
+                if token.type != tokenize.STRING:
+                    continue
+                if token.start[1] != start or token.end[1] != end:
+                    continue
+                value = ast.literal_eval(token.string)
+                if isinstance(value, str):
+                    return value, token.string
+        except (IndentationError, SyntaxError, tokenize.TokenError, ValueError):
+            return None
+        return None
+
+    @staticmethod
+    def _relocation_score(original: Occurrence, candidate: Occurrence) -> int | None:
+        original_unit = original.unit
+        candidate_unit = candidate.unit
+        if _normalize_fingerprint_text(original_unit.source_text) != _normalize_fingerprint_text(
+            candidate_unit.source_text
+        ):
+            return None
+        score = 100
+        original_locator = original.locator.locator
+        candidate_locator = candidate.locator.locator
+        if original_unit.file_rel_path == candidate_unit.file_rel_path:
+            score += 25
+        if original_unit.speaker_id == candidate_unit.speaker_id:
+            score += 15
+        if original_unit.speaker_name == candidate_unit.speaker_name:
+            score += 5
+        if original_locator.get("translate_block") == candidate_locator.get("translate_block"):
+            score += 15
+        if original_locator.get("block_occurrence") == candidate_locator.get("block_occurrence"):
+            score += 10
+        if original_locator.get("source_marker_kind") == candidate_locator.get("source_marker_kind"):
+            score += 5
+        if original_locator.get("ordinal") == candidate_locator.get("ordinal"):
+            score += 5
+        if original.content_fingerprint == candidate.content_fingerprint:
+            score += 25
+        return score
+
+    def _validation_reason_codes(
+        self,
+        legacy: ModuleType,
+        source_text: str,
+        translated_text: str,
+        message: str,
+    ) -> tuple[tuple[str, ...], tuple[Mapping[str, Any], ...]]:
+        reason_codes: list[str] = []
+        diagnostics: list[Mapping[str, Any]] = []
+        if not str(translated_text or "").strip():
+            reason_codes.append("common.translation.empty")
+        missing_terms = getattr(legacy, "missing_preserved_terms", lambda *_: [])(
+            source_text, translated_text
+        )
+        if missing_terms:
+            reason_codes.append("common.preserve_term.missing")
+            diagnostics.append({"code": "common.preserve_term.missing", "terms": list(missing_terms)})
+
+        source_tokens = self._token_counters(legacy, source_text)
+        translated_tokens = self._token_counters(legacy, translated_text)
+        token_codes = {
+            "tag": "renpy.tag.changed",
+            "field": "renpy.field.changed",
+            "percent": "renpy.percent_token.changed",
+        }
+        for kind, code in token_codes.items():
+            missing = source_tokens[kind] - translated_tokens[kind]
+            added = translated_tokens[kind] - source_tokens[kind]
+            if missing or added:
+                reason_codes.append(code)
+                if kind == "tag":
+                    if missing:
+                        reason_codes.append("renpy.placeholder.missing")
+                    if added:
+                        reason_codes.append("renpy.placeholder.added")
+                diagnostics.append(
+                    {
+                        "code": code,
+                        "kind": kind,
+                        "missing": self._counter_payload(missing),
+                        "added": self._counter_payload(added),
+                    }
+                )
+        if message == "No Chinese characters":
+            reason_codes.append("common.target_language.missing")
+        if not reason_codes and message and message != "OK":
+            reason_codes.append("renpy.string_literal.unrenderable")
+        if message and message != "OK":
+            diagnostics.append({"message": message})
+        return tuple(dict.fromkeys(reason_codes)), tuple(diagnostics)
+
     def relocate_occurrences(
         self,
         project: ProjectDiscovery,
         occurrences: Sequence[Occurrence],
         live_sources: Sequence[SourceDocument],
     ) -> RelocationResult:
-        raise NotImplementedError("Ren'Py occurrence relocation is intentionally deferred to P2.")
+        if project.engine != self.engine:
+            raise ValueError(f"RenPyAdapter cannot relocate engine={project.engine!r}.")
+        live_project = self._project_with_live_sources(project, live_sources)
+        live_inventory = self.inventory_candidates(live_project, InventoryPolicy())
+        approved_ids = [
+            candidate.candidate_id
+            for candidate in live_inventory.candidates
+            if candidate.classification in {"translatable", "already_translated"}
+        ]
+        live_occurrences = tuple(
+            self.extract_occurrences(live_project, live_inventory, approved_ids)
+        )
+        live_by_unit_id: dict[str, list[Occurrence]] = {}
+        for candidate in live_occurrences:
+            live_by_unit_id.setdefault(candidate.unit.id, []).append(candidate)
+
+        relocated: list[Occurrence] = []
+        unresolved: list[str] = []
+        diagnostics: list[Mapping[str, Any]] = []
+        used_live_ids: set[str] = set()
+        for original in occurrences:
+            if original.engine != self.engine:
+                raise ValueError(f"RenPyAdapter cannot relocate engine={original.engine!r}.")
+            exact_candidates = [
+                candidate
+                for candidate in live_by_unit_id.get(original.unit.id, [])
+                if candidate.occurrence_id not in used_live_ids
+            ]
+            match = exact_candidates[0] if len(exact_candidates) == 1 else None
+            match_kind = "identity_v2" if match is not None else "content_evidence"
+            score = None
+            if match is None:
+                scored = []
+                for candidate in live_occurrences:
+                    if candidate.occurrence_id in used_live_ids:
+                        continue
+                    candidate_score = self._relocation_score(original, candidate)
+                    if candidate_score is not None:
+                        scored.append((candidate_score, candidate))
+                scored.sort(key=lambda item: item[0], reverse=True)
+                if scored and (len(scored) == 1 or scored[0][0] > scored[1][0]):
+                    score, match = scored[0]
+                elif scored:
+                    diagnostics.append(
+                        {
+                            "occurrence_id": original.occurrence_id,
+                            "reason_code": "common.locator.unresolved",
+                            "status": "ambiguous",
+                            "candidate_count": len(scored),
+                        }
+                    )
+            if match is None:
+                unresolved.append(original.occurrence_id)
+                if not any(item.get("occurrence_id") == original.occurrence_id for item in diagnostics):
+                    diagnostics.append(
+                        {
+                            "occurrence_id": original.occurrence_id,
+                            "reason_code": "common.locator.unresolved",
+                            "status": "missing",
+                        }
+                    )
+                continue
+            used_live_ids.add(match.occurrence_id)
+            updated_unit = replace(match.unit, id=original.unit.id, mode=original.unit.mode)
+            relocated_occurrence_id = "occ1:" + digest_json(
+                {
+                    "engine": self.engine,
+                    "project_snapshot_fingerprint": live_project.project_snapshot_fingerprint,
+                    "locator": match.locator.to_dict(),
+                }
+            )
+            relocated.append(
+                replace(
+                    match,
+                    occurrence_id=relocated_occurrence_id,
+                    project_snapshot_fingerprint=live_project.project_snapshot_fingerprint,
+                    unit=updated_unit,
+                )
+            )
+            diagnostics.append(
+                {
+                    "occurrence_id": original.occurrence_id,
+                    "status": "relocated",
+                    "match": match_kind,
+                    "score": score,
+                    "live_occurrence_id": relocated_occurrence_id,
+                    "file_rel_path": updated_unit.file_rel_path,
+                    "line": updated_unit.line,
+                }
+            )
+        return RelocationResult(
+            occurrences=tuple(relocated),
+            unresolved_occurrence_ids=tuple(unresolved),
+            diagnostics=tuple(diagnostics),
+        )
 
     def validate_translation(
         self,
         occurrence: Occurrence,
         translated_text: str,
     ) -> ValidationResult:
-        raise NotImplementedError("Ren'Py engine validation is intentionally deferred to P2.")
+        if occurrence.engine != self.engine:
+            raise ValueError(f"RenPyAdapter cannot validate engine={occurrence.engine!r}.")
+        legacy = self._legacy()
+        source_text = occurrence.unit.source_text
+        translated_text = str(translated_text or "")
+        try:
+            valid, message = legacy.validate_translation(source_text, translated_text)
+        except Exception as exc:
+            valid, message = False, f"Validation failed: {type(exc).__name__}: {exc}"
+        reason_codes, diagnostics = self._validation_reason_codes(
+            legacy, source_text, translated_text, str(message or "")
+        )
+        if valid:
+            try:
+                self._render_literal(
+                    legacy, translated_text, occurrence.unit.prefix, occurrence.unit.quote
+                )
+            except Exception as exc:
+                valid = False
+                reason_codes = tuple(dict.fromkeys((*reason_codes, "renpy.string_literal.unrenderable")))
+                diagnostics = (*diagnostics, {"code": "renpy.string_literal.unrenderable", "message": str(exc)})
+        normalized = translated_text
+        if getattr(legacy, "USE_TRANSLATION_MEMORY", False):
+            normalized = legacy.apply_normalization(translated_text)
+        source_constraints_digest = digest_json(
+            {
+                "source": source_text,
+                "tokens": {
+                    kind: self._counter_payload(counter)
+                    for kind, counter in self._token_counters(legacy, source_text).items()
+                },
+            }
+        )
+        translation_digest = digest_json(
+            {
+                "validation_schema_version": VALIDATION_SCHEMA_VERSION,
+                "translation": normalized,
+            }
+        )
+        return ValidationResult(
+            occurrence_id=occurrence.occurrence_id,
+            engine=self.engine,
+            status="pass" if valid else "block",
+            reason_codes=tuple(reason_codes),
+            diagnostics=tuple(diagnostics),
+            source_constraints_digest=source_constraints_digest,
+            translation_digest=translation_digest,
+            normalized_translation=normalized if normalized != translated_text else None,
+        )
 
     def build_writeback_plan(
         self,
@@ -1269,7 +1609,112 @@ class RenPyAdapter:
         validated: Sequence[ValidatedTranslation],
         live_sources: Sequence[SourceDocument],
     ) -> WritebackPlan:
-        raise NotImplementedError("Ren'Py declarative writeback is intentionally deferred to P2.")
+        if project.engine != self.engine:
+            raise ValueError(f"RenPyAdapter cannot build a plan for engine={project.engine!r}.")
+        documents = {document.file_rel_path: document for document in live_sources}
+        source_snapshot_fingerprint = self._source_snapshot_fingerprint(live_sources)
+        operations: list[WritebackOperation] = []
+        spans: list[tuple[str, int, int, int]] = []
+        legacy = self._legacy()
+        for item in validated:
+            occurrence = item.occurrence
+            if occurrence.engine != self.engine:
+                raise ValueError(f"Unsupported occurrence engine: {occurrence.engine!r}")
+            if item.validation.status != "pass":
+                raise ValueError(
+                    "Cannot build writeback plan for non-pass validation: "
+                    + ",".join(item.validation.reason_codes)
+                )
+            unit = occurrence.unit
+            rel_path = _normalize_rel_path(unit.file_rel_path)
+            document = documents.get(rel_path)
+            if document is None:
+                raise ValueError(f"Writeback source document missing: {rel_path}")
+            lines = document.lines()
+            if unit.line < 0 or unit.line >= len(lines):
+                raise ValueError(f"Writeback source line missing: {rel_path}:{unit.line}")
+            if unit.start < 0 or unit.end > len(lines[unit.line]) or unit.start >= unit.end:
+                raise ValueError(f"Writeback span invalid: {rel_path}:{unit.line}:{unit.start}-{unit.end}")
+            raw_fragment = lines[unit.line][unit.start:unit.end]
+            literal = self._literal_at_span(lines[unit.line], unit.start, unit.end)
+            if literal is None or literal[0] != unit.text:
+                raise ValueError(f"Writeback span/source mismatch: {rel_path}:{unit.line}")
+            span = (rel_path, unit.line, unit.start, unit.end)
+            if any(
+                existing[0] == rel_path
+                and existing[1] == unit.line
+                and max(existing[2], unit.start) < min(existing[3], unit.end)
+                for existing in spans
+            ):
+                raise ValueError(f"Overlapping writeback span: {rel_path}:{unit.line}")
+            spans.append(span)
+            replacement_fragment = self._render_literal(
+                legacy, item.translated_text, unit.prefix, unit.quote
+            )
+            operation_payload = {
+                "kind": "text_span_replace",
+                "occurrence_id": occurrence.occurrence_id,
+                "target_root": "localization_catalog",
+                "target_rel_path": rel_path,
+                "expected_file_sha256": document.sha256,
+                "line": unit.line,
+                "start_col": unit.start,
+                "end_col": unit.end,
+                "expected_fragment_sha256": _sha256_bytes(raw_fragment.encode("utf-8")),
+                "expected_text_digest": _sha256_bytes(unit.text.encode("utf-8")),
+                "replacement_fragment": replacement_fragment,
+                "validation_digest": digest_json(item.validation.to_dict()),
+            }
+            operations.append(
+                WritebackOperation(
+                    operation_id="op1:" + digest_json(operation_payload),
+                    **operation_payload,
+                )
+            )
+        operations.sort(
+            key=lambda operation: (
+                operation.target_rel_path,
+                operation.line,
+                operation.start_col,
+                operation.operation_id,
+            )
+        )
+        project_identity_digest = digest_json(
+            {
+                "engine": project.engine,
+                "target_language": project.target_language,
+                "localization_mode": project.localization_mode.value,
+                "localization_root": os.path.realpath(project.localization_root),
+            }
+        )
+        coverage_digest = str(
+            project.coverage_digest or project.catalog_provenance.get("coverage_digest") or ""
+        )
+        coverage_review_digest = str(
+            project.coverage_review_digest
+            or project.catalog_provenance.get("coverage_review_digest")
+            or ""
+        )
+        plan_payload = {
+            "writeback_plan_schema_version": WRITEBACK_PLAN_SCHEMA_VERSION,
+            "engine": self.engine,
+            "adapter_version": self.adapter_version,
+            "project_identity_digest": project_identity_digest,
+            "source_snapshot_fingerprint": source_snapshot_fingerprint,
+            "coverage_digest": coverage_digest,
+            "coverage_review_digest": coverage_review_digest,
+            "operations": [operation.to_dict() for operation in operations],
+        }
+        return WritebackPlan(
+            engine=self.engine,
+            adapter_version=self.adapter_version,
+            project_identity_digest=project_identity_digest,
+            source_snapshot_fingerprint=source_snapshot_fingerprint,
+            coverage_digest=coverage_digest,
+            coverage_review_digest=coverage_review_digest,
+            operations=tuple(operations),
+            plan_digest=digest_json(plan_payload),
+        )
 
 
 def build_translation_snapshot(
@@ -1288,6 +1733,7 @@ def build_translation_snapshot(
         draft,
         adapter_behavior_digest=adapter.behavior_digest(),
     )
+    project = replace(project, coverage_digest=report.coverage_digest)
     approved_ids = [
         candidate.candidate_id
         for candidate in inventory.candidates

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -1331,6 +1331,8 @@ class RenPyAdapter:
     def _relocation_score(original: Occurrence, candidate: Occurrence) -> int | None:
         original_unit = original.unit
         candidate_unit = candidate.unit
+        if original_unit.file_rel_path != candidate_unit.file_rel_path:
+            return None
         if _normalize_fingerprint_text(original_unit.source_text) != _normalize_fingerprint_text(
             candidate_unit.source_text
         ):

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -57,6 +57,9 @@ from .writeback import source_snapshot_fingerprint
 
 ADAPTER_VERSION = "1.1.0"
 LOCATOR_SCHEMA_VERSION = 1
+# Same-file + same-source alone scores 125. Content-evidence matches must also
+# share at least one structural signal (speaker / block / marker / fingerprint).
+CONTENT_EVIDENCE_MIN_SCORE = 150
 
 
 @dataclass(frozen=True)
@@ -1456,13 +1459,27 @@ class RenPyAdapter:
                         scored.append((candidate_score, candidate))
                 scored.sort(key=lambda item: item[0], reverse=True)
                 if scored and (len(scored) == 1 or scored[0][0] > scored[1][0]):
-                    score, match = scored[0]
+                    top_score, top_match = scored[0]
+                    if top_score >= CONTENT_EVIDENCE_MIN_SCORE:
+                        score, match = top_score, top_match
+                    else:
+                        diagnostics.append(
+                            {
+                                "occurrence_id": original.occurrence_id,
+                                "reason_code": "common.locator.unresolved",
+                                "status": "weak_content_evidence",
+                                "score": top_score,
+                                "min_score": CONTENT_EVIDENCE_MIN_SCORE,
+                                "candidate_count": len(scored),
+                            }
+                        )
                 elif scored:
                     diagnostics.append(
                         {
                             "occurrence_id": original.occurrence_id,
                             "reason_code": "common.locator.unresolved",
                             "status": "ambiguous",
+                            "score": scored[0][0],
                             "candidate_count": len(scored),
                         }
                     )

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -52,6 +52,7 @@ from .coverage import (
     classification_rules_digest,
     digest_json,
 )
+from .writeback import source_snapshot_fingerprint
 
 
 ADAPTER_VERSION = "1.1.0"
@@ -1224,19 +1225,9 @@ class RenPyAdapter:
 
             unit = candidate.unit
             document = documents.get(unit.file_rel_path)
-            lines = document.lines() if document is not None else []
-            before = lines[unit.line - 1].strip() if unit.line > 0 else ""
-            after = lines[unit.line + 1].strip() if unit.line + 1 < len(lines) else ""
-            content_fingerprint = digest_json(
-                {
-                    "schema_version": CONTENT_FINGERPRINT_SCHEMA_VERSION,
-                    "source": _normalize_fingerprint_text(unit.source_text),
-                    "speaker_id": _normalize_fingerprint_text(unit.speaker_id),
-                    "speaker_name": _normalize_fingerprint_text(unit.speaker_name),
-                    "before": _normalize_fingerprint_text(before),
-                    "after": _normalize_fingerprint_text(after),
-                }
-            )
+            if document is None:
+                raise ValueError(f"Candidate source document is missing: {unit.file_rel_path}")
+            content_fingerprint = self._content_fingerprint(document, unit)
             occurrence_id = "occ1:" + digest_json(
                 {
                     "engine": self.engine,
@@ -1257,13 +1248,6 @@ class RenPyAdapter:
             )
         return tuple(occurrences)
 
-    @staticmethod
-    def _source_snapshot_fingerprint(source_documents: Sequence[SourceDocument]) -> str:
-        return digest_json([
-            document.manifest_entry()
-            for document in sorted(source_documents, key=lambda item: item.file_rel_path)
-        ])
-
     @classmethod
     def _project_with_live_sources(
         cls,
@@ -1271,7 +1255,7 @@ class RenPyAdapter:
         live_sources: Sequence[SourceDocument],
     ) -> ProjectDiscovery:
         documents = tuple(sorted(live_sources, key=lambda item: item.file_rel_path))
-        source_fingerprint = cls._source_snapshot_fingerprint(documents)
+        source_fingerprint = source_snapshot_fingerprint(documents)
         project_snapshot_fingerprint = digest_json(
             {
                 "engine": project.engine,
@@ -1325,30 +1309,7 @@ class RenPyAdapter:
         normalized = translated_text
         if getattr(legacy, "USE_TRANSLATION_MEMORY", False):
             normalized = legacy.apply_normalization(normalized)
-        quote = str(quote or '"')
-        quote_char = quote[0]
-        escapes = getattr(
-            legacy,
-            "SPECIAL_ESCAPES",
-            (
-                ("\\\\", "\\\\\\\\"),
-                ('"', '\\"'),
-                ("\\a", "\\\\a"),
-                ("\\b", "\\\\b"),
-                ("\\f", "\\\\f"),
-                ("\\n", "\\\\n"),
-                ("\\r", "\\\\r"),
-                ("\\t", "\\\\t"),
-                ("\\v", "\\\\v"),
-            ),
-        )
-        escaped = str(normalized)
-        for old, new in escapes:
-            if old == quote_char:
-                continue
-            escaped = escaped.replace(old, new)
-        escaped = escaped.replace(quote_char, "\\" + quote_char)
-        return f"{prefix or ''}{quote}{escaped}{quote}"
+        return legacy.quote_with(normalized, str(quote or '"'), prefix=prefix or "")
 
     @staticmethod
     def _literal_at_span(line: str, start: int, end: int) -> tuple[str, str] | None:
@@ -1612,7 +1573,7 @@ class RenPyAdapter:
         if project.engine != self.engine:
             raise ValueError(f"RenPyAdapter cannot build a plan for engine={project.engine!r}.")
         documents = {document.file_rel_path: document for document in live_sources}
-        source_snapshot_fingerprint = self._source_snapshot_fingerprint(live_sources)
+        live_source_fingerprint = source_snapshot_fingerprint(live_sources)
         operations: list[WritebackOperation] = []
         spans: list[tuple[str, int, int, int]] = []
         legacy = self._legacy()
@@ -1700,7 +1661,7 @@ class RenPyAdapter:
             "engine": self.engine,
             "adapter_version": self.adapter_version,
             "project_identity_digest": project_identity_digest,
-            "source_snapshot_fingerprint": source_snapshot_fingerprint,
+            "source_snapshot_fingerprint": live_source_fingerprint,
             "coverage_digest": coverage_digest,
             "coverage_review_digest": coverage_review_digest,
             "operations": [operation.to_dict() for operation in operations],
@@ -1709,7 +1670,7 @@ class RenPyAdapter:
             engine=self.engine,
             adapter_version=self.adapter_version,
             project_identity_digest=project_identity_digest,
-            source_snapshot_fingerprint=source_snapshot_fingerprint,
+            source_snapshot_fingerprint=live_source_fingerprint,
             coverage_digest=coverage_digest,
             coverage_review_digest=coverage_review_digest,
             operations=tuple(operations),

--- a/engine_adapters/writeback.py
+++ b/engine_adapters/writeback.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import ntpath
-from typing import Mapping, Sequence
+from typing import Mapping, NoReturn, Sequence
 
 from .contracts import (
     WRITEBACK_PLAN_SCHEMA_VERSION,
@@ -73,7 +73,7 @@ def _operation_payload(operation: WritebackOperation) -> dict:
     return payload
 
 
-def _fail(reason_code: str, message: str) -> None:
+def _fail(reason_code: str, message: str) -> NoReturn:
     raise WritebackPlanError(reason_code, message)
 
 

--- a/engine_adapters/writeback.py
+++ b/engine_adapters/writeback.py
@@ -1,0 +1,259 @@
+"""Common validation and rendering for declarative adapter writeback plans.
+
+Adapters describe safe text-span operations.  This module re-checks the plan
+against the live source snapshot and renders changed lines in memory.  It has
+no filesystem write authority; workflow code remains responsible for path
+resolution, transaction journaling, and atomic writes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ntpath
+from typing import Mapping, Sequence
+
+from .contracts import (
+    WRITEBACK_PLAN_SCHEMA_VERSION,
+    SourceDocument,
+    WritebackOperation,
+    WritebackPlan,
+)
+from .coverage import digest_json
+
+
+class WritebackPlanError(ValueError):
+    """Raised when a declarative writeback plan is not safe to consume."""
+
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def source_snapshot_fingerprint(source_documents: Sequence[SourceDocument]) -> str:
+    """Return the common source snapshot digest used by adapter plans."""
+
+    return digest_json(
+        [
+            document.manifest_entry()
+            for document in sorted(source_documents, key=lambda item: item.file_rel_path)
+        ]
+    )
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normal_relative_path(value: str) -> str:
+    raw = str(value or "")
+    if not raw or ntpath.isabs(raw) or ntpath.splitdrive(raw)[0]:
+        raise WritebackPlanError(
+            "common.writeback.path_escape",
+            f"Writeback target must be a relative path: {value!r}",
+        )
+    normalized = raw.replace("\\", "/")
+    parts = normalized.split("/")
+    if any(not part or part == "." or part == ".." for part in parts):
+        raise WritebackPlanError(
+            "common.writeback.path_escape",
+            f"Writeback target contains an unsafe path component: {value!r}",
+        )
+    return "/".join(parts)
+
+
+def _plan_payload(plan: WritebackPlan) -> dict:
+    payload = plan.to_dict()
+    payload.pop("plan_digest", None)
+    return payload
+
+
+def _operation_payload(operation: WritebackOperation) -> dict:
+    payload = operation.to_dict()
+    payload.pop("operation_id", None)
+    return payload
+
+
+def _fail(reason_code: str, message: str) -> None:
+    raise WritebackPlanError(reason_code, message)
+
+
+def _validate_operation(
+    operation: WritebackOperation,
+    documents: Mapping[str, SourceDocument],
+    spans: list[tuple[str, int, int, int]],
+) -> tuple[str, SourceDocument, list[str]]:
+    if operation.kind != "text_span_replace":
+        _fail(
+            "common.writeback.operation_unsupported",
+            f"Unsupported writeback operation kind: {operation.kind!r}",
+        )
+    if operation.target_root != "localization_catalog":
+        _fail(
+            "common.writeback.target_root_unsupported",
+            f"Unsupported writeback target root: {operation.target_root!r}",
+        )
+    if any(
+        not str(value or "")
+        for value in (
+            operation.occurrence_id,
+            operation.expected_file_sha256,
+            operation.expected_fragment_sha256,
+            operation.expected_text_digest,
+            operation.validation_digest,
+        )
+    ):
+        _fail(
+            "common.writeback.plan_invalid",
+            f"Writeback operation is missing required integrity fields: {operation.operation_id!r}",
+        )
+    if not operation.operation_id.startswith("op1:"):
+        _fail(
+            "common.writeback.plan_digest_mismatch",
+            f"Invalid writeback operation id: {operation.operation_id!r}",
+        )
+    if digest_json(_operation_payload(operation)) != operation.operation_id[4:]:
+        _fail(
+            "common.writeback.plan_digest_mismatch",
+            f"Writeback operation digest mismatch: {operation.operation_id!r}",
+        )
+
+    rel_path = _normal_relative_path(operation.target_rel_path)
+    if rel_path != operation.target_rel_path:
+        _fail(
+            "common.writeback.path_escape",
+            f"Writeback target path is not normalized: {operation.target_rel_path!r}",
+        )
+    document = documents.get(rel_path)
+    if document is None:
+        _fail(
+            "common.writeback.target_missing",
+            f"Writeback target is not in the live source snapshot: {rel_path}",
+        )
+    if operation.expected_file_sha256 != document.sha256:
+        _fail(
+            "common.writeback.source_snapshot_mismatch",
+            f"Writeback target file changed: {rel_path}",
+        )
+    lines = document.lines()
+    if operation.line < 0 or operation.line >= len(lines):
+        _fail(
+            "common.writeback.span_invalid",
+            f"Writeback line is outside the live file: {rel_path}:{operation.line}",
+        )
+    line = lines[operation.line]
+    if (
+        operation.start_col < 0
+        or operation.end_col <= operation.start_col
+        or operation.end_col > len(line)
+    ):
+        _fail(
+            "common.writeback.span_invalid",
+            f"Writeback span is outside the live line: {rel_path}:{operation.line}",
+        )
+    if "\n" in operation.replacement_fragment or "\r" in operation.replacement_fragment:
+        _fail(
+            "common.writeback.replacement_invalid",
+            f"Writeback replacement must stay on one line: {rel_path}:{operation.line}",
+        )
+    raw_fragment = line[operation.start_col : operation.end_col]
+    if _sha256_text(raw_fragment) != operation.expected_fragment_sha256:
+        _fail(
+            "common.writeback.span_mismatch",
+            f"Writeback span no longer matches the planned fragment: {rel_path}:{operation.line}",
+        )
+    if not operation.validation_digest:
+        _fail(
+            "common.writeback.validation_missing",
+            f"Writeback operation has no validation digest: {operation.occurrence_id}",
+        )
+
+    span = (rel_path, operation.line, operation.start_col, operation.end_col)
+    for existing in spans:
+        if (
+            existing[0] == span[0]
+            and existing[1] == span[1]
+            and max(existing[2], span[2]) < min(existing[3], span[3])
+        ):
+            _fail(
+                "common.writeback.span_overlap",
+                f"Overlapping writeback spans: {rel_path}:{operation.line}",
+            )
+    spans.append(span)
+    return rel_path, document, lines
+
+
+def validate_writeback_plan(
+    plan: WritebackPlan,
+    live_sources: Sequence[SourceDocument],
+) -> tuple[tuple[str, WritebackOperation, SourceDocument], ...]:
+    """Validate a plan against live documents and return normalized operations.
+
+    The returned tuple is metadata only.  No file is opened for writing and no
+    adapter-specific rendering is performed here.
+    """
+
+    if plan.writeback_plan_schema_version != WRITEBACK_PLAN_SCHEMA_VERSION:
+        _fail(
+            "common.writeback.schema_unsupported",
+            f"Unsupported writeback plan schema: {plan.writeback_plan_schema_version}",
+        )
+    if not plan.engine or not plan.adapter_version:
+        _fail(
+            "common.writeback.plan_invalid",
+            "Writeback plan must identify its engine and adapter version.",
+        )
+    if source_snapshot_fingerprint(live_sources) != plan.source_snapshot_fingerprint:
+        _fail(
+            "common.writeback.source_snapshot_mismatch",
+            "Writeback plan source snapshot does not match live sources.",
+        )
+    if digest_json(_plan_payload(plan)) != plan.plan_digest:
+        _fail(
+            "common.writeback.plan_digest_mismatch",
+            "Writeback plan digest does not match its payload.",
+        )
+
+    documents: dict[str, SourceDocument] = {}
+    for document in live_sources:
+        rel_path = _normal_relative_path(document.file_rel_path)
+        if rel_path in documents:
+            _fail(
+                "common.writeback.plan_invalid",
+                f"Duplicate live source document: {rel_path}",
+            )
+        documents[rel_path] = document
+    spans: list[tuple[str, int, int, int]] = []
+    validated: list[tuple[str, WritebackOperation, SourceDocument]] = []
+    for operation in plan.operations:
+        rel_path, document, _lines = _validate_operation(operation, documents, spans)
+        validated.append((rel_path, operation, document))
+    return tuple(validated)
+
+
+def render_writeback_plan(
+    plan: WritebackPlan,
+    live_sources: Sequence[SourceDocument],
+) -> dict[str, list[str]]:
+    """Render a validated plan into changed in-memory line arrays.
+
+    Callers must pass the result to their existing atomic writer.  This
+    function deliberately never resolves paths or mutates source documents.
+    """
+
+    validated = validate_writeback_plan(plan, live_sources)
+    validated = tuple(
+        sorted(
+            validated,
+            key=lambda item: (item[0], item[1].line, item[1].start_col),
+            reverse=True,
+        )
+    )
+    rendered: dict[str, list[str]] = {}
+    for rel_path, operation, document in validated:
+        lines = rendered.setdefault(rel_path, list(document.lines()))
+        lines[operation.line] = (
+            lines[operation.line][: operation.start_col]
+            + operation.replacement_fragment
+            + lines[operation.line][operation.end_col :]
+        )
+    return rendered

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -38,9 +38,16 @@ import batch_submit_recovery
 import cli_contract
 import cli_discovery
 import doctor_recommendations as doctor_rec
-from engine_adapters.contracts import ProjectDiscoveryRequest
+from engine_adapters.contracts import (
+    ProjectDiscoveryRequest,
+    ValidatedTranslation,
+)
 from engine_adapters.coverage import export_coverage_package
 from engine_adapters.renpy import RenPyAdapter, build_translation_snapshot
+from engine_adapters.writeback import (
+    WritebackPlanError,
+    render_writeback_plan,
+)
 import keyword_glossary_merge
 import model_usage_ledger
 import prompt_context
@@ -170,6 +177,7 @@ CHECK_BLOCK_REASON_CODES = {
     'target_file_missing',
     'target_file_path_escaped',
     'v2_relocation_missing',
+    'adapter_writeback_block',
 }
 
 RAG_ENABLED = False
@@ -6330,6 +6338,198 @@ def validate_result_replacements(manifest, replacements_by_file, summary):
     return validated_replacements, validated_lines_by_file, failure_entries
 
 
+def _adapter_request_for_manifest(manifest, file_keys):
+    identity = {}
+    try:
+        identity = manifest_project_identity(manifest)
+    except (Exception, SystemExit):
+        identity = {}
+
+    tl_dir = str(identity.get('tl_dir') or getattr(legacy, 'TL_DIR', '') or '')
+    if not tl_dir:
+        for file_key in file_keys:
+            file_info = (manifest.get('files') or {}).get(file_key) or {}
+            path_value = file_info.get('path') if isinstance(file_info, dict) else ''
+            if not path_value or not os.path.isabs(path_value):
+                continue
+            try:
+                rel_path = normalize_safe_rel_path(file_key, f'manifest file key {file_key}')
+                candidate = _canonical_abs_path(path_value)
+                for _part in Path(rel_path).parts:
+                    candidate = os.path.dirname(candidate)
+                tl_dir = candidate
+                break
+            except (Exception, SystemExit):
+                continue
+    if not tl_dir:
+        raise WritebackPlanError(
+            'common.writeback.project_mismatch',
+            "Cannot determine the live Ren'Py localization directory for writeback.",
+        )
+
+    project_root = str(
+        identity.get('base_dir')
+        or getattr(legacy, 'BASE_DIR', '')
+        or os.path.dirname(tl_dir)
+    )
+    return ProjectDiscoveryRequest(
+        project_root=project_root,
+        localization_root=tl_dir,
+        target_language=str(
+            manifest.get('target_language')
+            or manifest.get('language')
+            or getattr(legacy, 'PREP_LANGUAGE', '')
+            or ''
+        ),
+        include_files=tuple(sorted(str(value) for value in file_keys)),
+    )
+
+
+def _find_adapter_occurrence(occurrences, file_key, line, start, end, expected_text, item_id):
+    if item_id:
+        by_id = [
+            occurrence
+            for occurrence in occurrences
+            if occurrence.unit.id == item_id
+            and occurrence.unit.file_rel_path == file_key
+        ]
+        if len(by_id) == 1:
+            return by_id[0]
+
+    positioned = [
+        occurrence
+        for occurrence in occurrences
+        if occurrence.unit.file_rel_path == file_key
+        and occurrence.unit.line == line
+        and occurrence.unit.start == start
+        and occurrence.unit.end == end
+        and expected_text
+        in {
+            occurrence.unit.text,
+            occurrence.unit.source_text,
+            occurrence.unit.current_translation,
+        }
+    ]
+    if len(positioned) == 1:
+        return positioned[0]
+    if len(positioned) > 1:
+        raise WritebackPlanError(
+            'common.locator.unresolved',
+            f'Ambiguous adapter occurrence at {file_key}:{line}:{start}-{end}.',
+        )
+    raise WritebackPlanError(
+        'common.locator.unresolved',
+        f'Adapter occurrence could not be resolved at {file_key}:{line}:{start}-{end}.',
+    )
+
+
+def _build_adapter_writeback_plan(manifest, replacements_by_file):
+    file_keys = tuple(
+        sorted(
+            file_key
+            for file_key, replacements_by_line in replacements_by_file.items()
+            if any(replacements_by_line.values())
+        )
+    )
+    if not file_keys:
+        return None, None
+
+    request = _adapter_request_for_manifest(manifest, file_keys)
+    adapter = RenPyAdapter(legacy_module=legacy)
+    snapshot = build_translation_snapshot(adapter, request)
+    validated = []
+    used_occurrence_ids = set()
+    occurrences = tuple(snapshot.occurrences)
+
+    for file_key in file_keys:
+        replacements_by_line = replacements_by_file.get(file_key) or {}
+        for line, replacements in replacements_by_line.items():
+            for replacement in replacements:
+                start, end, translated, _prefix, _quote, expected_text, item_id, _chunk_key = (
+                    unpack_replacement_for_validation(replacement)
+                )
+                occurrence = _find_adapter_occurrence(
+                    occurrences,
+                    file_key,
+                    int(line),
+                    int(start),
+                    int(end),
+                    str(expected_text or ''),
+                    str(item_id or ''),
+                )
+                if occurrence.occurrence_id in used_occurrence_ids:
+                    raise WritebackPlanError(
+                        'common.writeback.span_overlap',
+                        f'Duplicate adapter occurrence in writeback: {file_key}:{line}:{start}-{end}.',
+                    )
+                used_occurrence_ids.add(occurrence.occurrence_id)
+                validation = adapter.validate_translation(
+                    occurrence,
+                    str(translated or ''),
+                )
+                if validation.status != 'pass':
+                    codes = ','.join(validation.reason_codes) or 'adapter.validation.block'
+                    raise WritebackPlanError(
+                        'adapter.validation.block',
+                        f'Adapter validation blocked {file_key}:{line}: {codes}.',
+                    )
+                validated.append(
+                    ValidatedTranslation(
+                        occurrence=occurrence,
+                        translated_text=str(translated or ''),
+                        validation=validation,
+                    )
+                )
+
+    plan = adapter.build_writeback_plan(
+        snapshot.project,
+        tuple(validated),
+        snapshot.project.source_documents,
+    )
+    return plan, snapshot
+
+
+def _validate_adapter_writeback_plan(
+    manifest,
+    replacements_by_file,
+    summary,
+    failure_entries,
+):
+    if not any(
+        any(replacements_by_line.values())
+        for replacements_by_line in replacements_by_file.values()
+    ):
+        summary['adapter_writeback_status'] = 'empty'
+        summary['adapter_writeback_operations'] = 0
+        return None, None
+    try:
+        plan, snapshot = _build_adapter_writeback_plan(
+            manifest,
+            replacements_by_file,
+        )
+        render_writeback_plan(plan, snapshot.project.source_documents)
+    except (Exception, SystemExit) as exc:
+        reason_code = getattr(exc, 'reason_code', '') or 'adapter_writeback_block'
+        bump_counter(summary['reason_counts'], 'adapter_writeback_block')
+        failure_entries.append(
+            make_failure_entry(
+                manifest,
+                f'Adapter writeback plan blocked: {exc}',
+                reason_code='adapter_writeback_block',
+                adapter_reason_code=reason_code,
+            )
+        )
+        summary['adapter_writeback_status'] = 'block'
+        summary['adapter_writeback_plan_digest'] = ''
+        summary['adapter_writeback_operations'] = 0
+        return None, None
+
+    summary['adapter_writeback_status'] = 'pass'
+    summary['adapter_writeback_plan_digest'] = plan.plan_digest
+    summary['adapter_writeback_operations'] = len(plan.operations)
+    return plan, snapshot
+
+
 def summarize_pending_replacements(replacements_by_file, translated_lines_by_file, summary):
     summary.setdefault('candidate_valid_items', summary.get('valid_items', 0))
     summary.setdefault('source_mismatch_items', 0)
@@ -6786,6 +6986,15 @@ def collect_revision_actions(manifest, validate_sources=False):
         )
         failure_entries.extend(validation_failures)
         preview_entries = reconcile_revision_preview_entries(preview_entries, validation_failures)
+        _plan, _snapshot = _validate_adapter_writeback_plan(
+            manifest,
+            replacements_by_file,
+            summary,
+            failure_entries,
+        )
+        if summary.get('adapter_writeback_status') == 'block':
+            replacements_by_file.clear()
+            revised_lines_by_file.clear()
         summary['failure_items'] = len(failure_entries)
     else:
         summarize_pending_replacements(replacements_by_file, revised_lines_by_file, summary)
@@ -7251,6 +7460,15 @@ def collect_result_actions(manifest, validate_sources=False):
             summary,
         )
         failure_entries.extend(validation_failures)
+        _plan, _snapshot = _validate_adapter_writeback_plan(
+            manifest,
+            replacements_by_file,
+            summary,
+            failure_entries,
+        )
+        if summary.get('adapter_writeback_status') == 'block':
+            replacements_by_file.clear()
+            translated_lines_by_file.clear()
         summary['failure_items'] = len(failure_entries)
     else:
         summarize_pending_replacements(replacements_by_file, translated_lines_by_file, summary)
@@ -7518,6 +7736,12 @@ def apply_results(target=None, force=False):
         revalidated_file_paths[file_key] = file_path
         revalidated_file_lines[file_key] = lines
 
+    adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
+        manifest,
+        revalidated_replacements_by_file,
+        summary,
+        failure_entries,
+    )
     attach_check_contract(manifest, summary)
     if summary.get('safety_level') != CHECK_SAFETY_SAFE:
         append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
@@ -7533,18 +7757,19 @@ def apply_results(target=None, force=False):
         raise SystemExit(f'Apply refused because source revalidation is not safe. Report: {report_path}')
 
     writeback_files = []
-    for file_key, replacements in revalidated_replacements_by_file.items():
-        if not replacements:
-            continue
-        writeback_files.append(
-            (
-                revalidated_file_paths[file_key],
-                legacy.render_replacement_lines(
-                    revalidated_file_lines[file_key],
-                    replacements,
-                ),
-            )
+    if adapter_plan is not None and adapter_snapshot is not None:
+        rendered_by_file = render_writeback_plan(
+            adapter_plan,
+            adapter_snapshot.project.source_documents,
         )
+        for file_key in revalidated_replacements_by_file:
+            if not revalidated_replacements_by_file[file_key]:
+                continue
+            rendered_lines = rendered_by_file.get(file_key)
+            if rendered_lines is not None:
+                writeback_files.append(
+                    (revalidated_file_paths[file_key], rendered_lines)
+                )
     if writeback_files:
         atomic_write_many_lines(
             writeback_files,
@@ -7627,7 +7852,8 @@ def apply_revisions(target=None, force=False):
     final_pending_files = 0
     final_pending_lines = 0
     rag_jobs = []
-    writeback_files = []
+    revalidated_replacements_by_file = {}
+    revalidated_file_paths = {}
     revision_updates = []
     for file_key, replacements in replacements_by_file.items():
         file_info = manifest['files'].get(file_key)
@@ -7652,11 +7878,36 @@ def apply_revisions(target=None, force=False):
         if not replacements and not line_numbers_set:
             continue
         if replacements:
-            writeback_files.append(
-                (file_path, legacy.render_replacement_lines(lines, replacements))
-            )
+            revalidated_replacements_by_file[file_key] = replacements
+            revalidated_file_paths[file_key] = file_path
         line_numbers = sorted(line_numbers_set)
         revision_updates.append((file_key, line_numbers, file_path))
+
+    adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
+        manifest,
+        revalidated_replacements_by_file,
+        summary,
+        failure_entries,
+    )
+    if summary.get('adapter_writeback_status') == 'block':
+        summary['pending_files'] = 0
+        summary['pending_lines'] = 0
+        append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
+        raise SystemExit(
+            'Revision apply refused because the adapter writeback plan is not safe. '
+            'No files were written.'
+        )
+
+    writeback_files = []
+    if adapter_plan is not None and adapter_snapshot is not None:
+        rendered_by_file = render_writeback_plan(
+            adapter_plan,
+            adapter_snapshot.project.source_documents,
+        )
+        for file_key in revalidated_replacements_by_file:
+            rendered_lines = rendered_by_file.get(file_key)
+            if rendered_lines is not None:
+                writeback_files.append((revalidated_file_paths[file_key], rendered_lines))
 
     if writeback_files:
         atomic_write_many_lines(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -1610,6 +1610,33 @@ def allow_non_chinese_batch_translation(manifest, chunk, original, translated, i
         known_terms=collect_chunk_known_terms(chunk),
     )
 
+
+def _adapter_target_language_policy_allows(
+    manifest,
+    chunk,
+    item,
+    original,
+    translated,
+    reason='',
+    reason_codes=(),
+):
+    """Allow only the legacy target-language failure through Batch policy."""
+
+    normalized_codes = {
+        str(code or '').strip()
+        for code in reason_codes or ()
+        if str(code or '').strip()
+    }
+    target_language_only = (
+        normalized_codes == {'common.target_language.missing'}
+        if normalized_codes
+        else reason == 'No Chinese characters'
+    )
+    return target_language_only and allow_non_chinese_batch_translation(
+        manifest, chunk or {}, original, translated, item=item
+    )
+
+
 def compact_text(text):
     return re.sub(r'\s+', ' ', text or '').strip()
 
@@ -6456,6 +6483,10 @@ def _build_adapter_writeback_plan(manifest, replacements_by_file, live_sources=N
     validated = []
     used_occurrence_ids = set()
     occurrences = tuple(snapshot.occurrences)
+    chunks_by_key = {
+        str(chunk.get('key') or ''): chunk
+        for chunk in manifest.get('chunks', [])
+    }
     if live_sources is not None:
         authoritative_sources = tuple(
             sorted(live_sources, key=lambda document: document.file_rel_path)
@@ -6476,7 +6507,7 @@ def _build_adapter_writeback_plan(manifest, replacements_by_file, live_sources=N
         replacements_by_line = replacements_by_file.get(file_key) or {}
         for line, replacements in replacements_by_line.items():
             for replacement in replacements:
-                start, end, translated, _prefix, _quote, expected_text, item_id, _chunk_key = (
+                start, end, translated, _prefix, _quote, expected_text, item_id, chunk_key = (
                     unpack_replacement_for_validation(replacement)
                 )
                 occurrence = _find_adapter_occurrence(
@@ -6499,11 +6530,47 @@ def _build_adapter_writeback_plan(manifest, replacements_by_file, live_sources=N
                     str(translated or ''),
                 )
                 if validation.status != 'pass':
-                    codes = ','.join(validation.reason_codes) or 'adapter.validation.block'
-                    raise WritebackPlanError(
-                        'adapter.validation.block',
-                        f'Adapter validation blocked {file_key}:{line}: {codes}.',
+                    policy_chunk = chunks_by_key.get(str(chunk_key or ''))
+                    if (
+                        policy_chunk is None
+                        or policy_chunk.get('file_rel_path') != file_key
+                    ):
+                        policy_chunk = next(
+                            (
+                                chunk
+                                for chunk in manifest.get('chunks', [])
+                                if chunk.get('file_rel_path') == file_key
+                            ),
+                            {'file_rel_path': file_key, 'items': []},
+                        )
+                    policy_item = next(
+                        (
+                            candidate
+                            for candidate in policy_chunk.get('items', [])
+                            if str(candidate.get('id') or '') == str(item_id or '')
+                        ),
+                        None,
                     )
+                    original_text = (
+                        occurrence.unit.source_text
+                        if manifest_mode(manifest) == MANIFEST_MODE_REVISION
+                        else occurrence.unit.text
+                    )
+                    if _adapter_target_language_policy_allows(
+                        manifest,
+                        policy_chunk,
+                        policy_item,
+                        original_text,
+                        str(translated or ''),
+                        reason_codes=validation.reason_codes,
+                    ):
+                        validation = replace(validation, status='pass')
+                    else:
+                        codes = ','.join(validation.reason_codes) or 'adapter.validation.block'
+                        raise WritebackPlanError(
+                            'adapter.validation.block',
+                            f'Adapter validation blocked {file_key}:{line}: {codes}.',
+                        )
                 validated.append(
                     ValidatedTranslation(
                         occurrence=occurrence,
@@ -7011,12 +7078,14 @@ def collect_revision_actions(manifest, validate_sources=False):
                         revised_translation,
                     )
                 )
-                if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
+                if not valid and _adapter_target_language_policy_allows(
                     manifest,
                     chunk,
+                    target_item,
                     source_text,
                     revised_translation,
-                    item=target_item,
+                    reason=reason,
+                    reason_codes=adapter_reason_codes,
                 ):
                     valid = True
                     reason = 'OK'
@@ -7490,12 +7559,14 @@ def collect_result_actions(manifest, validate_sources=False):
                         result_item['translation'],
                     )
                 )
-                if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
+                if not valid and _adapter_target_language_policy_allows(
                     manifest,
                     chunk,
+                    target_item,
                     target_unit.text,
                     result_item['translation'],
-                    item=target_item,
+                    reason=reason,
+                    reason_codes=adapter_reason_codes,
                 ):
                     valid = True
                     reason = 'OK'

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -6428,41 +6428,95 @@ def _source_document_from_path(file_key, file_path):
     )
 
 
+def _adapter_render_key(file_key):
+    try:
+        normalized = normalize_safe_rel_path(
+            str(file_key),
+            f'adapter writeback file key {file_key}',
+        )
+    except SystemExit as exc:
+        raise WritebackPlanError(
+            'common.writeback.path_escape',
+            str(exc),
+        ) from exc
+    return normalized.replace('\\', '/')
+
+
+def _normalize_adapter_rendered_files(rendered_by_file):
+    normalized = {}
+    for file_key, rendered_lines in rendered_by_file.items():
+        normalized_key = _adapter_render_key(file_key)
+        if normalized_key in normalized:
+            raise WritebackPlanError(
+                'common.writeback.plan_invalid',
+                f'Duplicate rendered adapter target: {normalized_key}.',
+            )
+        normalized[normalized_key] = rendered_lines
+    return normalized
+
+
+def _require_adapter_render_targets(replacements_by_file, rendered_by_file):
+    expected = {
+        _adapter_render_key(file_key)
+        for file_key, replacements_by_line in replacements_by_file.items()
+        if any(replacements_by_line.values())
+    }
+    actual = set(rendered_by_file)
+    if actual == expected:
+        return
+    missing = ', '.join(sorted(expected - actual)) or 'none'
+    unexpected = ', '.join(sorted(actual - expected)) or 'none'
+    raise WritebackPlanError(
+        'common.writeback.target_missing',
+        'Adapter rendered targets do not match validated replacements '
+        f'(missing: {missing}; unexpected: {unexpected}).',
+    )
+
+
 def _find_adapter_occurrence(occurrences, file_key, line, start, end, expected_text, item_id):
+    normalized_file_key = _adapter_render_key(file_key)
+
+    def matches_validated_replacement(occurrence):
+        unit = occurrence.unit
+        return (
+            unit.file_rel_path == normalized_file_key
+            and unit.line == line
+            and unit.start == start
+            and unit.end == end
+            and expected_text
+            in {
+                unit.text,
+                unit.source_text,
+                unit.current_translation,
+            }
+        )
+
     if item_id:
         by_id = [
             occurrence
             for occurrence in occurrences
             if occurrence.unit.id == item_id
-            and occurrence.unit.file_rel_path == file_key
+            and occurrence.unit.file_rel_path == normalized_file_key
         ]
-        if len(by_id) == 1:
+        if len(by_id) == 1 and matches_validated_replacement(by_id[0]):
             return by_id[0]
 
     positioned = [
         occurrence
         for occurrence in occurrences
-        if occurrence.unit.file_rel_path == file_key
-        and occurrence.unit.line == line
-        and occurrence.unit.start == start
-        and occurrence.unit.end == end
-        and expected_text
-        in {
-            occurrence.unit.text,
-            occurrence.unit.source_text,
-            occurrence.unit.current_translation,
-        }
+        if matches_validated_replacement(occurrence)
     ]
     if len(positioned) == 1:
         return positioned[0]
     if len(positioned) > 1:
         raise WritebackPlanError(
             'common.locator.unresolved',
-            f'Ambiguous adapter occurrence at {file_key}:{line}:{start}-{end}.',
+            f'Ambiguous adapter occurrence at {normalized_file_key}:{line}:{start}-{end}.',
         )
     raise WritebackPlanError(
         'common.locator.unresolved',
-        f'Adapter occurrence could not be resolved at {file_key}:{line}:{start}-{end}.',
+        'Adapter occurrence could not be resolved at '
+        f'{normalized_file_key}:{line}:{start}-{end}.',
     )
 
 
@@ -6607,8 +6661,11 @@ def _validate_adapter_writeback_plan(
             replacements_by_file,
             live_sources=live_sources,
         )
-        render_writeback_plan(plan, snapshot.project.source_documents)
-    except (Exception, SystemExit) as exc:
+        rendered_by_file = _normalize_adapter_rendered_files(
+            render_writeback_plan(plan, snapshot.project.source_documents)
+        )
+        _require_adapter_render_targets(replacements_by_file, rendered_by_file)
+    except (ValueError, OSError) as exc:
         reason_code = getattr(exc, 'reason_code', '') or 'adapter_writeback_block'
         bump_counter(summary['reason_counts'], 'adapter_writeback_block')
         failure_entries.append(
@@ -7971,18 +8028,23 @@ def apply_results(target=None, force=False):
 
     writeback_files = []
     if adapter_plan is not None and adapter_snapshot is not None:
-        rendered_by_file = render_writeback_plan(
-            adapter_plan,
-            adapter_snapshot.project.source_documents,
+        rendered_by_file = _normalize_adapter_rendered_files(
+            render_writeback_plan(
+                adapter_plan,
+                adapter_snapshot.project.source_documents,
+            )
+        )
+        _require_adapter_render_targets(
+            revalidated_replacements_by_file,
+            rendered_by_file,
         )
         for file_key in revalidated_replacements_by_file:
             if not revalidated_replacements_by_file[file_key]:
                 continue
-            rendered_lines = rendered_by_file.get(file_key)
-            if rendered_lines is not None:
-                writeback_files.append(
-                    (revalidated_file_paths[file_key], rendered_lines)
-                )
+            rendered_lines = rendered_by_file[_adapter_render_key(file_key)]
+            writeback_files.append(
+                (revalidated_file_paths[file_key], rendered_lines)
+            )
     if writeback_files:
         atomic_write_many_lines(
             writeback_files,
@@ -8119,14 +8181,19 @@ def apply_revisions(target=None, force=False):
 
     writeback_files = []
     if adapter_plan is not None and adapter_snapshot is not None:
-        rendered_by_file = render_writeback_plan(
-            adapter_plan,
-            adapter_snapshot.project.source_documents,
+        rendered_by_file = _normalize_adapter_rendered_files(
+            render_writeback_plan(
+                adapter_plan,
+                adapter_snapshot.project.source_documents,
+            )
+        )
+        _require_adapter_render_targets(
+            revalidated_replacements_by_file,
+            rendered_by_file,
         )
         for file_key in revalidated_replacements_by_file:
-            rendered_lines = rendered_by_file.get(file_key)
-            if rendered_lines is not None:
-                writeback_files.append((revalidated_file_paths[file_key], rendered_lines))
+            rendered_lines = rendered_by_file[_adapter_render_key(file_key)]
+            writeback_files.append((revalidated_file_paths[file_key], rendered_lines))
 
     if writeback_files:
         atomic_write_many_lines(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import time
 import tokenize
+from dataclasses import replace
 import traceback
 from datetime import datetime
 from pathlib import Path
@@ -39,7 +40,10 @@ import cli_contract
 import cli_discovery
 import doctor_recommendations as doctor_rec
 from engine_adapters.contracts import (
+    Occurrence,
+    OpaqueLocator,
     ProjectDiscoveryRequest,
+    SourceDocument,
     ValidatedTranslation,
 )
 from engine_adapters.coverage import export_coverage_package
@@ -47,6 +51,7 @@ from engine_adapters.renpy import RenPyAdapter, build_translation_snapshot
 from engine_adapters.writeback import (
     WritebackPlanError,
     render_writeback_plan,
+    source_snapshot_fingerprint,
 )
 import keyword_glossary_merge
 import model_usage_ledger
@@ -6385,6 +6390,17 @@ def _adapter_request_for_manifest(manifest, file_keys):
     )
 
 
+def _source_document_from_path(file_key, file_path):
+    content = Path(file_path).read_bytes()
+    return SourceDocument(
+        file_rel_path=str(file_key),
+        file_path=str(file_path),
+        size=len(content),
+        sha256=hashlib.sha256(content).hexdigest(),
+        content=content,
+    )
+
+
 def _find_adapter_occurrence(occurrences, file_key, line, start, end, expected_text, item_id):
     if item_id:
         by_id = [
@@ -6423,7 +6439,7 @@ def _find_adapter_occurrence(occurrences, file_key, line, start, end, expected_t
     )
 
 
-def _build_adapter_writeback_plan(manifest, replacements_by_file):
+def _build_adapter_writeback_plan(manifest, replacements_by_file, live_sources=None):
     file_keys = tuple(
         sorted(
             file_key
@@ -6440,6 +6456,21 @@ def _build_adapter_writeback_plan(manifest, replacements_by_file):
     validated = []
     used_occurrence_ids = set()
     occurrences = tuple(snapshot.occurrences)
+    if live_sources is not None:
+        authoritative_sources = tuple(
+            sorted(live_sources, key=lambda document: document.file_rel_path)
+        )
+        if source_snapshot_fingerprint(authoritative_sources) != source_snapshot_fingerprint(
+            snapshot.project.source_documents
+        ):
+            raise WritebackPlanError(
+                'common.writeback.source_snapshot_mismatch',
+                'Live source changed between apply validation and adapter discovery.',
+            )
+        snapshot = replace(
+            snapshot,
+            project=replace(snapshot.project, source_documents=authoritative_sources),
+        )
 
     for file_key in file_keys:
         replacements_by_line = replacements_by_file.get(file_key) or {}
@@ -6494,6 +6525,7 @@ def _validate_adapter_writeback_plan(
     replacements_by_file,
     summary,
     failure_entries,
+    live_sources=None,
 ):
     if not any(
         any(replacements_by_line.values())
@@ -6506,6 +6538,7 @@ def _validate_adapter_writeback_plan(
         plan, snapshot = _build_adapter_writeback_plan(
             manifest,
             replacements_by_file,
+            live_sources=live_sources,
         )
         render_writeback_plan(plan, snapshot.project.source_documents)
     except (Exception, SystemExit) as exc:
@@ -6594,36 +6627,95 @@ def is_v2_manifest(manifest):
     return manifest.get('manifest_version', 1) == 2 or manifest.get('version', 1) == 2
 
 
+def _manifest_occurrence(project, chunk, item, mode, item_index):
+    file_key = str(chunk.get('file_rel_path') or '')
+    unit = translation_core.unit_from_manifest_item(item, mode=mode, chunk=chunk)
+    block_name = str(item.get('block_name') or '_global')
+    block_occurrence = int(item.get('block_occurrence') or 1)
+    ordinal = int(item.get('block_index') or item.get('ordinal') or 0)
+    item_id = str(item.get('id') or '')
+    identity_prefix = file_key.replace('\\', '/') + ':'
+    if item_id.startswith(identity_prefix):
+        try:
+            block_token, ordinal_text, _source_hash = item_id[len(identity_prefix):].rsplit(':', 2)
+            if '#' in block_token:
+                parsed_block, parsed_occurrence = block_token.rsplit('#', 1)
+                block_name = parsed_block or block_name
+                block_occurrence = max(1, int(parsed_occurrence))
+            else:
+                block_name = block_token or block_name
+            ordinal = int(ordinal_text)
+        except (TypeError, ValueError):
+            pass
+    locator = OpaqueLocator(
+        engine='renpy',
+        locator_schema_version=1,
+        locator={
+            'file_rel_path': file_key,
+            'translate_block': block_name,
+            'block_occurrence': block_occurrence,
+            'ordinal': ordinal,
+            'line_hint': int(item.get('line_number') or int(item.get('line') or 0) + 1),
+            'start_col_hint': int(item.get('start') or 0),
+            'end_col_hint': int(item.get('end') or 0),
+            'source_marker_kind': str(item.get('source_marker_kind') or 'direct_source'),
+            'candidate_ordinal': int(item.get('candidate_ordinal') or item_index + 1),
+        },
+    )
+    return Occurrence(
+        occurrence_id=f'manifest:{file_key}:{item_id or item_index}',
+        engine='renpy',
+        project_snapshot_fingerprint=project.project_snapshot_fingerprint,
+        content_fingerprint=str(item.get('content_fingerprint') or ''),
+        candidate_id=f'manifest:{item_id or item_index}',
+        locator=locator,
+        unit=unit,
+    )
+
+
 def relocate_v2_chunk_items(manifest, chunk, scanned_units_by_file, mode):
     if not is_v2_manifest(manifest):
         return []
     file_key = chunk['file_rel_path']
     if file_key not in scanned_units_by_file:
-        file_path = manifest.get('files', {}).get(file_key, {}).get('path')
-        if not file_path or not os.path.exists(file_path):
-            file_path = os.path.join(legacy.TL_DIR, file_key)
-        file_lines = []
-        if os.path.exists(file_path):
-            with open(file_path, 'r', encoding='utf-8-sig') as f:
-                file_lines = f.readlines()
-        scanned_units_by_file[file_key] = legacy.scan_all_translation_units(
-            file_lines,
-            file_key,
-            mode=mode,
-        )
+        adapter = RenPyAdapter(legacy_module=legacy)
+        project = adapter.discover_project(_adapter_request_for_manifest(manifest, (file_key,)))
+        scanned_units_by_file[file_key] = {
+            'adapter': adapter,
+            'project': project,
+        }
 
-    scanned_map = scanned_units_by_file.get(file_key, {})
+    context = scanned_units_by_file[file_key]
+    adapter = context['adapter']
+    project = context['project']
+    items = list(chunk.get('items') or [])
+    originals = tuple(
+        _manifest_occurrence(project, chunk, item, mode, item_index)
+        for item_index, item in enumerate(items)
+    )
+    relocation = adapter.relocate_occurrences(
+        project,
+        originals,
+        project.source_documents,
+    )
+    relocated_by_id = {
+        occurrence.unit.id: occurrence
+        for occurrence in relocation.occurrences
+    }
     missing_items = []
-    for item in chunk.get('items') or []:
-        scanned = scanned_map.get(item.get('id'))
-        if not scanned:
+    context['relocated_by_id'] = relocated_by_id
+    for item in items:
+        relocated = relocated_by_id.get(str(item.get('id') or ''))
+        if relocated is None:
             missing_items.append(item)
             continue
-        scanned_line, scanned_start, scanned_end, _scanned_source = scanned
-        item['line'] = scanned_line
-        item['line_number'] = scanned_line + 1
-        item['start'] = scanned_start
-        item['end'] = scanned_end
+        unit = relocated.unit
+        item['line'] = unit.line
+        item['line_number'] = unit.line + 1
+        item['start'] = unit.start
+        item['end'] = unit.end
+        item['prefix'] = unit.prefix
+        item['quote'] = unit.quote
     return missing_items
 
 
@@ -6636,17 +6728,41 @@ def record_v2_relocation_failures(manifest, chunk, missing_items, summary, failu
         item_id = str(item.get('id') or '')
         if item_id:
             missing_ids.add(item_id)
-        failure_entries.append(make_failure_entry(
-            manifest,
-            'V2 relocation missing for result item',
-            file_rel_path=chunk.get('file_rel_path', ''),
-            item_id=item_id,
-            line=item.get('line'),
-            text=item.get('source', item.get('text', '')),
-            key=key or chunk.get('key', ''),
-            reason_code='v2_relocation_missing',
-        ))
+        failure_entries.append(
+            make_failure_entry(
+                manifest,
+                'V2 relocation missing for result item',
+                file_rel_path=chunk.get('file_rel_path', ''),
+                item_id=item_id,
+                line=item.get('line'),
+                text=item.get('source', item.get('text', '')),
+                key=key or chunk.get('key', ''),
+                reason_code='v2_relocation_missing',
+            )
+        )
     return missing_ids
+
+
+def validate_batch_item_translation(
+    scanned_units_by_file,
+    file_key,
+    item,
+    source_text,
+    translated_text,
+):
+    """Validate a relocated v2 item through its engine adapter."""
+
+    context = scanned_units_by_file.get(file_key) or {}
+    occurrence = (context.get('relocated_by_id') or {}).get(str(item.get('id') or ''))
+    adapter = context.get('adapter')
+    if occurrence is None or adapter is None:
+        valid, reason = legacy.validate_translation(source_text, translated_text)
+        return valid, reason, (), ()
+    validation = adapter.validate_translation(occurrence, translated_text)
+    if validation.status == 'pass':
+        return True, 'OK', validation.reason_codes, validation.diagnostics
+    reason = ', '.join(validation.reason_codes) or 'adapter.validation.block'
+    return False, reason, validation.reason_codes, validation.diagnostics
 
 
 def translated_text_variants(translated):
@@ -6886,7 +7002,15 @@ def collect_revision_actions(manifest, validate_sources=False):
                     continue
 
                 source_text = target_unit.source_text
-                valid, reason = legacy.validate_translation(source_text, revised_translation)
+                valid, reason, adapter_reason_codes, adapter_diagnostics = (
+                    validate_batch_item_translation(
+                        scanned_units_by_file,
+                        chunk['file_rel_path'],
+                        target_item,
+                        source_text,
+                        revised_translation,
+                    )
+                )
                 if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
                     manifest,
                     chunk,
@@ -6907,6 +7031,8 @@ def collect_revision_actions(manifest, validate_sources=False):
                         text=source_text,
                         key=key,
                         translation=revised_translation,
+                        adapter_reason_codes=list(adapter_reason_codes),
+                        adapter_diagnostics=list(adapter_diagnostics),
                         finish_reason=finish_reason,
                         usage_metadata=usage_metadata,
                     ))
@@ -7355,7 +7481,15 @@ def collect_result_actions(manifest, validate_sources=False):
                     mode=translation_core.MODE_TRANSLATION,
                     chunk=chunk,
                 )
-                valid, reason = legacy.validate_translation(target_unit.text, result_item['translation'])
+                valid, reason, adapter_reason_codes, adapter_diagnostics = (
+                    validate_batch_item_translation(
+                        scanned_units_by_file,
+                        chunk['file_rel_path'],
+                        target_item,
+                        target_unit.text,
+                        result_item['translation'],
+                    )
+                )
                 if not valid and reason == 'No Chinese characters' and allow_non_chinese_batch_translation(
                     manifest,
                     chunk,
@@ -7378,6 +7512,8 @@ def collect_result_actions(manifest, validate_sources=False):
                             'text': target_unit.text,
                             'error': f'Validation failed: {reason}',
                             'translation': result_item['translation'],
+                            'adapter_reason_codes': list(adapter_reason_codes),
+                            'adapter_diagnostics': list(adapter_diagnostics),
                             'finish_reason': finish_reason,
                             'usage_metadata': usage_metadata,
                         }
@@ -7706,6 +7842,7 @@ def apply_results(target=None, force=False):
     revalidated_file_paths = {}
     revalidated_file_lines = {}
     rag_jobs = []
+    revalidated_source_documents = {}
     file_keys = set(replacements_by_file) | set(translated_lines_by_file)
     for file_key in file_keys:
         replacements = replacements_by_file.get(file_key, {})
@@ -7713,8 +7850,8 @@ def apply_results(target=None, force=False):
         if not file_info:
             continue
         file_path = resolve_manifest_file_path(manifest, file_key, file_info)
-        with open(file_path, 'r', encoding='utf-8-sig') as handle:
-            lines = handle.readlines()
+        source_document = _source_document_from_path(file_key, file_path)
+        lines = source_document.lines()
         replacements, line_numbers_set, revalidation_failures, revalidated_skipped, revalidated_mismatches = validate_replacements_for_lines(
             manifest,
             file_key,
@@ -7735,12 +7872,18 @@ def apply_results(target=None, force=False):
         revalidated_line_numbers_by_file[file_key] = set(line_numbers_set)
         revalidated_file_paths[file_key] = file_path
         revalidated_file_lines[file_key] = lines
+        revalidated_source_documents[file_key] = source_document
 
     adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
         manifest,
         revalidated_replacements_by_file,
         summary,
         failure_entries,
+        live_sources=tuple(
+            revalidated_source_documents[file_key]
+            for file_key in revalidated_replacements_by_file
+            if file_key in revalidated_source_documents
+        ),
     )
     attach_check_contract(manifest, summary)
     if summary.get('safety_level') != CHECK_SAFETY_SAFE:
@@ -7855,13 +7998,14 @@ def apply_revisions(target=None, force=False):
     revalidated_replacements_by_file = {}
     revalidated_file_paths = {}
     revision_updates = []
+    revalidated_source_documents = {}
     for file_key, replacements in replacements_by_file.items():
         file_info = manifest['files'].get(file_key)
         if not file_info:
             continue
         file_path = resolve_manifest_file_path(manifest, file_key, file_info)
-        with open(file_path, 'r', encoding='utf-8-sig') as handle:
-            lines = handle.readlines()
+        source_document = _source_document_from_path(file_key, file_path)
+        lines = source_document.lines()
         replacements, line_numbers_set, revalidation_failures, revalidated_skipped, revalidated_mismatches = validate_replacements_for_lines(
             manifest,
             file_key,
@@ -7880,6 +8024,7 @@ def apply_revisions(target=None, force=False):
         if replacements:
             revalidated_replacements_by_file[file_key] = replacements
             revalidated_file_paths[file_key] = file_path
+            revalidated_source_documents[file_key] = source_document
         line_numbers = sorted(line_numbers_set)
         revision_updates.append((file_key, line_numbers, file_path))
 
@@ -7888,6 +8033,11 @@ def apply_revisions(target=None, force=False):
         revalidated_replacements_by_file,
         summary,
         failure_entries,
+        live_sources=tuple(
+            revalidated_source_documents[file_key]
+            for file_key in revalidated_replacements_by_file
+            if file_key in revalidated_source_documents
+        ),
     )
     if summary.get('adapter_writeback_status') == 'block':
         summary['pending_files'] = 0
@@ -12792,3 +12942,5 @@ def main(argv=None):
 
 if __name__ == '__main__':
     raise SystemExit(main())
+    Occurrence,
+    OpaqueLocator,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7840,7 +7840,6 @@ def apply_results(target=None, force=False):
     revalidated_replacements_by_file = {}
     revalidated_line_numbers_by_file = {}
     revalidated_file_paths = {}
-    revalidated_file_lines = {}
     rag_jobs = []
     revalidated_source_documents = {}
     file_keys = set(replacements_by_file) | set(translated_lines_by_file)
@@ -7868,11 +7867,11 @@ def apply_results(target=None, force=False):
             summary['failure_items'] = len(failure_entries)
         if not replacements and not line_numbers_set:
             continue
-        revalidated_replacements_by_file[file_key] = replacements
+        if replacements:
+            revalidated_replacements_by_file[file_key] = replacements
+            revalidated_source_documents[file_key] = source_document
         revalidated_line_numbers_by_file[file_key] = set(line_numbers_set)
         revalidated_file_paths[file_key] = file_path
-        revalidated_file_lines[file_key] = lines
-        revalidated_source_documents[file_key] = source_document
 
     adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
         manifest,
@@ -7920,10 +7919,9 @@ def apply_results(target=None, force=False):
             encoding='utf-8',
         )
 
-    for file_key, replacements in revalidated_replacements_by_file.items():
+    for file_key, line_numbers_set in revalidated_line_numbers_by_file.items():
         file_path = revalidated_file_paths[file_key]
-        lines = revalidated_file_lines[file_key]
-        line_numbers = sorted(revalidated_line_numbers_by_file[file_key])
+        line_numbers = sorted(line_numbers_set)
         update_progress(file_key, line_numbers)
         applied_files += 1
         applied_lines += len(line_numbers)
@@ -12942,5 +12940,3 @@ def main(argv=None):
 
 if __name__ == '__main__':
     raise SystemExit(main())
-    Occurrence,
-    OpaqueLocator,

--- a/gui_qt/sync_translation_report.py
+++ b/gui_qt/sync_translation_report.py
@@ -78,7 +78,11 @@ def summarize_sync_translation_output(
             facts=facts,
         )
 
-    if "Sync preview manifest:" not in output or "Preview status: safe" not in output:
+    preview_status_safe = "Preview status: safe" in output
+    preview_status_partial = "Preview status: partial" in output
+    if "Sync preview manifest:" not in output or not (
+        preview_status_safe or preview_status_partial
+    ):
         return WorkflowUpdate(
             status="failed",
             heading="同步翻译预览未完成",
@@ -89,10 +93,16 @@ def summarize_sync_translation_output(
     message = "同步翻译预览已生成；项目脚本尚未修改。请检查 diff 后再确认写回。"
     if files_done:
         message = f"已处理 {files_done} 个文件。{message}"
-    if lines_to_translate > 0 and translated_count < lines_to_translate:
+    translation_is_partial = (
+        lines_to_translate > 0 and translated_count < lines_to_translate
+    )
+    if preview_status_partial:
+        message = f"部分文件未通过写回计划校验，其余安全预览已生成。{message}"
+    if translation_is_partial:
         message = (
             f"部分完成（已翻译 {translated_count}/{lines_to_translate} 行）。{message}"
         )
+    if preview_status_partial or translation_is_partial:
         return WorkflowUpdate(
             status="warning",
             heading="同步翻译预览部分完成",
@@ -127,11 +137,12 @@ def _collect_facts(output: str) -> list[str]:
         (r"^Progress log: (.+)$", "进度日志"),
         (r"^Sync preview manifest: (.+)$", "预览清单"),
         (r"^Sync preview report: (.+)$", "差异报告"),
+        (r"^Preview failures: (\d+)$", "预览失败文件"),
         (r"^Applied files: (\d+)$", "已写回文件"),
     ):
         match = re.search(pattern, output, re.MULTILINE)
         if match:
-            if label in {"待处理文件", "已写回文件"}:
+            if label in {"待处理文件", "预览失败文件", "已写回文件"}:
                 facts.append(f"{label}：{match.group(1)} 个")
             else:
                 facts.append(f"{label}：{match.group(1).strip()}")

--- a/gui_qt/sync_translation_report.py
+++ b/gui_qt/sync_translation_report.py
@@ -97,10 +97,10 @@ def summarize_sync_translation_output(
         lines_to_translate > 0 and translated_count < lines_to_translate
     )
     if preview_status_partial:
-        message = f"部分文件未通过写回计划校验，其余安全预览已生成。{message}"
+        message = f"部分文件未通过写回计划校验，其余安全预览已生成。{message}"  # noqa: RUF001
     if translation_is_partial:
         message = (
-            f"部分完成（已翻译 {translated_count}/{lines_to_translate} 行）。{message}"
+            f"部分完成（已翻译 {translated_count}/{lines_to_translate} 行）。{message}"  # noqa: RUF001
         )
     if preview_status_partial or translation_is_partial:
         return WorkflowUpdate(

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -301,7 +301,7 @@ def prepare_sync_preview_apply(
         preview_sha = str(entry.get("preview_sha256") or "")
         if current_sha not in {source_sha, preview_sha}:
             raise ValueError(f"Source changed after sync preview: {relative_path}")
-        preview_text = preview_path.read_text(encoding="utf-8")
+        preview_text = preview_path.read_bytes().decode("utf-8")
         writeback_plan_payload = entry.get("writeback_plan")
         if writeback_plan_payload is not None:
             from engine_adapters.contracts import SourceDocument

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -58,7 +58,7 @@ def _artifact_path(package_dir: Path, value: Any) -> Path:
 
 
 def _fingerprint_payload(manifest: dict[str, Any]) -> dict[str, Any]:
-    return {
+    payload = {
         "schema": manifest.get("schema"),
         "version": manifest.get("version"),
         "created_at": manifest.get("created_at"),
@@ -69,6 +69,9 @@ def _fingerprint_payload(manifest: dict[str, Any]) -> dict[str, Any]:
         "summary": manifest.get("summary"),
         "files": manifest.get("files"),
     }
+    if "failures" in manifest:
+        payload["failures"] = manifest.get("failures")
+    return payload
 
 
 def _fingerprint(manifest: dict[str, Any]) -> str:
@@ -82,6 +85,14 @@ def _fingerprint(manifest: dict[str, Any]) -> str:
 
 
 def _deserialize_writeback_plan(payload: Any):
+    """Reconstruct a validated writeback plan from persisted manifest JSON.
+
+    The payload must contain every plan and operation field consumed by
+    ``render_writeback_plan``, with numeric line and column coordinates. Shape
+    and coercion failures are normalized to ``ValueError`` so preview apply can
+    reject malformed or edited manifests through one public failure mode.
+    """
+
     from engine_adapters.contracts import WritebackOperation, WritebackPlan
 
     if not isinstance(payload, dict):

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -135,10 +135,19 @@ def create_sync_preview(
     project_root: str | os.PathLike[str],
     tl_dir: str | os.PathLike[str],
     files: Iterable[dict[str, Any]],
+    failures: Iterable[dict[str, Any]] = (),
 ) -> tuple[str, dict[str, Any]]:
     """Persist source/proposed snapshots, a unified diff, and a bound manifest."""
     created = datetime.now(timezone.utc)
     run_name = created.strftime("%Y%m%dT%H%M%S.%fZ")
+    failure_entries = [
+        {
+            "relative_path": str(item.get("relative_path") or ""),
+            "reason_code": str(item.get("reason_code") or "adapter.writeback.block"),
+            "message": str(item.get("message") or ""),
+        }
+        for item in failures
+    ]
     package_dir = Path(log_dir) / "sync_runs" / run_name
     package_dir.mkdir(parents=True, exist_ok=False)
 
@@ -206,8 +215,11 @@ def create_sync_preview(
         "summary": {
             "files_changed": len(entries),
             "translated_items": total_items,
+            "failure_files": len(failure_entries),
+            "adapter_writeback_status": "partial" if failure_entries else "pass",
         },
         "files": entries,
+        "failures": failure_entries,
     }
     manifest["preview_fingerprint"] = _fingerprint(manifest)
     manifest_path = package_dir / "manifest.json"

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -81,6 +81,54 @@ def _fingerprint(manifest: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _deserialize_writeback_plan(payload: Any):
+    from engine_adapters.contracts import WritebackOperation, WritebackPlan
+
+    if not isinstance(payload, dict):
+        raise ValueError("Sync preview writeback plan must be an object.")
+    raw_operations = payload.get("operations")
+    if not isinstance(raw_operations, list):
+        raise ValueError("Sync preview writeback plan operations must be a list.")
+    operations = []
+    operation_fields = (
+        "operation_id",
+        "kind",
+        "occurrence_id",
+        "target_root",
+        "target_rel_path",
+        "expected_file_sha256",
+        "line",
+        "start_col",
+        "end_col",
+        "expected_fragment_sha256",
+        "expected_text_digest",
+        "replacement_fragment",
+        "validation_digest",
+    )
+    try:
+        for raw_operation in raw_operations:
+            if not isinstance(raw_operation, dict):
+                raise ValueError("Sync preview writeback operation must be an object.")
+            values = {field: raw_operation[field] for field in operation_fields}
+            values["line"] = int(values["line"])
+            values["start_col"] = int(values["start_col"])
+            values["end_col"] = int(values["end_col"])
+            operations.append(WritebackOperation(**values))
+        return WritebackPlan(
+            engine=str(payload["engine"]),
+            adapter_version=str(payload["adapter_version"]),
+            project_identity_digest=str(payload["project_identity_digest"]),
+            source_snapshot_fingerprint=str(payload["source_snapshot_fingerprint"]),
+            coverage_digest=str(payload.get("coverage_digest") or ""),
+            coverage_review_digest=str(payload.get("coverage_review_digest") or ""),
+            operations=tuple(operations),
+            plan_digest=str(payload["plan_digest"]),
+            writeback_plan_schema_version=int(payload["writeback_plan_schema_version"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid sync preview writeback plan: {exc}") from exc
+
+
 def create_sync_preview(
     *,
     log_dir: str | os.PathLike[str],
@@ -130,6 +178,8 @@ def create_sync_preview(
                 "translated_items": translated_items,
             }
         )
+        if raw.get("writeback_plan") is not None:
+            entries[-1]["writeback_plan"] = raw.get("writeback_plan")
         report_lines.extend(
             difflib.unified_diff(
                 source_text.splitlines(keepends=True),
@@ -229,6 +279,28 @@ def prepare_sync_preview_apply(
         if current_sha not in {source_sha, preview_sha}:
             raise ValueError(f"Source changed after sync preview: {relative_path}")
         preview_text = preview_path.read_text(encoding="utf-8")
+        writeback_plan_payload = entry.get("writeback_plan")
+        if writeback_plan_payload is not None:
+            from engine_adapters.contracts import SourceDocument
+            from engine_adapters.writeback import render_writeback_plan
+
+            source_content = source_snapshot.read_bytes()
+            source_document = SourceDocument(
+                file_rel_path=relative_path,
+                file_path=str(target),
+                size=len(source_content),
+                sha256=hashlib.sha256(source_content).hexdigest(),
+                content=source_content,
+            )
+            plan = _deserialize_writeback_plan(writeback_plan_payload)
+            rendered_by_file = render_writeback_plan(plan, (source_document,))
+            rendered_text = "".join(rendered_by_file.get(relative_path, ()))
+            if source_content.startswith(b"\xef\xbb\xbf") and not rendered_text.startswith("\ufeff"):
+                rendered_text = "\ufeff" + rendered_text
+            if rendered_text != preview_text:
+                raise ValueError(
+                    f"Sync preview writeback plan does not match proposed file: {relative_path}"
+                )
         prepared.append(
             {
                 "entry": entry,

--- a/tests/test_batch_non_chinese_rules.py
+++ b/tests/test_batch_non_chinese_rules.py
@@ -83,6 +83,37 @@ class BatchNonChineseRulesTests(unittest.TestCase):
             )
         )
 
+    def test_adapter_policy_allows_only_target_language_failure(self):
+        manifest = {
+            'non_chinese_rules': copy.deepcopy(
+                batch_non_chinese_rules.DEFAULT_NON_CHINESE_RULES
+            ),
+        }
+        chunk = {'file_rel_path': 'screens_patronlistitem.rpy'}
+        self.assertTrue(
+            batch_mod._adapter_target_language_policy_allows(
+                manifest,
+                chunk,
+                None,
+                'Alpha, Beta, Gamma',
+                'Alpha， Beta， Gamma',
+                reason_codes=('common.target_language.missing',),
+            )
+        )
+        self.assertFalse(
+            batch_mod._adapter_target_language_policy_allows(
+                manifest,
+                chunk,
+                None,
+                'Alpha {player}',
+                'Alpha',
+                reason_codes=(
+                    'common.target_language.missing',
+                    'renpy.tag.changed',
+                ),
+            )
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1610,6 +1610,148 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertEqual(manifest['apply_summary']['applied_lines'], 2)
         self.assertEqual(manifest['apply_summary']['recoverable_items'], 2)
         self.assertEqual(manifest['apply_summary']['skipped_items'], 0)
+    def test_apply_results_excludes_progress_only_files_from_adapter_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'tl'
+            package_dir = root / 'package'
+            tl_dir.mkdir()
+            package_dir.mkdir()
+            first_file = tl_dir / 'first.rpy'
+            second_file = tl_dir / 'second.rpy'
+            first_line = '    e "Hello"\n'
+            second_line = '    e "World"\n'
+            first_start = first_line.index('"Hello"')
+            second_start = second_line.index('"World"')
+            first_file.write_text(first_line, encoding='utf-8')
+            second_file.write_text(second_line, encoding='utf-8')
+            result_path = package_dir / 'results.jsonl'
+            manifest_path = package_dir / 'manifest.json'
+            result_rows = (
+                {
+                    'key': 'chunk-first',
+                    'response': {
+                        'candidates': [
+                            {
+                                'content': {
+                                    'parts': [
+                                        {
+                                            'text': json.dumps(
+                                                [
+                                                    {
+                                                        'id': f'first.rpy:0:{first_start}',
+                                                        'translation': '你好',
+                                                    }
+                                                ],
+                                                ensure_ascii=False,
+                                            )
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                },
+                {
+                    'key': 'chunk-second',
+                    'response': {
+                        'candidates': [
+                            {
+                                'content': {
+                                    'parts': [
+                                        {
+                                            'text': json.dumps(
+                                                [
+                                                    {
+                                                        'id': f'second.rpy:0:{second_start}',
+                                                        'translation': '世界',
+                                                    }
+                                                ],
+                                                ensure_ascii=False,
+                                            )
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                },
+            )
+            result_path.write_text(
+                ''.join(
+                    json.dumps(row, ensure_ascii=False) + '\n'
+                    for row in result_rows
+                ),
+                encoding='utf-8',
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        'execution': 'sync',
+                        'files': {
+                            'first.rpy': {'path': str(first_file)},
+                            'second.rpy': {'path': str(second_file)},
+                        },
+                        'result_jsonl_path': str(result_path),
+                        'chunks': [
+                            {
+                                'key': 'chunk-first',
+                                'file_rel_path': 'first.rpy',
+                                'items': [
+                                    {
+                                        'id': f'first.rpy:0:{first_start}',
+                                        'line': 0,
+                                        'start': first_start,
+                                        'end': first_start + len('"Hello"'),
+                                        'text': 'Hello',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    }
+                                ],
+                            },
+                            {
+                                'key': 'chunk-second',
+                                'file_rel_path': 'second.rpy',
+                                'items': [
+                                    {
+                                        'id': f'second.rpy:0:{second_start}',
+                                        'line': 0,
+                                        'start': second_start,
+                                        'end': second_start + len('"World"'),
+                                        'text': 'World',
+                                        'prefix': '',
+                                        'quote': '"',
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod, 'update_progress') as update_progress,
+            ):
+                batch_mod.check_results(str(manifest_path))
+                first_file.write_text('    e "你好"\n', encoding='utf-8')
+                manifest = batch_mod.apply_results(str(manifest_path))
+
+            self.assertEqual(first_file.read_text(encoding='utf-8'), '    e "你好"\n')
+            self.assertEqual(second_file.read_text(encoding='utf-8'), '    e "世界"\n')
+
+        update_progress.assert_has_calls(
+            [
+                mock.call('first.rpy', [0]),
+                mock.call('second.rpy', [0]),
+            ],
+            any_order=True,
+        )
+        self.assertEqual(manifest['apply_summary']['applied_files'], 2)
+        self.assertEqual(manifest['apply_summary']['applied_lines'], 2)
+
 
     def test_apply_results_revalidates_snapshot_before_writing(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1930,6 +1930,111 @@ class BatchRepairRegressionTests(unittest.TestCase):
 
         self.assertEqual(unchanged_script, line)
         append_failures.assert_not_called()
+    def test_apply_results_force_refuses_adapter_block_before_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_dir = root / 'package'
+            package_dir.mkdir()
+            target_file = root / 'script.rpy'
+            original_line = '    e "Hello"\n'
+            target_file.write_text(original_line, encoding='utf-8')
+            start = original_line.index('"Hello"')
+            replacements = {
+                0: [
+                    (
+                        start,
+                        start + len('"Hello"'),
+                        '你好',
+                        '',
+                        '"',
+                        'Hello',
+                        'item-1',
+                        'chunk-1',
+                    )
+                ]
+            }
+            manifest = {
+                'applied_at': '2026-05-12T12:00:00',
+                '_package_dir': str(package_dir),
+                '_manifest_path': str(package_dir / 'manifest.json'),
+                'execution': 'sync',
+                'files': {'script.rpy': {'path': str(target_file)}},
+            }
+            summary = {'reason_counts': {}, 'valid_items': 1, 'failure_items': 0}
+            failures = []
+
+            def block_adapter_plan(
+                _manifest,
+                _replacements_by_file,
+                live_summary,
+                failure_entries,
+                live_sources=None,
+            ):
+                del live_sources
+                batch_mod.bump_counter(
+                    live_summary['reason_counts'],
+                    'adapter_writeback_block',
+                )
+                live_summary['adapter_writeback_status'] = 'block'
+                failure_entries.append({'reason_code': 'adapter_writeback_block'})
+                return None, None
+
+            def attach_block(_manifest, live_summary):
+                live_summary['safety_level'] = batch_mod.CHECK_SAFETY_BLOCK
+                return live_summary
+
+            with (
+                mock.patch.object(batch_mod, 'load_manifest', return_value=manifest),
+                mock.patch.object(batch_mod, 'require_manifest_mode'),
+                mock.patch.object(batch_mod, 'require_manifest_project_match'),
+                mock.patch.object(batch_mod, 'recover_atomic_write_transaction'),
+                mock.patch.object(batch_mod, 'require_safe_check_for_apply'),
+                mock.patch.object(
+                    batch_mod,
+                    'collect_result_actions',
+                    return_value=(
+                        {'script.rpy': replacements},
+                        {'script.rpy': {0}},
+                        failures,
+                        summary,
+                    ),
+                ),
+                mock.patch.object(
+                    batch_mod,
+                    'resolve_manifest_file_path',
+                    return_value=str(target_file),
+                ),
+                mock.patch.object(
+                    batch_mod,
+                    'validate_replacements_for_lines',
+                    return_value=(replacements, {0}, [], 0, 0),
+                ),
+                mock.patch.object(
+                    batch_mod,
+                    '_validate_adapter_writeback_plan',
+                    side_effect=block_adapter_plan,
+                ),
+                mock.patch.object(
+                    batch_mod,
+                    'attach_check_contract',
+                    side_effect=attach_block,
+                ),
+                mock.patch.object(batch_mod, 'append_failure_entries'),
+                mock.patch.object(
+                    batch_mod,
+                    'write_apply_failure_report',
+                    return_value=str(package_dir / 'apply_failure_report.json'),
+                ),
+                mock.patch.object(batch_mod, 'save_manifest'),
+                mock.patch.object(batch_mod, 'atomic_write_many_lines') as atomic_write,
+                mock.patch.object(batch_mod, 'update_progress') as update_progress,
+            ):
+                with self.assertRaisesRegex(SystemExit, 'not safe'):
+                    batch_mod.apply_results('manifest.json', force=True)
+
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original_line)
+            atomic_write.assert_not_called()
+            update_progress.assert_not_called()
 
     def test_apply_results_rejects_warn_check_without_writing(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_engine_adapter_p0_characterization.py
+++ b/tests/test_engine_adapter_p0_characterization.py
@@ -133,7 +133,7 @@ class TestEngineAdapterP0Characterization(unittest.TestCase):
         self.assertEqual(original_map[second_id][0], 5)
         self.assertEqual(drifted_map[second_id][0], 9)
 
-    def test_v2_relocation_updates_live_span_and_reports_missing_identity(self):
+    def test_v2_relocation_uses_adapter_content_fallback_and_reports_missing_identity(self):
         file_rel_path = "chapter.rpy"
         live_lines = [
             "\n",
@@ -144,7 +144,7 @@ class TestEngineAdapterP0Characterization(unittest.TestCase):
             '    e "Hello there"\n',
         ]
         item_id = translation_core.build_identity_v2(
-            file_rel_path, "chapter", 1, "Hello there"
+            file_rel_path, "stale-chapter", 99, "Hello there"
         )
         item = {
             "id": item_id,

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -876,13 +876,13 @@ translate schinese start:
         )
         self.assertTrue((Path(manifest_path).parent / "requests.jsonl").is_file())
 
-    def test_sync_preview_preserves_utf8_bom_in_source_and_preview_text(self):
+    def test_sync_preview_preserves_utf8_bom_and_crlf_through_apply(self):
         root = Path(tempfile.mkdtemp())
         self.addCleanup(lambda: __import__("shutil").rmtree(root, ignore_errors=True))
         tl_dir = root / "game" / "tl" / "schinese"
         tl_dir.mkdir(parents=True)
         target = tl_dir / "script.rpy"
-        body = 'translate schinese start:\n    # "Hello"\n    "Hello"\n'
+        body = 'translate schinese start:\r\n    # "Hello"\r\n    "Hello"\r\n'
         target.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
 
         def translate_batch(batch, replacements, usage_run_id="", **_kwargs):
@@ -926,7 +926,10 @@ translate schinese start:
             active_project_root=root,
             active_tl_dir=tl_dir,
         )
-        self.assertEqual(target.read_text(encoding="utf-8-sig"), body.replace('    "Hello"', '    "你好"'))
+        self.assertEqual(
+            target.read_bytes(),
+            b"\xef\xbb\xbf" + body.replace('    "Hello"', '    "你好"').encode("utf-8"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -36,6 +36,7 @@ from engine_adapters.renpy import (
 )
 import translation_core
 import translator_runtime as runtime
+import sync_translation_preview as preview
 
 
 class TestRenPyAdapterP1(unittest.TestCase):
@@ -60,7 +61,7 @@ class TestRenPyAdapterP1(unittest.TestCase):
             **kwargs,
         )
 
-    def test_protocol_and_capabilities_are_read_only_in_p1(self):
+    def test_protocol_and_capabilities_expose_p2_contract(self):
         adapter = RenPyAdapter(legacy_module=runtime)
         self.assertIsInstance(adapter, EngineAdapter)
         capabilities = adapter.capabilities()
@@ -68,16 +69,12 @@ class TestRenPyAdapterP1(unittest.TestCase):
         self.assertEqual(capabilities.selected_localization_mode.value, "hybrid")
         self.assertTrue(capabilities.source_inventory)
         self.assertTrue(capabilities.native_catalog)
-        self.assertFalse(capabilities.relocation)
-        self.assertEqual(capabilities.declarative_writeback, ())
+        self.assertTrue(capabilities.relocation)
+        self.assertEqual(capabilities.declarative_writeback, ("text_span_replace",))
         self.assertTrue(capabilities.native_catalog_required_for_writeback)
+        self.assertEqual(capabilities.adapter_version, "1.1.0")
+        self.assertNotEqual(adapter.behavior_digest(), "")
 
-        with self.assertRaises(NotImplementedError):
-            adapter.relocate_occurrences(None, (), ())
-        with self.assertRaises(NotImplementedError):
-            adapter.validate_translation(None, "译文")
-        with self.assertRaises(NotImplementedError):
-            adapter.build_writeback_plan(None, (), ())
 
     def test_adapter_matches_legacy_units_ids_speakers_sources_and_spans(self):
         lines = [
@@ -922,6 +919,14 @@ translate schinese start:
             manifest["files"][0]["source_sha256"],
             hashlib.sha256(target.read_bytes()).hexdigest(),
         )
+        self.assertIn("writeback_plan", manifest["files"][0])
+
+        preview.apply_sync_preview(
+            manifest_path,
+            active_project_root=root,
+            active_tl_dir=tl_dir,
+        )
+        self.assertEqual(target.read_text(encoding="utf-8-sig"), body.replace('    "Hello"', '    "你好"'))
 
 
 if __name__ == "__main__":

--- a/tests/test_engine_adapter_p2.py
+++ b/tests/test_engine_adapter_p2.py
@@ -149,6 +149,55 @@ class TestRenPyAdapterP2(unittest.TestCase):
         self.assertEqual(result.occurrences, ())
         self.assertEqual(result.unresolved_occurrence_ids, (original.occurrence_id,))
 
+    def test_relocation_rejects_weak_unique_content_evidence(self):
+        """Same-file + same-source alone (score 125) must not relocate."""
+        source = (
+            'translate schinese chapter:\n'
+            '    # e "Same text"\n'
+            '    e "Same text"\n'
+        )
+        _root, _tl_dir, adapter, snapshot = self.snapshot(source)
+        original = self.occurrence_for(snapshot, "Same text")
+        weak = replace(
+            original,
+            content_fingerprint="not-a-real-fingerprint",
+            locator=OpaqueLocator(
+                engine="renpy",
+                locator_schema_version=1,
+                locator={
+                    "file_rel_path": "script.rpy",
+                    "translate_block": "gone",
+                    "block_occurrence": 99,
+                    "ordinal": 99,
+                    "line_hint": 1,
+                    "start_col_hint": 0,
+                    "end_col_hint": 0,
+                    "source_marker_kind": "other",
+                    "candidate_ordinal": 99,
+                },
+            ),
+            unit=replace(
+                original.unit,
+                id="script.rpy:gone:99:deadbeef",
+                speaker_id="z",
+                speaker_name="Z",
+            ),
+        )
+
+        result = adapter.relocate_occurrences(
+            snapshot.project,
+            (weak,),
+            snapshot.project.source_documents,
+        )
+
+        self.assertEqual(result.occurrences, ())
+        self.assertEqual(result.unresolved_occurrence_ids, (weak.occurrence_id,))
+        self.assertEqual(result.diagnostics[0]["status"], "weak_content_evidence")
+        self.assertLess(
+            result.diagnostics[0]["score"],
+            result.diagnostics[0]["min_score"],
+        )
+
     def test_relocation_reports_source_change_as_unresolved(self):
         source = (
             'translate schinese chapter:\n'

--- a/tests/test_engine_adapter_p2.py
+++ b/tests/test_engine_adapter_p2.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import hashlib
 import json
 from pathlib import Path
 import tempfile
@@ -127,6 +128,27 @@ class TestRenPyAdapterP2(unittest.TestCase):
         self.assertEqual(result.unresolved_occurrence_ids, (stale.occurrence_id,))
         self.assertEqual(result.diagnostics[0]["status"], "ambiguous")
 
+    def test_relocation_rejects_unique_content_fallback_in_another_file(self):
+        source = (
+            'translate schinese chapter:\n'
+            '    # e "Same text"\n'
+            '    e "Same text"\n'
+        )
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        original = self.occurrence_for(snapshot, "Same text")
+        (tl_dir / "script.rpy").write_text('e "Changed"\n', encoding="utf-8")
+        (tl_dir / "moved.rpy").write_text(source, encoding="utf-8")
+        live = adapter.discover_project(self.request(root, tl_dir))
+
+        result = adapter.relocate_occurrences(
+            snapshot.project,
+            (original,),
+            live.source_documents,
+        )
+
+        self.assertEqual(result.occurrences, ())
+        self.assertEqual(result.unresolved_occurrence_ids, (original.occurrence_id,))
+
     def test_relocation_reports_source_change_as_unresolved(self):
         source = (
             'translate schinese chapter:\n'
@@ -190,6 +212,10 @@ class TestRenPyAdapterP2(unittest.TestCase):
         self.assertEqual(operation.target_rel_path, "script.rpy")
         self.assertNotIn("\\", operation.target_rel_path)
         self.assertEqual(operation.expected_file_sha256, snapshot.project.source_documents[0].sha256)
+        self.assertEqual(
+            operation.expected_text_digest,
+            hashlib.sha256("Hello {player}!".encode("utf-8")).hexdigest(),
+        )
         self.assertEqual(operation.replacement_fragment, '\"你好 {player}!\"')
         self.assertNotIn(str(tl_dir), json.dumps(plan.to_dict(), ensure_ascii=False))
         self.assertTrue(plan.plan_digest)
@@ -219,6 +245,47 @@ class TestRenPyAdapterP2(unittest.TestCase):
             render_writeback_plan(plan, live.source_documents)
         self.assertEqual(context.exception.reason_code, "common.writeback.source_snapshot_mismatch")
 
+
+    def test_common_plan_consumer_rejects_tampered_plan_digest(self):
+        _root, _tl_dir, adapter, snapshot = self.snapshot('e "Hello"\n')
+        occurrence = self.occurrence_for(snapshot, "Hello")
+        validation = adapter.validate_translation(occurrence, "你好")
+        plan = adapter.build_writeback_plan(
+            snapshot.project,
+            (ValidatedTranslation(occurrence, "你好", validation),),
+            snapshot.project.source_documents,
+        )
+
+        with self.assertRaises(WritebackPlanError) as context:
+            render_writeback_plan(
+                replace(plan, plan_digest="0" * 64),
+                snapshot.project.source_documents,
+            )
+
+        self.assertEqual(context.exception.reason_code, "common.writeback.plan_digest_mismatch")
+
+    def test_common_plan_consumer_rejects_tampered_operation_id(self):
+        _root, _tl_dir, adapter, snapshot = self.snapshot('e "Hello"\n')
+        occurrence = self.occurrence_for(snapshot, "Hello")
+        validation = adapter.validate_translation(occurrence, "你好")
+        plan = adapter.build_writeback_plan(
+            snapshot.project,
+            (ValidatedTranslation(occurrence, "你好", validation),),
+            snapshot.project.source_documents,
+        )
+        tampered_operation = replace(
+            plan.operations[0],
+            expected_text_digest="0" * 64,
+        )
+        tampered_plan = replace(plan, operations=(tampered_operation,))
+        plan_payload = tampered_plan.to_dict()
+        plan_payload.pop("plan_digest")
+        tampered_plan = replace(tampered_plan, plan_digest=digest_json(plan_payload))
+
+        with self.assertRaises(WritebackPlanError) as context:
+            render_writeback_plan(tampered_plan, snapshot.project.source_documents)
+
+        self.assertEqual(context.exception.reason_code, "common.writeback.plan_digest_mismatch")
     def test_common_plan_consumer_rejects_path_escape(self):
         _root, _tl_dir, adapter, snapshot = self.snapshot('e "Hello {player}!"\n')
         occurrence = self.occurrence_for(snapshot, "Hello {player}!")

--- a/tests/test_engine_adapter_p2.py
+++ b/tests/test_engine_adapter_p2.py
@@ -9,7 +9,11 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from engine_adapters.contracts import ProjectDiscoveryRequest, ValidatedTranslation
+from engine_adapters.contracts import (
+    OpaqueLocator,
+    ProjectDiscoveryRequest,
+    ValidatedTranslation,
+)
 from engine_adapters.coverage import digest_json
 from engine_adapters.renpy import RenPyAdapter, build_translation_snapshot
 from engine_adapters.writeback import WritebackPlanError, render_writeback_plan
@@ -85,6 +89,44 @@ class TestRenPyAdapterP2(unittest.TestCase):
             any(item.get("match") == "content_evidence" for item in result.diagnostics)
         )
 
+    def test_relocation_rejects_ambiguous_content_fallback(self):
+        source = (
+            'translate schinese first:\n'
+            '    # e "Same text"\n'
+            '    e "Same text"\n'
+            'translate schinese second:\n'
+            '    # e "Same text"\n'
+            '    e "Same text"\n'
+        )
+        _root, _tl_dir, adapter, snapshot = self.snapshot(source)
+        original = self.occurrence_for(snapshot, "Same text")
+        stale = replace(
+            original,
+            content_fingerprint="",
+            locator=OpaqueLocator(
+                engine="renpy",
+                locator_schema_version=1,
+                locator={
+                    "file_rel_path": "script.rpy",
+                    "translate_block": "stale",
+                    "block_occurrence": 1,
+                    "ordinal": 99,
+                    "line_hint": 1,
+                    "start_col_hint": 0,
+                    "end_col_hint": 0,
+                    "source_marker_kind": "direct_source",
+                    "candidate_ordinal": 99,
+                },
+            ),
+            unit=replace(original.unit, id="script.rpy:stale:99:deadbeef"),
+        )
+        result = adapter.relocate_occurrences(
+            snapshot.project, (stale,), snapshot.project.source_documents
+        )
+        self.assertEqual(result.occurrences, ())
+        self.assertEqual(result.unresolved_occurrence_ids, (stale.occurrence_id,))
+        self.assertEqual(result.diagnostics[0]["status"], "ambiguous")
+
     def test_relocation_reports_source_change_as_unresolved(self):
         source = (
             'translate schinese chapter:\n'
@@ -129,7 +171,7 @@ class TestRenPyAdapterP2(unittest.TestCase):
 
     def test_writeback_plan_is_declarative_and_uses_live_source_hashes(self):
         source = 'e "Hello {player}!"\n'
-        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        _root, tl_dir, adapter, snapshot = self.snapshot(source)
         occurrence = self.occurrence_for(snapshot, "Hello {player}!")
         validation = adapter.validate_translation(occurrence, "你好 {player}!")
         self.assertEqual(validation.status, "pass")
@@ -154,8 +196,10 @@ class TestRenPyAdapterP2(unittest.TestCase):
         self.assertEqual((tl_dir / "script.rpy").read_text(encoding="utf-8"), source)
 
     def test_common_plan_consumer_rechecks_snapshot_and_only_renders_memory_lines(self):
-        source = 'e "Hello {player}!"\n'
+        source = 'e "Hello {player}!"\r\n'
         root, tl_dir, adapter, snapshot = self.snapshot(source)
+        (tl_dir / "script.rpy").write_bytes(source.encode("utf-8"))
+        snapshot = build_translation_snapshot(adapter, self.request(root, tl_dir))
         occurrence = self.occurrence_for(snapshot, "Hello {player}!")
         validation = adapter.validate_translation(occurrence, "你好 {player}!")
         plan = adapter.build_writeback_plan(
@@ -167,7 +211,7 @@ class TestRenPyAdapterP2(unittest.TestCase):
         rendered = render_writeback_plan(plan, snapshot.project.source_documents)
 
         self.assertEqual(rendered["script.rpy"], ['e "你好 {player}!"\r\n'])
-        self.assertEqual((tl_dir / "script.rpy").read_text(encoding="utf-8"), source)
+        self.assertEqual((tl_dir / "script.rpy").read_bytes(), source.encode("utf-8"))
 
         (tl_dir / "script.rpy").write_text('e "Changed {player}!"\n', encoding="utf-8")
         live = adapter.discover_project(self.request(root, tl_dir))

--- a/tests/test_engine_adapter_p2.py
+++ b/tests/test_engine_adapter_p2.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""P2 Ren'Py relocation, validation, and declarative writeback tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from engine_adapters.contracts import ProjectDiscoveryRequest, ValidatedTranslation
+from engine_adapters.coverage import digest_json
+from engine_adapters.renpy import RenPyAdapter, build_translation_snapshot
+from engine_adapters.writeback import WritebackPlanError, render_writeback_plan
+import translator_runtime as runtime
+
+
+class TestRenPyAdapterP2(unittest.TestCase):
+    def make_project(self, source: str):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        tl_dir = root / "game" / "tl" / "schinese"
+        tl_dir.mkdir(parents=True)
+        (tl_dir / "script.rpy").write_text(source, encoding="utf-8")
+        return root, tl_dir
+
+    @staticmethod
+    def request(root: Path, tl_dir: Path) -> ProjectDiscoveryRequest:
+        return ProjectDiscoveryRequest(
+            project_root=str(root),
+            localization_root=str(tl_dir),
+            target_language="schinese",
+        )
+
+    @staticmethod
+    def occurrence_for(snapshot, source_text: str):
+        return next(
+            occurrence
+            for occurrence in snapshot.occurrences
+            if occurrence.unit.source_text == source_text
+        )
+
+    def snapshot(self, source: str):
+        root, tl_dir = self.make_project(source)
+        adapter = RenPyAdapter(legacy_module=runtime)
+        snapshot = build_translation_snapshot(
+            adapter,
+            self.request(root, tl_dir),
+        )
+        return root, tl_dir, adapter, snapshot
+
+    def test_relocation_handles_inserted_lines_and_preserves_identity_v2(self):
+        source = (
+            'translate schinese chapter:\n'
+            '    # e "Hello {player}!"\n'
+            '    e "Hello {player}!"\n'
+        )
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        original = self.occurrence_for(snapshot, "Hello {player}!")
+        original_id = original.unit.id
+        (tl_dir / "script.rpy").write_text(
+            'translate schinese chapter:\n'
+            '    # e "Inserted"\n'
+            '    e "Inserted"\n'
+            '    # e "Hello {player}!"\n'
+            '    e "Hello {player}!"\n',
+            encoding="utf-8",
+        )
+        live = adapter.discover_project(self.request(root, tl_dir))
+
+        result = adapter.relocate_occurrences(
+            snapshot.project,
+            (original,),
+            live.source_documents,
+        )
+
+        self.assertEqual(result.unresolved_occurrence_ids, ())
+        self.assertEqual(len(result.occurrences), 1)
+        relocated = result.occurrences[0]
+        self.assertEqual(relocated.unit.id, original_id)
+        self.assertGreater(relocated.unit.line, original.unit.line)
+        self.assertTrue(
+            any(item.get("match") == "content_evidence" for item in result.diagnostics)
+        )
+
+    def test_relocation_reports_source_change_as_unresolved(self):
+        source = (
+            'translate schinese chapter:\n'
+            '    # e "Hello {player}!"\n'
+            '    e "Hello {player}!"\n'
+        )
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        original = self.occurrence_for(snapshot, "Hello {player}!")
+        (tl_dir / "script.rpy").write_text(
+            'translate schinese chapter:\n'
+            '    # e "Goodbye {player}!"\n'
+            '    e "Goodbye {player}!"\n',
+            encoding="utf-8",
+        )
+        live = adapter.discover_project(self.request(root, tl_dir))
+
+        result = adapter.relocate_occurrences(
+            snapshot.project,
+            (original,),
+            live.source_documents,
+        )
+
+        self.assertEqual(result.occurrences, ())
+        self.assertEqual(result.unresolved_occurrence_ids, (original.occurrence_id,))
+        self.assertEqual(result.diagnostics[0]["reason_code"], "common.locator.unresolved")
+
+    def test_validation_maps_renpy_token_differences_to_stable_reason_codes(self):
+        _, _, adapter, snapshot = self.snapshot('e "Hello {player} [count] %d"\n')
+        occurrence = self.occurrence_for(snapshot, "Hello {player} [count] %d")
+
+        valid = adapter.validate_translation(
+            occurrence,
+            "你好 {player} [count] %d",
+        )
+        invalid = adapter.validate_translation(occurrence, "你好")
+
+        self.assertEqual(valid.status, "pass")
+        self.assertEqual(invalid.status, "block")
+        self.assertIn("renpy.tag.changed", invalid.reason_codes)
+        self.assertIn("renpy.field.changed", invalid.reason_codes)
+        self.assertIn("renpy.percent_token.changed", invalid.reason_codes)
+
+    def test_writeback_plan_is_declarative_and_uses_live_source_hashes(self):
+        source = 'e "Hello {player}!"\n'
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        occurrence = self.occurrence_for(snapshot, "Hello {player}!")
+        validation = adapter.validate_translation(occurrence, "你好 {player}!")
+        self.assertEqual(validation.status, "pass")
+
+        plan = adapter.build_writeback_plan(
+            snapshot.project,
+            (ValidatedTranslation(occurrence, "你好 {player}!", validation),),
+            snapshot.project.source_documents,
+        )
+
+        self.assertEqual(plan.engine, "renpy")
+        self.assertEqual(len(plan.operations), 1)
+        operation = plan.operations[0]
+        self.assertEqual(operation.kind, "text_span_replace")
+        self.assertEqual(operation.target_root, "localization_catalog")
+        self.assertEqual(operation.target_rel_path, "script.rpy")
+        self.assertNotIn("\\", operation.target_rel_path)
+        self.assertEqual(operation.expected_file_sha256, snapshot.project.source_documents[0].sha256)
+        self.assertEqual(operation.replacement_fragment, '\"你好 {player}!\"')
+        self.assertNotIn(str(tl_dir), json.dumps(plan.to_dict(), ensure_ascii=False))
+        self.assertTrue(plan.plan_digest)
+        self.assertEqual((tl_dir / "script.rpy").read_text(encoding="utf-8"), source)
+
+    def test_common_plan_consumer_rechecks_snapshot_and_only_renders_memory_lines(self):
+        source = 'e "Hello {player}!"\n'
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        occurrence = self.occurrence_for(snapshot, "Hello {player}!")
+        validation = adapter.validate_translation(occurrence, "你好 {player}!")
+        plan = adapter.build_writeback_plan(
+            snapshot.project,
+            (ValidatedTranslation(occurrence, "你好 {player}!", validation),),
+            snapshot.project.source_documents,
+        )
+
+        rendered = render_writeback_plan(plan, snapshot.project.source_documents)
+
+        self.assertEqual(rendered["script.rpy"], ['e "你好 {player}!"\r\n'])
+        self.assertEqual((tl_dir / "script.rpy").read_text(encoding="utf-8"), source)
+
+        (tl_dir / "script.rpy").write_text('e "Changed {player}!"\n', encoding="utf-8")
+        live = adapter.discover_project(self.request(root, tl_dir))
+        with self.assertRaises(WritebackPlanError) as context:
+            render_writeback_plan(plan, live.source_documents)
+        self.assertEqual(context.exception.reason_code, "common.writeback.source_snapshot_mismatch")
+
+    def test_common_plan_consumer_rejects_path_escape(self):
+        root, tl_dir, adapter, snapshot = self.snapshot('e "Hello {player}!"\n')
+        occurrence = self.occurrence_for(snapshot, "Hello {player}!")
+        validation = adapter.validate_translation(occurrence, "你好 {player}!")
+        plan = adapter.build_writeback_plan(
+            snapshot.project,
+            (ValidatedTranslation(occurrence, "你好 {player}!", validation),),
+            snapshot.project.source_documents,
+        )
+
+        operation = replace(plan.operations[0], target_rel_path="../outside.rpy")
+        operation_payload = operation.to_dict()
+        operation_payload.pop("operation_id")
+        operation = replace(
+            operation,
+            operation_id="op1:" + digest_json(operation_payload),
+        )
+        escaped_plan = replace(plan, operations=(operation,))
+        plan_payload = escaped_plan.to_dict()
+        plan_payload.pop("plan_digest")
+        escaped_plan = replace(escaped_plan, plan_digest=digest_json(plan_payload))
+
+        with self.assertRaises(WritebackPlanError) as context:
+            render_writeback_plan(escaped_plan, snapshot.project.source_documents)
+        self.assertEqual(context.exception.reason_code, "common.writeback.path_escape")
+
+    def test_writeback_plan_rejects_stale_live_span(self):
+        source = 'e "Hello {player}!"\n'
+        root, tl_dir, adapter, snapshot = self.snapshot(source)
+        occurrence = self.occurrence_for(snapshot, "Hello {player}!")
+        validation = adapter.validate_translation(occurrence, "你好 {player}!")
+        (tl_dir / "script.rpy").write_text('e "Changed {player}!"\n', encoding="utf-8")
+        live = adapter.discover_project(self.request(root, tl_dir))
+
+        with self.assertRaisesRegex(ValueError, "span/source mismatch"):
+            adapter.build_writeback_plan(
+                snapshot.project,
+                (ValidatedTranslation(occurrence, "你好 {player}!", validation),),
+                live.source_documents,
+            )
+
+    def test_writeback_plan_rejects_non_pass_validation(self):
+        _, _, adapter, snapshot = self.snapshot('e "Hello {player}!"\n')
+        occurrence = self.occurrence_for(snapshot, "Hello {player}!")
+        validation = adapter.validate_translation(occurrence, "你好")
+
+        with self.assertRaisesRegex(ValueError, "non-pass validation"):
+            adapter.build_writeback_plan(
+                snapshot.project,
+                (ValidatedTranslation(occurrence, "你好", validation),),
+                snapshot.project.source_documents,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_adapter_p2.py
+++ b/tests/test_engine_adapter_p2.py
@@ -220,7 +220,7 @@ class TestRenPyAdapterP2(unittest.TestCase):
         self.assertEqual(context.exception.reason_code, "common.writeback.source_snapshot_mismatch")
 
     def test_common_plan_consumer_rejects_path_escape(self):
-        root, tl_dir, adapter, snapshot = self.snapshot('e "Hello {player}!"\n')
+        _root, _tl_dir, adapter, snapshot = self.snapshot('e "Hello {player}!"\n')
         occurrence = self.occurrence_for(snapshot, "Hello {player}!")
         validation = adapter.validate_translation(occurrence, "你好 {player}!")
         plan = adapter.build_writeback_plan(

--- a/tests/test_gui_sync_translation_report.py
+++ b/tests/test_gui_sync_translation_report.py
@@ -89,6 +89,27 @@ class GuiSyncTranslationReportTests(unittest.TestCase):
         self.assertEqual(update.status, "warning")
         self.assertIn("部分完成", update.message)
 
+    def test_summarize_partial_adapter_preview_warns_and_remains_applyable(self):
+        update = summarize_sync_translation_output(
+            "Found 2 files.\n"
+            "Processing: first.rpy\n"
+            "  Found 1 lines to translate.\n"
+            "  Translated 1/1 items. (Received 8 chars of translation)\n"
+            "  Previewed first.rpy.\n"
+            "Sync preview manifest: logs/sync_runs/demo/manifest.json\n"
+            "Sync preview report: logs/sync_runs/demo/preview.diff\n"
+            "Preview files: 1\n"
+            "Preview translations: 1\n"
+            "Preview failures: 1\n"
+            "Preview status: partial\n",
+            0,
+        )
+
+        self.assertEqual(update.status, "warning")
+        self.assertIn("部分完成", update.heading)
+        self.assertIn("其余安全预览", update.message)
+        self.assertTrue(any("预览失败文件" in fact for fact in update.facts))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_sync_translation_workflow.py
+++ b/tests/test_gui_sync_translation_workflow.py
@@ -34,6 +34,27 @@ class GuiSyncTranslationWorkflowTests(unittest.TestCase):
         self.assertEqual(workflow.manifest_path, "C:/run/manifest.json")
         self.assertIsNone(workflow.current_step())
 
+
+    def test_partial_preview_warns_but_keeps_manifest_applyable(self):
+        workflow = SyncTranslationWorkflow.start_new()
+        output = (
+            "Found 2 files.\nProcessing: a.rpy\n"
+            "  Found 1 lines to translate.\n"
+            "  Translated 1/1 items. (Received 8 chars of translation)\n"
+            "  Previewed a.rpy.\n"
+            "Sync preview manifest: C:/run/manifest.json\n"
+            "Sync preview report: C:/run/preview.diff\n"
+            "Preview files: 1\n"
+            "Preview translations: 1\n"
+            "Preview failures: 1\n"
+            "Preview status: partial\n"
+        )
+
+        update = workflow.complete_current_step(0, output)
+
+        self.assertEqual(update.status, "warning")
+        self.assertEqual(workflow.manifest_path, "C:/run/manifest.json")
+        self.assertIsNone(workflow.current_step())
     def test_apply_workflow_uses_explicit_manifest(self):
         workflow = SyncTranslationWorkflow.apply_existing("C:/run/manifest.json")
 

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -389,7 +389,7 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         Path(file_path).write_text("".join(lines), encoding="utf-8")
         scanned = runtime.scan_all_translation_units(lines, file_rel_path)
         item_id, (line, start, end, source_text) = next(iter(scanned.items()))
-        translated_text = "Alpha， Beta， Gamma"
+        translated_text = "Alpha， Beta， Gamma"  # noqa: RUF001
         manifest = {
             "version": 2,
             "manifest_version": 2,
@@ -458,7 +458,10 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         self.assertEqual(summary["valid_items"], 1)
         self.assertEqual(summary["adapter_writeback_status"], "pass")
         self.assertIsNotNone(plan)
-        self.assertEqual(plan.operations[0].replacement_fragment, '"Alpha， Beta， Gamma"')
+        self.assertEqual(
+            plan.operations[0].replacement_fragment,
+            '"Alpha， Beta， Gamma"',  # noqa: RUF001
+        )
 
     def test_collect_result_actions_relocates_missing_v2_response_items(self):
         file_rel_path = "script.rpy"

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -724,6 +724,123 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         safety = batch_mod.summarize_check_safety(summary)
         self.assertEqual(safety["level"], batch_mod.CHECK_SAFETY_SAFE)
 
+    def test_collect_result_actions_blocks_ambiguous_same_score_content_evidence(self):
+        """Two equal-score content candidates must fail closed through collect/check."""
+        file_rel_path = "script.rpy"
+        file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        current_lines = [
+            "translate schinese first:\n",
+            "    # \"Same text\"\n",
+            "    \"Same text\"\n",
+            "translate schinese second:\n",
+            "    # \"Same text\"\n",
+            "    \"Same text\"\n",
+        ]
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.writelines(current_lines)
+
+        stale_id = translation_core.build_identity_v2(
+            file_rel_path, "stale_block", 99, "Same text"
+        )
+        result_path = os.path.join(self.tmp_dir, "ambiguous_relocation_results.jsonl")
+        manifest = {
+            "version": 2,
+            "manifest_version": 2,
+            "core_schema_version": 2,
+            "mode": batch_mod.MANIFEST_MODE_TRANSLATION,
+            "input_jsonl_path": os.path.join(self.tmp_dir, "requests.jsonl"),
+            "result_jsonl_path": result_path,
+            "settings": {},
+            "files": {
+                file_rel_path: {
+                    "path": file_path,
+                    "task_count": 1,
+                }
+            },
+            "chunks": [
+                {
+                    "key": "chunk_0",
+                    "file_rel_path": file_rel_path,
+                    "chunk_index": 1,
+                    "items": [
+                        {
+                            "id": stale_id,
+                            "text": "Same text",
+                            "line": 2,
+                            "start": 4,
+                            "end": 15,
+                            "quote": "\"",
+                        }
+                    ],
+                }
+            ],
+            "_manifest_path": os.path.join(self.tmp_dir, "manifest.json"),
+            "_package_dir": self.tmp_dir,
+        }
+
+        response_text = json.dumps(
+            [{"id": stale_id, "translation": "同一文本"}],
+            ensure_ascii=False,
+        )
+        with open(result_path, "w", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "key": "chunk_0",
+                        "response": {
+                            "candidates": [
+                                {
+                                    "content": {
+                                        "parts": [{"text": response_text}]
+                                    }
+                                }
+                            ]
+                        },
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+        replacements, _, failures, summary = batch_mod.collect_result_actions(
+            manifest,
+            validate_sources=True,
+        )
+
+        self.assertEqual(replacements.get(file_rel_path, {}), {})
+        self.assertEqual(summary["reason_counts"].get("v2_relocation_missing"), 1)
+        self.assertTrue(
+            any(failure.get("reason_code") == "v2_relocation_missing" for failure in failures)
+        )
+        safety = batch_mod.summarize_check_safety(summary)
+        self.assertNotEqual(safety["level"], batch_mod.CHECK_SAFETY_SAFE)
+
+        original_text = Path(file_path).read_text(encoding="utf-8")
+        with (
+            mock.patch.object(batch_mod, "load_manifest", return_value=manifest),
+            mock.patch.object(batch_mod, "require_manifest_mode"),
+            mock.patch.object(batch_mod, "require_manifest_project_match"),
+            mock.patch.object(batch_mod, "recover_atomic_write_transaction"),
+            mock.patch.object(batch_mod, "require_safe_check_for_apply"),
+            mock.patch.object(batch_mod, "append_failure_entries"),
+            mock.patch.object(
+                batch_mod,
+                "write_apply_failure_report",
+                return_value=os.path.join(self.tmp_dir, "apply_failure_report.json"),
+            ),
+            mock.patch.object(batch_mod, "save_manifest"),
+            mock.patch.object(batch_mod, "atomic_write_many_lines") as atomic_write,
+            mock.patch.object(batch_mod, "update_progress") as update_progress,
+        ):
+            with self.assertRaises(SystemExit):
+                batch_mod.apply_results(manifest["_manifest_path"], force=True)
+
+        self.assertEqual(Path(file_path).read_text(encoding="utf-8"), original_text)
+        atomic_write.assert_not_called()
+        update_progress.assert_not_called()
+
     def test_collect_revision_actions_uses_v2_identity_after_line_drift(self):
         file_rel_path = "script.rpy"
         file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -382,6 +382,84 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         action_tuple = replacements[file_rel_path][6][0]
         self.assertEqual(action_tuple[2], "你好世界")
 
+    def test_adapter_plan_preserves_batch_non_chinese_policy_allowance(self):
+        file_rel_path = "screens_patronlistitem.rpy"
+        file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
+        lines = ['    "Alpha, Beta, Gamma"\n']
+        Path(file_path).write_text("".join(lines), encoding="utf-8")
+        scanned = runtime.scan_all_translation_units(lines, file_rel_path)
+        item_id, (line, start, end, source_text) = next(iter(scanned.items()))
+        translated_text = "Alpha， Beta， Gamma"
+        manifest = {
+            "version": 2,
+            "manifest_version": 2,
+            "core_schema_version": 2,
+            "mode": batch_mod.MANIFEST_MODE_TRANSLATION,
+            "base_dir": self.tmp_dir,
+            "tl_dir": batch_mod.legacy.TL_DIR,
+            "result_jsonl_path": os.path.join(self.tmp_dir, "results.jsonl"),
+            "files": {file_rel_path: {"path": file_path, "task_count": 1}},
+            "chunks": [
+                {
+                    "key": "chunk_0",
+                    "file_rel_path": file_rel_path,
+                    "items": [
+                        {
+                            "id": item_id,
+                            "text": source_text,
+                            "line": line,
+                            "line_number": line + 1,
+                            "start": start,
+                            "end": end,
+                            "prefix": "",
+                            "quote": '"',
+                        }
+                    ],
+                }
+            ],
+            "_manifest_path": os.path.join(self.tmp_dir, "manifest.json"),
+            "_package_dir": self.tmp_dir,
+        }
+        result = {
+            "key": "chunk_0",
+            "response": {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": json.dumps(
+                                        [{"id": item_id, "translation": translated_text}]
+                                    )
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+        }
+        Path(manifest["result_jsonl_path"]).write_text(
+            json.dumps(result, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        replacements, _translated, failures, summary = batch_mod.collect_result_actions(
+            manifest,
+            validate_sources=True,
+        )
+        plan, _snapshot = batch_mod._validate_adapter_writeback_plan(
+            manifest,
+            replacements,
+            summary,
+            failures,
+        )
+
+        self.assertEqual(failures, [])
+        self.assertEqual(summary["valid_items"], 1)
+        self.assertEqual(summary["adapter_writeback_status"], "pass")
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.operations[0].replacement_fragment, '"Alpha， Beta， Gamma"')
+
     def test_collect_result_actions_relocates_missing_v2_response_items(self):
         file_rel_path = "script.rpy"
         file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -473,7 +473,7 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         missing = [failure for failure in failures if failure.get("id") == id2][0]
         self.assertEqual(missing["line"], 8)
 
-    def test_collect_result_actions_blocks_missing_v2_relocation(self):
+    def test_collect_result_actions_uses_unique_content_fallback_for_stale_v2_identity(self):
         file_rel_path = "script.rpy"
         file_path = os.path.join(batch_mod.legacy.TL_DIR, file_rel_path)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
@@ -545,13 +545,11 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
             validate_sources=True,
         )
 
-        self.assertEqual(replacements, {})
-        self.assertEqual(summary["reason_counts"]["v2_relocation_missing"], 1)
-        self.assertEqual(len(failures), 1)
-        self.assertEqual(failures[0]["id"], missing_id)
-        self.assertEqual(failures[0]["reason_code"], "v2_relocation_missing")
+        self.assertIn(2, replacements[file_rel_path])
+        self.assertEqual(failures, [])
+        self.assertNotIn("v2_relocation_missing", summary["reason_counts"])
         safety = batch_mod.summarize_check_safety(summary)
-        self.assertEqual(safety["level"], batch_mod.CHECK_SAFETY_BLOCK)
+        self.assertEqual(safety["level"], batch_mod.CHECK_SAFETY_SAFE)
 
     def test_collect_revision_actions_uses_v2_identity_after_line_drift(self):
         file_rel_path = "script.rpy"

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -546,6 +546,8 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
         )
 
         self.assertIn(2, replacements[file_rel_path])
+        self.assertEqual(len(replacements[file_rel_path][2]), 1)
+        self.assertEqual(replacements[file_rel_path][2][0][2], "同一文本")
         self.assertEqual(failures, [])
         self.assertNotIn("v2_relocation_missing", summary["reason_counts"])
         safety = batch_mod.summarize_check_safety(summary)

--- a/tests/test_identity_v2.py
+++ b/tests/test_identity_v2.py
@@ -5,6 +5,7 @@ import unittest
 import json
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import translation_core
@@ -462,6 +463,95 @@ class TestIdentityV2AndCompatibility(unittest.TestCase):
             plan.operations[0].replacement_fragment,
             '"Alpha， Beta， Gamma"',  # noqa: RUF001
         )
+
+    def test_find_adapter_occurrence_binds_identity_to_validated_span(self):
+        first = SimpleNamespace(
+            unit=SimpleNamespace(
+                id="identity-match",
+                file_rel_path="script.rpy",
+                line=0,
+                start=4,
+                end=10,
+                text="Same",
+                source_text="Same",
+                current_translation="",
+            )
+        )
+        positioned = SimpleNamespace(
+            unit=SimpleNamespace(
+                id="position-match",
+                file_rel_path="script.rpy",
+                line=1,
+                start=4,
+                end=10,
+                text="Same",
+                source_text="Same",
+                current_translation="",
+            )
+        )
+
+        matched = batch_mod._find_adapter_occurrence(
+            (first, positioned),
+            "script.rpy",
+            1,
+            4,
+            10,
+            "Same",
+            "identity-match",
+        )
+
+        self.assertIs(matched, positioned)
+
+    def test_adapter_plan_blocks_missing_rendered_target(self):
+        plan = SimpleNamespace(plan_digest="plan", operations=(SimpleNamespace(),))
+        snapshot = SimpleNamespace(
+            project=SimpleNamespace(source_documents=()),
+        )
+        summary = {"reason_counts": {}, "valid_items": 1}
+        failures = []
+
+        with (
+            mock.patch.object(
+                batch_mod,
+                "_build_adapter_writeback_plan",
+                return_value=(plan, snapshot),
+            ),
+            mock.patch.object(batch_mod, "render_writeback_plan", return_value={}),
+        ):
+            result_plan, result_snapshot = batch_mod._validate_adapter_writeback_plan(
+                {"_package_dir": self.tmp_dir},
+                {"script.rpy": {0: [(0, 1, "译文", "", '"')]}},
+                summary,
+                failures,
+            )
+
+        self.assertIsNone(result_plan)
+        self.assertIsNone(result_snapshot)
+        self.assertEqual(summary["adapter_writeback_status"], "block")
+        self.assertEqual(
+            failures[0]["adapter_reason_code"],
+            "common.writeback.target_missing",
+        )
+
+    def test_adapter_plan_does_not_swallow_system_exit(self):
+        summary = {"reason_counts": {}, "valid_items": 1}
+        failures = []
+
+        with (
+            mock.patch.object(
+                batch_mod,
+                "_build_adapter_writeback_plan",
+                side_effect=SystemExit("project mismatch"),
+            ),
+            self.assertRaisesRegex(SystemExit, "project mismatch"),
+        ):
+            batch_mod._validate_adapter_writeback_plan(
+                {"_package_dir": self.tmp_dir},
+                {"script.rpy": {0: [(0, 1, "译文", "", '"')]}},
+                summary,
+                failures,
+            )
+
 
     def test_collect_result_actions_relocates_missing_v2_response_items(self):
         file_rel_path = "script.rpy"

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -48,6 +48,21 @@ class SyncTranslationPreviewTests(unittest.TestCase):
             report = (manifest_path.parent / "preview.diff").read_text(encoding="utf-8")
             self.assertIn('-    "Hello 1"', report)
             self.assertIn('+    "你好 1"', report)
+    def test_load_accepts_legacy_preview_without_failures_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tl_dir, manifest_path, manifest = self._create_preview(root)
+            manifest.pop("failures")
+            manifest["preview_fingerprint"] = preview._fingerprint(manifest)
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            loaded = preview.load_sync_preview(manifest_path)
+
+            self.assertNotIn("failures", loaded)
+
 
     def test_create_preview_records_partial_adapter_failures(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -79,6 +94,15 @@ class SyncTranslationPreviewTests(unittest.TestCase):
                 manifest["failures"][0]["reason_code"],
                 "common.locator.unresolved",
             )
+
+            persisted = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+            persisted["failures"][0]["message"] = "edited audit detail"
+            Path(manifest_path).write_text(
+                json.dumps(persisted, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "manifest changed"):
+                preview.load_sync_preview(manifest_path)
 
     def test_build_sync_adapter_preview_isolates_plan_failure(self):
         error = runtime.WritebackPlanError("common.locator.unresolved", "ambiguous")

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -48,6 +48,7 @@ class SyncTranslationPreviewTests(unittest.TestCase):
             report = (manifest_path.parent / "preview.diff").read_text(encoding="utf-8")
             self.assertIn('-    "Hello 1"', report)
             self.assertIn('+    "你好 1"', report)
+
     def test_load_accepts_legacy_preview_without_failures_field(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -49,6 +49,47 @@ class SyncTranslationPreviewTests(unittest.TestCase):
             self.assertIn('-    "Hello 1"', report)
             self.assertIn('+    "你好 1"', report)
 
+    def test_create_preview_records_partial_adapter_failures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / "game" / "tl" / "schinese"
+            tl_dir.mkdir(parents=True)
+
+            manifest_path, manifest = preview.create_sync_preview(
+                log_dir=root / "logs",
+                project_root=root,
+                tl_dir=tl_dir,
+                files=(),
+                failures=(
+                    {
+                        "relative_path": "broken.rpy",
+                        "reason_code": "common.locator.unresolved",
+                        "message": "ambiguous occurrence",
+                    },
+                ),
+            )
+
+            self.assertTrue(Path(manifest_path).is_file())
+            self.assertEqual(manifest["summary"]["failure_files"], 1)
+            self.assertEqual(
+                manifest["summary"]["adapter_writeback_status"],
+                "partial",
+            )
+            self.assertEqual(
+                manifest["failures"][0]["reason_code"],
+                "common.locator.unresolved",
+            )
+
+    def test_build_sync_adapter_preview_isolates_plan_failure(self):
+        error = runtime.WritebackPlanError("common.locator.unresolved", "ambiguous")
+        with mock.patch.object(runtime, "build_sync_adapter_writeback_plan", side_effect=error):
+            plan, rendered, failure = runtime.build_sync_adapter_preview(
+                object(), object(), "broken.rpy", (), {0: [(0, 1, "你好", "", '"')]}
+            )
+        self.assertIsNone(plan)
+        self.assertIsNone(rendered)
+        self.assertEqual(failure["reason_code"], "common.locator.unresolved")
+
     def test_sync_validation_rejects_changed_tags_and_placeholders(self):
         valid, message = runtime.validate_translation(
             "Hello [player] {i}%s{/i}",

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -1361,6 +1361,46 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(successful, ['task:0:1'])
         self.assertEqual(replacements, {0: [(1, 8, '\u4f60\u597d', '', '"')]})
 
+    def test_process_batch_uses_injected_adapter_validator(self):
+        batch = [
+            {
+                'id': 'file:0:1',
+                'text': 'Hello',
+                'line': 0,
+                'start': 1,
+                'end': 8,
+                'prefix': '',
+                'quote': '"',
+                'progress_entry': 'task:0:1',
+            },
+            {
+                'id': 'file:0:10',
+                'text': 'World',
+                'line': 0,
+                'start': 10,
+                'end': 17,
+                'prefix': '',
+                'quote': '"',
+                'progress_entry': 'task:0:10',
+            },
+        ]
+        validator = mock.Mock(
+            side_effect=lambda entry, _translated: (
+                entry['id'] == 'file:0:10',
+                'adapter.validation.block',
+            )
+        )
+        replacements = {}
+        with mock.patch.object(runtime, 'call_gemini_sdk', return_value=[
+            {'id': 'file:0:1', 'translation': '你好'},
+            {'id': 'file:0:10', 'translation': '世界'},
+        ]):
+            successful = runtime.process_batch(
+                batch, replacements, translation_validator=validator
+            )
+        self.assertEqual(successful, ['task:0:10'])
+        self.assertEqual(validator.call_count, 2)
+
     def test_process_batch_stores_normalized_text_for_sync_rag(self):
         old_normalize_map = runtime.NORMALIZE_TRANSLATION_MAP
         old_use_memory = runtime.USE_TRANSLATION_MEMORY

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -3650,7 +3650,7 @@ def _upgrade_legacy_progress_keys(progress, file_paths):
 
 
 def build_sync_adapter_writeback_plan(adapter, snapshot, file_rel_path, tasks, replacements):
-    """Validate sync replacements through the adapter and build a declarative plan."""
+    """Validate replacements and return a plan with its exact source tuple."""
 
     occurrences = tuple(
         occurrence
@@ -3735,28 +3735,24 @@ def build_sync_adapter_writeback_plan(adapter, snapshot, file_rel_path, tasks, r
         for document in snapshot.project.source_documents
         if document.file_rel_path == file_rel_path
     )
-    return adapter.build_writeback_plan(
+    plan = adapter.build_writeback_plan(
         snapshot.project,
         tuple(validated),
         live_sources,
     )
+    return plan, live_sources
 
 
 def build_sync_adapter_preview(adapter, snapshot, file_rel_path, tasks, replacements):
     """Build and render one sync preview file without aborting sibling files."""
 
     try:
-        plan = build_sync_adapter_writeback_plan(
+        plan, live_sources = build_sync_adapter_writeback_plan(
             adapter,
             snapshot,
             file_rel_path,
             tasks,
             replacements,
-        )
-        live_sources = tuple(
-            document
-            for document in snapshot.project.source_documents
-            if document.file_rel_path == file_rel_path
         )
         rendered = render_writeback_plan(plan, live_sources)
     except (KeyError, ValueError) as exc:

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -34,9 +34,13 @@ def locked_runtime_state():
 
 from atomic_io import atomic_write_json, atomic_write_lines
 import cli_contract
-from engine_adapters.contracts import ProjectDiscoveryRequest
+from engine_adapters.contracts import ProjectDiscoveryRequest, ValidatedTranslation
 from engine_adapters.coverage import export_coverage_package
 from engine_adapters.renpy import RenPyAdapter, build_translation_snapshot
+from engine_adapters.writeback import (
+    WritebackPlanError,
+    render_writeback_plan,
+)
 from gemini_model_catalog import (
     DEFAULT_GEMINI_EMBEDDING_MODEL,
     DEFAULT_GEMINI_TRANSLATION_MODEL,
@@ -3645,6 +3649,99 @@ def _upgrade_legacy_progress_keys(progress, file_paths):
     return progress
 
 
+def build_sync_adapter_writeback_plan(adapter, snapshot, file_rel_path, tasks, replacements):
+    """Validate sync replacements through the adapter and build a declarative plan."""
+
+    occurrences = tuple(
+        occurrence
+        for occurrence in snapshot.occurrences
+        if occurrence.unit.file_rel_path == file_rel_path
+    )
+    occurrences_by_unit_id = {
+        occurrence.unit.id: occurrence
+        for occurrence in occurrences
+        if occurrence.unit.id
+    }
+    tasks_by_span = {
+        (
+            int(task.get('line') or 0),
+            int(task.get('start') or 0),
+            int(task.get('end') or 0),
+        ): task
+        for task in tasks
+    }
+    validated = []
+    used_occurrence_ids = set()
+
+    for line, line_replacements in replacements.items():
+        for replacement in line_replacements:
+            start, end, translated, _prefix, _quote = replacement[:5]
+            task = tasks_by_span.get((int(line), int(start), int(end)))
+            occurrence = None
+            if task is not None:
+                occurrence = occurrences_by_unit_id.get(str(task.get('id') or ''))
+            if occurrence is None:
+                candidates = [
+                    candidate
+                    for candidate in occurrences
+                    if candidate.unit.line == int(line)
+                    and candidate.unit.start == int(start)
+                    and candidate.unit.end == int(end)
+                    and (
+                        not task
+                        or not task.get('text')
+                        or candidate.unit.text == task.get('text')
+                        or candidate.unit.source_text == task.get('text')
+                    )
+                ]
+                if len(candidates) == 1:
+                    occurrence = candidates[0]
+                elif len(candidates) > 1:
+                    raise WritebackPlanError(
+                        'common.locator.unresolved',
+                        f'Ambiguous sync occurrence at {file_rel_path}:{line}:{start}-{end}.',
+                    )
+            if occurrence is None:
+                raise WritebackPlanError(
+                    'common.locator.unresolved',
+                    f'Sync occurrence could not be resolved at {file_rel_path}:{line}:{start}-{end}.',
+                )
+            if occurrence.occurrence_id in used_occurrence_ids:
+                raise WritebackPlanError(
+                    'common.writeback.span_overlap',
+                    f'Duplicate sync occurrence at {file_rel_path}:{line}:{start}-{end}.',
+                )
+            used_occurrence_ids.add(occurrence.occurrence_id)
+            validation = adapter.validate_translation(
+                occurrence,
+                str(translated or ''),
+            )
+            if validation.status != 'pass':
+                codes = ','.join(validation.reason_codes) or 'adapter.validation.block'
+                raise WritebackPlanError(
+                    'adapter.validation.block',
+                    f'Adapter validation blocked {file_rel_path}:{line}: {codes}.',
+                )
+            validated.append(
+                ValidatedTranslation(
+                    occurrence=occurrence,
+                    translated_text=str(translated or ''),
+                    validation=validation,
+                )
+            )
+
+    live_sources = tuple(
+        document
+        for document in snapshot.project.source_documents
+        if document.file_rel_path == file_rel_path
+    )
+    return adapter.build_writeback_plan(
+        snapshot.project,
+        tuple(validated),
+        live_sources,
+    )
+
+
 def render_replacement_lines(lines, replacements):
     """Return replacement output without modifying the caller's source lines."""
     rendered = list(lines)
@@ -4978,8 +5075,9 @@ def run_translation(*, prepare=False):
         if not os.path.isdir(TL_DIR):
             print("WARNING: TL_DIR does not exist in preview mode.")
 
+        adapter = RenPyAdapter(legacy_module=sys.modules[__name__])
         adapter_snapshot = build_translation_snapshot(
-            RenPyAdapter(legacy_module=sys.modules[__name__]),
+            adapter,
             ProjectDiscoveryRequest(
                 project_root=BASE_DIR,
                 localization_root=TL_DIR,
@@ -5057,7 +5155,23 @@ def run_translation(*, prepare=False):
 
             if replacements:
                 normalized_entries = _normalize_progress_entries(successful_entries)
-                preview_lines = render_replacement_lines(lines, replacements)
+                adapter_plan = build_sync_adapter_writeback_plan(
+                    adapter,
+                    adapter_snapshot,
+                    progress_key,
+                    tasks,
+                    replacements,
+                )
+                live_sources = tuple(
+                    document
+                    for document in adapter_snapshot.project.source_documents
+                    if document.file_rel_path == progress_key
+                )
+                rendered_by_file = render_writeback_plan(
+                    adapter_plan,
+                    live_sources,
+                )
+                preview_lines = rendered_by_file[progress_key]
                 source_text = "".join(lines)
                 preview_text = "".join(preview_lines)
                 # Preserve a leading UTF-8 BOM so source_sha256 (raw bytes) and
@@ -5075,6 +5189,7 @@ def run_translation(*, prepare=False):
                         "preview_text": preview_text,
                         "progress_entries": normalized_entries,
                         "translated_items": len(normalized_entries),
+                        "writeback_plan": adapter_plan.to_dict(),
                     }
                 )
             print(f"  Previewed {filename}.")

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -3742,6 +3742,32 @@ def build_sync_adapter_writeback_plan(adapter, snapshot, file_rel_path, tasks, r
     )
 
 
+def build_sync_adapter_preview(adapter, snapshot, file_rel_path, tasks, replacements):
+    """Build and render one sync preview file without aborting sibling files."""
+
+    try:
+        plan = build_sync_adapter_writeback_plan(
+            adapter,
+            snapshot,
+            file_rel_path,
+            tasks,
+            replacements,
+        )
+        live_sources = tuple(
+            document
+            for document in snapshot.project.source_documents
+            if document.file_rel_path == file_rel_path
+        )
+        rendered = render_writeback_plan(plan, live_sources)
+    except (KeyError, ValueError) as exc:
+        return None, None, {
+            "relative_path": file_rel_path,
+            "reason_code": getattr(exc, "reason_code", "adapter.writeback.block"),
+            "message": str(exc),
+        }
+    return plan, rendered, None
+
+
 def render_replacement_lines(lines, replacements):
     """Return replacement output without modifying the caller's source lines."""
     rendered = list(lines)
@@ -4356,6 +4382,7 @@ def process_batch(
     usage_run_id='',
     usage_buffer=None,
     usage_operation_id='',
+    translation_validator=None,
 ):
     glossary_hits = retrieve_sync_glossary_hits(batch) if SYNC_RAG_ENABLED else []
     history_hits, rag_stats = retrieve_sync_history_hits(batch) if SYNC_RAG_ENABLED else ([], {})
@@ -4396,7 +4423,10 @@ def process_batch(
 
         translated = item.get("translation", "")
         memory_translation = apply_normalization(translated) if USE_TRANSLATION_MEMORY else translated
-        valid, msg = validate_translation(entry["text"], translated)
+        if translation_validator is None:
+            valid, msg = validate_translation(entry["text"], translated)
+        else:
+            valid, msg = translation_validator(entry, translated)
 
         if not valid:
             print(f"  Warning: Validation failed for {entry['id']}: {msg}")
@@ -4426,6 +4456,7 @@ def process_batch_with_retry(
     usage_run_id='',
     usage_buffer=None,
     usage_operation_id='',
+    translation_validator=None,
 ):
     if retry_depth >= 5:
         log_failure(batch, "Max retry depth reached")
@@ -4441,6 +4472,7 @@ def process_batch_with_retry(
             return process_batch(
                 batch,
                 replacements,
+                translation_validator=translation_validator,
                 usage_run_id=usage_run_id,
                 usage_buffer=usage_buffer,
                 usage_operation_id=usage_operation_id,
@@ -4499,12 +4531,14 @@ def process_batch_with_retry(
             usage_run_id=usage_run_id,
             usage_buffer=usage_buffer,
             usage_operation_id=usage_operation_id,
+            translation_validator=translation_validator,
         )
         r2 = process_batch_with_retry(
             batch[mid:], replacements, retry_depth + 1,
             usage_run_id=usage_run_id,
             usage_buffer=usage_buffer,
             usage_operation_id=usage_operation_id,
+            translation_validator=translation_validator,
         )
         return r1 + r2
 
@@ -5087,6 +5121,22 @@ def run_translation(*, prepare=False):
             ),
         )
         source_documents = adapter_snapshot.project.source_documents
+        occurrences_by_unit_id = {
+            occurrence.unit.id: occurrence
+            for occurrence in adapter_snapshot.occurrences
+            if occurrence.unit.id
+        }
+
+        def validate_sync_translation(entry, translated):
+            occurrence = occurrences_by_unit_id.get(str(entry.get("id") or ""))
+            if occurrence is None:
+                return False, "common.locator.unresolved"
+            validation = adapter.validate_translation(occurrence, translated)
+            if validation.status == "pass":
+                return True, "OK"
+            reason = ", ".join(validation.reason_codes) or "adapter.validation.block"
+            return False, reason
+
         files_to_process = [
             document.file_path
             for document in source_documents
@@ -5095,6 +5145,7 @@ def run_translation(*, prepare=False):
 
         global_progress = _upgrade_legacy_progress_keys(load_progress(), files_to_process)
         preview_files = []
+        preview_failures = []
         for document in source_documents:
             file_path = document.file_path
             filename = os.path.basename(file_path)
@@ -5137,6 +5188,7 @@ def run_translation(*, prepare=False):
                         batch,
                         replacements,
                         usage_run_id=usage_run_id,
+                        translation_validator=validate_sync_translation,
                         usage_buffer=usage_buffer,
                         usage_operation_id=usage_operation_id,
                     ))
@@ -5149,28 +5201,24 @@ def run_translation(*, prepare=False):
                     batch,
                     replacements,
                     usage_run_id=usage_run_id,
+                    translation_validator=validate_sync_translation,
                     usage_buffer=usage_buffer,
                     usage_operation_id=usage_operation_id,
                 ))
 
-            if replacements:
+            if any(replacements.values()):
                 normalized_entries = _normalize_progress_entries(successful_entries)
-                adapter_plan = build_sync_adapter_writeback_plan(
+                adapter_plan, rendered_by_file, preview_failure = build_sync_adapter_preview(
                     adapter,
                     adapter_snapshot,
                     progress_key,
                     tasks,
                     replacements,
                 )
-                live_sources = tuple(
-                    document
-                    for document in adapter_snapshot.project.source_documents
-                    if document.file_rel_path == progress_key
-                )
-                rendered_by_file = render_writeback_plan(
-                    adapter_plan,
-                    live_sources,
-                )
+                if preview_failure is not None:
+                    preview_failures.append(preview_failure)
+                    print(f"  Warning: Preview skipped for {filename}: {preview_failure['message']}")
+                    continue
                 preview_lines = rendered_by_file[progress_key]
                 source_text = "".join(lines)
                 preview_text = "".join(preview_lines)
@@ -5199,6 +5247,7 @@ def run_translation(*, prepare=False):
             project_root=BASE_DIR,
             tl_dir=TL_DIR,
             files=preview_files,
+            failures=preview_failures,
         )
         try:
             export_coverage_package(
@@ -5217,7 +5266,11 @@ def run_translation(*, prepare=False):
         print(f"Sync preview report: {report_path}")
         print(f"Preview files: {int(summary.get('files_changed') or 0)}")
         print(f"Preview translations: {int(summary.get('translated_items') or 0)}")
-        print("Preview status: safe")
+        if preview_failures:
+            print(f"Preview failures: {len(preview_failures)}")
+            print("Preview status: partial")
+        else:
+            print("Preview status: safe")
         print("No project scripts were modified. Review the diff, then run with --apply MANIFEST.")
         return manifest_path
     finally:


### PR DESCRIPTION
## Summary

- Implement Ren'Py P2 occurrence relocation using identity v2 first, then unique source/context evidence fallback.
- Add stable adapter validation reason codes for tags, fields, percent tokens, and placeholders.
- Add declarative text-span writeback plans with common source fingerprint, path containment, span, hash, overlap, and plan-digest checks.
- Route sync preview, Batch, and revision flows through the common adapter-plan gate while retaining existing check -> apply, source re-read, transaction, and atomic-write safety.
- Persist and revalidate the writeback plan for sync preview apply.
- Add P2 regression coverage and update the adapter contract documentation.

## Why

#265 P2 requires engine-specific relocation and format validation without duplicating writeback safety in each workflow. This keeps Ren'Py rendering semantics in the adapter while keeping project, manifest, path, stale-source, transaction, and writeback safety in the common layer.

## Validation

- Focused adapter, sync preview, identity, Batch, and runtime regression suites passed.
- `python -B tests/run_cli_tests.py -q` — 854 tests passed, 1 skipped.
- `python -B tests/run_gui_tests.py -q` — 900 tests passed.
- `python scripts/run_quality_gates.py all` — all blocking gates passed.

Refs #265

P3/P4 and later epic phases remain outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持同步翻译预览、普通批量翻译及修订预览/应用流程。
  * 新增文本定位、占位符与格式校验，以及声明式写回计划。
  * 预览结果记录失败详情，并区分安全与部分完成状态。

* **安全性改进**
  * 应用前重新验证源文件，检测过期、冲突、重叠或不安全操作并阻止写入。
  * 支持源文件变化后的可靠定位，同时保留 UTF-8 BOM 等文件特性。

* **文档**
  * 更新引擎适配器能力、工作流及安全边界说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->