### PR TITLE
fix: pin Ren'Py integration CI to 8.5.3

### DIFF
--- a/.github/workflows/renpy-integration.yml
+++ b/.github/workflows/renpy-integration.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      RENPY_VERSION: "8.5.2"
-      RENPY_ARCHIVE_SHA256: "cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4"
+      RENPY_VERSION: "8.5.3"
+      RENPY_ARCHIVE_SHA256: "eb0a9be7f0fb13632fe25ceade9a8bed5a1b4d6b6e83bd19eeeb29e1a1bb4a45"
 
     steps:
       - name: Check out repository

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -58,11 +58,13 @@ python -B scripts/run_quality_gates.py all
 
 `.github/workflows/renpy-integration.yml` 每周定时运行，也可从 Actions 手动触发。它不会在普通 pull request 上运行，因为官方 SDK 约 146 MiB，并且 Ren'Py 8.5 的自动测试会经过真实 GUI / OpenGL 渲染路径。
 
-工作流固定使用 Ren'Py 8.5.2：
+工作流固定使用 Ren'Py 8.5.3：
 
-- 下载：`https://www.renpy.org/dl/8.5.2/renpy-8.5.2-sdk.tar.bz2`
-- SHA-256：`cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4`
-- 官方校验来源：`https://www.renpy.org/dl/8.5.2/checksums.txt`
+- 下载：`https://www.renpy.org/dl/8.5.3/renpy-8.5.3-sdk.tar.bz2`
+- SHA-256：`eb0a9be7f0fb13632fe25ceade9a8bed5a1b4d6b6e83bd19eeeb29e1a1bb4a45`
+- 官方校验来源：`https://www.renpy.org/dl/8.5.3/checksums.txt`
+
+说明：8.5.2 的 `lint --error-code` 会把 fixture 里的 `testsuite` / `testcase` 误报为 Unreachable Statements（8.5.3 已在 lint 可达性分析中把 `Testcase` 标为 weakly reachable）。
 
 集成 runner 会把 `tests/fixtures/renpy_smoke/` 复制到临时目录，然后依次：
 
@@ -75,13 +77,13 @@ python -B scripts/run_quality_gates.py all
 本地已有 SDK 时可复现：
 
 ```powershell
-python -B scripts/run_renpy_integration.py --sdk C:\RenPy_Workspace\renpy-8.5.2-sdk
+python -B scripts/run_renpy_integration.py --sdk C:\RenPy_Workspace\renpy-8.5.3-sdk
 ```
 
 Linux 无桌面环境时，在 Xvfb 下执行同一 runner：
 
 ```bash
-xvfb-run -a python -B scripts/run_renpy_integration.py --sdk /path/to/renpy-8.5.2-sdk
+xvfb-run -a python -B scripts/run_renpy_integration.py --sdk /path/to/renpy-8.5.3-sdk
 ```
 
 SDK 缺失、模板没有生成、lint 失败或 testcase 失败都会返回非零退出码和明确诊断。

--- a/tests/test_renpy_integration_runner.py
+++ b/tests/test_renpy_integration_runner.py
@@ -87,7 +87,7 @@ class RenPyIntegrationRunnerTests(unittest.TestCase):
             integration.REPO_ROOT / ".github" / "workflows" / "renpy-integration.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertIn('RENPY_VERSION: "8.5.2"', workflow)
+        self.assertIn('RENPY_VERSION: "8.5.3"', workflow)
         version_reference = chr(36) + "{RENPY_VERSION}"
         self.assertIn(
             f"https://www.renpy.org/dl/{version_reference}/"
@@ -95,7 +95,7 @@ class RenPyIntegrationRunnerTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
-            "cf9ed145e5b32521a4b2caddb4cd3073c64259ac51e1f7aab94a8a8ff72b55c4",
+            "eb0a9be7f0fb13632fe25ceade9a8bed5a1b4d6b6e83bd19eeeb29e1a1bb4a45",
             workflow,
         )
         self.assertIn("schedule:", workflow)


### PR DESCRIPTION
## Summary
- Bump the scheduled Ren'Py integration workflow from 8.5.2 to 8.5.3 and refresh the official SDK checksum.
- Document why 8.5.2 fails: `lint --error-code` misreports fixture `testsuite`/`testcase` as unreachable; 8.5.3 marks `Testcase` as weakly reachable.
- Update the workflow pin unit test accordingly.

## Context
All three scheduled `Ren'Py integration` runs failed at `lint --error-code` with unreachable statements on `game/testcases.rpy` lines 1 and 5. Local reproduction with 8.5.3 passes the full translate → lint → test path.

## Test plan
- [x] `python -m unittest tests.test_renpy_integration_runner -v`
- [x] Local full integration with Ren'Py 8.5.3: `python -B scripts/run_renpy_integration.py --sdk …` (passed)
- [ ] After merge: Actions → Ren'Py integration → Run workflow (manual) to confirm CI green
