### PR TITLE
fix: keep doctor readonly and tighten local CLI entry semantics

### DIFF
--- a/docs/games_registry.md
+++ b/docs/games_registry.md
@@ -22,7 +22,7 @@ Registry 回答的是：「工作区里有哪些项目？各自路径、版本�
 工作区根目录**必须显式指定**，不会默认使用工具安装目录的上一级：
 
 - GUI：**设置 → 项目列表 → 创建 / 接入工作区…**（预览后初始化或接入 `games_registry.json`，成功后再写入 `translator_config.json` 的 `workspace_root`）
-- CLI：`python games_registry.py setup --workspace <path>`（可用 `--dry-run` 只预览）；其它子命令使用 `--workspace <path>`，或先在 `translator_config.json` 中设置 `workspace_root`
+- CLI：`python games_registry.py --workspace <path> setup`（可用 `--dry-run` 只预览）；其它子命令同样把全局 `--workspace` 放在子命令前，或先在 `translator_config.json` 中设置 `workspace_root`
 - 未设置时：项目列表为空状态；CLI 的 registry 命令以退出码 2 报错
 - SDK、API 密钥与工具日志**不是**工作区必需文件；接入工作区不会自动下载 SDK，也不会运行项目级 prepare。GUI 向导第二步可**可选**查找 / 浏览 / 下载推荐 SDK，或跳过
 
@@ -97,8 +97,8 @@ Markdown 与 JSON 一致，请再执行「同步 GAMES.md」。
 
 ```powershell
 # 创建或接入工作区（推荐首次使用；--dry-run 只预览）
-python games_registry.py setup --workspace path\to\RenPy_Workspace --dry-run
-python games_registry.py setup --workspace path\to\RenPy_Workspace
+python games_registry.py --workspace path\to\RenPy_Workspace setup --dry-run
+python games_registry.py --workspace path\to\RenPy_Workspace setup
 # 可选：--import-md / --no-import-md、--discover / --no-discover、--render-md、--create-directory
 
 # 从现有 GAMES.md 初始化 / 合并导入（首次迁移时常用）

--- a/games_registry.py
+++ b/games_registry.py
@@ -5,7 +5,7 @@ The registry file (``games_registry.json``) lives at the RenPy workspace root.
 
 Commands::
 
-    python games_registry.py setup --workspace path/to/workspace
+    python games_registry.py --workspace path/to/workspace setup
     python games_registry.py import-md
     python games_registry.py discover
     python games_registry.py ingest --source path/to/game_or.zip

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -11263,7 +11263,7 @@ def build_arg_parser():
         description='Batch translator for Ren\'Py tl files using Gemini Batch API.'
     )
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
-    subparsers = parser.add_subparsers(dest='command')
+    subparsers = parser.add_subparsers(dest='command', required=True)
 
     doctor_parser = subparsers.add_parser('doctor', help='Inspect prepare, SDK, and TL template compatibility without writing files.')
     add_machine_output_argument(doctor_parser)
@@ -12103,7 +12103,8 @@ def dispatch_command(parser, args):
         validate_machine_invocation(args)
 
     if command == 'doctor':
-        legacy.load_translator_settings()
+        # doctor is read-only: never persist auto-corrected game_root.
+        legacy.load_translator_settings(persist_corrected_game_root=False)
         legacy.load_glossary()
         load_batch_settings()
         print_banner()

--- a/relation_analyzer/__init__.py
+++ b/relation_analyzer/__init__.py
@@ -1,3 +1,6 @@
-"""extract_relations 的内部实现包。"""
+"""extract_relations 的内部实现包。
 
-from .cli import main
+CLI 入口请使用 ``python -m relation_analyzer.cli`` 或 ``relation_analyzer.cli:main``。
+本包初始化故意不导入 CLI，避免 ``python -m relation_analyzer.cli`` 触发
+``sys.modules`` RuntimeWarning 并丢失帮助输出。
+"""

--- a/relation_analyzer/cli.py
+++ b/relation_analyzer/cli.py
@@ -94,3 +94,7 @@ def main():
         analyze_and_plot(vectors, char_texts, output_path, active_portraits)
     else:
         raise SystemExit('❌ 提取到的有效角色少于 2 个，无法计算关系。')
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/requirements-lock/manifest.json
+++ b/requirements-lock/manifest.json
@@ -21,6 +21,6 @@
     "requirements-litellm.txt": "7790852dec5aabc5e60d5384a698590eedd6e01da7bf7ba8eb57cc32a2a84d5b",
     "requirements-relation-analyzer.txt": "927db0bb8c14a9d0acfa712224cc6b8b5bfbae4d6b1a280b703ac32a68a6c39e",
     "requirements.txt": "d2e7f9fd2fb3b6a83b3a48b62e6b633f2576a0a869c7c9d9a25f5c910aeae2df",
-    "scripts/compile_dependency_locks.py": "573e1015fc798839cd4bbea57fda3b4606963cf187628f7701eeceadd29f11a7"
+    "scripts/compile_dependency_locks.py": "797cd32a342461704c9e596fb95d8f1ab32a67100bb6e6371d593cf81c2ac6b3"
   }
 }

--- a/scripts/compile_dependency_locks.py
+++ b/scripts/compile_dependency_locks.py
@@ -209,12 +209,13 @@ def generate_locks(uv_command: str, *, upgrade: bool = False) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--check",
         action="store_true",
         help="verify committed source and lock hashes without network access",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--upgrade",
         action="store_true",
         help="allow transitive upgrades while regenerating all locks",

--- a/tests/test_batch_rag.py
+++ b/tests/test_batch_rag.py
@@ -887,9 +887,10 @@ class BatchRagRegressionTests(unittest.TestCase):
         self.assertNotIn('Dialogue translation blocks do not include source comments', ' '.join(report['warnings']))
 
     def test_doctor_command_does_not_require_api_keys(self):
+        load_settings = mock.Mock()
         with (
             mock.patch.object(batch_mod, 'initialize_batch_logging') as logging_mock,
-            mock.patch.object(batch_mod.legacy, 'load_translator_settings'),
+            mock.patch.object(batch_mod.legacy, 'load_translator_settings', load_settings),
             mock.patch.object(batch_mod.legacy, 'load_glossary'),
             mock.patch.object(batch_mod, 'load_batch_settings'),
             mock.patch.object(batch_mod, 'print_banner'),
@@ -901,6 +902,39 @@ class BatchRagRegressionTests(unittest.TestCase):
 
         load_config_mock.assert_not_called()
         logging_mock.assert_not_called()
+        load_settings.assert_called_once_with(persist_corrected_game_root=False)
+
+    def test_doctor_command_does_not_persist_corrected_game_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / 'Game_Example'
+            (project / 'original' / 'game').mkdir(parents=True)
+            (project / 'work' / 'game' / 'tl' / 'schinese').mkdir(parents=True)
+            (project / 'work' / 'game' / 'script.rpy').write_text('label start:\n    return\n', encoding='utf-8')
+            config_path = root / 'translator_config.json'
+            config_path.write_text(
+                json.dumps({'game_root': str(project), 'tl_subdir': 'game/tl/schinese'}, ensure_ascii=False, indent=2)
+                + '\n',
+                encoding='utf-8',
+            )
+            before = config_path.read_bytes()
+
+            with (
+                mock.patch.object(batch_mod.legacy, 'TRANSLATOR_CONFIG', str(config_path)),
+                mock.patch.object(batch_mod.legacy, 'persist_game_root') as persist_mock,
+                mock.patch.object(batch_mod, 'print_banner'),
+                mock.patch.object(batch_mod, 'print_doctor_report'),
+            ):
+                exit_code = batch_mod.main(['doctor'])
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(config_path.read_bytes(), before)
+            persist_mock.assert_not_called()
+
+    def test_main_without_command_exits_usage(self):
+        with self.assertRaises(SystemExit) as raised:
+            batch_mod.main([])
+        self.assertEqual(raised.exception.code, 2)
 
     def test_doctor_report_explains_custom_template_command_errors(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_batch_rag.py
+++ b/tests/test_batch_rag.py
@@ -924,6 +924,7 @@ class BatchRagRegressionTests(unittest.TestCase):
                 mock.patch.object(batch_mod.legacy, 'persist_game_root') as persist_mock,
                 mock.patch.object(batch_mod, 'print_banner'),
                 mock.patch.object(batch_mod, 'print_doctor_report'),
+                runtime.runtime_config_scope(),
             ):
                 exit_code = batch_mod.main(['doctor'])
 

--- a/tests/test_dependency_locks.py
+++ b/tests/test_dependency_locks.py
@@ -131,5 +131,11 @@ class DependencyLockTests(unittest.TestCase):
         self.assertNotIn("py311-linux-gui.txt", workflow)
 
 
+    def test_check_and_upgrade_are_mutually_exclusive(self):
+        with self.assertRaises(SystemExit) as raised:
+            locks.build_parser().parse_args(["--check", "--upgrade"])
+        self.assertEqual(raised.exception.code, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine_adapter_p1.py
+++ b/tests/test_engine_adapter_p1.py
@@ -841,13 +841,17 @@ translate schinese start:
             r"nested\script.rpy": ["id:1"],
             "top.rpy": ["id:2"],
         }
-        upgraded = runtime._upgrade_legacy_progress_keys(
-            progress,
-            [
-                str(Path("nested") / "script.rpy"),
-                "top.rpy",
-            ],
-        )
+        with (
+            mock.patch.object(runtime, "TL_DIR", ""),
+            mock.patch.object(runtime, "save_progress"),
+        ):
+            upgraded = runtime._upgrade_legacy_progress_keys(
+                progress,
+                [
+                    "nested/script.rpy",
+                    "top.rpy",
+                ],
+            )
         self.assertIn("nested/script.rpy", upgraded)
         self.assertEqual(upgraded["nested/script.rpy"], ["id:1"])
         self.assertEqual(upgraded["top.rpy"], ["id:2"])

--- a/tests/test_games_registry.py
+++ b/tests/test_games_registry.py
@@ -1138,5 +1138,13 @@ class GamesRegistryTests(unittest.TestCase):
             self.assertFalse(config_path.exists())
 
 
+    def test_global_workspace_flag_precedes_subcommand(self):
+        parser = registry.build_arg_parser()
+        args = parser.parse_args(["--workspace", "C:/ws", "setup", "--dry-run"])
+        self.assertEqual(args.command, "setup")
+        self.assertEqual(Path(args.workspace), Path("C:/ws"))
+        self.assertTrue(args.dry_run)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_relation_analyzer.py
+++ b/tests/test_relation_analyzer.py
@@ -1,4 +1,6 @@
 import csv
+import subprocess
+import sys
 import json
 import tempfile
 import unittest
@@ -576,6 +578,23 @@ class RelationAnalyzerTests(unittest.TestCase):
 
         self.assertEqual(embeddings.shape, (1, 2))
         self.assertEqual(embeddings.tolist(), [[3.0, 4.0]])
+
+
+    def test_module_cli_help_entrypoint(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "relation_analyzer.cli", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout.lower())
+        self.assertNotIn("RuntimeWarning", result.stderr)
+
+    def test_package_init_does_not_import_cli_main(self):
+        import relation_analyzer
+
+        self.assertFalse(hasattr(relation_analyzer, "main"))
 
 
 if __name__ == '__main__':

--- a/tests/test_relation_analyzer.py
+++ b/tests/test_relation_analyzer.py
@@ -585,11 +585,15 @@ class RelationAnalyzerTests(unittest.TestCase):
             [sys.executable, "-m", "relation_analyzer.cli", "--help"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
         self.assertEqual(result.returncode, 0)
-        self.assertIn("usage:", result.stdout.lower())
-        self.assertNotIn("RuntimeWarning", result.stderr)
+        self.assertIn("usage:", stdout.lower())
+        self.assertNotIn("RuntimeWarning", stderr)
 
     def test_package_init_does_not_import_cli_main(self):
         import relation_analyzer

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -54,18 +54,24 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             else:
                 sys.modules.pop(module_name, None)
 
-    def test_batch_cli_without_command_prints_help_without_submit(self):
+    def test_batch_cli_without_command_exits_usage_without_submit(self):
         output = io.StringIO()
+        err = io.StringIO()
 
         with (
             mock.patch('sys.stdout', output),
+            mock.patch('sys.stderr', err),
             mock.patch.object(batch_mod, 'initialize_batch_logging') as logging_mock,
             mock.patch.object(batch_mod.legacy, 'load_config') as load_config_mock,
             mock.patch.object(batch_mod, 'submit_manifest') as submit_mock,
         ):
-            batch_mod.main([])
+            with self.assertRaises(SystemExit) as raised:
+                batch_mod.main([])
 
-        self.assertIn('usage:', output.getvalue())
+        self.assertEqual(raised.exception.code, 2)
+        combined = output.getvalue() + err.getvalue()
+        self.assertIn('usage:', combined)
+        self.assertIn('required: command', combined)
         logging_mock.assert_not_called()
         load_config_mock.assert_not_called()
         submit_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- Make `doctor` load settings with `persist_corrected_game_root=False`, so auto-corrected `game_root` stays in memory only and never rewrites `translator_config.json`.
- Require a Batch CLI subcommand (`exit 2`) instead of printing help and returning 0.
- Fix `games_registry` docstring/docs so global `--workspace` is shown before the subcommand.
- Remove package-level CLI import side effects from `relation_analyzer`, and add a proper `python -m relation_analyzer.cli` entrypoint.
- Make `compile_dependency_locks.py --check` and `--upgrade` mutually exclusive, and refresh the owned source hash.

## Why
Issue #295 tracked several local CLI correctness holes: doctor was not truly readonly, some entrypoints returned misleading success, and a few docs/options silently disagreed with actual argparse behavior.

## Test plan
- [x] `python -m unittest tests.test_batch_rag.BatchRagRegressionTests.test_doctor_command_does_not_require_api_keys tests.test_batch_rag.BatchRagRegressionTests.test_doctor_command_does_not_persist_corrected_game_root tests.test_batch_rag.BatchRagRegressionTests.test_main_without_command_exits_usage tests.test_dependency_locks tests.test_games_registry.GamesRegistryTests.test_global_workspace_flag_precedes_subcommand tests.test_relation_analyzer.RelationAnalyzerTests.test_module_cli_help_entrypoint tests.test_relation_analyzer.RelationAnalyzerTests.test_package_init_does_not_import_cli_main tests.test_gemini_translate_batch_cli_contract -q`
- [x] `git diff --check`

Refs #295