### PR TITLE
fix: keep offline batch commands free of API key and output-file collisions

### DIFF
--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -13068,7 +13068,6 @@ def _collect_output_file_protected_paths(args):
         'summary_jsonl',
         'summary_markdown',
         'variants_file',
-        'glossary',
     ):
         value = getattr(args, attr, None)
         if not isinstance(value, str) or not value.strip():
@@ -13078,6 +13077,15 @@ def _collect_output_file_protected_paths(args):
         add_path(abs_path)
         if os.path.isdir(abs_path):
             add_path(os.path.join(abs_path, 'manifest.json'))
+
+    # merge-keywords-to-glossary falls back to the active glossary file.
+    glossary_value = getattr(args, 'glossary', None)
+    if isinstance(glossary_value, str) and glossary_value.strip():
+        add_path(os.path.abspath(glossary_value.strip()))
+    elif str(getattr(args, 'command', '') or '') == 'merge-keywords-to-glossary':
+        default_glossary = getattr(legacy, 'GLOSSARY_FILE', '') or ''
+        if default_glossary:
+            add_path(os.path.abspath(default_glossary))
 
     for manifest_path in _candidate_manifest_paths_from_args(args):
         add_path(manifest_path)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -98,6 +98,21 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
     }
 )
 EXPLICIT_TARGET_COMMANDS = frozenset({'submit', 'status', 'download', 'check', 'apply'})
+# Local-only batch commands must not be blocked by API-key preflight.
+OFFLINE_BATCH_COMMANDS = frozenset(
+    {
+        'check',
+        'apply',
+        'estimate-cost',
+        'preview-revisions',
+        'apply-revisions',
+        'split',
+        'build-retry',
+        'merge-retry',
+        'export-keywords',
+        'merge-keywords-to-glossary',
+    }
+)
 
 
 class DualLogger(object):
@@ -12458,7 +12473,8 @@ def dispatch_command(parser, args):
         except model_usage_ledger.UsageLedgerError as exc:
             raise SystemExit(f'Model usage ledger error: {exc}') from exc
 
-    legacy.load_config()
+    require_api_key = command not in OFFLINE_BATCH_COMMANDS
+    legacy.load_config(require_api_key=require_api_key)
     legacy.load_translator_settings()
     legacy.load_glossary()
     load_batch_settings()
@@ -12909,8 +12925,185 @@ def _write_machine_document(
     return document
 
 
+def _candidate_manifest_paths_from_args(args):
+    """Collect explicit or implied manifest paths for --output-file conflict checks."""
+
+    candidates = []
+    seen = set()
+
+    def add_candidate(value):
+        if not isinstance(value, str) or not value.strip():
+            return
+        raw = value.strip()
+        abs_path = os.path.abspath(raw)
+        if os.path.isdir(abs_path):
+            abs_path = os.path.join(abs_path, 'manifest.json')
+        key = _normalized_abs_path(abs_path)
+        if key in seen:
+            return
+        seen.add(key)
+        candidates.append(abs_path)
+
+    for attr in ('target', 'parent', 'retry'):
+        add_candidate(getattr(args, attr, None))
+
+    if not candidates and os.path.isfile(LATEST_MANIFEST_FILE):
+        try:
+            with open(LATEST_MANIFEST_FILE, 'r', encoding='utf-8') as handle:
+                latest = handle.read().strip()
+        except OSError:
+            latest = ''
+        add_candidate(latest)
+
+    return candidates
+
+
+def _collect_manifest_protected_paths(manifest_path):
+    """Return task inputs and writeback targets associated with one manifest."""
+
+    protected = [manifest_path]
+    package_dir = os.path.dirname(manifest_path)
+    try:
+        with open(manifest_path, 'r', encoding='utf-8') as handle:
+            manifest = json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return protected
+    if not isinstance(manifest, dict):
+        return protected
+
+    manifest = dict(manifest)
+    manifest['_manifest_path'] = manifest_path
+    manifest['_package_dir'] = package_dir
+
+    def add_path(value):
+        if not isinstance(value, str) or not value.strip():
+            return
+        raw = value.strip()
+        try:
+            if os.path.isabs(raw):
+                protected.append(_canonical_abs_path(raw))
+            else:
+                protected.append(
+                    resolve_path_under_dir(package_dir, raw, 'protected output path')
+                )
+        except SystemExit:
+            protected.append(os.path.abspath(os.path.join(package_dir, raw)))
+
+    try:
+        result_path = resolve_manifest_result_path(manifest)
+    except SystemExit:
+        result_path = os.path.join(package_dir, 'results.jsonl')
+    protected.append(result_path)
+    protected.append(f'{result_path}.sha256')
+
+    for key in (
+        'input_jsonl_path',
+        'last_check_report_path',
+        'last_status_snapshot_path',
+        'last_apply_failure_report_path',
+        'next_split_manifest_path',
+        'last_retry_manifest_path',
+    ):
+        add_path(manifest.get(key))
+
+    values = manifest.get('retry_children')
+    if isinstance(values, list):
+        for item in values:
+            add_path(item)
+
+    last_preview = manifest.get('last_revision_preview')
+    if isinstance(last_preview, dict):
+        add_path(last_preview.get('jsonl_path'))
+        add_path(last_preview.get('markdown_path'))
+
+    files = manifest.get('files')
+    if isinstance(files, dict):
+        for file_key, file_info in files.items():
+            path_value = ''
+            if isinstance(file_info, dict):
+                path_value = file_info.get('path') or ''
+            if isinstance(path_value, str) and path_value.strip() and os.path.isabs(path_value):
+                add_path(path_value)
+                continue
+            try:
+                protected.append(
+                    resolve_manifest_file_path(
+                        manifest,
+                        file_key,
+                        file_info if isinstance(file_info, dict) else {},
+                    )
+                )
+            except (SystemExit, cli_contract.MachineContractError, OSError, TypeError, ValueError):
+                continue
+
+    return protected
+
+
+def _collect_output_file_protected_paths(args):
+    """Collect paths that --output-file must never overwrite."""
+
+    protected = []
+    seen = set()
+
+    def add_path(value):
+        if not isinstance(value, str) or not value.strip():
+            return
+        try:
+            canonical = _canonical_abs_path(value)
+            key = _normalized_abs_path(canonical)
+        except (OSError, TypeError, ValueError):
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        protected.append(canonical)
+
+    for attr in (
+        'target',
+        'parent',
+        'retry',
+        'report',
+        'jsonl',
+        'markdown',
+        'summary_jsonl',
+        'summary_markdown',
+        'variants_file',
+        'glossary',
+    ):
+        value = getattr(args, attr, None)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        raw = value.strip()
+        abs_path = os.path.abspath(raw)
+        add_path(abs_path)
+        if os.path.isdir(abs_path):
+            add_path(os.path.join(abs_path, 'manifest.json'))
+
+    for manifest_path in _candidate_manifest_paths_from_args(args):
+        add_path(manifest_path)
+        if os.path.isfile(manifest_path):
+            for path in _collect_manifest_protected_paths(manifest_path):
+                add_path(path)
+
+    return protected
+
+
+def _find_output_file_path_conflict(args, output_target):
+    """Return conflict details when --output-file collides with a task path."""
+
+    output_key = _normalized_abs_path(output_target)
+    for protected in _collect_output_file_protected_paths(args):
+        if _normalized_abs_path(protected) == output_key:
+            return {
+                'output_file': _canonical_abs_path(output_target),
+                'conflict_path': protected,
+                'command': str(getattr(args, 'command', '') or ''),
+            }
+    return None
+
+
 def _preflight_output_file(args):
-    """Verify that an output target is writable before workflow side effects."""
+    """Verify that an output target is safe and writable before workflow side effects."""
 
     output_file = str(getattr(args, 'output_file', '') or '').strip()
     if not output_file:
@@ -12918,6 +13111,19 @@ def _preflight_output_file(args):
     target = os.path.abspath(output_file)
     if os.path.isdir(target):
         raise IsADirectoryError(f'Output path is a directory: {target}')
+    conflict = _find_output_file_path_conflict(args, target)
+    if conflict:
+        raise cli_contract.MachineContractError(
+            (
+                f'--output-file collides with a task input or writeback path: '
+                f'{conflict["output_file"]} == {conflict["conflict_path"]}. '
+                'Choose an independent report path.'
+            ),
+            code_name='OUTPUT_FILE_PATH_CONFLICT',
+            suggested_action='choose_independent_output_file',
+            details=conflict,
+            semantic_exit_code=cli_contract.EXIT_USAGE,
+        )
     directory = os.path.dirname(target) or os.curdir
     os.makedirs(directory, exist_ok=True)
     fd, probe_path = tempfile.mkstemp(
@@ -13114,6 +13320,39 @@ def main(argv=None):
     if getattr(args, 'output_file', ''):
         try:
             _preflight_output_file(args)
+        except cli_contract.MachineContractError as exc:
+            # Never write the error envelope to the conflicting --output-file path.
+            safe_args = copy.copy(args)
+            safe_args.output_file = ''
+            if output == 'json' or args.command in {'capabilities', 'schema'}:
+                envelope = cli_contract.error_envelope(
+                    str(args.command or ''),
+                    code=exc.code_name,
+                    message=str(exc),
+                    retryable=exc.retryable,
+                    suggested_action=exc.suggested_action,
+                    details={
+                        **dict(exc.details),
+                        'command_completed': False,
+                        'workflow_started': False,
+                        'semantic_exit_code': exc.semantic_exit_code,
+                    },
+                )
+                _write_machine_document(
+                    envelope,
+                    safe_args,
+                    record_output_artifact=False,
+                    command_completed=False,
+                    workflow_started=False,
+                )
+                if getattr(args, 'strict_exit_codes', False):
+                    return exc.semantic_exit_code
+                return (
+                    cli_contract.EXIT_USAGE
+                    if exc.semantic_exit_code == cli_contract.EXIT_USAGE
+                    else 1
+                )
+            raise SystemExit(str(exc)) from exc
         except (OSError, ValueError) as exc:
             _write_output_file_failure(
                 args,

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1093,8 +1093,8 @@ class BatchCliContractTests(unittest.TestCase):
                 json.dumps({"result_jsonl_path": "results.jsonl"}, ensure_ascii=False),
                 encoding="utf-8",
             )
-            # Build a same-path alias that still normalizes to results.jsonl.
-            conflict_path = package / "." / "results.jsonl"
+            # Keep a raw alias so pathlib cannot collapse it before CLI normalization.
+            conflict_path = f"{package}{os.sep}.{os.sep}results.jsonl"
             with (
                 mock.patch.object(batch, "dispatch_command") as dispatch,
                 contextlib.redirect_stdout(stdout),
@@ -1106,7 +1106,7 @@ class BatchCliContractTests(unittest.TestCase):
                         "--output",
                         "json",
                         "--output-file",
-                        str(conflict_path),
+                        conflict_path,
                     ]
                 )
 
@@ -1119,30 +1119,64 @@ class BatchCliContractTests(unittest.TestCase):
         )
         dispatch.assert_not_called()
 
-    def test_output_file_conflict_in_text_mode_exits_nonzero(self):
+    def test_output_file_conflict_without_output_json_uses_discovery_json_path(self):
+        # Discovery commands allow --output-file without --output json and still
+        # emit a structured conflict envelope on stdout.
+        stdout = io.StringIO()
+
         with tempfile.TemporaryDirectory() as tmp:
             package = Path(tmp)
             manifest_path = package / "manifest.json"
+            latest_path = package / "latest.txt"
             manifest_path.write_text("{}", encoding="utf-8")
-            args = SimpleNamespace(
-                command="status",
-                target=str(manifest_path),
-                parent="",
-                retry="",
-                report="",
-                jsonl="",
-                markdown="",
-                summary_jsonl="",
-                summary_markdown="",
-                variants_file="",
-                glossary="",
-                output_file=str(manifest_path),
-            )
-            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
-                batch._preflight_output_file(args)
+            latest_path.write_text(str(manifest_path), encoding="utf-8")
+            with (
+                mock.patch.object(batch, "LATEST_MANIFEST_FILE", str(latest_path)),
+                mock.patch.object(batch, "dispatch_command") as dispatch,
+                contextlib.redirect_stdout(stdout),
+            ):
+                exit_code = batch.main(
+                    [
+                        "capabilities",
+                        "--output-file",
+                        str(manifest_path),
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_PATH_CONFLICT")
+        self.assertFalse(payload["error"]["details"]["workflow_started"])
+        dispatch.assert_not_called()
+
+    def test_default_glossary_is_protected_for_merge_keywords(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            glossary_path = package / "glossary.json"
+            glossary_path.write_text("{}", encoding="utf-8")
+            with mock.patch.object(batch.legacy, "GLOSSARY_FILE", str(glossary_path)):
+                args = SimpleNamespace(
+                    command="merge-keywords-to-glossary",
+                    target="candidates.jsonl",
+                    parent="",
+                    retry="",
+                    report="",
+                    jsonl="",
+                    markdown="",
+                    summary_jsonl="",
+                    summary_markdown="",
+                    variants_file="",
+                    glossary="",
+                    output_file=str(glossary_path),
+                )
+                with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                    batch._preflight_output_file(args)
 
         self.assertEqual(raised.exception.code_name, "OUTPUT_FILE_PATH_CONFLICT")
-        self.assertIn("collides with a task input", str(raised.exception))
+        self.assertEqual(
+            batch._normalized_abs_path(raised.exception.details["conflict_path"]),
+            batch._normalized_abs_path(str(glossary_path)),
+        )
 
     def test_independent_output_file_still_allowed(self):
         manifest = {

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1071,12 +1071,12 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_PATH_CONFLICT")
         self.assertFalse(payload["error"]["details"]["workflow_started"])
         self.assertEqual(
-            payload["error"]["details"]["output_file"],
-            os.path.abspath(str(manifest_path)),
+            batch._normalized_abs_path(payload["error"]["details"]["output_file"]),
+            batch._normalized_abs_path(str(manifest_path)),
         )
         self.assertEqual(
-            payload["error"]["details"]["conflict_path"],
-            os.path.abspath(str(manifest_path)),
+            batch._normalized_abs_path(payload["error"]["details"]["conflict_path"]),
+            batch._normalized_abs_path(str(manifest_path)),
         )
         self.assertNotIn("Traceback", stderr.getvalue())
         dispatch.assert_not_called()
@@ -1114,8 +1114,8 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
         self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_PATH_CONFLICT")
         self.assertEqual(
-            os.path.normcase(payload["error"]["details"]["conflict_path"]),
-            os.path.normcase(os.path.abspath(str(results_path))),
+            batch._normalized_abs_path(payload["error"]["details"]["conflict_path"]),
+            batch._normalized_abs_path(str(results_path)),
         )
         dispatch.assert_not_called()
 

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -905,6 +905,281 @@ class BatchCliContractTests(unittest.TestCase):
                 self.assertEqual(raised.exception.code, 2)
                 self.assertIn("requires --output json", stderr.getvalue())
 
+
+    def test_offline_batch_commands_skip_api_key_requirement(self):
+        for command in sorted(batch.OFFLINE_BATCH_COMMANDS):
+            with self.subTest(command=command):
+                load_config = mock.Mock()
+                with (
+                    mock.patch.object(batch, "initialize_batch_logging"),
+                    mock.patch.object(batch.legacy, "load_config", load_config),
+                    mock.patch.object(batch.legacy, "load_translator_settings"),
+                    mock.patch.object(batch.legacy, "load_glossary"),
+                    mock.patch.object(batch, "load_batch_settings"),
+                    mock.patch.object(batch, "print_banner"),
+                    mock.patch.object(
+                        batch,
+                        "dispatch_command",
+                        wraps=batch.dispatch_command,
+                    ),
+                ):
+                    # Patch the actual offline command handlers after the load gate.
+                    handler_patches = []
+                    if command == "check":
+                        handler_patches.append(
+                            mock.patch.object(batch, "check_results", return_value={"ok": True})
+                        )
+                    elif command == "apply":
+                        handler_patches.append(
+                            mock.patch.object(batch, "apply_results", return_value={"ok": True})
+                        )
+                    elif command == "estimate-cost":
+                        handler_patches.extend(
+                            [
+                                mock.patch.object(
+                                    batch,
+                                    "load_manifest",
+                                    return_value={"_manifest_path": "manifest.json"},
+                                ),
+                                mock.patch.object(
+                                    batch,
+                                    "ensure_manifest_cost_estimate",
+                                    return_value={"total": 1},
+                                ),
+                                mock.patch.object(
+                                    batch.batch_cost_estimate,
+                                    "format_cost_estimate_lines",
+                                    return_value=["cost"],
+                                ),
+                            ]
+                        )
+                    elif command == "preview-revisions":
+                        handler_patches.append(
+                            mock.patch.object(batch, "preview_revisions", return_value={"ok": True})
+                        )
+                    elif command == "apply-revisions":
+                        handler_patches.append(
+                            mock.patch.object(batch, "apply_revisions", return_value={"ok": True})
+                        )
+                    elif command == "split":
+                        handler_patches.append(
+                            mock.patch.object(batch, "split_manifest", return_value=None)
+                        )
+                    elif command == "build-retry":
+                        handler_patches.append(
+                            mock.patch.object(batch, "build_retry_package", return_value=None)
+                        )
+                    elif command == "merge-retry":
+                        handler_patches.append(
+                            mock.patch.object(batch, "merge_retry_results", return_value=None)
+                        )
+                    elif command == "export-keywords":
+                        handler_patches.append(
+                            mock.patch.object(
+                                batch, "export_keyword_candidates", return_value=None
+                            )
+                        )
+                    elif command == "merge-keywords-to-glossary":
+                        handler_patches.extend(
+                            [
+                                mock.patch.object(
+                                    batch.keyword_glossary_merge,
+                                    "resolve_keyword_candidates_path",
+                                    return_value="candidates.jsonl",
+                                ),
+                                mock.patch.object(
+                                    batch.keyword_glossary_merge,
+                                    "merge_keywords_to_glossary",
+                                    return_value=None,
+                                ),
+                                mock.patch.object(
+                                    batch.legacy,
+                                    "GLOSSARY_FILE",
+                                    "glossary.json",
+                                ),
+                            ]
+                        )
+
+                    with contextlib.ExitStack() as stack:
+                        for patcher in handler_patches:
+                            stack.enter_context(patcher)
+                        if command == "merge-retry":
+                            argv = ["merge-retry", "parent.json", "retry.json"]
+                        elif command == "merge-keywords-to-glossary":
+                            argv = ["merge-keywords-to-glossary", "candidates.jsonl", "--yes"]
+                        else:
+                            argv = [command, "manifest.json"]
+                        exit_code = batch.main(argv)
+
+                self.assertEqual(exit_code, 0)
+                load_config.assert_called_once_with(require_api_key=False)
+
+    def test_remote_batch_commands_still_require_api_key(self):
+        load_config = mock.Mock()
+        with (
+            mock.patch.object(batch, "initialize_batch_logging"),
+            mock.patch.object(batch.legacy, "load_config", load_config),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner"),
+            mock.patch.object(batch, "show_status", return_value={"job_state": "JOB_STATE_PENDING"}),
+        ):
+            exit_code = batch.main(["status", "manifest.json"])
+
+        self.assertEqual(exit_code, 0)
+        load_config.assert_called_once_with(require_api_key=True)
+
+    def test_output_file_conflict_with_manifest_is_rejected_before_dispatch(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            manifest_path = package / "manifest.json"
+            results_path = package / "results.jsonl"
+            results_path.write_text("{}" + "\n", encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "result_jsonl_path": "results.jsonl",
+                        "input_jsonl_path": "input.jsonl",
+                        "files": {},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(batch, "dispatch_command") as dispatch,
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                exit_code = batch.main(
+                    [
+                        "status",
+                        str(manifest_path),
+                        "--output",
+                        "json",
+                        "--output-file",
+                        str(manifest_path),
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_PATH_CONFLICT")
+        self.assertFalse(payload["error"]["details"]["workflow_started"])
+        self.assertEqual(
+            payload["error"]["details"]["output_file"],
+            os.path.abspath(str(manifest_path)),
+        )
+        self.assertEqual(
+            payload["error"]["details"]["conflict_path"],
+            os.path.abspath(str(manifest_path)),
+        )
+        self.assertNotIn("Traceback", stderr.getvalue())
+        dispatch.assert_not_called()
+
+    def test_output_file_conflict_with_results_uses_normalized_paths(self):
+        stdout = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            manifest_path = package / "manifest.json"
+            results_path = package / "results.jsonl"
+            results_path.write_text("{}" + "\n", encoding="utf-8")
+            manifest_path.write_text(
+                json.dumps({"result_jsonl_path": "results.jsonl"}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            # Build a same-path alias that still normalizes to results.jsonl.
+            conflict_path = package / "." / "results.jsonl"
+            with (
+                mock.patch.object(batch, "dispatch_command") as dispatch,
+                contextlib.redirect_stdout(stdout),
+            ):
+                exit_code = batch.main(
+                    [
+                        "check",
+                        str(manifest_path),
+                        "--output",
+                        "json",
+                        "--output-file",
+                        str(conflict_path),
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "OUTPUT_FILE_PATH_CONFLICT")
+        self.assertEqual(
+            os.path.normcase(payload["error"]["details"]["conflict_path"]),
+            os.path.normcase(os.path.abspath(str(results_path))),
+        )
+        dispatch.assert_not_called()
+
+    def test_output_file_conflict_in_text_mode_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            manifest_path = package / "manifest.json"
+            manifest_path.write_text("{}", encoding="utf-8")
+            args = SimpleNamespace(
+                command="status",
+                target=str(manifest_path),
+                parent="",
+                retry="",
+                report="",
+                jsonl="",
+                markdown="",
+                summary_jsonl="",
+                summary_markdown="",
+                variants_file="",
+                glossary="",
+                output_file=str(manifest_path),
+            )
+            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                batch._preflight_output_file(args)
+
+        self.assertEqual(raised.exception.code_name, "OUTPUT_FILE_PATH_CONFLICT")
+        self.assertIn("collides with a task input", str(raised.exception))
+
+    def test_independent_output_file_still_allowed(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "job_state": "JOB_STATE_SUCCEEDED",
+        }
+        stdout = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            manifest_path = package / "manifest.json"
+            report_path = package / "status-report.json"
+            manifest_path.write_text(
+                json.dumps({"result_jsonl_path": "results.jsonl"}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(batch, "dispatch_command", return_value=manifest),
+                contextlib.redirect_stdout(stdout),
+            ):
+                exit_code = batch.main(
+                    [
+                        "status",
+                        str(manifest_path),
+                        "--output",
+                        "json",
+                        "--output-file",
+                        str(report_path),
+                    ]
+                )
+
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(payload["status"], "JOB_STATE_SUCCEEDED")
+
     def test_text_mode_preserves_human_stdout(self):
         stdout = io.StringIO()
 


### PR DESCRIPTION
## Summary
- Load offline Batch commands with `require_api_key=False`, so local workflows such as `check`, `apply`, `estimate-cost`, revision preview/apply, split/retry, and keyword export/merge reach their real validation paths without an API key.
- Reject `--output-file` paths that collide with task inputs or writeback targets before workflow side effects, including manifest/results, report paths, and target `.rpy` files after path normalization.
- Emit a structured `OUTPUT_FILE_PATH_CONFLICT` error in JSON mode without writing into the colliding path, while still allowing independent report files to be overwritten.

## Why
Issue #293 tracked two correctness holes: offline Batch commands were blocked by the default API-key gate, and machine output could overwrite task inputs such as `manifest.json` or `results.jsonl`.

## Test plan
- [x] `python -m unittest tests.test_gemini_translate_batch_cli_contract tests.test_cli_contract tests.test_cli_discovery tests.test_batch_repair tests.test_runtime_config -q`
- [x] `git diff --check`

Refs #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline batch commands can now run without an API key.
  * Added safeguards to prevent output files from overwriting manifests, reports, translation files, and related artifacts.
  * Conflicting output paths now provide clear errors before processing begins.
  * Independent output paths continue to support JSON and text results.

* **Bug Fixes**
  * Improved command validation and output-path handling to prevent unintended file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->