### PR TITLE
fix: bind revision apply to valid preview and report true outcome (#294)

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -118,6 +118,8 @@ python gemini_translate_batch.py sync-revisions --apply
 
 `revision_applied_at` 只在 `applied` / `partial` 时写入；`no_op` / `blocked` 不会把 final-review finding 错误标记为已应用。
 
+重新运行 `preview-revisions` 会清空旧的 apply 终态（blocked/no_op/partial）并重新打开写回闸门；若此前已真实写回过，旧写回记录会移到 `revision_apply_history`，`revision_applied_at` 不再拦截新的 preview/apply 流程。
+
 当前 `safe / warn / block` 强制闸门只覆盖普通 translation manifest 的 `check/apply`；订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
 
 `sync-revisions` 复用订正 prompt、schema、RAG / Story Memory 注入、预览报告和写回前源快照校验；默认只预览，传 `--apply` 才调用 `apply-revisions` 写回。

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -107,7 +107,16 @@ python gemini_translate_batch.py sync-revisions --limit 3
 python gemini_translate_batch.py sync-revisions --apply
 ```
 
-`build-revisions` 会复用 include 过滤、glossary、macro setting、可选 RAG / Story Memory，把已有原文和当前译文送入 Batch。`preview-revisions` 导出 `revision_preview.jsonl` 和 `revision_preview.md`，`apply-revisions` 会在写回前重新校验当前文件中的旧译文快照。
+`build-revisions` 会复用 include 过滤、glossary、macro setting、可选 RAG / Story Memory，把已有原文和当前译文送入 Batch。`preview-revisions` 导出 `revision_preview.jsonl` 和 `revision_preview.md`，并把合同绑定写回 manifest：结果文件 SHA-256、manifest / 项目身份指纹、涉及源文件的快照指纹、preview schema 版本与生成时间。`apply-revisions` 必须找到有效且匹配的 preview 才允许写回；`--force` 只能绕过「已写回」守卫，不能绕过 preview 缺失、结果被替换、项目变化或源文件快照变化。
+
+`apply-revisions` 的终态写在 manifest 的 `revision_apply_state`，固定区分：
+
+- `applied`：全部可写回项已成功写回；
+- `no_op`：有效 preview 没有需要修改的内容（不写 `revision_applied_at`）；
+- `blocked`：没有发生写回且存在阻断（preview 缺失/过期或全部源快照不匹配，不写 `revision_applied_at`）；
+- `partial`：部分写回、部分跳过/失败（仅真实写回的行计入 applied）。
+
+`revision_applied_at` 只在 `applied` / `partial` 时写入；`no_op` / `blocked` 不会把 final-review finding 错误标记为已应用。
 
 当前 `safe / warn / block` 强制闸门只覆盖普通 translation manifest 的 `check/apply`；订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -113,14 +113,14 @@ python gemini_translate_batch.py sync-revisions --apply
 
 - `applied`：全部可写回项已成功写回；
 - `no_op`：有效 preview 没有需要修改的内容（不写 `revision_applied_at`）；
-- `blocked`：没有发生写回且存在阻断（preview 缺失/过期或全部源快照不匹配，不写 `revision_applied_at`）；
+- `blocked`：没有发生写回且存在阻断（preview 缺失/过期、适配器写回计划不安全，或全部条目被跳过/源不匹配/校验失败，不写 `revision_applied_at`）；
 - `partial`：部分写回、部分跳过/失败（仅真实写回的行计入 applied）。
 
 `revision_applied_at` 只在 `applied` / `partial` 时写入；`no_op` / `blocked` 不会把 final-review finding 错误标记为已应用。
 
 重新运行 `preview-revisions` 会清空旧的 apply 终态（blocked/no_op/partial）并重新打开写回闸门；若此前已真实写回过，旧写回记录会移到 `revision_apply_history`，`revision_applied_at` 不再拦截新的 preview/apply 流程。
 
-阻断的退出语义：preview 校验类阻断（preview 缺失、结果/项目/源快照变化）以非零退出码结束；有效 preview 下全部条目被跳过/源不匹配/校验失败时的 `blocked` 以零退出码结束，但 machine envelope 的 `status=blocked` 且 manifest 写有 `revision_apply_blocked_reason`。依赖退出码的自动化应解析 `revision_apply_state` / `status`，不要仅凭零退出码判定写回成功。
+阻断的退出语义：preview 校验类阻断（preview 缺失、结果/项目/源快照变化）与 `adapter_writeback_block` 以非零退出码结束；有效 preview 下全部条目被跳过/源不匹配/校验失败时的 `blocked` 以零退出码结束，但 machine envelope 的 `status=blocked` 且 manifest 写有 `revision_apply_blocked_reason`。依赖退出码的自动化应解析 `revision_apply_state` / `status`，不要仅凭零退出码判定写回成功。
 
 当前 `safe / warn / block` 强制闸门只覆盖普通 translation manifest 的 `check/apply`；订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -120,6 +120,8 @@ python gemini_translate_batch.py sync-revisions --apply
 
 重新运行 `preview-revisions` 会清空旧的 apply 终态（blocked/no_op/partial）并重新打开写回闸门；若此前已真实写回过，旧写回记录会移到 `revision_apply_history`，`revision_applied_at` 不再拦截新的 preview/apply 流程。
 
+阻断的退出语义：preview 校验类阻断（preview 缺失、结果/项目/源快照变化）以非零退出码结束；有效 preview 下全部条目被跳过/源不匹配/校验失败时的 `blocked` 以零退出码结束，但 machine envelope 的 `status=blocked` 且 manifest 写有 `revision_apply_blocked_reason`。依赖退出码的自动化应解析 `revision_apply_state` / `status`，不要仅凭零退出码判定写回成功。
+
 当前 `safe / warn / block` 强制闸门只覆盖普通 translation manifest 的 `check/apply`；订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
 
 `sync-revisions` 复用订正 prompt、schema、RAG / Story Memory 注入、预览报告和写回前源快照校验；默认只预览，传 `--apply` 才调用 `apply-revisions` 写回。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -296,7 +296,7 @@ python gemini_translate_batch.py preview-revisions <manifest>
 订正写回与普通翻译写回**分离**：
 
 - 普通 `check -> apply` 的「可写回 / 需处理 / 禁止写回」闸门**不覆盖**订正任务记录。
-- 订正写回走独立流程：`preview-revisions -> apply-revisions`，apply 必须绑定有效 preview（结果文件、项目身份与源文件快照一致），写回前还会重新校验当前文件中的旧译文快照。
+- 订正写回走独立流程：`preview-revisions -> apply-revisions`，apply 必须绑定有效 preview（同一 manifest/目标、结果文件 SHA-256、项目身份与源文件快照一致；缺失源文件也会使校验失败）。`--force` 只能绕过“已经写回过”保护，不能绕过 preview、结果、身份或快照校验。写回前还会重新校验当前文件中的旧译文快照。
 - 写回结果区分 `applied` / `partial` / `no_op` / `blocked`：只有真实写回时才显示“已写回”；无改动、全部阻断或部分失败不会被误报成完成，也不会错误把 final-review finding 标记为已应用。
 - GUI 在订正页结果区、预览显示有可写回项且记录尚未写回过时，才启用「写回订正」；已写回过的记录不会再次启用。
 - **不要在唯一原项目上直接整批写回**；请先在副本或备份上验证预览报告（`revision_preview.jsonl` / `revision_preview.md`）。

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -296,7 +296,8 @@ python gemini_translate_batch.py preview-revisions <manifest>
 订正写回与普通翻译写回**分离**：
 
 - 普通 `check -> apply` 的「可写回 / 需处理 / 禁止写回」闸门**不覆盖**订正任务记录。
-- 订正写回走独立流程：`preview-revisions -> apply-revisions`，写回前会重新校验当前文件中的旧译文快照。
+- 订正写回走独立流程：`preview-revisions -> apply-revisions`，apply 必须绑定有效 preview（结果文件、项目身份与源文件快照一致），写回前还会重新校验当前文件中的旧译文快照。
+- 写回结果区分 `applied` / `partial` / `no_op` / `blocked`：只有真实写回时才显示“已写回”；无改动、全部阻断或部分失败不会被误报成完成，也不会错误把 final-review finding 标记为已应用。
 - GUI 在订正页结果区、预览显示有可写回项且记录尚未写回过时，才启用「写回订正」；已写回过的记录不会再次启用。
 - **不要在唯一原项目上直接整批写回**；请先在副本或备份上验证预览报告（`revision_preview.jsonl` / `revision_preview.md`）。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7380,6 +7380,8 @@ def _revision_manifest_identity(manifest):
         'mode', 'manifest_version', 'version', 'core_schema_version', 'display_name',
         'job_name', 'created_at', 'execution', 'batch_model', 'model',
         'base_dir', 'tl_dir', 'target_language', 'language',
+        'input_jsonl_path', 'result_jsonl_path',
+        'settings', 'revision_settings',
         'summary', 'files', 'chunks', 'final_review_source',
     )
     payload = {key: manifest.get(key) for key in keys}

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -95,6 +95,7 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'download',
         'check',
         'apply',
+        'apply-revisions',
     }
 )
 EXPLICIT_TARGET_COMMANDS = frozenset({'submit', 'status', 'download', 'check', 'apply'})
@@ -8396,8 +8397,7 @@ def apply_revisions(target=None, force=False):
         _mark_revision_apply_blocked(
             manifest,
             'adapter_writeback_block',
-            'Revision apply refused because the adapter writeback plan is not safe. '
-            'No files were written.',
+            'the adapter writeback plan is not safe. No files were written.',
         )
 
     writeback_files = []
@@ -12117,6 +12117,7 @@ def build_arg_parser():
             'preview and source snapshot validation still apply.'
         ),
     )
+    add_machine_output_argument(revision_apply_parser)
 
     sync_keyword_parser = subparsers.add_parser(
         'sync-keywords',

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7572,6 +7572,18 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
         'revision_apply_message',
     ):
         manifest.pop(stale_key, None)
+    if manifest.get('revision_applied_at'):
+        history = list(manifest.get('revision_apply_history') or [])
+        history.append(
+            {
+                'applied_at': manifest['revision_applied_at'],
+                'summary': dict(manifest.get('revision_apply_summary') or {}),
+            }
+        )
+        manifest['revision_apply_history'] = history
+        manifest.pop('revision_applied_at', None)
+        manifest.pop('revision_apply_summary', None)
+        manifest.pop('last_revision_apply_summary', None)
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
     if manifest.get('final_review_source'):
         import final_review as fr
@@ -8443,6 +8455,11 @@ def apply_revisions(target=None, force=False):
     )
     if applied_lines == 0 and has_blocking_outcome:
         apply_state = 'blocked'
+        manifest['revision_apply_blocked_reason'] = 'all_items_blocked'
+        manifest['revision_apply_message'] = (
+            'No revisions could be written back because every candidate was skipped, '
+            'source-mismatched, or failed validation.'
+        )
     elif applied_lines == 0:
         apply_state = 'no_op'
     elif has_blocking_outcome:
@@ -8496,6 +8513,8 @@ def apply_revisions(target=None, force=False):
 
     print_revision_summary(summary)
     print(f'Revision apply state: {apply_state}')
+    if apply_state == 'blocked':
+        print(f'Revision apply reason: {manifest.get("revision_apply_blocked_reason") or ""}')
     print(f'Applied files: {applied_files}')
     print(f'Applied lines: {applied_lines}')
     print(f'Failures logged: {len(failure_entries)}')
@@ -12962,6 +12981,17 @@ def build_machine_success_envelope(command, value, args):
         result['apply'] = dict(manifest.get('apply_summary') or {})
         result['apply']['next_split_manifest'] = manifest.get('next_split_manifest_path', '')
         status = 'applied' if manifest.get('applied_at') else 'completed'
+    elif command == 'apply-revisions':
+        result['revision_apply'] = dict(manifest.get('revision_apply_summary') or {})
+        result['revision_apply_state'] = manifest.get('revision_apply_state') or ''
+        if manifest.get('revision_apply_blocked_reason'):
+            result['revision_apply_blocked_reason'] = manifest.get(
+                'revision_apply_blocked_reason'
+            )
+        status = str(
+            manifest.get('revision_apply_state')
+            or ('applied' if manifest.get('revision_applied_at') else 'completed')
+        )
 
     return cli_contract.success_envelope(
         command,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -114,6 +114,9 @@ OFFLINE_BATCH_COMMANDS = frozenset(
     }
 )
 
+REVISION_PREVIEW_CONTRACT_VERSION = 1
+REVISION_APPLY_STATES = frozenset({'applied', 'no_op', 'blocked', 'partial'})
+
 
 class DualLogger(object):
     def __init__(self, filename):
@@ -7363,6 +7366,138 @@ def validate_revision_output_paths(manifest, jsonl_path, markdown_path):
             raise SystemExit(f'Revision preview output would overwrite reserved package file: {output_path}')
 
 
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, 'rb') as handle:
+        for block in iter(lambda: handle.read(65536), b''):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _revision_manifest_identity(manifest):
+    """Stable fingerprint of the revision manifest content bound by preview."""
+    keys = (
+        'mode', 'manifest_version', 'version', 'core_schema_version', 'display_name',
+        'job_name', 'created_at', 'execution', 'batch_model', 'model',
+        'base_dir', 'tl_dir', 'target_language', 'language',
+        'summary', 'files', 'chunks', 'final_review_source',
+    )
+    payload = {key: manifest.get(key) for key in keys}
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode('utf-8')
+    ).hexdigest()
+
+
+def _revision_source_snapshots(manifest):
+    """Per-file SHA-256 of every source file named by the manifest.
+
+    Missing files are recorded as ``None`` so a file appearing or disappearing
+    between preview and apply is detected as a snapshot change.
+    """
+    snapshots = {}
+    for file_key, file_info in (manifest.get('files') or {}).items():
+        try:
+            file_path = resolve_manifest_file_path(manifest, file_key, file_info)
+        except SystemExit:
+            snapshots[str(file_key)] = None
+            continue
+        snapshots[str(file_key)] = (
+            _sha256_file(file_path) if os.path.isfile(file_path) else None
+        )
+    return snapshots
+
+
+def _mark_revision_apply_blocked(manifest, reason, message):
+    """Persist a blocked apply outcome before refusing the command."""
+    now = datetime.now().isoformat(timespec='seconds')
+    manifest['revision_apply_state'] = 'blocked'
+    manifest['revision_apply_checked_at'] = now
+    manifest['revision_apply_blocked_reason'] = reason
+    manifest['revision_apply_message'] = message
+    save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
+    raise SystemExit(f'Revision apply refused: {message}')
+
+
+def _require_valid_revision_preview(manifest):
+    """Require a valid, matching preview before any revision writeback.
+
+    ``--force`` deliberately does not bypass preview staleness, project identity
+    or source snapshot checks: it only bypasses the already-applied guard.
+    """
+    preview = manifest.get('last_revision_preview')
+    if (
+        not isinstance(preview, dict)
+        or preview.get('schema_version') != REVISION_PREVIEW_CONTRACT_VERSION
+    ):
+        _mark_revision_apply_blocked(
+            manifest,
+            'missing_preview',
+            'run preview-revisions before apply-revisions.',
+        )
+
+    result_path = resolve_manifest_result_path(manifest)
+    if not os.path.isfile(result_path):
+        _mark_revision_apply_blocked(
+            manifest,
+            'results_missing',
+            'result JSONL no longer exists; run preview-revisions again.',
+        )
+    if _sha256_file(result_path) != preview.get('results_sha256'):
+        _mark_revision_apply_blocked(
+            manifest,
+            'results_changed',
+            'result JSONL changed since preview; run preview-revisions again.',
+        )
+    if _revision_manifest_identity(manifest) != preview.get('manifest_identity'):
+        _mark_revision_apply_blocked(
+            manifest,
+            'manifest_changed',
+            'manifest changed since preview; run preview-revisions again.',
+        )
+
+    try:
+        current_project = manifest_project_identity(manifest)
+    except Exception as exc:
+        _mark_revision_apply_blocked(
+            manifest,
+            'project_unknown',
+            f'cannot resolve project identity: {exc}',
+        )
+    current_identity = {
+        'base_dir': _normalized_abs_path(str(current_project.get('base_dir') or '')),
+        'tl_dir': _normalized_abs_path(str(current_project.get('tl_dir') or '')),
+        'source': str(current_project.get('source') or ''),
+    }
+    expected_project = preview.get('project_identity')
+    if not isinstance(expected_project, dict):
+        _mark_revision_apply_blocked(
+            manifest,
+            'project_changed',
+            'project identity changed since preview; run preview-revisions again.',
+        )
+    expected_identity = {
+        'base_dir': _normalized_abs_path(str(expected_project.get('base_dir') or '')),
+        'tl_dir': _normalized_abs_path(str(expected_project.get('tl_dir') or '')),
+        'source': str(expected_project.get('source') or ''),
+    }
+    if current_identity != expected_identity:
+        _mark_revision_apply_blocked(
+            manifest,
+            'project_changed',
+            'project identity changed since preview; run preview-revisions again.',
+        )
+
+    current_snapshots = _revision_source_snapshots(manifest)
+    expected_snapshots = preview.get('source_snapshots')
+    if not isinstance(expected_snapshots, dict) or current_snapshots != expected_snapshots:
+        _mark_revision_apply_blocked(
+            manifest,
+            'source_changed',
+            'source files changed since preview; run preview-revisions again.',
+        )
+    return preview
+
+
 def write_revision_markdown(path, entries, summary):
     lines = [
         '# Revision Preview',
@@ -7411,10 +7546,18 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
             handle.write(json.dumps(entry, ensure_ascii=False) + '\n')
     write_revision_markdown(markdown_path, preview_entries, summary)
 
-    manifest['last_revision_preview_at'] = datetime.now().isoformat(timespec='seconds')
+    now = datetime.now().isoformat(timespec='seconds')
+    manifest['last_revision_preview_at'] = now
     manifest['last_revision_preview'] = {
+        'schema_version': REVISION_PREVIEW_CONTRACT_VERSION,
+        'generated_at': now,
         'jsonl_path': jsonl_path,
         'markdown_path': markdown_path,
+        'results_path': _canonical_abs_path(resolve_manifest_result_path(manifest)),
+        'results_sha256': _sha256_file(resolve_manifest_result_path(manifest)),
+        'manifest_identity': _revision_manifest_identity(manifest),
+        'project_identity': manifest_project_identity(manifest),
+        'source_snapshots': _revision_source_snapshots(manifest),
         'summary': summary,
     }
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
@@ -8159,6 +8302,7 @@ def apply_revisions(target=None, force=False):
         raise SystemExit('Revision manifest was already applied. Re-run apply-revisions with --force to bypass this guard; source validation still applies.')
 
     require_manifest_project_match(manifest, 'apply-revisions')
+    _require_valid_revision_preview(manifest)
     if manifest.get('final_review_source'):
         import final_review as fr
         import final_review_revision
@@ -8175,14 +8319,8 @@ def apply_revisions(target=None, force=False):
         validate_sources=True,
     )
 
-    applied_files = 0
-    applied_lines = 0
-    final_pending_files = 0
-    final_pending_lines = 0
-    rag_jobs = []
     revalidated_replacements_by_file = {}
     revalidated_file_paths = {}
-    revision_updates = []
     revalidated_source_documents = {}
     for file_key, replacements in replacements_by_file.items():
         file_info = manifest['files'].get(file_key)
@@ -8210,8 +8348,6 @@ def apply_revisions(target=None, force=False):
             revalidated_replacements_by_file[file_key] = replacements
             revalidated_file_paths[file_key] = file_path
             revalidated_source_documents[file_key] = source_document
-        line_numbers = sorted(line_numbers_set)
-        revision_updates.append((file_key, line_numbers, file_path))
 
     adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
         manifest,
@@ -8228,9 +8364,11 @@ def apply_revisions(target=None, force=False):
         summary['pending_files'] = 0
         summary['pending_lines'] = 0
         append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
-        raise SystemExit(
+        _mark_revision_apply_blocked(
+            manifest,
+            'adapter_writeback_block',
             'Revision apply refused because the adapter writeback plan is not safe. '
-            'No files were written.'
+            'No files were written.',
         )
 
     writeback_files = []
@@ -8256,59 +8394,90 @@ def apply_revisions(target=None, force=False):
             encoding='utf-8',
         )
 
-    for file_key, line_numbers, file_path in revision_updates:
+    applied_files = len(writeback_files)
+    applied_lines = sum(
+        len(replacements_by_line)
+        for replacements_by_line in revalidated_replacements_by_file.values()
+    )
+    rag_jobs = []
+    for file_key, replacements_by_line in revalidated_replacements_by_file.items():
+        line_numbers = sorted(replacements_by_line.keys())
         update_progress(file_key, line_numbers)
-        applied_files += 1
-        applied_lines += len(line_numbers)
-        final_pending_files += 1
-        final_pending_lines += len(line_numbers)
         if line_numbers:
-            rag_jobs.append({'file_rel_path': file_key, 'file_path': file_path})
+            rag_jobs.append(
+                {
+                    'file_rel_path': file_key,
+                    'file_path': revalidated_file_paths[file_key],
+                }
+            )
 
-    summary['pending_files'] = final_pending_files
-    summary['pending_lines'] = final_pending_lines
+    summary['pending_files'] = len(revalidated_replacements_by_file)
+    summary['pending_lines'] = applied_lines
     append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
 
     rag_apply_summary = {}
     if RAG_ENABLED and rag_jobs:
         rag_apply_summary = sync_rag_store_for_jobs(rag_jobs, quality_state='revision_applied')
 
-    manifest['revision_applied_at'] = datetime.now().isoformat(timespec='seconds')
+    has_blocking_outcome = (
+        summary.get('skipped_items', 0) > 0
+        or summary.get('source_mismatch_items', 0) > 0
+        or len(failure_entries) > 0
+    )
+    if applied_lines == 0 and has_blocking_outcome:
+        apply_state = 'blocked'
+    elif applied_lines == 0:
+        apply_state = 'no_op'
+    elif has_blocking_outcome:
+        apply_state = 'partial'
+    else:
+        apply_state = 'applied'
+
+    now = datetime.now().isoformat(timespec='seconds')
+    manifest['revision_apply_state'] = apply_state
+    manifest['revision_apply_checked_at'] = now
     manifest['revision_apply_summary'] = {
+        'state': apply_state,
         'applied_files': applied_files,
         'applied_lines': applied_lines,
         'candidate_items': summary.get('candidate_valid_items', summary['valid_items']),
         'recoverable_items': summary['valid_items'],
         'unchanged_items': summary.get('unchanged_items', 0),
+        'already_applied_items': summary.get('already_applied_items', 0),
         'skipped_items': summary.get('skipped_items', 0),
         'source_mismatch_items': summary.get('source_mismatch_items', 0),
         'failure_count': len(failure_entries),
         'rag': rag_apply_summary,
     }
     manifest['last_revision_apply_summary'] = summary
+    if apply_state in ('applied', 'partial'):
+        manifest['revision_applied_at'] = now
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
     if manifest.get('final_review_source'):
         import final_review as fr
         import final_review_revision
 
-        applied_lines_by_file = {
-            file_key: set(line_numbers)
-            for file_key, line_numbers, _file_path in revision_updates
-        }
-        applied_item_ids = {
-            str(item.get('id') or '')
-            for chunk in manifest.get('chunks', [])
-            for item in chunk.get('items', [])
-            if item.get('line')
-            in applied_lines_by_file.get(chunk.get('file_rel_path'), set())
-        }
-        final_review_revision.sync_linked_findings(
-            manifest,
-            fr.REVISION_STATE_APPLIED,
-            identity_ids=applied_item_ids,
-        )
+        if apply_state in ('applied', 'partial'):
+            applied_lines_by_file = {
+                file_key: set(replacements_by_line.keys())
+                for file_key, replacements_by_line
+                in revalidated_replacements_by_file.items()
+            }
+            applied_item_ids = {
+                str(item.get('id') or '')
+                for chunk in manifest.get('chunks', [])
+                for item in chunk.get('items', [])
+                if item.get('line')
+                in applied_lines_by_file.get(chunk.get('file_rel_path'), set())
+            }
+            final_review_revision.sync_linked_findings(
+                manifest,
+                fr.REVISION_STATE_APPLIED,
+                identity_ids=applied_item_ids,
+            )
 
     print_revision_summary(summary)
+    print(f'Revision apply state: {apply_state}')
     print(f'Applied files: {applied_files}')
     print(f'Applied lines: {applied_lines}')
     print(f'Failures logged: {len(failure_entries)}')

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7564,7 +7564,7 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
     }
     # A fresh preview invalidates any prior blocked/no_op/partial terminal state:
     # the user may have fixed the blocker and expects the writeback gate to reopen.
-    # revision_applied_at / revision_apply_summary are preserved as historical facts.
+    # A prior real writeback is preserved in revision_apply_history.
     for stale_key in (
         'revision_apply_state',
         'revision_apply_checked_at',
@@ -7581,9 +7581,9 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
             }
         )
         manifest['revision_apply_history'] = history
-        manifest.pop('revision_applied_at', None)
-        manifest.pop('revision_apply_summary', None)
-        manifest.pop('last_revision_apply_summary', None)
+    manifest.pop('revision_applied_at', None)
+    manifest.pop('revision_apply_summary', None)
+    manifest.pop('last_revision_apply_summary', None)
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
     if manifest.get('final_review_source'):
         import final_review as fr
@@ -8323,7 +8323,10 @@ def apply_revisions(target=None, force=False):
     manifest = load_manifest(target)
     require_manifest_mode(manifest, MANIFEST_MODE_REVISION, 'apply-revisions')
     if manifest.get('revision_applied_at') and not force:
-        raise SystemExit('Revision manifest was already applied. Re-run apply-revisions with --force to bypass this guard; source validation still applies.')
+        raise SystemExit(
+            'Revision manifest was already applied. Run preview-revisions again to '
+            'refresh the writeback gate; --force does not bypass source snapshot checks.'
+        )
 
     require_manifest_project_match(manifest, 'apply-revisions')
     _require_valid_revision_preview(manifest)
@@ -12107,7 +12110,10 @@ def build_arg_parser():
     revision_apply_parser.add_argument(
         '--force',
         action='store_true',
-        help='Bypass the revision_applied_at guard; source validation still applies.',
+        help=(
+            'Bypass the revision_applied_at guard without refreshing preview; '
+            'preview and source snapshot validation still apply.'
+        ),
     )
 
     sync_keyword_parser = subparsers.add_parser(
@@ -12181,7 +12187,10 @@ def build_arg_parser():
     sync_revision_parser.add_argument(
         '--force',
         action='store_true',
-        help='When used with --apply, bypass the revision_applied_at guard; source validation still applies.',
+        help=(
+            'When used with --apply, bypass the revision_applied_at guard without '
+            'refreshing preview; preview and source snapshot validation still apply.'
+        ),
     )
     sync_revision_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7415,6 +7415,8 @@ def _mark_revision_apply_blocked(manifest, reason, message):
     manifest['revision_apply_blocked_reason'] = reason
     manifest['revision_apply_message'] = message
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
+    print(f'Revision apply state: blocked')
+    print(f'Revision apply reason: {reason}')
     raise SystemExit(f'Revision apply refused: {message}')
 
 
@@ -7560,6 +7562,16 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
         'source_snapshots': _revision_source_snapshots(manifest),
         'summary': summary,
     }
+    # A fresh preview invalidates any prior blocked/no_op/partial terminal state:
+    # the user may have fixed the blocker and expects the writeback gate to reopen.
+    # revision_applied_at / revision_apply_summary are preserved as historical facts.
+    for stale_key in (
+        'revision_apply_state',
+        'revision_apply_checked_at',
+        'revision_apply_blocked_reason',
+        'revision_apply_message',
+    ):
+        manifest.pop(stale_key, None)
     save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
     if manifest.get('final_review_source'):
         import final_review as fr
@@ -8372,6 +8384,7 @@ def apply_revisions(target=None, force=False):
         )
 
     writeback_files = []
+    applied_file_keys = set()
     if adapter_plan is not None and adapter_snapshot is not None:
         rendered_by_file = _normalize_adapter_rendered_files(
             render_writeback_plan(
@@ -8386,6 +8399,7 @@ def apply_revisions(target=None, force=False):
         for file_key in revalidated_replacements_by_file:
             rendered_lines = rendered_by_file[_adapter_render_key(file_key)]
             writeback_files.append((revalidated_file_paths[file_key], rendered_lines))
+            applied_file_keys.add(file_key)
 
     if writeback_files:
         atomic_write_many_lines(
@@ -8394,13 +8408,16 @@ def apply_revisions(target=None, force=False):
             encoding='utf-8',
         )
 
-    applied_files = len(writeback_files)
+    applied_files = len(applied_file_keys)
     applied_lines = sum(
         len(replacements_by_line)
-        for replacements_by_line in revalidated_replacements_by_file.values()
+        for file_key, replacements_by_line in revalidated_replacements_by_file.items()
+        if file_key in applied_file_keys
     )
     rag_jobs = []
     for file_key, replacements_by_line in revalidated_replacements_by_file.items():
+        if file_key not in applied_file_keys:
+            continue
         line_numbers = sorted(replacements_by_line.keys())
         update_progress(file_key, line_numbers)
         if line_numbers:
@@ -8411,7 +8428,7 @@ def apply_revisions(target=None, force=False):
                 }
             )
 
-    summary['pending_files'] = len(revalidated_replacements_by_file)
+    summary['pending_files'] = applied_files
     summary['pending_lines'] = applied_lines
     append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
 
@@ -8462,6 +8479,7 @@ def apply_revisions(target=None, force=False):
                 file_key: set(replacements_by_line.keys())
                 for file_key, replacements_by_line
                 in revalidated_replacements_by_file.items()
+                if file_key in applied_file_keys
             }
             applied_item_ids = {
                 str(item.get('id') or '')

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -21,6 +21,19 @@ def _parse_line_value(output: str, prefix: str) -> str:
 
 
 def parse_revision_summary(output: str) -> dict[str, object]:
+    """Parse CLI revision summary text into stable keys.
+
+    Recognized count fields map to ``expected_chunks``, ``result_rows``,
+    ``processed_chunks``, ``expected_items``, ``parsed_items``,
+    ``candidate_items``, ``valid_items``, ``unchanged_items``,
+    ``pending_files``, ``pending_lines``, ``skipped_items``,
+    ``source_mismatch_items``, ``failure_items``, ``applied_files``,
+    ``applied_lines`` and ``failures_logged``. Preview/apply paths and the
+    ``Revision apply state`` / ``Revision apply reason`` lines are returned as
+    ``preview_jsonl`` / ``preview_markdown`` / ``apply_state`` /
+    ``apply_reason``. Missing fields are simply absent from the returned dict;
+    callers must not assume a count exists.
+    """
     parsed: dict[str, object] = {
         "findings": [],
     }
@@ -198,6 +211,15 @@ def summarize_revision_apply_output(
     *,
     manifest_path: str = "",
 ) -> WritebackSummary:
+    """Summarize an apply-revisions run for the writeback page.
+
+    ``blocked`` parsed from output takes precedence over ``exit_code`` so an
+    all-items-blocked run (which exits 0 with ``Revision apply state: blocked``)
+    and a preview-contract refusal (non-zero exit with the same state line) both
+    render as blocked. ``no_op`` renders as idle, ``partial`` renders as applied
+    with a partial heading, and a clean run renders as applied; every terminal
+    state disables further apply.
+    """
     parsed = parse_revision_summary(output)
     if parsed.get("apply_state") == "blocked":
         facts: list[str] = []

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -56,6 +56,9 @@ def parse_revision_summary(output: str) -> dict[str, object]:
     apply_state = _parse_line_value(output, "Revision apply state:")
     if apply_state:
         parsed["apply_state"] = apply_state
+    apply_reason = _parse_line_value(output, "Revision apply reason:")
+    if apply_reason:
+        parsed["apply_reason"] = apply_reason
 
     current_section = ""
     for raw_line in output.splitlines():
@@ -195,6 +198,23 @@ def summarize_revision_apply_output(
     *,
     manifest_path: str = "",
 ) -> WritebackSummary:
+    parsed = parse_revision_summary(output)
+    if parsed.get("apply_state") == "blocked":
+        facts: list[str] = []
+        if manifest_path:
+            facts.append(format_manifest_path_fact(manifest_path))
+        reason = _parse_line_value(output, "Revision apply reason:")
+        if reason:
+            facts.append(f"阻断原因：{reason}")
+        return WritebackSummary(
+            status="failed",
+            heading="订正写回被阻止",
+            message="存在阻断项，没有发生写回；请查看诊断日志后重新预览。",
+            facts=facts,
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
     if exit_code != 0:
         return WritebackSummary(
             status="failed",
@@ -206,7 +226,6 @@ def summarize_revision_apply_output(
             manifest_path=manifest_path,
         )
 
-    parsed = parse_revision_summary(output)
     facts: list[str] = []
     if manifest_path:
         facts.append(format_manifest_path_fact(manifest_path))

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -53,6 +53,10 @@ def parse_revision_summary(output: str) -> dict[str, object]:
     if preview_markdown:
         parsed["preview_markdown"] = preview_markdown
 
+    apply_state = _parse_line_value(output, "Revision apply state:")
+    if apply_state:
+        parsed["apply_state"] = apply_state
+
     current_section = ""
     for raw_line in output.splitlines():
         line = raw_line.strip()
@@ -221,6 +225,38 @@ def summarize_revision_apply_output(
         for finding in parsed.get("findings", [])
         if isinstance(finding, str) and finding.strip()
     ]
+
+    apply_state = parsed.get("apply_state")
+    if apply_state == "no_op":
+        return WritebackSummary(
+            status="idle",
+            heading="没有需要写回的订正",
+            message="订正写回已检查，但没有需要修改的内容（no-op）。",
+            facts=extend_facts_with_notices(facts, findings),
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+    if apply_state == "blocked":
+        return WritebackSummary(
+            status="failed",
+            heading="订正写回被阻止",
+            message="存在阻断项，没有发生写回；请查看诊断日志后重新预览。",
+            facts=extend_facts_with_notices(facts, findings),
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+    if apply_state == "partial":
+        return WritebackSummary(
+            status="applied",
+            heading="订正部分写回",
+            message="部分订正已写回，其余条目被跳过或失败；请查看失败日志后重新生成订正任务。",
+            facts=extend_facts_with_notices(facts, findings),
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
 
     return WritebackSummary(
         status="applied",

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -102,6 +102,14 @@ def summarize_revision_writeback_from_preview_output(
 def summarize_revision_writeback_from_manifest(
     manifest: dict[str, object],
 ) -> WritebackSummary | None:
+    """Derive the writeback summary from a revision manifest.
+
+    Priority: an explicit ``revision_apply_state`` (blocked/no_op/partial)
+    reflects the latest apply outcome; otherwise ``revision_applied_at`` means
+    the task was written back; otherwise a valid ``last_revision_preview`` with
+    recoverable items enables apply. Any terminal state disables apply, and a
+    missing preview returns ``None`` so the caller can show the idle state.
+    """
     manifest_path = manifest.get("_manifest_path")
     if not isinstance(manifest_path, str) or not manifest_path.strip():
         manifest_path = ""

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -106,6 +106,55 @@ def summarize_revision_writeback_from_manifest(
     if not isinstance(manifest_path, str) or not manifest_path.strip():
         manifest_path = ""
 
+    apply_state = manifest.get("revision_apply_state")
+    if apply_state in ("blocked", "no_op", "partial"):
+        facts: list[str] = []
+        if manifest_path:
+            facts.append(format_manifest_path_fact(manifest_path))
+        apply_summary = manifest.get("revision_apply_summary")
+        if isinstance(apply_summary, dict):
+            applied_files = apply_summary.get("applied_files")
+            applied_lines = apply_summary.get("applied_lines")
+            if isinstance(applied_files, int) and isinstance(applied_lines, int):
+                facts.append(f"已写回 {applied_files} 个文件，{applied_lines} 处译文行")
+            unchanged_items = apply_summary.get("unchanged_items")
+            if isinstance(unchanged_items, int) and unchanged_items > 0:
+                facts.append(f"无需修改项：{unchanged_items}")
+        if apply_state == "no_op":
+            return WritebackSummary(
+                status="idle",
+                heading="当前没有可写回订正",
+                message="最近一次订正预览有效，但没有需要写回的内容（no-op）。",
+                facts=facts,
+                findings=[],
+                can_apply=False,
+                manifest_path=manifest_path,
+            )
+        if apply_state == "partial":
+            return WritebackSummary(
+                status="applied",
+                heading="订正部分写回",
+                message="部分订正已写回，其余条目被跳过或失败；请查看失败日志后重新生成订正任务。",
+                facts=facts,
+                findings=[],
+                can_apply=False,
+                manifest_path=manifest_path,
+            )
+        reason = manifest.get("revision_apply_blocked_reason") or ""
+        detail = manifest.get("revision_apply_message") or ""
+        message = "订正写回被阻止，请查看诊断日志后重新预览。"
+        if reason:
+            message = f"订正写回被阻止（{reason}）；请查看诊断日志后重新预览。"
+        return WritebackSummary(
+            status="failed",
+            heading="订正写回被阻止",
+            message=message,
+            facts=facts + ([detail] if detail else []),
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
     if manifest.get("revision_applied_at"):
         apply_summary = manifest.get("revision_apply_summary")
         facts: list[str] = []

--- a/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
@@ -59,11 +59,13 @@
     }
   ],
   "revision_apply_summary": {
+    "state": "applied",
     "applied_files": 1,
     "applied_lines": 2,
     "candidate_items": 2,
     "recoverable_items": 2,
     "unchanged_items": 1,
+    "already_applied_items": 0,
     "skipped_items": 0,
     "source_mismatch_items": 0,
     "failure_count": 0,

--- a/tests/test_batch_golden_corpus.py
+++ b/tests/test_batch_golden_corpus.py
@@ -682,6 +682,8 @@ class RevisionGoldenCorpusTests(unittest.TestCase):
                 applied_manifest = batch_mod.apply_revisions(str(manifest_path))
                 progress = json.loads(Path(batch_mod.PROGRESS_LOG).read_text(encoding='utf-8'))
 
+                self.assertEqual(applied_manifest['revision_apply_state'], 'applied')
+                self.assertIn('revision_applied_at', applied_manifest)
                 preview_apply_snapshot = {
                     'last_revision_preview_summary': self._stable_revision_summary(
                         preview_manifest['last_revision_preview']['summary']
@@ -752,6 +754,8 @@ class RevisionGoldenCorpusTests(unittest.TestCase):
                 self.assertEqual(applied_manifest['revision_apply_summary']['skipped_items'], 1)
                 self.assertEqual(applied_manifest['revision_apply_summary']['source_mismatch_items'], 1)
                 self.assertEqual(applied_manifest['revision_apply_summary']['failure_count'], 1)
+                self.assertEqual(applied_manifest['revision_apply_state'], 'partial')
+                self.assertIn('revision_applied_at', applied_manifest)
             finally:
                 self._restore_batch_environment(old_values)
 

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -2635,15 +2635,17 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
         current_new='虚空门',
         revised='虚空之门',
         should_update=True,
+        file_new=None,
     ):
         tl_dir = root / 'tl'
         package_dir = root / 'package'
         tl_dir.mkdir()
         package_dir.mkdir()
         target_file = tl_dir / 'script.rpy'
-        new_line = f'    new "{current_new}"\n'
-        start = new_line.index(f'"{current_new}"')
-        end = start + len(current_new) + 2
+        file_new = file_new if file_new is not None else current_new
+        new_line = f'    new "{file_new}"\n'
+        start = new_line.index(f'"{file_new}"')
+        end = start + len(file_new) + 2
         target_file.write_text(
             'translate schinese start:\n'
             '    old "Void Gate"\n'
@@ -2823,6 +2825,28 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
             self.assertNotIn('revision_applied_at', manifest)
             self.assertEqual(target_file.read_text(encoding='utf-8'), original)
 
+    def test_all_mismatch_apply_records_blocked_reason_and_message(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(
+                root,
+                current_new='虚空门',
+                file_new='星门',
+            )
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = batch_mod.apply_revisions(str(manifest_path))
+
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'all_items_blocked')
+            self.assertIn(
+                'No revisions could be written back',
+                manifest['revision_apply_message'],
+            )
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(manifest['revision_apply_summary']['applied_files'], 0)
+
     def test_apply_unchanged_only_reports_no_op_without_applied_timestamp(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -2884,6 +2908,34 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
 
                 applied = batch_mod.apply_revisions(str(manifest_path))
                 self.assertEqual(applied['revision_apply_state'], 'applied')
+
+    def test_fresh_preview_after_applied_moves_history_and_reopens_apply(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(root)
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                first = batch_mod.apply_revisions(str(manifest_path))
+                self.assertEqual(first['revision_apply_state'], 'applied')
+                self.assertIn('revision_applied_at', first)
+                first_applied_at = first['revision_applied_at']
+
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = self._load_manifest(manifest_path)
+                self.assertNotIn('revision_applied_at', manifest)
+                self.assertNotIn('revision_apply_state', manifest)
+                history = manifest.get('revision_apply_history') or []
+                self.assertEqual(len(history), 1)
+                self.assertEqual(history[0]['applied_at'], first_applied_at)
+
+                second = batch_mod.apply_revisions(str(manifest_path))
+                # The same revision was already written back; the reopened gate
+                # now reports no_op instead of being blocked by a stale guard.
+                self.assertEqual(second['revision_apply_state'], 'no_op')
+                self.assertNotIn('revision_applied_at', second)
+                manifest = self._load_manifest(manifest_path)
+                self.assertEqual(len(manifest.get('revision_apply_history') or []), 1)
 
 
 

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1166,6 +1166,8 @@ class BatchRepairRegressionTests(unittest.TestCase):
                 json.dumps(
                     {
                         'mode': batch_mod.MANIFEST_MODE_REVISION,
+                        'base_dir': str(package_dir),
+                        'tl_dir': str(package_dir),
                         'input_jsonl_path': str(package_dir / 'requests.jsonl'),
                         'result_jsonl_path': str(result_path),
                         'chunks': [],
@@ -2621,6 +2623,230 @@ class BatchRepairRegressionTests(unittest.TestCase):
         self.assertIn('STORY MEMORY', prompt)
         self.assertIn('Void Gate -> 虚空门', prompt)
         self.assertEqual(summary['chunks_with_story_hits'], 1)
+
+
+class RevisionApplyPreviewContractTests(unittest.TestCase):
+    """Issue #294: apply must bind to a valid preview and report true outcome."""
+
+    def _make_package(
+        self,
+        root,
+        *,
+        current_new='虚空门',
+        revised='虚空之门',
+        should_update=True,
+    ):
+        tl_dir = root / 'tl'
+        package_dir = root / 'package'
+        tl_dir.mkdir()
+        package_dir.mkdir()
+        target_file = tl_dir / 'script.rpy'
+        new_line = f'    new "{current_new}"\n'
+        start = new_line.index(f'"{current_new}"')
+        end = start + len(current_new) + 2
+        target_file.write_text(
+            'translate schinese start:\n'
+            '    old "Void Gate"\n'
+            + new_line,
+            encoding='utf-8',
+        )
+        result_path = package_dir / 'results.jsonl'
+        manifest_path = package_dir / 'manifest.json'
+        item_id = f'script.rpy:2:{start}:revision:0'
+        response_text = json.dumps(
+            [
+                {
+                    'id': item_id,
+                    'should_update': should_update,
+                    'revised_translation': revised,
+                    'reason': '统一术语',
+                }
+            ],
+            ensure_ascii=False,
+        )
+        result_path.write_text(
+            json.dumps(
+                {
+                    'key': 'rv-1',
+                    'response': {
+                        'candidates': [
+                            {'content': {'parts': [{'text': response_text}]}}
+                        ]
+                    },
+                },
+                ensure_ascii=False,
+            )
+            + '\n',
+            encoding='utf-8',
+        )
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    'mode': batch_mod.MANIFEST_MODE_REVISION,
+                    'files': {'script.rpy': {'path': str(target_file)}},
+                    'result_jsonl_path': str(result_path),
+                    'chunks': [
+                        {
+                            'key': 'rv-1',
+                            'file_rel_path': 'script.rpy',
+                            'items': [
+                                {
+                                    'id': item_id,
+                                    'line': 2,
+                                    'line_number': 3,
+                                    'start': start,
+                                    'end': end,
+                                    'text': 'Void Gate',
+                                    'source': 'Void Gate',
+                                    'current_translation': current_new,
+                                    'prefix': '',
+                                    'quote': '"',
+                                }
+                            ],
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding='utf-8',
+        )
+        return manifest_path, target_file, result_path
+
+    def _load_manifest(self, manifest_path):
+        return json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+
+    def test_apply_without_preview_blocks_and_keeps_manifest_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(root)
+            original = target_file.read_text(encoding='utf-8')
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                with self.assertRaisesRegex(SystemExit, 'run preview-revisions'):
+                    batch_mod.apply_revisions(str(manifest_path))
+
+            manifest = self._load_manifest(manifest_path)
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'missing_preview')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original)
+
+    def test_apply_rejects_replaced_results_since_preview(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, result_path = self._make_package(root)
+            original = target_file.read_text(encoding='utf-8')
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                result_path.write_text(
+                    result_path.read_text(encoding='utf-8').rstrip()
+                    + '\n{"replacement": true}\n',
+                    encoding='utf-8',
+                )
+                with self.assertRaisesRegex(SystemExit, 'result JSONL changed since preview'):
+                    batch_mod.apply_revisions(str(manifest_path))
+
+            manifest = self._load_manifest(manifest_path)
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'results_changed')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original)
+
+    def test_apply_rejects_source_changed_since_preview(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(root)
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                target_file.write_text(
+                    target_file.read_text(encoding='utf-8').replace('虚空门', '星门'),
+                    encoding='utf-8',
+                )
+                changed = target_file.read_text(encoding='utf-8')
+                with self.assertRaisesRegex(SystemExit, 'source files changed since preview'):
+                    batch_mod.apply_revisions(str(manifest_path))
+
+            manifest = self._load_manifest(manifest_path)
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'source_changed')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(target_file.read_text(encoding='utf-8'), changed)
+
+    def test_apply_rejects_manifest_changed_since_preview(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(root)
+            original = target_file.read_text(encoding='utf-8')
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = self._load_manifest(manifest_path)
+                manifest['summary'] = {'item_count': 999}
+                manifest_path.write_text(
+                    json.dumps(manifest, ensure_ascii=False, indent=2),
+                    encoding='utf-8',
+                )
+                with self.assertRaisesRegex(SystemExit, 'manifest changed since preview'):
+                    batch_mod.apply_revisions(str(manifest_path))
+
+            manifest = self._load_manifest(manifest_path)
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'manifest_changed')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original)
+
+    def test_apply_rejects_project_identity_changed_since_preview(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(root)
+            original = target_file.read_text(encoding='utf-8')
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = self._load_manifest(manifest_path)
+                manifest['last_revision_preview']['project_identity']['tl_dir'] = (
+                    str(root / 'other' / 'tl')
+                )
+                manifest_path.write_text(
+                    json.dumps(manifest, ensure_ascii=False, indent=2),
+                    encoding='utf-8',
+                )
+                with self.assertRaisesRegex(SystemExit, 'project identity changed since preview'):
+                    batch_mod.apply_revisions(str(manifest_path))
+
+            manifest = self._load_manifest(manifest_path)
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(manifest['revision_apply_blocked_reason'], 'project_changed')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original)
+
+    def test_apply_unchanged_only_reports_no_op_without_applied_timestamp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, _ = self._make_package(
+                root,
+                revised='虚空门',
+                should_update=True,
+            )
+            original = target_file.read_text(encoding='utf-8')
+            tl_dir = target_file.parent
+            with (
+                mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)),
+                mock.patch.object(batch_mod, 'update_progress') as update_progress,
+            ):
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = batch_mod.apply_revisions(str(manifest_path))
+
+            self.assertEqual(manifest['revision_apply_state'], 'no_op')
+            self.assertNotIn('revision_applied_at', manifest)
+            self.assertEqual(manifest['revision_apply_summary']['applied_files'], 0)
+            self.assertEqual(manifest['revision_apply_summary']['applied_lines'], 0)
+            self.assertEqual(manifest['revision_apply_summary']['unchanged_items'], 1)
+            update_progress.assert_not_called()
+            self.assertEqual(target_file.read_text(encoding='utf-8'), original)
 
 
 

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -2848,6 +2848,43 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
             update_progress.assert_not_called()
             self.assertEqual(target_file.read_text(encoding='utf-8'), original)
 
+    def test_fresh_preview_clears_stale_apply_terminal_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, target_file, result_path = self._make_package(root)
+            tl_dir = target_file.parent
+            with mock.patch.object(batch_mod.legacy, 'TL_DIR', str(tl_dir)):
+                batch_mod.preview_revisions(str(manifest_path))
+                result_path.write_text(
+                    result_path.read_text(encoding='utf-8').rstrip()
+                    + '\n{"replacement": true}\n',
+                    encoding='utf-8',
+                )
+                with self.assertRaisesRegex(SystemExit, 'result JSONL changed since preview'):
+                    batch_mod.apply_revisions(str(manifest_path))
+                manifest = self._load_manifest(manifest_path)
+                self.assertEqual(manifest['revision_apply_state'], 'blocked')
+                self.assertIn('revision_apply_blocked_reason', manifest)
+
+                result_path.write_text(
+                    '\n'.join(
+                        line
+                        for line in result_path.read_text(encoding='utf-8').splitlines()
+                        if '"replacement": true' not in line
+                    )
+                    + '\n',
+                    encoding='utf-8',
+                )
+                batch_mod.preview_revisions(str(manifest_path))
+                manifest = self._load_manifest(manifest_path)
+                self.assertNotIn('revision_apply_state', manifest)
+                self.assertNotIn('revision_apply_blocked_reason', manifest)
+                self.assertNotIn('revision_apply_message', manifest)
+                self.assertEqual(manifest['last_revision_preview']['summary']['valid_items'], 1)
+
+                applied = batch_mod.apply_revisions(str(manifest_path))
+                self.assertEqual(applied['revision_apply_state'], 'applied')
+
 
 
 if __name__ == '__main__':

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -2904,6 +2904,8 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
                 self.assertNotIn('revision_apply_state', manifest)
                 self.assertNotIn('revision_apply_blocked_reason', manifest)
                 self.assertNotIn('revision_apply_message', manifest)
+                self.assertNotIn('revision_apply_summary', manifest)
+                self.assertNotIn('last_revision_apply_summary', manifest)
                 self.assertEqual(manifest['last_revision_preview']['summary']['valid_items'], 1)
 
                 applied = batch_mod.apply_revisions(str(manifest_path))
@@ -2925,6 +2927,7 @@ class RevisionApplyPreviewContractTests(unittest.TestCase):
                 manifest = self._load_manifest(manifest_path)
                 self.assertNotIn('revision_applied_at', manifest)
                 self.assertNotIn('revision_apply_state', manifest)
+                self.assertNotIn('revision_apply_summary', manifest)
                 history = manifest.get('revision_apply_history') or []
                 self.assertEqual(len(history), 1)
                 self.assertEqual(history[0]['applied_at'], first_applied_at)

--- a/tests/test_final_review_revision.py
+++ b/tests/test_final_review_revision.py
@@ -174,6 +174,21 @@ class FinalReviewRevisionHandoffTests(unittest.TestCase):
         finding = fr.load_campaign_package(campaign)["findings"][0]
         self.assertEqual(finding["revision_state"], fr.REVISION_STATE_PREVIEWED)
 
+    def test_repreview_after_applied_keeps_finding_applied(self):
+        campaign, finding_id = self._campaign()
+        manifest = handoff.create_revision_package(batch, campaign, [finding_id])
+        applied = batch.apply_revisions(manifest["_manifest_path"])
+        self.assertEqual(applied["revision_apply_state"], "applied")
+
+        refreshed = batch.preview_revisions(manifest["_manifest_path"])
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_APPLIED)
+
+        no_op = batch.apply_revisions(refreshed["_manifest_path"])
+        self.assertEqual(no_op["revision_apply_state"], "no_op")
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_APPLIED)
+
     def test_stale_translation_refuses_candidate_creation(self):
         campaign, finding_id = self._campaign()
         path = next(self.tl_dir.rglob("*.rpy"))

--- a/tests/test_final_review_revision.py
+++ b/tests/test_final_review_revision.py
@@ -126,10 +126,53 @@ class FinalReviewRevisionHandoffTests(unittest.TestCase):
 
         applied = batch.apply_revisions(manifest["_manifest_path"])
         self.assertEqual(applied["revision_apply_summary"]["applied_lines"], 1)
+        self.assertEqual(applied["revision_apply_state"], "applied")
+        self.assertIn("revision_applied_at", applied)
         finding = fr.load_campaign_package(campaign)["findings"][0]
         self.assertEqual(finding["revision_state"], fr.REVISION_STATE_APPLIED)
         text = next(self.tl_dir.rglob("*.rpy")).read_text(encoding="utf-8")
         self.assertIn("虚空之门", text)
+
+    def test_unchanged_selection_reports_no_op_without_marking_finding_applied(self):
+        campaign, finding_id = self._campaign()
+        package = fr.load_campaign_package(campaign)
+        finding = next(
+            row
+            for row in package["findings"]
+            if str(row.get("finding_id") or "") == finding_id
+        )
+        finding["suggested_revision"] = finding["current_translation"]
+        paths = package["paths"]
+        manifest = dict(package["manifest"])
+        manifest["summary"] = {**dict(manifest.get("summary") or {}), "finding_count": 1}
+        fr.write_campaign_package(
+            paths["package_dir"],
+            manifest=manifest,
+            snapshot=package["snapshot"],
+            units=package["units"],
+            findings=[finding],
+        )
+
+        revision_manifest = handoff.create_revision_package(batch, campaign, [finding_id])
+        applied = batch.apply_revisions(revision_manifest["_manifest_path"])
+
+        self.assertEqual(applied["revision_apply_state"], "no_op")
+        self.assertNotIn("revision_applied_at", applied)
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_PREVIEWED)
+
+    def test_blocked_apply_keeps_finding_previewed(self):
+        campaign, finding_id = self._campaign()
+        manifest = handoff.create_revision_package(batch, campaign, [finding_id])
+        result_path = Path(manifest["_package_dir"]) / manifest["result_jsonl_path"]
+        result_path.write_text(
+            result_path.read_text(encoding="utf-8").rstrip() + '\n{"replaced": true}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(SystemExit, "result JSONL changed since preview"):
+            batch.apply_revisions(manifest["_manifest_path"])
+        finding = fr.load_campaign_package(campaign)["findings"][0]
+        self.assertEqual(finding["revision_state"], fr.REVISION_STATE_PREVIEWED)
 
     def test_stale_translation_refuses_candidate_creation(self):
         campaign, finding_id = self._campaign()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -512,6 +512,39 @@ class BatchCliContractTests(unittest.TestCase):
                         "C:/jobs/part02/manifest.json",
                     )
 
+    def test_machine_result_builder_covers_revision_apply_states(self):
+        args = SimpleNamespace(target="")
+        revision_manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "revision_apply_state": "partial",
+            "revision_apply_summary": {"applied_files": 1, "applied_lines": 1},
+        }
+        envelope = batch.build_machine_success_envelope(
+            "apply-revisions",
+            dict(revision_manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "partial")
+        self.assertEqual(envelope["result"]["revision_apply_state"], "partial")
+        self.assertEqual(envelope["result"]["revision_apply"]["applied_files"], 1)
+
+        blocked = dict(revision_manifest)
+        blocked["revision_apply_state"] = "blocked"
+        blocked["revision_apply_blocked_reason"] = "all_items_blocked"
+        envelope = batch.build_machine_success_envelope(
+            "apply-revisions",
+            blocked,
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "blocked")
+        self.assertEqual(
+            envelope["result"]["revision_apply_blocked_reason"],
+            "all_items_blocked",
+        )
+
     def test_build_without_pending_work_does_not_load_latest_manifest(self):
         args = SimpleNamespace(target="")
 

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -545,6 +545,13 @@ class BatchCliContractTests(unittest.TestCase):
             "all_items_blocked",
         )
 
+    def test_apply_revisions_is_registered_for_machine_output(self):
+        self.assertIn("apply-revisions", batch.MACHINE_OUTPUT_COMMANDS)
+        args = batch.build_arg_parser().parse_args(
+            ["apply-revisions", "C:/jobs/demo/manifest.json", "--output", "json"]
+        )
+        self.assertEqual(args.output, "json")
+
     def test_build_without_pending_work_does_not_load_latest_manifest(self):
         args = SimpleNamespace(target="")
 

--- a/tests/test_gui_revision_report.py
+++ b/tests/test_gui_revision_report.py
@@ -161,6 +161,18 @@ class GuiRevisionReportTests(unittest.TestCase):
         self.assertIn("订正写回被阻止", summary.heading)
         self.assertFalse(summary.can_apply)
 
+    def test_summarize_apply_output_blocked_on_nonzero_exit(self):
+        summary = summarize_revision_apply_output(
+            APPLY_BLOCKED_OUTPUT + "\nRevision apply reason: results_changed\n",
+            1,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertEqual(summary.heading, "订正写回被阻止")
+        self.assertIn("results_changed", "\n".join(summary.facts))
+        self.assertFalse(summary.can_apply)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_revision_report.py
+++ b/tests/test_gui_revision_report.py
@@ -19,9 +19,34 @@ Preview Markdown: C:\\package\\revision_preview.md
 
 APPLY_OUTPUT = """
 Recoverable revision items: 2
+Revision apply state: applied
 Applied files: 1
 Applied lines: 2
 Failures logged: 0
+"""
+
+APPLY_PARTIAL_OUTPUT = """
+Recoverable revision items: 2
+Revision apply state: partial
+Applied files: 1
+Applied lines: 1
+Failures logged: 1
+"""
+
+APPLY_NOOP_OUTPUT = """
+Recoverable revision items: 0
+Revision apply state: no_op
+Applied files: 0
+Applied lines: 0
+Failures logged: 0
+"""
+
+APPLY_BLOCKED_OUTPUT = """
+Recoverable revision items: 0
+Revision apply state: blocked
+Applied files: 0
+Applied lines: 0
+Failures logged: 1
 """
 
 SYNC_OUTPUT = """
@@ -44,6 +69,11 @@ class GuiRevisionReportTests(unittest.TestCase):
         self.assertEqual(parsed["pending_lines"], 2)
         self.assertEqual(parsed["preview_jsonl"], "C:\\package\\revision_preview.jsonl")
         self.assertEqual(parsed["preview_markdown"], "C:\\package\\revision_preview.md")
+
+    def test_parse_revision_summary_extracts_apply_state(self):
+        parsed = parse_revision_summary(APPLY_PARTIAL_OUTPUT)
+
+        self.assertEqual(parsed["apply_state"], "partial")
 
     def test_summarize_preview_success_marks_done(self):
         update = summarize_revision_preview_output(PREVIEW_OUTPUT, 0)
@@ -97,6 +127,39 @@ class GuiRevisionReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "applied")
         self.assertFalse(summary.can_apply)
         self.assertIn("已写回 1 个文件", "\n".join(summary.facts))
+
+    def test_summarize_apply_output_partial(self):
+        summary = summarize_revision_apply_output(
+            APPLY_PARTIAL_OUTPUT,
+            0,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "applied")
+        self.assertIn("订正部分写回", summary.heading)
+        self.assertFalse(summary.can_apply)
+
+    def test_summarize_apply_output_no_op(self):
+        summary = summarize_revision_apply_output(
+            APPLY_NOOP_OUTPUT,
+            0,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "idle")
+        self.assertIn("no-op", summary.message)
+        self.assertFalse(summary.can_apply)
+
+    def test_summarize_apply_output_blocked(self):
+        summary = summarize_revision_apply_output(
+            APPLY_BLOCKED_OUTPUT,
+            0,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertIn("订正写回被阻止", summary.heading)
+        self.assertFalse(summary.can_apply)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_revision_writeback_report.py
+++ b/tests/test_gui_revision_writeback_report.py
@@ -103,6 +103,63 @@ class GuiRevisionWritebackReportTests(unittest.TestCase):
 
         self.assertIsNone(summary)
 
+    def test_manifest_blocked_apply_reports_blocked(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": "C:\\package\\manifest.json",
+                "revision_apply_state": "blocked",
+                "revision_apply_blocked_reason": "results_changed",
+                "revision_apply_message": "result JSONL changed since preview.",
+                "revision_apply_summary": {
+                    "applied_files": 0,
+                    "applied_lines": 0,
+                },
+            }
+        )
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.status, "failed")
+        self.assertEqual(summary.heading, "订正写回被阻止")
+        self.assertIn("results_changed", summary.message)
+        self.assertFalse(summary.can_apply)
+
+    def test_manifest_no_op_apply_reports_idle(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": "C:\\package\\manifest.json",
+                "revision_apply_state": "no_op",
+                "revision_apply_summary": {
+                    "applied_files": 0,
+                    "applied_lines": 0,
+                    "unchanged_items": 3,
+                },
+            }
+        )
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.status, "idle")
+        self.assertIn("no-op", summary.message)
+        self.assertFalse(summary.can_apply)
+        self.assertIn("无需修改项：3", "\n".join(summary.facts))
+
+    def test_manifest_partial_apply_reports_partial(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": "C:\\package\\manifest.json",
+                "revision_apply_state": "partial",
+                "revision_apply_summary": {
+                    "applied_files": 1,
+                    "applied_lines": 1,
+                },
+            }
+        )
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.status, "applied")
+        self.assertEqual(summary.heading, "订正部分写回")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("已写回 1 个文件", "\n".join(summary.facts))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #294

## 变更

### preview-revisions 持久化合同
- \last_revision_preview\ 新增 \schema_version\ / \generated_at\ / \esults_path\ / \esults_sha256\ / \manifest_identity\ / \project_identity\ / \source_snapshots\。
- 源文件快照为 manifest 中每个文件当前字节的 SHA-256；文件缺失记录为 \
ull\，预览后新增/消失也会被识别为变化。

### apply-revisions 强制绑定
- 未执行 preview、results 被替换、manifest 身份变化、项目身份变化或任一源文件快照变化时拒绝写回且不改源文件。
- \--force\ 只绕过「已写回」守卫，不能绕过 preview 过期、项目身份或源快照校验。
- 阻断原因写入 manifest：\evision_apply_state=blocked\ + \evision_apply_blocked_reason\ + \evision_apply_message\。

### 状态语义
- \evision_apply_state\ 固定取值：\pplied\ / \
o_op\ / \locked\ / \partial\。
- \evision_applied_at\ 只在 \pplied\ / \partial\ 写入；\
o_op\ / \locked\ 不写。
- final-review linked finding 只在真实写回行时推进到 \pplied\；\
o_op\ / \locked\ 保持 \previewed\。
- GUI 订正摘要按新状态区分：部分写回 / no-op / 阻断，不再把 0 行写回显示为完成。

## 验证
- 验收模块 116 项通过：\	est_batch_repair\、\	est_batch_golden_corpus\、\	est_final_review_revision\、\	est_gui_revision_workflow\、\	est_gui_revision_writeback_report\（另含 \	est_gui_revision_report\、\	est_identity_v2\）
- CLI contract 模块 53 项通过
- \python -B tests/run_cli_tests.py -q\：911 项通过（1 skipped）
- 本地 Markdown 链接与 \git diff --check\ 通过
- golden revision fixture 快照仅新增 \state\ 与 \lready_applied_items\ 两个稳定字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned preview validation for revision applications.
  * Revision results now distinguish applied, partial, no-op, and blocked outcomes.
  * Machine-readable results include applied-file counts, timestamps, and blocking reasons.
  * Added apply history and clearer progress tracking for files actually written.
  * GUI reports now provide distinct messages for each revision outcome.

* **Bug Fixes**
  * Prevented stale or modified previews and source files from being applied.
  * Prevented unchanged suggestions from being incorrectly marked as applied.
  * Clarified that force mode does not bypass preview or source validation.

* **Documentation**
  * Updated batch workflow and GUI guidance with validation, status, history, and exit-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->