### PR TITLE
fix(gui): settings nav never silently clips at minimum width

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -2997,14 +2997,14 @@ class MainWindow(QMainWindow):
         self.settings_nav = QListWidget()
         self.settings_nav.setObjectName("settings_nav")
         self.settings_nav.setFixedHeight(50)
-        self.settings_nav.setSpacing(2)
+        self.settings_nav.setSpacing(1)
         self.settings_nav.setFrameShape(QFrame.Shape.NoFrame)
         self.settings_nav.setFlow(QListView.Flow.LeftToRight)
         self.settings_nav.setMovement(QListView.Movement.Static)
         self.settings_nav.setResizeMode(QListView.ResizeMode.Adjust)
         self.settings_nav.setWrapping(False)
         self.settings_nav.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
         self.settings_nav.setVerticalScrollBarPolicy(
             Qt.ScrollBarPolicy.ScrollBarAlwaysOff

--- a/gui_qt/resources/app_template.qss
+++ b/gui_qt/resources/app_template.qss
@@ -356,8 +356,8 @@ QListWidget#settings_nav {
 
 QListWidget#settings_nav::item {
     color: ${fg_body};
-    padding: 6px 12px;
-    margin: 0 2px;
+    padding: 6px 10px;
+    margin: 0 1px;
     border-radius: 6px;
 }
 

--- a/tests/test_gui_settings_layout.py
+++ b/tests/test_gui_settings_layout.py
@@ -6,9 +6,6 @@ import unittest
 try:
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QFormLayout, QScrollArea
-
-    from gui_qt.app import MainWindow, _SETTINGS_PAGE_SPECS
-    from gui_qt.theme import apply_theme, clear_theme_caches
 except ImportError as exc:
     Qt = None  # type: ignore[assignment,misc]
     QApplication = None  # type: ignore[assignment,misc]
@@ -20,6 +17,10 @@ except ImportError as exc:
     clear_theme_caches = None  # type: ignore[assignment,misc]
     IMPORT_ERROR = exc
 else:
+    # Project imports stay outside the PySide6 guard: failures here are real
+    # test failures, not a missing-GUI skip.
+    from gui_qt.app import MainWindow, _SETTINGS_PAGE_SPECS
+    from gui_qt.theme import apply_theme, clear_theme_caches
     IMPORT_ERROR = None
 
 from tests import gui_test_support
@@ -235,23 +236,40 @@ class GuiSettingsLayoutTests(unittest.TestCase):
         # (QSS margins/padding). Load it here so the regression exercises the
         # production metrics; otherwise the default style stays comfortably
         # narrow and would never reproduce the clipping bug.
-        apply_theme(self._app, self.window._resources_dir, "light")
         try:
+            apply_theme(self._app, self.window._resources_dir, "light")
             self.window.resize(960, 640)
             _process(self._app, 12)
             nav = self.window.settings_nav
-            # Structural fallback: overflow must never be silently hidden.
-            self.assertNotEqual(
+            # Exact policy: overflow must be scrollable, never silently hidden.
+            self.assertEqual(
                 nav.horizontalScrollBarPolicy(),
-                Qt.ScrollBarPolicy.ScrollBarAlwaysOff,
+                Qt.ScrollBarPolicy.ScrollBarAsNeeded,
             )
-            # Functional reachability: every section must be scrollable into
-            # view at the minimum window size, whatever the platform font.
             last_item = nav.item(nav.count() - 1)
+            # Default fitted state: strict horizontal containment. QRect's
+            # right() is inclusive, so equality with the viewport width would
+            # already be one pixel outside the viewport.
+            self.assertLess(
+                nav.visualItemRect(last_item).right(),
+                nav.viewport().width(),
+            )
+            # Overflow fallback (wider items force the horizontal scrollbar):
+            # the last section must stay reachable and its text line must fit
+            # the scrollbar-compressed viewport height.
+            nav.setStyleSheet(
+                "QListWidget#settings_nav::item { padding: 6px 60px; }"
+            )
+            _process(self._app, 8)
+            self.assertTrue(nav.horizontalScrollBar().isVisible())
             nav.scrollToItem(last_item)
             _process(self._app, 5)
             rect = nav.visualItemRect(last_item)
-            self.assertLessEqual(rect.right(), nav.viewport().width())
+            self.assertLess(rect.right(), nav.viewport().width())
+            self.assertLessEqual(
+                nav.fontMetrics().height(),
+                nav.viewport().height(),
+            )
         finally:
             # Restore the unthemed state used by the other layout tests.
             # apply_theme(..., "") would normalize to the system theme instead

--- a/tests/test_gui_settings_layout.py
+++ b/tests/test_gui_settings_layout.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 import unittest
 
 try:
+    from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QFormLayout, QScrollArea
 
     from gui_qt.app import MainWindow, _SETTINGS_PAGE_SPECS
+    from gui_qt.theme import apply_theme, clear_theme_caches
 except ImportError as exc:
+    Qt = None  # type: ignore[assignment,misc]
     QApplication = None  # type: ignore[assignment,misc]
     QFormLayout = None  # type: ignore[assignment,misc]
     QScrollArea = None  # type: ignore[assignment,misc]
     MainWindow = None  # type: ignore[assignment,misc]
     _SETTINGS_PAGE_SPECS = ()  # type: ignore[assignment,misc]
+    apply_theme = None  # type: ignore[assignment,misc]
+    clear_theme_caches = None  # type: ignore[assignment,misc]
     IMPORT_ERROR = exc
 else:
     IMPORT_ERROR = None
@@ -224,6 +229,35 @@ class GuiSettingsLayoutTests(unittest.TestCase):
                         self.window.settings_nav.visualItemRect(item)
                     )
                 )
+
+    def test_settings_nav_overflow_is_never_silently_clipped(self) -> None:
+        # The real GUI loads the theme stylesheet, which widens every nav item
+        # (QSS margins/padding). Load it here so the regression exercises the
+        # production metrics; otherwise the default style stays comfortably
+        # narrow and would never reproduce the clipping bug.
+        apply_theme(self._app, self.window._resources_dir, "light")
+        try:
+            self.window.resize(960, 640)
+            _process(self._app, 12)
+            nav = self.window.settings_nav
+            # Structural fallback: overflow must never be silently hidden.
+            self.assertNotEqual(
+                nav.horizontalScrollBarPolicy(),
+                Qt.ScrollBarPolicy.ScrollBarAlwaysOff,
+            )
+            # Functional reachability: every section must be scrollable into
+            # view at the minimum window size, whatever the platform font.
+            last_item = nav.item(nav.count() - 1)
+            nav.scrollToItem(last_item)
+            _process(self._app, 5)
+            rect = nav.visualItemRect(last_item)
+            self.assertLessEqual(rect.right(), nav.viewport().width())
+        finally:
+            # Restore the unthemed state used by the other layout tests.
+            # apply_theme(..., "") would normalize to the system theme instead
+            # of clearing the stylesheet, so reset it directly.
+            self._app.setStyleSheet("")
+            clear_theme_caches()
 
     def test_settings_forms_share_label_and_field_spacing(self) -> None:
         form_count = 0


### PR DESCRIPTION
Closes #314

## 现象

960×640 最小窗口下，设置横向导航最后一个分区「高级」被裁切；`settings_nav` 的横向滚动条为 `ScrollBarAlwaysOff`，超出的部分不可见也不可滚动。

带主题实测（修复前）：viewport 704px，内容总宽 766px，超出约 62px（比 issue 记录的 4px 更严重，QSS padding/margin 放大后更明显）。

## 修复

1. 微调间距让默认字体下全部 fit：
   - `QListWidget#settings_nav::item` padding `12px` → `10px`、margin `2px` → `1px`；
   - `setSpacing(2)` → `setSpacing(1)`。
   修复后内容总宽 688px ≤ 704px，10 个分区完整可见，无滚动条。
2. 横向滚动条 `AlwaysOff` → `AsNeeded` 作为字体/DPI 差异下的兜底：即使内容超宽，用户也能滚动到被裁部分，杜绝静默裁切。

## 验证

- 新增 `test_settings_nav_overflow_is_never_silently_clipped`：加载真实主题 QSS，在 960×640 下断言滚动条策略不是 `AlwaysOff`，且最后一个分区可通过 `scrollToItem` 完整到达（跨平台字体安全）。
- `tests.test_gui_settings_layout`（9） + `tests.test_gui_control_layout_audit`（3）全部通过。
- 全量 GUI 973 项：6 失败 + 1 错误均为本地环境问题（真实 `translator_config.json` 项目配置导致的 task-page gate 时序差异 + 沙箱外写 `games_registry.json` 权限），已在干净基线 worktree 上确认与本次改动无关，CI 干净环境不受影响。
- `git diff --check` 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings navigation spacing to display more items within the available width.
  * Added horizontal scrolling so navigation items are no longer silently clipped when space is limited.

* **Tests**
  * Added regression coverage to verify that the final settings navigation item can be accessed when overflow occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->