### PR TITLE
fix: tighten doctor signals and speed up environment checks

### DIFF
--- a/docs/doctor_recommendations.md
+++ b/docs/doctor_recommendations.md
@@ -44,7 +44,7 @@ GUI 文案入口名称（须与界面一致）：
 - 布局：当前路径、work 目录、original/game 是否存在。
 - 模板：TL 目录、翻译文件、Ren'Py SDK、自定义模板命令是否可用。
 - 工作量：待译条目数、待译文件数、翻译块和原文注释数量。
-- 翻译阶段：是否已有旧译、是否属于全新初译或增量补译。
+- 翻译阶段：是否已有**中文**旧译（`translated_task_count`，不是模板里的 `old_lines`）、是否属于全新初译或增量补译。
 - 上下文系统：RAG、原文索引是否启用，store 是否存在，记录或片段是否完整。
 - 项目分析：按当前项目解析是否启用，再检查产物是否缺失/过期、生成模型与 API Key 是否可用。
 - 项目资产：术语表和风格设定是否存在、路径是否匹配当前项目。
@@ -168,6 +168,7 @@ if source_index_needs_bootstrap:
     recommend("bootstrap_source_index", severity="required", priority=80)
 if rag_needs_bootstrap:
     recommend("bootstrap_rag", severity="required", priority=70)
+# has_existing_translations = translated_task_count > 0（已有中文译文，非 old 模板行）
 elif has_existing_translations and pending_count >= 150 and not rag_enabled:
     recommend("enable_rag_for_consistency", severity="optional", priority=30)
 if new_project and not source_index_enabled:

--- a/docs/doctor_states_matrix.md
+++ b/docs/doctor_states_matrix.md
@@ -39,7 +39,7 @@
 | **`commented_original_lines`** | 统计对话翻译块内部，以 `#` 开头的原文备份注释行。 | 作为重配对、RAG 或订正的上下文对照基准线。 |
 | **`old_lines`** / **`new_lines`** | 匹配界面字符串块中的 `old "..."` / `new "..."` 数量。 | 界面文本原文/译文行数（如果不等，会触发“行数不一致”的格式警报）。**空白模板也会有 `old` 行，不能当作已有中文译文。** |
 | **`translated_task_count`** | `summarize_translation_progress()`：目标行中已含汉字的任务数。 | 真实中文译文进度；`0` 表示尚未产生可检索的历史译文。 |
-| **`has_existing_translations`** | 派生：优先 `translated_task_count > 0`；报告缺少该字段时，回退为 `translate_blocks > 0 and 0 < pending < translate_blocks`。**不使用 `old_lines`。** | 判定当前项目是“全新初译”还是“已有旧译（增量补译）”；仅后者才适合建议启用 RAG。 |
+| **`has_existing_translations`** | 派生：优先 `translated_task_count > 0`；报告缺少该字段时按全新初译处理（`False`），不再用 `translate_blocks`/`pending`/`old_lines` 推断。 | 判定当前项目是“全新初译”还是“已有旧译（增量补译）”；仅后者才适合建议启用 RAG。 |
 | **`pending_task_count`** | `collect_pending_file_jobs()` 提取出的所有待翻译任务数。 | 过滤掉纯数字、纯标点、URL 等无效翻译后，剩余需提交翻译的行数。 |
 | **`pending_is_minor`** | 派生：`pending < 50` 或 `pending / baseline < 0.01` | 剩余翻译量是否已经微乎其微（对应项目基本译完）。 |
 

--- a/docs/doctor_states_matrix.md
+++ b/docs/doctor_states_matrix.md
@@ -37,8 +37,9 @@
 | **`rpy_files`** | 统计 `counts['rpy_files']` (翻译目录下所有的 `.rpy` 脚本数量)。 | 模板文件数。为 0 时表示未生成任何模板。 |
 | **`translate_blocks`** | 匹配以 `translate <language> <label>:` 开头的对话翻译块。 | 对话翻译块总数（剧情句子的总行数基准）。 |
 | **`commented_original_lines`** | 统计对话翻译块内部，以 `#` 开头的原文备份注释行。 | 作为重配对、RAG 或订正的上下文对照基准线。 |
-| **`old_lines`** / **`new_lines`** | 匹配界面字符串块中的 `old "..."` / `new "..."` 数量。 | 界面文本原文/译文行数（如果不等，会触发“行数不一致”的格式警报）。 |
-| **`has_existing_translations`** | 派生：`counts['old_lines'] > 0` 或 `translate_blocks > pending_task_count`。 | 判定当前项目是“全新初译”还是“已有旧译（增量补译）”。 |
+| **`old_lines`** / **`new_lines`** | 匹配界面字符串块中的 `old "..."` / `new "..."` 数量。 | 界面文本原文/译文行数（如果不等，会触发“行数不一致”的格式警报）。**空白模板也会有 `old` 行，不能当作已有中文译文。** |
+| **`translated_task_count`** | `summarize_translation_progress()`：目标行中已含汉字的任务数。 | 真实中文译文进度；`0` 表示尚未产生可检索的历史译文。 |
+| **`has_existing_translations`** | 派生：优先 `translated_task_count > 0`；报告缺少该字段时，回退为 `translate_blocks > 0 and 0 < pending < translate_blocks`。**不使用 `old_lines`。** | 判定当前项目是“全新初译”还是“已有旧译（增量补译）”；仅后者才适合建议启用 RAG。 |
 | **`pending_task_count`** | `collect_pending_file_jobs()` 提取出的所有待翻译任务数。 | 过滤掉纯数字、纯标点、URL 等无效翻译后，剩余需提交翻译的行数。 |
 | **`pending_is_minor`** | 派生：`pending < 50` 或 `pending / baseline < 0.01` | 剩余翻译量是否已经微乎其微（对应项目基本译完）。 |
 
@@ -77,7 +78,7 @@
 
 | 资产文件 | 检测逻辑与物理位置 | 对应报警/处理机制 |
 | :--- | :--- | :--- |
-| **术语表 (`glossary.json`)** | 1. 检测文件是否存在；<br>2. 用 `paths_match_project()` 检测路径是否与当前 `base_dir` 严格匹配。 | 1. 路径非当前项目：报**配置路径偏移警告**；<br>2. 物理缺失：报**缺失警告**（降级使用默认保留词）。 |
+| **术语表 (`glossary.json`)** | 1. 相对路径（含裸名 `glossary.json`）一律相对当前 work 解析，不再优先落到工具目录；<br>2. 用 `paths_match_project()` 检测解析结果是否与当前 `base_dir` 严格匹配；<br>3. 检测文件是否存在。 | 1. 绝对路径仍指向其他位置：报**配置路径偏移警告**（可用「切换项目」强制同步）；<br>2. 物理缺失：报**缺失警告**（降级使用默认保留词）。 |
 | **风格规范 (`macro_setting.md`)**| 1. 检测文件是否存在；<br>2. 用 `paths_match_project()` 检测。 | 同上。偏移报**偏移警告**；物理缺失报**缺少风格指引警告**。 |
 | **术语/记忆冲突** | 对比术语表 `normalize_map` 和剧情记忆 `story_graph.json` 实体表。 | **术语冲突警告**：如果两者对同一个词给出了不同的翻译设定，会报出冲突，要求人工统一。 |
 

--- a/engine_adapters/contracts.py
+++ b/engine_adapters/contracts.py
@@ -78,8 +78,9 @@ class SourceDocument:
     sha256: str
     content: bytes = field(repr=False, compare=False)
     # Lazy decode/split caches. Frozen dataclass still allows object.__setattr__.
+    # Lines are cached as an immutable tuple so callers cannot mutate shared state.
     _text_cache: str | None = field(default=None, init=False, repr=False, compare=False)
-    _lines_cache: list[str] | None = field(
+    _lines_cache: tuple[str, ...] | None = field(
         default=None, init=False, repr=False, compare=False
     )
 
@@ -91,11 +92,11 @@ class SourceDocument:
         object.__setattr__(self, "_text_cache", decoded)
         return decoded
 
-    def lines(self) -> list[str]:
+    def lines(self) -> tuple[str, ...]:
         cached = self._lines_cache
         if cached is not None:
             return cached
-        split = self.text().splitlines(keepends=True)
+        split = tuple(self.text().splitlines(keepends=True))
         object.__setattr__(self, "_lines_cache", split)
         return split
 

--- a/engine_adapters/contracts.py
+++ b/engine_adapters/contracts.py
@@ -77,12 +77,27 @@ class SourceDocument:
     size: int
     sha256: str
     content: bytes = field(repr=False, compare=False)
+    # Lazy decode/split caches. Frozen dataclass still allows object.__setattr__.
+    _text_cache: str | None = field(default=None, init=False, repr=False, compare=False)
+    _lines_cache: list[str] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
     def text(self) -> str:
-        return self.content.decode("utf-8-sig")
+        cached = self._text_cache
+        if cached is not None:
+            return cached
+        decoded = self.content.decode("utf-8-sig")
+        object.__setattr__(self, "_text_cache", decoded)
+        return decoded
 
     def lines(self) -> list[str]:
-        return self.text().splitlines(keepends=True)
+        cached = self._lines_cache
+        if cached is not None:
+            return cached
+        split = self.text().splitlines(keepends=True)
+        object.__setattr__(self, "_lines_cache", split)
+        return split
 
     def manifest_entry(self) -> dict[str, Any]:
         return {

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -1704,6 +1704,7 @@ def build_translation_snapshot(
     policy: InventoryPolicy | None = None,
     *,
     include_occurrences: bool = True,
+    include_task_payloads: bool = True,
 ) -> RenPyTranslationSnapshot:
     """Run the P1 read-only pipeline once for sync or Batch translation build.
 
@@ -1711,6 +1712,11 @@ def build_translation_snapshot(
     Progress-only callers (environment check pending/translated counts) may set
     it to False: pending tasks and per-file progress still come from inventory,
     but occurrence extraction is skipped.
+
+    ``include_task_payloads`` controls whether per-task payload dictionaries are
+    materialized into ``pending_tasks_by_file``. Progress-only callers may set
+    it to False to avoid copying every pending task; counts can be derived from
+    the candidate inventory instead.
     """
     inventory_policy = policy or InventoryPolicy()
     project = adapter.discover_project(request)
@@ -1743,13 +1749,16 @@ def build_translation_snapshot(
     else:
         occurrences = ()
 
-    pending_tasks: dict[str, list[Mapping[str, Any]]] = {
-        document.file_rel_path: [] for document in project.source_documents
-    }
-    for candidate in inventory.candidates:
-        if candidate.classification == "translatable" and candidate.legacy_item is not None:
-            rel_path = str(candidate.locator.locator.get("file_rel_path") or "")
-            pending_tasks.setdefault(rel_path, []).append(dict(candidate.legacy_item))
+    if include_task_payloads:
+        pending_tasks: dict[str, list[Mapping[str, Any]]] = {
+            document.file_rel_path: [] for document in project.source_documents
+        }
+        for candidate in inventory.candidates:
+            if candidate.classification == "translatable" and candidate.legacy_item is not None:
+                rel_path = str(candidate.locator.locator.get("file_rel_path") or "")
+                pending_tasks.setdefault(rel_path, []).append(dict(candidate.legacy_item))
+    else:
+        pending_tasks = {}
     progress_by_file = {
         str(entry.get("file_rel_path") or ""): {
             "translated_count": int(entry.get("translated_count") or 0)

--- a/engine_adapters/renpy.py
+++ b/engine_adapters/renpy.py
@@ -1702,8 +1702,16 @@ def build_translation_snapshot(
     adapter: RenPyAdapter,
     request: ProjectDiscoveryRequest,
     policy: InventoryPolicy | None = None,
+    *,
+    include_occurrences: bool = True,
 ) -> RenPyTranslationSnapshot:
-    """Run the P1 read-only pipeline once for sync or Batch translation build."""
+    """Run the P1 read-only pipeline once for sync or Batch translation build.
+
+    ``include_occurrences`` defaults to True for writeback/build consumers.
+    Progress-only callers (environment check pending/translated counts) may set
+    it to False: pending tasks and per-file progress still come from inventory,
+    but occurrence extraction is skipped.
+    """
     inventory_policy = policy or InventoryPolicy()
     project = adapter.discover_project(request)
     inventory = adapter.inventory_candidates(project, inventory_policy)
@@ -1715,22 +1723,25 @@ def build_translation_snapshot(
         adapter_behavior_digest=adapter.behavior_digest(),
     )
     project = replace(project, coverage_digest=report.coverage_digest)
-    approved_ids = [
-        candidate.candidate_id
-        for candidate in inventory.candidates
-        if candidate.classification
-        in {
-            "translatable",
-            "already_translated",
-        }
-    ]
-    occurrences = tuple(
-        adapter.extract_occurrences(
-            project,
-            inventory,
-            approved_ids,
+    if include_occurrences:
+        approved_ids = [
+            candidate.candidate_id
+            for candidate in inventory.candidates
+            if candidate.classification
+            in {
+                "translatable",
+                "already_translated",
+            }
+        ]
+        occurrences = tuple(
+            adapter.extract_occurrences(
+                project,
+                inventory,
+                approved_ids,
+            )
         )
-    )
+    else:
+        occurrences = ()
 
     pending_tasks: dict[str, list[Mapping[str, Any]]] = {
         document.file_rel_path: [] for document in project.source_documents

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -10208,13 +10208,10 @@ def _doctor_has_existing_translations(report):
         return int(report.get('translated_task_count') or 0) > 0
 
     # Hand-built / older report shapes without an explicit Chinese progress
-    # field: treat dialogue already partially complete as existing progress.
-    # Do not use old_lines (template structure only).
-    counts = report.get('counts') or {}
-    translate_blocks = int(counts.get('translate_blocks') or 0)
-    pending = _doctor_pending_task_count(report)
-    if translate_blocks > 0 and pending > 0 and pending < translate_blocks:
-        return True
+    # field: do not guess from counts. Template structure (old_lines) is
+    # unreliable, and ``pending < translate_blocks`` also holds when many rows
+    # are filtered as non-translatable, so a wrong signal would suggest RAG /
+    # incremental state for a first-pass project. Treat as first-pass.
     return False
 
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2804,12 +2804,22 @@ class TranslationFileJobs(list):
         self.coverage_snapshot = coverage_snapshot
 
 
-def collect_pending_file_jobs(*, include_complete_files=False):
+def collect_pending_file_jobs(
+    *,
+    include_complete_files=False,
+    include_occurrences=True,
+    include_task_payloads=True,
+):
     """Collect per-file pending translation tasks.
 
     By default only files with at least one pending task are returned (batch build).
     Pass ``include_complete_files=True`` for doctor progress so fully-translated
     files still contribute to ``translated_count``.
+
+    Progress-only callers (environment check) should pass
+    ``include_occurrences=False`` and usually ``include_task_payloads=False``:
+    pending/translated counts stay identical to the full build path, but the
+    expensive occurrence extraction and large task list copies are skipped.
     """
     adapter_snapshot = build_translation_snapshot(
         RenPyAdapter(legacy_module=legacy),
@@ -2820,25 +2830,36 @@ def collect_pending_file_jobs(*, include_complete_files=False):
             include_files=tuple(sorted(legacy.INCLUDE_FILES)),
             include_prefixes=tuple(sorted(legacy.INCLUDE_PREFIXES)),
         ),
+        include_occurrences=include_occurrences,
     )
     jobs = TranslationFileJobs(coverage_snapshot=adapter_snapshot)
 
     for document in adapter_snapshot.project.source_documents:
         rel_path = document.file_rel_path
         file_path = document.file_path
-        pending = [
-            dict(task)
-            for task in adapter_snapshot.pending_tasks_by_file.get(rel_path, ())
-            if not legacy.is_non_translatable(task['text'])
-        ]
+        raw_pending = adapter_snapshot.pending_tasks_by_file.get(rel_path, ())
+        if include_task_payloads:
+            pending = [
+                dict(task)
+                for task in raw_pending
+                if not legacy.is_non_translatable(task['text'])
+            ]
+            task_count = len(pending)
+        else:
+            task_count = sum(
+                1
+                for task in raw_pending
+                if not legacy.is_non_translatable(task['text'])
+            )
+            pending = []
         progress = adapter_snapshot.progress_by_file.get(rel_path, {})
         translated_count = int(progress.get('translated_count') or 0)
-        if pending or (include_complete_files and translated_count):
+        if task_count or (include_complete_files and translated_count):
             jobs.append(
                 {
                     'file_rel_path': rel_path,
                     'file_path': file_path,
-                    'task_count': len(pending),
+                    'task_count': task_count,
                     'translated_count': translated_count,
                     'tasks': pending,
                 }
@@ -2865,6 +2886,21 @@ def summarize_translation_progress(file_jobs):
         'total_task_count': pending_task_count + translated_task_count,
         'pending_file_count': pending_file_count,
     }
+
+
+def collect_doctor_translation_progress():
+    """Doctor-only progress summary: same counts as full pending jobs, cheaper path.
+
+    Uses the same inventory/classification and ``is_non_translatable`` filter as
+    :func:`collect_pending_file_jobs`, but skips occurrence extraction and does
+    not materialize per-task payloads.
+    """
+    file_jobs = collect_pending_file_jobs(
+        include_complete_files=True,
+        include_occurrences=False,
+        include_task_payloads=False,
+    )
+    return summarize_translation_progress(file_jobs)
 
 
 def format_context_block(lines, empty_label):
@@ -10160,10 +10196,21 @@ def _doctor_rag_needs_bootstrap(rag):
 
 
 def _doctor_has_existing_translations(report):
-    counts = report.get('counts') or {}
-    if int(counts.get('old_lines') or 0) > 0:
-        return True
+    """True when the project already has real Chinese translation progress.
 
+    Blank Ren'Py templates still contain ``old``/``new`` string pairs, so
+    ``old_lines`` alone must not count as historical translations. That signal
+    is used for RAG tips and incremental vs first-pass workflow state; both
+    require actual translated targets (Han characters), not template structure.
+    """
+    # Full doctor reports always include this field (0 when nothing is translated).
+    if 'translated_task_count' in report:
+        return int(report.get('translated_task_count') or 0) > 0
+
+    # Hand-built / older report shapes without an explicit Chinese progress
+    # field: treat dialogue already partially complete as existing progress.
+    # Do not use old_lines (template structure only).
+    counts = report.get('counts') or {}
     translate_blocks = int(counts.get('translate_blocks') or 0)
     pending = _doctor_pending_task_count(report)
     if translate_blocks > 0 and pending > 0 and pending < translate_blocks:
@@ -10577,7 +10624,12 @@ def collect_glossary_story_graph_conflicts(glossary_path='', story_graph_path=''
 
 
 def collect_doctor_project_assets_status(base_dir):
-    from project_asset_paths import expected_project_asset_paths, paths_match_project
+    from project_asset_paths import (
+        expected_project_asset_paths,
+        paths_match_project,
+        resolve_glossary_path,
+        resolve_macro_setting_path,
+    )
 
     config = _read_translator_config_object()
     expected = expected_project_asset_paths(base_dir)
@@ -10586,28 +10638,28 @@ def collect_doctor_project_assets_status(base_dir):
     batch = config.get('batch') if isinstance(config.get('batch'), dict) else {}
     macro_configured = batch.get('macro_setting_file') or ''
 
-    glossary_resolved = (
-        legacy._resolve_preferred_path(legacy.TOOL_DIR, base_dir, glossary_configured)
-        if glossary_configured
-        else expected['glossary_file']
-    )
-    macro_resolved = (
-        legacy._resolve_preferred_path(base_dir, base_dir, macro_configured)
-        if macro_configured
-        else expected['macro_setting_file']
-    )
+    glossary_resolved = resolve_glossary_path(
+        glossary_configured,
+        game_root=base_dir,
+        tool_dir=legacy.TOOL_DIR,
+    ) or expected['glossary_file']
+    macro_resolved = resolve_macro_setting_path(
+        macro_configured,
+        game_root=base_dir,
+        tool_dir=legacy.TOOL_DIR,
+    ) or expected['macro_setting_file']
 
     return {
-        'glossary_file': glossary_resolved or expected['glossary_file'],
-        'glossary_exists': os.path.isfile(glossary_resolved or expected['glossary_file']),
+        'glossary_file': glossary_resolved,
+        'glossary_exists': os.path.isfile(glossary_resolved),
         'glossary_matches_project': paths_match_project(
-            glossary_resolved or glossary_configured,
+            glossary_resolved,
             expected['glossary_file'],
         ),
-        'macro_setting_file': macro_resolved or expected['macro_setting_file'],
-        'macro_exists': os.path.isfile(macro_resolved or expected['macro_setting_file']),
+        'macro_setting_file': macro_resolved,
+        'macro_exists': os.path.isfile(macro_resolved),
         'macro_matches_project': paths_match_project(
-            macro_resolved or macro_configured,
+            macro_resolved,
             expected['macro_setting_file'],
         ),
         'expected_glossary_file': expected['glossary_file'],
@@ -10792,10 +10844,11 @@ def collect_doctor_report():
     translated_task_count = 0
     total_task_count = 0
     # Avoid walking a TL tree that may sit outside the project root.
+    # Progress counts use the same inventory filter as batch build, without the
+    # occurrence-extraction work that build/writeback needs.
     if has_tl_files and not tl_path_invalid:
         try:
-            file_jobs = collect_pending_file_jobs(include_complete_files=True)
-            progress = summarize_translation_progress(file_jobs)
+            progress = collect_doctor_translation_progress()
             pending_file_count = progress['pending_file_count']
             pending_task_count = progress['pending_task_count']
             translated_task_count = progress['translated_task_count']

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2831,25 +2831,28 @@ def collect_pending_file_jobs(
             include_prefixes=tuple(sorted(legacy.INCLUDE_PREFIXES)),
         ),
         include_occurrences=include_occurrences,
+        include_task_payloads=include_task_payloads,
     )
     jobs = TranslationFileJobs(coverage_snapshot=adapter_snapshot)
 
     for document in adapter_snapshot.project.source_documents:
         rel_path = document.file_rel_path
         file_path = document.file_path
-        raw_pending = adapter_snapshot.pending_tasks_by_file.get(rel_path, ())
         if include_task_payloads:
             pending = [
                 dict(task)
-                for task in raw_pending
+                for task in adapter_snapshot.pending_tasks_by_file.get(rel_path, ())
                 if not legacy.is_non_translatable(task['text'])
             ]
             task_count = len(pending)
         else:
             task_count = sum(
                 1
-                for task in raw_pending
-                if not legacy.is_non_translatable(task['text'])
+                for candidate in adapter_snapshot.inventory.candidates
+                if candidate.classification == "translatable"
+                and candidate.legacy_item is not None
+                and str(candidate.locator.locator.get("file_rel_path") or "") == rel_path
+                and not legacy.is_non_translatable(candidate.legacy_item["text"])
             )
             pending = []
         progress = adapter_snapshot.progress_by_file.get(rel_path, {})
@@ -10624,6 +10627,7 @@ def collect_doctor_project_assets_status(base_dir):
     from project_asset_paths import (
         expected_project_asset_paths,
         paths_match_project,
+        resolve_configured_glossary_value,
         resolve_glossary_path,
         resolve_macro_setting_path,
     )
@@ -10631,7 +10635,7 @@ def collect_doctor_project_assets_status(base_dir):
     config = _read_translator_config_object()
     expected = expected_project_asset_paths(base_dir)
 
-    glossary_configured = config.get('glossary_file') or config.get('glossary_path') or ''
+    glossary_configured = resolve_configured_glossary_value(config)
     batch = config.get('batch') if isinstance(config.get('batch'), dict) else {}
     macro_configured = batch.get('macro_setting_file') or ''
 

--- a/gui_qt/project_state.py
+++ b/gui_qt/project_state.py
@@ -21,7 +21,10 @@ from .manifest_lite import (
     read_manifest_index_fields,
     read_manifest_lite,
 )
-from project_asset_paths import sync_project_asset_paths_in_config
+from project_asset_paths import (
+    normalize_relative_project_assets_in_config,
+    sync_project_asset_paths_in_config,
+)
 
 from .path_utils import canonical_abs_path, resolve_effective_game_root
 
@@ -567,5 +570,16 @@ class ProjectState:
             return {}
 
     def save_translator_config(self, config: dict[str, Any]) -> None:
-        """Write config while trying to preserve structure."""
+        """Write config while trying to preserve structure.
+
+        Relative glossary/macro paths are rewritten under the current
+        ``game_root`` so a settings save cannot reintroduce tool-directory
+        drift for bare names like ``glossary.json``.
+        """
+        if isinstance(config, dict):
+            game_root = str(config.get("game_root") or "").strip()
+            if not game_root and self._game_root is not None:
+                game_root = str(self._game_root)
+            if game_root:
+                normalize_relative_project_assets_in_config(config, game_root)
         self._write_json_object(self.config_path, config)

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -915,7 +915,8 @@ FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
         "batch_macro_setting_file",
         ("batch", "macro_setting_file"),
         "风格设定文件",
-        "macro_setting.md 路径。相对路径相对当前 work；切换项目时会同步到当前 work。",
+        "macro_setting.md 路径。相对路径相对当前 work；切换项目时会同步到当前 work。"
+        "留空则使用当前 work 下的 macro_setting.md。",
         "str",
         "macro_setting.md",
         "术语与风格",

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -726,7 +726,8 @@ FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
         "glossary_file",
         ("glossary_file",),
         "术语表路径",
-        "glossary.json 路径；留空时使用默认术语表路径。",
+        "glossary.json 路径。相对路径（如 glossary.json）相对当前 work；"
+        "切换项目时会同步到当前 work。留空则使用当前 work 下的 glossary.json。",
         "str",
         "glossary.json",
         "项目与资源",
@@ -914,7 +915,7 @@ FULL_COVERAGE_SETTING_FIELDS: tuple[SettingField, ...] = (
         "batch_macro_setting_file",
         ("batch", "macro_setting_file"),
         "风格设定文件",
-        "macro_setting.md 路径；通常位于当前 work 目录。",
+        "macro_setting.md 路径。相对路径相对当前 work；切换项目时会同步到当前 work。",
         "str",
         "macro_setting.md",
         "术语与风格",

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -451,11 +451,17 @@ def translate_doctor_warning(warning: str) -> str:
     if text.startswith("RAG store contains legacy ID format keys."):
         return "记忆库含有旧版键格式，下次写回时会自动迁移。"
     if text.startswith("glossary_file does not match current project;"):
-        return "术语表路径仍指向其他项目，切换项目后应自动同步到当前 work 目录。"
+        return (
+            "术语表路径仍指向其他位置，与当前 work 不一致。"
+            "请用「切换项目」同步到当前项目，或在设置中改为当前 work 下的 glossary.json。"
+        )
     if text.startswith("glossary.json not found for current project"):
         return "当前项目缺少 glossary.json，批量翻译将使用默认保留词。"
     if text.startswith("macro_setting_file does not match current project;"):
-        return "风格设定路径仍指向其他项目，切换项目后应自动同步到当前 work 目录。"
+        return (
+            "风格设定路径仍指向其他位置，与当前 work 不一致。"
+            "请用「切换项目」同步到当前项目，或在设置中改为当前 work 下的 macro_setting.md。"
+        )
     if text.startswith("macro_setting.md not found for current project"):
         return "当前项目缺少 macro_setting.md，批量翻译将缺少项目口吻与风格指引。"
     if text.startswith("Translation conflict for "):

--- a/keyword_glossary_merge.py
+++ b/keyword_glossary_merge.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Callable, Iterable
 
-from project_asset_paths import canonical_abs_path, expected_project_asset_paths
-
 GLOSSARY_SECTION_PRESERVE = 'preserve_terms'
 GLOSSARY_SECTION_NON_TRANSLATABLE = 'non_translatable_exact'
 GLOSSARY_SECTION_NORMALIZE = 'normalize_map'
@@ -463,20 +461,14 @@ def resolve_glossary_path_from_config(
     game_root: str = '',
     tool_root: str = '',
 ) -> str:
+    from project_asset_paths import resolve_glossary_path
+
     glossary_configured = config.get('glossary_file') or config.get('glossary_path') or ''
-    if isinstance(glossary_configured, str) and glossary_configured.strip():
-        configured = glossary_configured.strip()
-        if os.path.isabs(configured):
-            return canonical_abs_path(configured)
-        base_dir = game_root or tool_root
-        if base_dir:
-            return canonical_abs_path(os.path.join(base_dir, configured))
-        return canonical_abs_path(configured)
-    if game_root:
-        return expected_project_asset_paths(game_root)['glossary_file']
-    if tool_root:
-        return os.path.join(canonical_abs_path(tool_root), 'glossary.json')
-    return ''
+    return resolve_glossary_path(
+        glossary_configured if isinstance(glossary_configured, str) else '',
+        game_root=game_root,
+        tool_dir=tool_root,
+    )
 
 
 def resolve_macro_setting_path_from_config(
@@ -485,21 +477,17 @@ def resolve_macro_setting_path_from_config(
     game_root: str = '',
     tool_root: str = '',
 ) -> str:
+    from project_asset_paths import resolve_macro_setting_path
+
     batch = config.get('batch')
     if not isinstance(batch, dict):
         batch = {}
     macro_configured = batch.get('macro_setting_file') or ''
-    if isinstance(macro_configured, str) and macro_configured.strip():
-        configured = macro_configured.strip()
-        if os.path.isabs(configured):
-            return canonical_abs_path(configured)
-        base_dir = game_root or tool_root
-        if base_dir:
-            return canonical_abs_path(os.path.join(base_dir, configured))
-        return canonical_abs_path(configured)
-    if game_root:
-        return expected_project_asset_paths(game_root)['macro_setting_file']
-    return ''
+    return resolve_macro_setting_path(
+        macro_configured if isinstance(macro_configured, str) else '',
+        game_root=game_root,
+        tool_dir=tool_root,
+    )
 
 
 def load_macro_setting_text(macro_path: str) -> str:

--- a/keyword_glossary_merge.py
+++ b/keyword_glossary_merge.py
@@ -461,11 +461,14 @@ def resolve_glossary_path_from_config(
     game_root: str = '',
     tool_root: str = '',
 ) -> str:
-    from project_asset_paths import resolve_glossary_path
+    from project_asset_paths import (
+        resolve_configured_glossary_value,
+        resolve_glossary_path,
+    )
 
-    glossary_configured = config.get('glossary_file') or config.get('glossary_path') or ''
+    glossary_configured = resolve_configured_glossary_value(config)
     return resolve_glossary_path(
-        glossary_configured if isinstance(glossary_configured, str) else '',
+        glossary_configured,
         game_root=game_root,
         tool_dir=tool_root,
     )

--- a/project_asset_paths.py
+++ b/project_asset_paths.py
@@ -28,11 +28,77 @@ def expected_project_asset_paths(game_root: str | os.PathLike[str]) -> dict[str,
     }
 
 
+def resolve_project_asset_path(
+    configured: str | os.PathLike[str] | None,
+    *,
+    game_root: str | os.PathLike[str] = "",
+    tool_dir: str | os.PathLike[str] = "",
+    default_name: str,
+) -> str:
+    """Resolve a project asset path, preferring the current work directory.
+
+    Relative values (including bare names like ``glossary.json``) are always
+    joined under ``game_root`` when it is set. They must not silently fall back
+    to a same-named file under the tool install directory.
+
+    Absolute paths are kept as-is so a deliberately shared glossary still works.
+    """
+    text = str(configured or "").strip()
+    root = canonical_abs_path(game_root) if game_root else ""
+    tool = canonical_abs_path(tool_dir) if tool_dir else ""
+
+    if text and os.path.isabs(text):
+        return canonical_abs_path(text)
+
+    if root:
+        if text:
+            return canonical_abs_path(os.path.join(root, text))
+        return os.path.join(root, default_name)
+
+    if tool:
+        if text:
+            return canonical_abs_path(os.path.join(tool, text))
+        return os.path.join(tool, default_name)
+
+    return text
+
+
+def resolve_glossary_path(
+    configured: str | os.PathLike[str] | None,
+    *,
+    game_root: str | os.PathLike[str] = "",
+    tool_dir: str | os.PathLike[str] = "",
+) -> str:
+    return resolve_project_asset_path(
+        configured,
+        game_root=game_root,
+        tool_dir=tool_dir,
+        default_name=DEFAULT_GLOSSARY_NAME,
+    )
+
+
+def resolve_macro_setting_path(
+    configured: str | os.PathLike[str] | None,
+    *,
+    game_root: str | os.PathLike[str] = "",
+    tool_dir: str | os.PathLike[str] = "",
+) -> str:
+    return resolve_project_asset_path(
+        configured,
+        game_root=game_root,
+        tool_dir=tool_dir,
+        default_name=DEFAULT_MACRO_SETTING_NAME,
+    )
+
+
 def sync_project_asset_paths_in_config(
     config: dict[str, Any],
     game_root: str | os.PathLike[str],
 ) -> dict[str, Any]:
-    """Point glossary/macro_setting paths at the current work directory."""
+    """Force glossary/macro_setting paths to the current work directory.
+
+    Used when switching projects: assets are always re-homed to the new work.
+    """
     if not isinstance(config, dict):
         config = {}
     expected = expected_project_asset_paths(game_root)
@@ -42,6 +108,50 @@ def sync_project_asset_paths_in_config(
         batch = {}
         config["batch"] = batch
     batch["macro_setting_file"] = expected["macro_setting_file"]
+    return config
+
+
+def normalize_relative_project_assets_in_config(
+    config: dict[str, Any],
+    game_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Rewrite relative glossary/macro paths under game_root; keep abs paths.
+
+    Unlike :func:`sync_project_asset_paths_in_config`, this does not force
+    absolute custom paths back onto the default work filenames. It only stops
+    bare names like ``glossary.json`` from drifting to the tool directory.
+    """
+    if not isinstance(config, dict):
+        config = {}
+
+    root = str(game_root or "").strip() or str(config.get("game_root") or "").strip()
+    if not root:
+        return config
+
+    expected = expected_project_asset_paths(root)
+
+    glossary_configured = config.get("glossary_file")
+    if glossary_configured is None:
+        glossary_configured = config.get("glossary_path")
+    glossary_text = str(glossary_configured or "").strip()
+    if not glossary_text:
+        config["glossary_file"] = expected["glossary_file"]
+    elif not os.path.isabs(glossary_text):
+        config["glossary_file"] = resolve_glossary_path(
+            glossary_text, game_root=root
+        )
+
+    batch = config.get("batch")
+    if not isinstance(batch, dict):
+        batch = {}
+        config["batch"] = batch
+    macro_text = str(batch.get("macro_setting_file") or "").strip()
+    if not macro_text:
+        batch["macro_setting_file"] = expected["macro_setting_file"]
+    elif not os.path.isabs(macro_text):
+        batch["macro_setting_file"] = resolve_macro_setting_path(
+            macro_text, game_root=root
+        )
     return config
 
 

--- a/project_asset_paths.py
+++ b/project_asset_paths.py
@@ -79,6 +79,21 @@ def resolve_glossary_path(
     )
 
 
+def resolve_configured_glossary_value(config: dict[str, Any] | None) -> str:
+    """Return the configured glossary value, primary key with legacy fallback.
+
+    ``glossary_file`` is the primary key; the legacy ``glossary_path`` is used
+    when the primary value is missing or empty (an explicitly empty value means
+    "use the default"), matching settings-page semantics across all consumers.
+    """
+    if not isinstance(config, dict):
+        return ""
+    value = config.get("glossary_file")
+    if value is None or (isinstance(value, str) and not value.strip()):
+        value = config.get("glossary_path")
+    return value if isinstance(value, str) else ""
+
+
 def resolve_macro_setting_path(
     configured: str | os.PathLike[str] | None,
     *,
@@ -133,10 +148,7 @@ def normalize_relative_project_assets_in_config(
     if not root:
         return config
 
-    glossary_configured = config.get("glossary_file")
-    if glossary_configured is None:
-        glossary_configured = config.get("glossary_path")
-    glossary_text = str(glossary_configured or "").strip()
+    glossary_text = resolve_configured_glossary_value(config)
     if glossary_text and not os.path.isabs(glossary_text):
         config["glossary_file"] = resolve_glossary_path(
             glossary_text, game_root=root

--- a/project_asset_paths.py
+++ b/project_asset_paths.py
@@ -42,6 +42,8 @@ def resolve_project_asset_path(
     to a same-named file under the tool install directory.
 
     Absolute paths are kept as-is so a deliberately shared glossary still works.
+    With no base at all, a relative value is canonicalized against the process
+    CWD (matching the legacy resolver) instead of being returned raw.
     """
     text = str(configured or "").strip()
     root = canonical_abs_path(game_root) if game_root else ""
@@ -60,7 +62,7 @@ def resolve_project_asset_path(
             return canonical_abs_path(os.path.join(tool, text))
         return os.path.join(tool, default_name)
 
-    return text
+    return canonical_abs_path(text) if text else ""
 
 
 def resolve_glossary_path(
@@ -120,6 +122,9 @@ def normalize_relative_project_assets_in_config(
     Unlike :func:`sync_project_asset_paths_in_config`, this does not force
     absolute custom paths back onto the default work filenames. It only stops
     bare names like ``glossary.json`` from drifting to the tool directory.
+    Empty/missing entries are left untouched: read-time resolution homes them
+    under the current work root, so moving a work directory never leaves a
+    stale absolute path behind.
     """
     if not isinstance(config, dict):
         config = {}
@@ -128,15 +133,11 @@ def normalize_relative_project_assets_in_config(
     if not root:
         return config
 
-    expected = expected_project_asset_paths(root)
-
     glossary_configured = config.get("glossary_file")
     if glossary_configured is None:
         glossary_configured = config.get("glossary_path")
     glossary_text = str(glossary_configured or "").strip()
-    if not glossary_text:
-        config["glossary_file"] = expected["glossary_file"]
-    elif not os.path.isabs(glossary_text):
+    if glossary_text and not os.path.isabs(glossary_text):
         config["glossary_file"] = resolve_glossary_path(
             glossary_text, game_root=root
         )
@@ -146,9 +147,7 @@ def normalize_relative_project_assets_in_config(
         batch = {}
         config["batch"] = batch
     macro_text = str(batch.get("macro_setting_file") or "").strip()
-    if not macro_text:
-        batch["macro_setting_file"] = expected["macro_setting_file"]
-    elif not os.path.isabs(macro_text):
+    if macro_text and not os.path.isabs(macro_text):
         batch["macro_setting_file"] = resolve_macro_setting_path(
             macro_text, game_root=root
         )

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -259,6 +259,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 11800
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -303,6 +304,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 11800
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -342,6 +344,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 45
+        report["translated_task_count"] = 119900
         report["counts"] = {
             "rpy_files": 48,
             "translate_blocks": 120000,
@@ -400,12 +403,52 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 0
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 240,
             "old_lines": 0,
         }
 
+        self.assertEqual(
+            batch_mod.collect_doctor_workflow_state(report),
+            doctor_rec.START_PENDING_BATCH,
+        )
+
+    def test_blank_template_old_lines_do_not_count_as_existing_translations(self):
+        """Template old/new pairs alone must not trigger RAG or incremental workflow."""
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=22,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 21416
+        report["translated_task_count"] = 0
+        report["counts"] = {
+            "rpy_files": 22,
+            "translate_blocks": 21015,
+            "string_sections": 16,
+            "old_lines": 571,
+            "new_lines": 571,
+            "commented_original_lines": 21015,
+        }
+        report["context_status"] = {
+            "rag": {"enabled": False},
+            "source_index": {
+                "enabled": True,
+                "store_exists": True,
+                "source_segments": 1000,
+                "expected_segments": 1000,
+            },
+        }
+
+        self.assertFalse(batch_mod._doctor_has_existing_translations(report))
+        recommendations = batch_mod.collect_doctor_recommendations(report)
+        self.assertEqual(recommendations, [])
+        self.assertNotIn(
+            doctor_rec.ENABLE_RAG_FOR_CONSISTENCY,
+            doctor_rec.doctor_recommendation_codes(recommendations),
+        )
         self.assertEqual(
             batch_mod.collect_doctor_workflow_state(report),
             doctor_rec.START_PENDING_BATCH,
@@ -418,6 +461,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 11800
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -449,6 +493,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 11800
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -487,6 +532,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             layout_status="ready",
         )
         report["pending_task_count"] = 240
+        report["translated_task_count"] = 11800
         report["counts"] = {
             "rpy_files": 20,
             "translate_blocks": 12000,
@@ -537,6 +583,7 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             # ready incremental (no recs)
             {
                 "pending_task_count": 240,
+                "translated_task_count": 11800,
                 "counts": {
                     "rpy_files": 20,
                     "translate_blocks": 12000,

--- a/tests/test_doctor_layout_status.py
+++ b/tests/test_doctor_layout_status.py
@@ -454,6 +454,27 @@ class DoctorRecommendationMatrixTests(unittest.TestCase):
             doctor_rec.START_PENDING_BATCH,
         )
 
+    def test_report_without_progress_field_never_guesses_existing_translations(self):
+        """Legacy reports must not infer translations from block/pending deltas."""
+        report = _layout_report(
+            base_dir="C:/Games/Example/work",
+            rpy_files=20,
+            layout_status="ready",
+        )
+        report["pending_task_count"] = 80
+        report["counts"] = {
+            "rpy_files": 20,
+            "translate_blocks": 100,
+            "old_lines": 20,
+            "new_lines": 20,
+        }
+
+        self.assertFalse(batch_mod._doctor_has_existing_translations(report))
+        self.assertEqual(
+            batch_mod.collect_doctor_workflow_state(report),
+            doctor_rec.START_PENDING_BATCH,
+        )
+
     def test_existing_translations_without_rag_recommends_enable_rag(self):
         report = _layout_report(
             base_dir="C:/Games/Example/work",

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -653,6 +653,65 @@ translate schinese start:
             list(jobs.coverage_snapshot.pending_tasks_by_file["script.rpy"]),
         )
 
+    def test_progress_only_snapshot_matches_full_pending_counts(self):
+        """Doctor path skips occurrences but must keep pending/translated totals."""
+        import gemini_translate_batch as batch
+
+        root, tl_dir = self.make_project(
+            {
+                "script.rpy": (
+                    "translate schinese start:\n"
+                    '    # "Hello there."\n'
+                    '    "Hello there."\n'
+                    '    # "Already done."\n'
+                    '    "已经完成。"\n'
+                ),
+                "common.rpy": (
+                    "translate schinese strings:\n"
+                    '    old "Save"\n'
+                    '    new "Save"\n'
+                ),
+            }
+        )
+        with (
+            mock.patch.object(batch.legacy, "BASE_DIR", str(root)),
+            mock.patch.object(batch.legacy, "TL_DIR", str(tl_dir)),
+            mock.patch.object(batch.legacy, "INCLUDE_FILES", set()),
+            mock.patch.object(batch.legacy, "INCLUDE_PREFIXES", set()),
+        ):
+            full_jobs = batch.collect_pending_file_jobs(include_complete_files=True)
+            full = batch.summarize_translation_progress(full_jobs)
+            doctor = batch.collect_doctor_translation_progress()
+            light_jobs = batch.collect_pending_file_jobs(
+                include_complete_files=True,
+                include_occurrences=False,
+                include_task_payloads=False,
+            )
+
+        self.assertEqual(doctor, full)
+        self.assertEqual(batch.summarize_translation_progress(light_jobs), full)
+        self.assertEqual(light_jobs.coverage_snapshot.occurrences, ())
+        self.assertTrue(full_jobs.coverage_snapshot.occurrences)
+        # Progress-only jobs omit task payloads but keep the same task_count.
+        self.assertEqual(
+            sorted((job["file_rel_path"], job["task_count"], job["translated_count"]) for job in light_jobs),
+            sorted((job["file_rel_path"], job["task_count"], job["translated_count"]) for job in full_jobs),
+        )
+        self.assertTrue(all(job["tasks"] == [] for job in light_jobs))
+
+    def test_source_document_lines_are_cached(self):
+        from engine_adapters.contracts import SourceDocument
+
+        document = SourceDocument(
+            file_rel_path="script.rpy",
+            file_path="script.rpy",
+            size=4,
+            sha256="x",
+            content=b"a\nb\n",
+        )
+        self.assertIs(document.lines(), document.lines())
+        self.assertIs(document.text(), document.text())
+
     def test_batch_package_exports_coverage_without_changing_manifest_v2(self):
         import gemini_translate_batch as batch
 

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -710,6 +710,7 @@ translate schinese start:
             content=b"a\nb\n",
         )
         self.assertIs(document.lines(), document.lines())
+        self.assertIsInstance(document.lines(), tuple)
         self.assertIs(document.text(), document.text())
 
     def test_batch_package_exports_coverage_without_changing_manifest_v2(self):

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -691,7 +691,9 @@ translate schinese start:
         self.assertEqual(doctor, full)
         self.assertEqual(batch.summarize_translation_progress(light_jobs), full)
         self.assertEqual(light_jobs.coverage_snapshot.occurrences, ())
+        self.assertEqual(light_jobs.coverage_snapshot.pending_tasks_by_file, {})
         self.assertTrue(full_jobs.coverage_snapshot.occurrences)
+        self.assertTrue(full_jobs.coverage_snapshot.pending_tasks_by_file)
         # Progress-only jobs omit task payloads but keep the same task_count.
         self.assertEqual(
             sorted((job["file_rel_path"], job["task_count"], job["translated_count"]) for job in light_jobs),

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -11,6 +11,7 @@ from project_asset_paths import (
     expected_project_asset_paths,
     normalize_relative_project_assets_in_config,
     paths_match_project,
+    resolve_configured_glossary_value,
     resolve_glossary_path,
     resolve_macro_setting_path,
     sync_project_asset_paths_in_config,
@@ -18,6 +19,26 @@ from project_asset_paths import (
 
 
 class ProjectAssetPathsTests(unittest.TestCase):
+    def test_resolve_configured_glossary_value_falls_back_when_primary_empty(self):
+        self.assertEqual(
+            resolve_configured_glossary_value(
+                {"glossary_file": "", "glossary_path": "legacy.json"}
+            ),
+            "legacy.json",
+        )
+        self.assertEqual(
+            resolve_configured_glossary_value({"glossary_path": "legacy.json"}),
+            "legacy.json",
+        )
+        self.assertEqual(
+            resolve_configured_glossary_value(
+                {"glossary_file": "primary.json", "glossary_path": "legacy.json"}
+            ),
+            "primary.json",
+        )
+        self.assertEqual(resolve_configured_glossary_value({}), "")
+        self.assertEqual(resolve_configured_glossary_value(None), "")
+
     def test_canonical_abs_path_resolves_relative_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
             nested = Path(tmp) / "Game" / "work"

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -55,37 +55,51 @@ class ProjectAssetPathsTests(unittest.TestCase):
             self.assertFalse(paths_match_project(resolved, tool_dir / "glossary.json"))
 
     def test_absolute_glossary_is_preserved(self):
-        shared = "C:/Shared/team-glossary.json"
-        resolved = resolve_glossary_path(
-            shared,
-            game_root="C:/Games/Example/work",
-            tool_dir="C:/Tools/renpy-translation-lab",
-        )
-        self.assertTrue(paths_match_project(resolved, shared))
+        with tempfile.TemporaryDirectory() as tmp:
+            shared = str(Path(tmp) / "shared" / "team-glossary.json")
+            work_dir = str(Path(tmp) / "Game" / "work")
+            tool_dir = str(Path(tmp) / "tool")
+            Path(shared).parent.mkdir(parents=True)
+            Path(work_dir).mkdir(parents=True)
+            Path(tool_dir).mkdir(parents=True)
+
+            resolved = resolve_glossary_path(
+                shared,
+                game_root=work_dir,
+                tool_dir=tool_dir,
+            )
+            self.assertTrue(paths_match_project(resolved, shared))
 
     def test_normalize_relative_project_assets_keeps_absolute_custom_paths(self):
-        work_dir = "C:/Games/Example/work"
-        config = {
-            "game_root": work_dir,
-            "glossary_file": "glossary.json",
-            "batch": {
-                "model": "gemini-test",
-                "macro_setting_file": "C:/Shared/style.md",
-            },
-        }
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = str(Path(tmp) / "Game" / "work")
+            shared_macro = str(Path(tmp) / "shared" / "style.md")
+            Path(work_dir).mkdir(parents=True)
+            Path(shared_macro).parent.mkdir(parents=True)
+            config = {
+                "game_root": work_dir,
+                "glossary_file": "glossary.json",
+                "batch": {
+                    "model": "gemini-test",
+                    "macro_setting_file": shared_macro,
+                },
+            }
 
-        normalize_relative_project_assets_in_config(config, work_dir)
+            normalize_relative_project_assets_in_config(config, work_dir)
 
-        self.assertTrue(
-            paths_match_project(
-                config["glossary_file"],
-                expected_project_asset_paths(work_dir)["glossary_file"],
+            self.assertTrue(
+                paths_match_project(
+                    config["glossary_file"],
+                    expected_project_asset_paths(work_dir)["glossary_file"],
+                )
             )
-        )
-        self.assertTrue(
-            paths_match_project(config["batch"]["macro_setting_file"], "C:/Shared/style.md")
-        )
-        self.assertEqual(config["batch"]["model"], "gemini-test")
+            self.assertTrue(
+                paths_match_project(
+                    config["batch"]["macro_setting_file"],
+                    shared_macro,
+                )
+            )
+            self.assertEqual(config["batch"]["model"], "gemini-test")
 
     def test_sync_project_asset_paths_in_config(self):
         work_dir = "C:/Games/Example/work"

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -101,6 +101,23 @@ class ProjectAssetPathsTests(unittest.TestCase):
             )
             self.assertEqual(config["batch"]["model"], "gemini-test")
 
+    def test_normalize_relative_project_assets_leaves_empty_entries_alone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = str(Path(tmp) / "Game" / "work")
+            Path(work_dir).mkdir(parents=True)
+            config = {"game_root": work_dir}
+
+            normalize_relative_project_assets_in_config(config, work_dir)
+
+            self.assertNotIn("glossary_file", config)
+            self.assertEqual(config["batch"], {})
+
+    def test_resolve_glossary_path_without_bases_canonicalizes_relative_value(self):
+        resolved = resolve_glossary_path("glossary.json")
+
+        self.assertTrue(os.path.isabs(resolved))
+        self.assertEqual(resolved, canonical_abs_path("glossary.json"))
+
     def test_sync_project_asset_paths_in_config(self):
         work_dir = "C:/Games/Example/work"
         config = {

--- a/tests/test_project_asset_paths.py
+++ b/tests/test_project_asset_paths.py
@@ -9,7 +9,10 @@ import gemini_translate_batch as batch_mod
 from project_asset_paths import (
     canonical_abs_path,
     expected_project_asset_paths,
+    normalize_relative_project_assets_in_config,
     paths_match_project,
+    resolve_glossary_path,
+    resolve_macro_setting_path,
     sync_project_asset_paths_in_config,
 )
 
@@ -28,6 +31,61 @@ class ProjectAssetPathsTests(unittest.TestCase):
             self.assertTrue(
                 paths_match_project(resolved, expected),
             )
+
+    def test_relative_glossary_prefers_game_root_even_if_tool_file_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tool_dir = Path(tmp) / "tool"
+            work_dir = Path(tmp) / "Game" / "work"
+            tool_dir.mkdir(parents=True)
+            work_dir.mkdir(parents=True)
+            (tool_dir / "glossary.json").write_text('{"from":"tool"}', encoding="utf-8")
+
+            resolved = resolve_glossary_path(
+                "glossary.json",
+                game_root=work_dir,
+                tool_dir=tool_dir,
+            )
+
+            self.assertTrue(
+                paths_match_project(
+                    resolved,
+                    expected_project_asset_paths(work_dir)["glossary_file"],
+                )
+            )
+            self.assertFalse(paths_match_project(resolved, tool_dir / "glossary.json"))
+
+    def test_absolute_glossary_is_preserved(self):
+        shared = "C:/Shared/team-glossary.json"
+        resolved = resolve_glossary_path(
+            shared,
+            game_root="C:/Games/Example/work",
+            tool_dir="C:/Tools/renpy-translation-lab",
+        )
+        self.assertTrue(paths_match_project(resolved, shared))
+
+    def test_normalize_relative_project_assets_keeps_absolute_custom_paths(self):
+        work_dir = "C:/Games/Example/work"
+        config = {
+            "game_root": work_dir,
+            "glossary_file": "glossary.json",
+            "batch": {
+                "model": "gemini-test",
+                "macro_setting_file": "C:/Shared/style.md",
+            },
+        }
+
+        normalize_relative_project_assets_in_config(config, work_dir)
+
+        self.assertTrue(
+            paths_match_project(
+                config["glossary_file"],
+                expected_project_asset_paths(work_dir)["glossary_file"],
+            )
+        )
+        self.assertTrue(
+            paths_match_project(config["batch"]["macro_setting_file"], "C:/Shared/style.md")
+        )
+        self.assertEqual(config["batch"]["model"], "gemini-test")
 
     def test_sync_project_asset_paths_in_config(self):
         work_dir = "C:/Games/Example/work"
@@ -51,6 +109,46 @@ class ProjectAssetPathsTests(unittest.TestCase):
             expected_project_asset_paths(work_dir)["macro_setting_file"],
         )
         self.assertEqual(synced["batch"]["model"], "gemini-test")
+
+    def test_doctor_relative_glossary_matches_project_when_tool_has_same_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tool_dir = Path(tmp) / "tool"
+            work_dir = Path(tmp) / "Game" / "work"
+            tool_dir.mkdir(parents=True)
+            work_dir.mkdir(parents=True)
+            (tool_dir / "glossary.json").write_text("{}", encoding="utf-8")
+            config_path = tool_dir / "translator_config.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "game_root": str(work_dir),
+                        "glossary_file": "glossary.json",
+                        "batch": {"macro_setting_file": "macro_setting.md"},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(batch_mod.legacy, "BASE_DIR", str(work_dir)),
+                mock.patch.object(batch_mod.legacy, "TOOL_DIR", str(tool_dir)),
+                mock.patch.object(batch_mod.legacy, "TRANSLATOR_CONFIG", str(config_path)),
+            ):
+                assets = batch_mod.collect_doctor_project_assets_status(str(work_dir))
+
+            self.assertTrue(assets["glossary_matches_project"])
+            self.assertTrue(assets["macro_matches_project"])
+            self.assertTrue(
+                paths_match_project(
+                    assets["glossary_file"],
+                    expected_project_asset_paths(work_dir)["glossary_file"],
+                )
+            )
+            warnings = batch_mod.collect_doctor_project_assets_warnings(assets)
+            self.assertFalse(
+                any("does not match current project" in warning for warning in warnings)
+            )
 
     def test_collect_doctor_project_assets_warnings_for_missing_files(self):
         work_dir = "C:/Games/Example/work"

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1653,11 +1653,12 @@ def load_translator_settings(*, persist_corrected_game_root: bool = True):
 
     load_context_storage_settings(config)
 
-    from project_asset_paths import resolve_glossary_path
+    from project_asset_paths import (
+        resolve_configured_glossary_value,
+        resolve_glossary_path,
+    )
 
-    glossary_file = config.get("glossary_file")
-    if glossary_file is None:
-        glossary_file = config.get("glossary_path")
+    glossary_file = resolve_configured_glossary_value(config)
     # Prefer current work over the tool directory for relative/bare names so
     # "glossary.json" cannot silently resolve to the install-tree default.
     resolved_glossary = resolve_glossary_path(

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -1653,14 +1653,19 @@ def load_translator_settings(*, persist_corrected_game_root: bool = True):
 
     load_context_storage_settings(config)
 
+    from project_asset_paths import resolve_glossary_path
+
     glossary_file = config.get("glossary_file")
     if glossary_file is None:
         glossary_file = config.get("glossary_path")
-    if glossary_file is not None:
-        resolved_glossary = _resolve_preferred_path(TOOL_DIR, BASE_DIR, glossary_file)
-        GLOSSARY_FILE = resolved_glossary or DEFAULT_GLOSSARY_FILE
-    else:
-        GLOSSARY_FILE = DEFAULT_GLOSSARY_FILE
+    # Prefer current work over the tool directory for relative/bare names so
+    # "glossary.json" cannot silently resolve to the install-tree default.
+    resolved_glossary = resolve_glossary_path(
+        glossary_file,
+        game_root=BASE_DIR,
+        tool_dir=TOOL_DIR,
+    )
+    GLOSSARY_FILE = resolved_glossary or DEFAULT_GLOSSARY_FILE
 
     tl_subdir = config.get("tl_subdir")
     try:


### PR DESCRIPTION
## Summary
- Treat **existing translations** as real Chinese progress (`translated_task_count`), not blank template `old_lines`, so doctor no longer recommends enabling RAG on first-pass projects.
- Resolve relative `glossary.json` / `macro_setting.md` under the current **work** directory (not the tool install tree), normalize on settings save, and clarify mismatch copy.
- Speed up environment checks by skipping occurrence extraction and task payload copies when only pending/translated counts are needed; cache `SourceDocument` text/lines. Batch build defaults remain full-fidelity.

## Test plan
- [x] `python -m unittest tests.test_doctor_layout_status tests.test_project_asset_paths tests.test_engine_adapter_p1 tests.test_engine_adapter_p2 -q`
- [x] Equivalence: doctor progress summary matches full pending-path counts on fixture
- [x] Manual timing on a large TL project: doctor progress ~5s vs previous ~1min-class full path; counts unchanged
- [ ] GUI: run environment check on a blank-template project — no `enable_rag_for_consistency`; relative glossary no longer flags tool-dir mismatch
- [ ] GUI: switch project still rewrites glossary/macro to current work absolute paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation status detection so blank templates and incomplete reports are not mistaken for existing translations.
  - Fixed glossary and macro paths to resolve correctly for the active project, including when switching projects.
  - Preserved custom absolute paths while normalizing relative project asset paths.

- **Improvements**
  - Doctor diagnostics now load progress information more efficiently.
  - Clarified settings and warning messages for glossary and macro path handling.
  - Improved document processing consistency through cached text and line access.

- **Documentation**
  - Updated guidance for translation counts, project asset paths, and recommendation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->