### PR TITLE
feat(revision): export read-only polishing corpus (#320)

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -238,6 +238,33 @@ logs/batch_jobs/<ts>_<project>_final_review/
 
 相关配置见 `translator_config.example.json` 的 `batch.final_review`。
 
+## 润色语料导出
+
+`export-revision-corpus` 是只读导出命令（#318 P1 / #320）：把当前项目中全部
+revision old/new 对照导出为 JSONL、Markdown 和 manifest，供人工线性通读或
+Agent 分批起草润色提案：
+
+```bash
+python gemini_translate_batch.py export-revision-corpus
+python gemini_translate_batch.py export-revision-corpus --output-dir C:/tmp/corpus
+python gemini_translate_batch.py export-revision-corpus --output json
+```
+
+- 默认写入 `logs/batch_jobs/<timestamp>_<project>_revision_corpus/`；
+  `--output-dir` 可指定其他目录。
+- 产物：`revision_corpus.jsonl`（权威结构化合同）、`revision_corpus.md`
+  （线性通读报告）、`revision_corpus_manifest.json`（项目身份、scanner/schema、
+  源快照 digest、范围计数）。
+- 每个 item 携带 schema version、`identity_v2` occurrence、文件相对路径、
+  locator（行号 / 起止 / ordinal）、speaker（可得时）、原文、现译和
+  old/new 快照 digest；重复原文保留不同 occurrence，不按文本去重。
+- 文件与 item 顺序跨运行稳定（文件按相对路径排序，item 保持文件内顺序）；
+  相同输入、adapter 和配置产生相同 item 集合与 digest。
+- 导出前后会重算 TL 文件 digest，扫描期间源文件变化会在 manifest 中标记
+  `source_changed_during_scan`，而不是静默混入。
+- 只读：不修改 `.rpy`、manifest、glossary 或 RAG；机器输出可用
+  `--output json`（envelope 含三个产物路径与 item/file 计数）。
+
 ## 关键词提取流程
 
 关键词提取模式只生成候选报告，不写回 `.rpy` / `glossary.json` / `story_graph.json`：

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -252,6 +252,8 @@ python gemini_translate_batch.py export-revision-corpus --output json
 
 - 默认写入 `logs/batch_jobs/<timestamp>_<project>_revision_corpus/`；
   `--output-dir` 可指定其他目录。
+- 导出范围与当前配置一致：应用 `include_files` / `include_prefixes` 过滤后
+  的 TL 文件；不是无条件导出项目内全部 revision 对。
 - 产物：`revision_corpus.jsonl`（权威结构化合同）、`revision_corpus.md`
   （线性通读报告）、`revision_corpus_manifest.json`（项目身份、scanner/schema、
   源快照 digest、范围计数）。

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3428,7 +3428,13 @@ def collect_revision_file_jobs(file_paths=None, include_empty_files=False):
         with open(file_path, 'rb') as handle:
             raw = handle.read()
         source_digest = hashlib.sha256(raw).hexdigest()
-        lines = raw.decode('utf-8-sig').splitlines(keepends=True)
+        text = raw.decode('utf-8-sig')
+        # Mirror the legacy text-mode read (universal newlines): CRLF/CR are
+        # normalized to LF and only LF splits lines, so parsing is identical
+        # for every consumer (build-revisions, final-review handoff, export).
+        lines = text.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+        if lines and lines[-1] == '':
+            lines.pop()
         entries = collect_translation_entries_from_lines(lines, file_rel_path=rel_path)
 
         items = []

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3411,13 +3411,15 @@ def should_include_revision_entry(entry):
     return bool(source and current_translation)
 
 
-def collect_revision_file_jobs(file_paths=None):
+def collect_revision_file_jobs(file_paths=None, include_empty_files=False):
     """Collect revision old/new jobs, optionally over an explicit file set.
 
     ``file_paths`` must be an iterable of ``(rel_path, abs_path)`` pairs (for
     example the output of ``collect_files_to_process()``). Passing the same set
     that produced the source digests removes the new-file race window between
-    digest collection and scanning.
+    digest collection and scanning. ``include_empty_files`` keeps jobs for
+    scanned files without recognized entries so coverage summaries can account
+    for every in-scope file instead of silently dropping empty ones.
     """
     jobs = []
     if file_paths is None:
@@ -3460,12 +3462,13 @@ def collect_revision_file_jobs(file_paths=None):
                 item['speaker_id'] = speaker_id
             items.append(item)
 
-        if items:
+        if items or include_empty_files:
             jobs.append(
                 {
                     'file_rel_path': rel_path,
                     'file_path': file_path,
                     'source_digest': source_digest,
+                    'line_count': len(lines),
                     'task_count': len(items),
                     'items': items,
                 }
@@ -3483,7 +3486,10 @@ def run_revision_corpus_export(output_dir=None):
     file_paths = list(collect_files_to_process())
     file_path_map = {rel_path: file_path for rel_path, file_path in file_paths}
     digests_before = revision_corpus.collect_file_digests(file_path_map)
-    file_jobs = collect_revision_file_jobs(file_paths=file_paths)
+    file_jobs = collect_revision_file_jobs(
+        file_paths=file_paths,
+        include_empty_files=True,
+    )
     if output_dir and str(output_dir).strip():
         target_dir = os.path.abspath(str(output_dir).strip())
         os.makedirs(target_dir, exist_ok=True)
@@ -3495,6 +3501,9 @@ def run_revision_corpus_export(output_dir=None):
     digests_after = revision_corpus.collect_file_digests(file_path_map)
     scanned_digests = {
         job['file_rel_path']: job['source_digest'] for job in file_jobs
+    }
+    file_line_counts = {
+        job['file_rel_path']: job.get('line_count') or 0 for job in file_jobs
     }
     manifest = revision_corpus.export_revision_corpus(
         target_dir,
@@ -3508,6 +3517,7 @@ def run_revision_corpus_export(output_dir=None):
         source_digests_before=digests_before,
         source_digests_after=digests_after,
         source_digests_scanned=scanned_digests,
+        file_line_counts=file_line_counts,
     )
     print(f'Exported revision corpus: {target_dir}')
     print(

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3423,8 +3423,11 @@ def collect_revision_file_jobs(file_paths=None):
     if file_paths is None:
         file_paths = collect_files_to_process()
     for rel_path, file_path in file_paths:
-        with open(file_path, 'r', encoding='utf-8-sig') as handle:
-            entries = collect_translation_entries_from_lines(handle.readlines(), file_rel_path=rel_path)
+        with open(file_path, 'rb') as handle:
+            raw = handle.read()
+        source_digest = hashlib.sha256(raw).hexdigest()
+        lines = raw.decode('utf-8-sig').splitlines(keepends=True)
+        entries = collect_translation_entries_from_lines(lines, file_rel_path=rel_path)
 
         items = []
         for entry in entries:
@@ -3462,6 +3465,7 @@ def collect_revision_file_jobs(file_paths=None):
                 {
                     'file_rel_path': rel_path,
                     'file_path': file_path,
+                    'source_digest': source_digest,
                     'task_count': len(items),
                     'items': items,
                 }
@@ -3489,6 +3493,9 @@ def run_revision_corpus_export(output_dir=None):
             f'{stamp}_{guess_project_slug()}_revision_corpus'
         )
     digests_after = revision_corpus.collect_file_digests(file_path_map)
+    scanned_digests = {
+        job['file_rel_path']: job['source_digest'] for job in file_jobs
+    }
     manifest = revision_corpus.export_revision_corpus(
         target_dir,
         file_jobs,
@@ -3500,6 +3507,7 @@ def run_revision_corpus_export(output_dir=None):
         include_prefixes=sorted(legacy.INCLUDE_PREFIXES),
         source_digests_before=digests_before,
         source_digests_after=digests_after,
+        source_digests_scanned=scanned_digests,
     )
     print(f'Exported revision corpus: {target_dir}')
     print(
@@ -12742,6 +12750,16 @@ def dispatch_command(parser, args):
             raise SystemExit(f'Project analysis error: {exc}') from exc
 
     initialize_batch_logging()
+    if command == 'export-revision-corpus':
+        # Read-only export: avoid the common load path below, which can
+        # persist a corrected game_root into translator_config.json.
+        legacy.load_translator_settings(persist_corrected_game_root=False)
+        legacy.load_glossary()
+        load_batch_settings()
+        return run_revision_corpus_export(
+            getattr(args, 'output_dir', '') or None,
+        )
+
     if command in {'usage-import', 'usage-report'}:
         as_json = bool(getattr(args, 'json', False))
 
@@ -12820,14 +12838,6 @@ def dispatch_command(parser, args):
             chunk_size=args.chunk_size,
         )
         return
-
-    if command == 'export-revision-corpus':
-        legacy.load_translator_settings(persist_corrected_game_root=False)
-        legacy.load_glossary()
-        load_batch_settings()
-        return run_revision_corpus_export(
-            getattr(args, 'output_dir', '') or None,
-        )
 
     if command == 'bootstrap-rag':
         bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3411,9 +3411,18 @@ def should_include_revision_entry(entry):
     return bool(source and current_translation)
 
 
-def collect_revision_file_jobs():
+def collect_revision_file_jobs(file_paths=None):
+    """Collect revision old/new jobs, optionally over an explicit file set.
+
+    ``file_paths`` must be an iterable of ``(rel_path, abs_path)`` pairs (for
+    example the output of ``collect_files_to_process()``). Passing the same set
+    that produced the source digests removes the new-file race window between
+    digest collection and scanning.
+    """
     jobs = []
-    for rel_path, file_path in collect_files_to_process():
+    if file_paths is None:
+        file_paths = collect_files_to_process()
+    for rel_path, file_path in file_paths:
         with open(file_path, 'r', encoding='utf-8-sig') as handle:
             entries = collect_translation_entries_from_lines(handle.readlines(), file_rel_path=rel_path)
 
@@ -3467,11 +3476,10 @@ def run_revision_corpus_export(output_dir=None):
     digests are computed before and after the scan so a corpus produced while
     sources changed is explicitly flagged instead of silently mixed.
     """
-    file_paths = {
-        rel_path: file_path for rel_path, file_path in collect_files_to_process()
-    }
-    digests_before = revision_corpus.collect_file_digests(file_paths)
-    file_jobs = collect_revision_file_jobs()
+    file_paths = list(collect_files_to_process())
+    file_path_map = {rel_path: file_path for rel_path, file_path in file_paths}
+    digests_before = revision_corpus.collect_file_digests(file_path_map)
+    file_jobs = collect_revision_file_jobs(file_paths=file_paths)
     if output_dir and str(output_dir).strip():
         target_dir = os.path.abspath(str(output_dir).strip())
         os.makedirs(target_dir, exist_ok=True)
@@ -3480,7 +3488,7 @@ def run_revision_corpus_export(output_dir=None):
         target_dir = create_batch_package_dir(
             f'{stamp}_{guess_project_slug()}_revision_corpus'
         )
-    digests_after = revision_corpus.collect_file_digests(file_paths)
+    digests_after = revision_corpus.collect_file_digests(file_path_map)
     manifest = revision_corpus.export_revision_corpus(
         target_dir,
         file_jobs,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -56,6 +56,7 @@ from engine_adapters.writeback import (
 import keyword_glossary_merge
 import model_usage_ledger
 import prompt_context
+import revision_corpus
 import translation_ab_experiment
 import story_memory
 import translation_core
@@ -98,6 +99,7 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'check',
         'apply',
         'apply-revisions',
+        'export-revision-corpus',
     }
 )
 EXPLICIT_TARGET_COMMANDS = frozenset({'submit', 'status', 'download', 'check', 'apply'})
@@ -109,6 +111,7 @@ OFFLINE_BATCH_COMMANDS = frozenset(
         'estimate-cost',
         'preview-revisions',
         'apply-revisions',
+        'export-revision-corpus',
         'split',
         'build-retry',
         'merge-retry',
@@ -3455,6 +3458,54 @@ def collect_revision_file_jobs():
                 }
             )
     return jobs
+
+
+def run_revision_corpus_export(output_dir=None):
+    """Export the read-only revision polishing corpus for the active project.
+
+    Files are scanned once with the existing revision scanner; per-file source
+    digests are computed before and after the scan so a corpus produced while
+    sources changed is explicitly flagged instead of silently mixed.
+    """
+    file_paths = {
+        rel_path: file_path for rel_path, file_path in collect_files_to_process()
+    }
+    digests_before = revision_corpus.collect_file_digests(file_paths)
+    file_jobs = collect_revision_file_jobs()
+    if output_dir and str(output_dir).strip():
+        target_dir = os.path.abspath(str(output_dir).strip())
+        os.makedirs(target_dir, exist_ok=True)
+    else:
+        stamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+        target_dir = create_batch_package_dir(
+            f'{stamp}_{guess_project_slug()}_revision_corpus'
+        )
+    digests_after = revision_corpus.collect_file_digests(file_paths)
+    manifest = revision_corpus.export_revision_corpus(
+        target_dir,
+        file_jobs,
+        project_slug=guess_project_slug(),
+        game_root=legacy.BASE_DIR,
+        tl_dir=legacy.TL_DIR,
+        tl_subdir=legacy.TL_SUBDIR,
+        include_files=sorted(legacy.INCLUDE_FILES),
+        include_prefixes=sorted(legacy.INCLUDE_PREFIXES),
+        source_digests_before=digests_before,
+        source_digests_after=digests_after,
+    )
+    print(f'Exported revision corpus: {target_dir}')
+    print(
+        f"Files: {manifest['scope']['file_count']}, "
+        f"items: {manifest['scope']['item_count']}"
+    )
+    print(f"JSONL: {manifest['paths']['jsonl']}")
+    print(f"Markdown: {manifest['paths']['markdown']}")
+    if manifest.get('source', {}).get('source_changed_during_scan'):
+        print(
+            'Warning: source files changed during the scan; '
+            'rerun export for a consistent snapshot.'
+        )
+    return manifest
 
 
 def format_revision_context_block(items, empty_label):
@@ -11573,6 +11624,21 @@ def build_arg_parser():
         help='Old/new pair count per revision chunk. Defaults to batch.revision.chunk_size.',
     )
 
+    export_revision_corpus_parser = subparsers.add_parser(
+        'export-revision-corpus',
+        help=(
+            'Export a read-only revision polishing corpus '
+            '(JSONL + Markdown + manifest) without modifying game files.'
+        ),
+    )
+    export_revision_corpus_parser.add_argument(
+        '--output-dir',
+        default='',
+        metavar='DIR',
+        help='Write the corpus into DIR instead of a fresh timestamped Batch jobs subdirectory.',
+    )
+    add_machine_output_argument(export_revision_corpus_parser)
+
     bootstrap_rag_parser = subparsers.add_parser(
         'bootstrap-rag',
         help='Prebuild or refresh the Batch RAG history store from all allowed TL files.',
@@ -12747,6 +12813,14 @@ def dispatch_command(parser, args):
         )
         return
 
+    if command == 'export-revision-corpus':
+        legacy.load_translator_settings(persist_corrected_game_root=False)
+        legacy.load_glossary()
+        load_batch_settings()
+        return run_revision_corpus_export(
+            getattr(args, 'output_dir', '') or None,
+        )
+
     if command == 'bootstrap-rag':
         bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)
         return
@@ -13028,6 +13102,32 @@ def build_machine_success_envelope(command, value, args):
         status = str(
             manifest.get('revision_apply_state')
             or ('applied' if manifest.get('revision_applied_at') else 'completed')
+        )
+    elif command == 'export-revision-corpus':
+        corpus = dict(value or {})
+        paths = dict(corpus.get('paths') or {})
+        scope = dict(corpus.get('scope') or {})
+        source = dict(corpus.get('source') or {})
+        result = {
+            'output_dir': paths.get('output_dir') or '',
+            'corpus_jsonl': paths.get('jsonl') or '',
+            'corpus_markdown': paths.get('markdown') or '',
+            'corpus_manifest': paths.get('manifest') or '',
+            'file_count': scope.get('file_count') or 0,
+            'item_count': scope.get('item_count') or 0,
+            'source_changed_during_scan': bool(
+                source.get('source_changed_during_scan')
+            ),
+        }
+        return cli_contract.success_envelope(
+            command,
+            status='completed',
+            result=result,
+            artifacts={
+                'corpus_manifest': paths.get('manifest') or '',
+                'corpus_jsonl': paths.get('jsonl') or '',
+                'corpus_markdown': paths.get('markdown') or '',
+            },
         )
 
     return cli_contract.success_envelope(

--- a/revision_corpus.py
+++ b/revision_corpus.py
@@ -217,13 +217,18 @@ def export_revision_corpus(
     include_prefixes: Sequence[str] = (),
     source_digests_before: Mapping[str, str] | None = None,
     source_digests_after: Mapping[str, str] | None = None,
+    source_digests_scanned: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Write JSONL + Markdown + manifest into ``output_dir``; return the manifest.
 
     The manifest carries project identity, scanner/schema identity, the source
     snapshot digest (per-file and aggregate), scope counts, and whether source
-    files changed while the scan was running. ``_output_dir`` / ``_manifest_path``
-    are CLI-facing conveniences and are not persisted inside the manifest file.
+    files changed while the scan was running. ``source_digests_scanned`` must be
+    the digests of the exact bytes the scanner consumed (recorded at read time);
+    a mismatch against either boundary digest means a file changed mid-scan and
+    was restored, so the corpus is flagged instead of silently mixed.
+    ``_output_dir`` / ``_manifest_path`` are CLI-facing conveniences and are not
+    persisted inside the manifest file.
     """
     items, diagnostics = build_corpus_items(file_jobs)
     os.makedirs(output_dir, exist_ok=True)
@@ -240,10 +245,22 @@ def export_revision_corpus(
     source_digests = dict(source_digests_before or {})
     scanned_files = {str(row.get("file_rel_path") or "") for row in items}
     scanned_files_missing_digest = sorted(scanned_files - set(source_digests))
+    scanned_digests = dict(source_digests_scanned or {})
+    scanned_files_digest_mismatch = sorted(
+        rel_path
+        for rel_path, digest in scanned_digests.items()
+        if digest != source_digests.get(rel_path)
+        or (
+            source_digests_after is not None
+            and digest != source_digests_after.get(rel_path)
+        )
+    )
     source_changed = (
         source_digests_after is not None
         and source_digests_after != source_digests
     ) or bool(scanned_files_missing_digest)
+    if scanned_files_digest_mismatch:
+        source_changed = True
     manifest = {
         "schema_version": REVISION_CORPUS_SCHEMA_VERSION,
         "kind": "revision_corpus",
@@ -270,6 +287,7 @@ def export_revision_corpus(
             "file_digests": dict(sorted(source_digests.items())),
             "source_changed_during_scan": bool(source_changed),
             "scanned_files_missing_digest": scanned_files_missing_digest,
+            "scanned_files_digest_mismatch": scanned_files_digest_mismatch,
         },
         "scope": {
             "file_count": len({str(row.get("file_rel_path") or "") for row in items}),

--- a/revision_corpus.py
+++ b/revision_corpus.py
@@ -57,35 +57,105 @@ def aggregate_digest(digests: Mapping[str, str]) -> str:
     return stable_text_sha256(payload)
 
 
-def build_corpus_items(file_jobs: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    """Build deterministic corpus rows from revision scan jobs.
+def _int_or_zero(value: Any) -> tuple[int, str | None]:
+    """Coerce a locator value to int; report a diagnostic on failure."""
+    try:
+        return int(value or 0), None
+    except (TypeError, ValueError):
+        return 0, repr(value)
 
-    ``file_jobs`` must already be in a stable order (the CLI sorts files by rel
-    path); items keep their in-file order and carry a per-file 1-based ordinal.
-    Duplicate source text keeps distinct occurrences through ``identity_v2``
-    instead of being deduplicated by text.
+
+def _attach_adjacent_context(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach same-file previous/next old/new pairs as human-review context."""
+    by_file: dict[str, list[dict[str, Any]]] = {}
+    file_order: list[str] = []
+    for row in items:
+        rel_path = str(row.get("file_rel_path") or "")
+        if rel_path not in by_file:
+            by_file[rel_path] = []
+            file_order.append(rel_path)
+        by_file[rel_path].append(row)
+    for rel_path in file_order:
+        rows = by_file[rel_path]
+        for index, row in enumerate(rows):
+            previous = rows[index - 1] if index > 0 else None
+            following = rows[index + 1] if index + 1 < len(rows) else None
+            row["context"] = {
+                "previous": (
+                    {
+                        "source": previous["source"],
+                        "current_translation": previous["current_translation"],
+                    }
+                    if previous is not None
+                    else None
+                ),
+                "next": (
+                    {
+                        "source": following["source"],
+                        "current_translation": following["current_translation"],
+                    }
+                    if following is not None
+                    else None
+                ),
+            }
+    return items
+
+
+def build_corpus_items(
+    file_jobs: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Build deterministic corpus rows (and diagnostics) from revision scan jobs.
+
+    Jobs are explicitly sorted by rel path so item order is stable regardless
+    of caller ordering; items keep their in-file order and carry a per-file
+    1-based ordinal. Duplicate source text keeps distinct occurrences through
+    ``identity_v2`` instead of being deduplicated by text. Non-numeric locator
+    values degrade to 0 and produce a ``LOCATOR_NON_NUMERIC`` diagnostic instead
+    of aborting the export.
     """
     items: list[dict[str, Any]] = []
-    for job in file_jobs:
+    diagnostics: list[dict[str, Any]] = []
+    ordered_jobs = sorted(
+        file_jobs,
+        key=lambda job: str(job.get("file_rel_path") or ""),
+    )
+    for job in ordered_jobs:
         file_rel_path = str(job.get("file_rel_path") or "")
         for ordinal, item in enumerate(job.get("items") or [], start=1):
             identity_v2 = str(item.get("identity_v2") or item.get("id") or "")
             source = str(item.get("source") or "")
             current_translation = str(item.get("current_translation") or "")
-            try:
-                line_number = int(item.get("line_number") or 0)
-            except (TypeError, ValueError):
-                line_number = 0
+            line, line_diag = _int_or_zero(item.get("line"))
+            start, start_diag = _int_or_zero(item.get("start"))
+            end, end_diag = _int_or_zero(item.get("end"))
+            line_number, line_number_diag = _int_or_zero(item.get("line_number"))
+            for field, diagnostic in (
+                ("line", line_diag),
+                ("start", start_diag),
+                ("end", end_diag),
+                ("line_number", line_number_diag),
+            ):
+                if diagnostic is not None:
+                    diagnostics.append(
+                        {
+                            "code": "LOCATOR_NON_NUMERIC",
+                            "identity_v2": identity_v2,
+                            "field": field,
+                            "value": diagnostic,
+                        }
+                    )
             row = {
                 "schema_version": REVISION_CORPUS_SCHEMA_VERSION,
                 "occurrence_id": identity_v2,
                 "identity_v2": identity_v2,
                 "file_rel_path": file_rel_path,
                 "locator": {
-                    "line": int(item.get("line") or 0),
+                    "line": line,
                     "line_number": line_number,
-                    "start": int(item.get("start") or 0),
-                    "end": int(item.get("end") or 0),
+                    "start": start,
+                    "end": end,
                     "ordinal": ordinal,
                 },
                 "display_line": line_number,
@@ -98,7 +168,7 @@ def build_corpus_items(file_jobs: Sequence[Mapping[str, Any]]) -> list[dict[str,
                 ),
             }
             items.append(row)
-    return items
+    return _attach_adjacent_context(items), diagnostics
 
 
 def render_corpus_markdown(
@@ -155,7 +225,7 @@ def export_revision_corpus(
     files changed while the scan was running. ``_output_dir`` / ``_manifest_path``
     are CLI-facing conveniences and are not persisted inside the manifest file.
     """
-    items = build_corpus_items(file_jobs)
+    items, diagnostics = build_corpus_items(file_jobs)
     os.makedirs(output_dir, exist_ok=True)
     jsonl_path = os.path.abspath(os.path.join(output_dir, CORPUS_JSONL_NAME))
     markdown_path = os.path.abspath(os.path.join(output_dir, CORPUS_MARKDOWN_NAME))
@@ -168,9 +238,12 @@ def export_revision_corpus(
     )
 
     source_digests = dict(source_digests_before or {})
-    source_changed = source_digests_after is not None and (
-        source_digests_after != source_digests
-    )
+    scanned_files = {str(row.get("file_rel_path") or "") for row in items}
+    scanned_files_missing_digest = sorted(scanned_files - set(source_digests))
+    source_changed = (
+        source_digests_after is not None
+        and source_digests_after != source_digests
+    ) or bool(scanned_files_missing_digest)
     manifest = {
         "schema_version": REVISION_CORPUS_SCHEMA_VERSION,
         "kind": "revision_corpus",
@@ -186,16 +259,27 @@ def export_revision_corpus(
         "scanner": {
             "engine": SCANNER_ENGINE,
             "identity_schema": IDENTITY_SCHEMA,
+            "description": (
+                "Reuses the legacy revision scanner: translate-block old/new "
+                "pairs and comment translations recognized by the revision "
+                "entry collector. Other source content is outside the corpus scope."
+            ),
         },
         "source": {
             "snapshot_digest": aggregate_digest(source_digests),
             "file_digests": dict(sorted(source_digests.items())),
             "source_changed_during_scan": bool(source_changed),
+            "scanned_files_missing_digest": scanned_files_missing_digest,
         },
         "scope": {
             "file_count": len({str(row.get("file_rel_path") or "") for row in items}),
             "item_count": len(items),
+            "note": (
+                "Only revision-scanner-recognized old/new and comment-translation "
+                "entries are included; other source content is outside the corpus scope."
+            ),
         },
+        "diagnostics": diagnostics,
         "paths": {
             "output_dir": os.path.abspath(output_dir),
             "jsonl": jsonl_path,

--- a/revision_corpus.py
+++ b/revision_corpus.py
@@ -218,6 +218,7 @@ def export_revision_corpus(
     source_digests_before: Mapping[str, str] | None = None,
     source_digests_after: Mapping[str, str] | None = None,
     source_digests_scanned: Mapping[str, str] | None = None,
+    file_line_counts: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Write JSONL + Markdown + manifest into ``output_dir``; return the manifest.
 
@@ -231,6 +232,21 @@ def export_revision_corpus(
     persisted inside the manifest file.
     """
     items, diagnostics = build_corpus_items(file_jobs)
+    item_count_by_file: dict[str, int] = {}
+    for row in items:
+        rel_path = str(row.get("file_rel_path") or "")
+        item_count_by_file[rel_path] = item_count_by_file.get(rel_path, 0) + 1
+    line_counts = {
+        str(rel_path): int(count or 0)
+        for rel_path, count in (file_line_counts or {}).items()
+    }
+    file_summaries = {
+        rel_path: {
+            "line_count": line_counts.get(rel_path, 0),
+            "item_count": item_count_by_file.get(rel_path, 0),
+        }
+        for rel_path in sorted(set(line_counts) | set(item_count_by_file))
+    }
     os.makedirs(output_dir, exist_ok=True)
     jsonl_path = os.path.abspath(os.path.join(output_dir, CORPUS_JSONL_NAME))
     markdown_path = os.path.abspath(os.path.join(output_dir, CORPUS_MARKDOWN_NAME))
@@ -297,6 +313,18 @@ def export_revision_corpus(
                 "entries are included; other source content is outside the corpus scope."
             ),
         },
+        "coverage": {
+            "mode": "revision_recognized_only",
+            "scanned_file_count": len(file_summaries),
+            "recognized_item_count": len(items),
+            "note": (
+                "Every in-scope TL file was scanned by the revision entry "
+                "collector; per-file line/item counts are reported in "
+                "file_summaries so unrecognized content is visible instead of "
+                "silently dropped."
+            ),
+        },
+        "file_summaries": file_summaries,
         "diagnostics": diagnostics,
         "paths": {
             "output_dir": os.path.abspath(output_dir),

--- a/revision_corpus.py
+++ b/revision_corpus.py
@@ -1,0 +1,209 @@
+"""Read-only export of the revision (old/new) polishing corpus.
+
+P1 of #318: a stable, deterministic, auditable export contract consumed by
+human reviewers and Agent batching. This module never modifies ``.rpy`` files,
+manifests, glossary, or RAG state; write-back remains exclusively behind the
+existing ``preview-revisions`` / ``apply-revisions`` gates.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
+
+REVISION_CORPUS_SCHEMA_VERSION = 1
+CORPUS_JSONL_NAME = "revision_corpus.jsonl"
+CORPUS_MARKDOWN_NAME = "revision_corpus.md"
+CORPUS_MANIFEST_NAME = "revision_corpus_manifest.json"
+SCANNER_ENGINE = "renpy-legacy-revision-scan-v1"
+IDENTITY_SCHEMA = "identity_v2"
+
+
+def stable_text_sha256(value: str) -> str:
+    """Return the stable UTF-8 SHA-256 of ``value``."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def item_snapshot_digest(source: str, current_translation: str) -> str:
+    """Digest of one old/new pair; the safety anchor for future proposals."""
+    return stable_text_sha256(f"source\0{source}\0current\0{current_translation}")
+
+
+def collect_file_digests(file_paths: Mapping[str, str]) -> dict[str, str]:
+    """Map rel path -> content SHA-256 over a stable rel-path ordering.
+
+    Unreadable or missing files raise so a partial corpus can never be
+    presented as a complete snapshot.
+    """
+    digests: dict[str, str] = {}
+    for rel_path in sorted(file_paths):
+        with open(file_paths[rel_path], "rb") as handle:
+            digests[rel_path] = hashlib.sha256(handle.read()).hexdigest()
+    return digests
+
+
+def aggregate_digest(digests: Mapping[str, str]) -> str:
+    """Stable aggregate digest over a sorted rel-path digest map."""
+    payload = json.dumps(
+        {rel_path: digests[rel_path] for rel_path in sorted(digests)},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return stable_text_sha256(payload)
+
+
+def build_corpus_items(file_jobs: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Build deterministic corpus rows from revision scan jobs.
+
+    ``file_jobs`` must already be in a stable order (the CLI sorts files by rel
+    path); items keep their in-file order and carry a per-file 1-based ordinal.
+    Duplicate source text keeps distinct occurrences through ``identity_v2``
+    instead of being deduplicated by text.
+    """
+    items: list[dict[str, Any]] = []
+    for job in file_jobs:
+        file_rel_path = str(job.get("file_rel_path") or "")
+        for ordinal, item in enumerate(job.get("items") or [], start=1):
+            identity_v2 = str(item.get("identity_v2") or item.get("id") or "")
+            source = str(item.get("source") or "")
+            current_translation = str(item.get("current_translation") or "")
+            try:
+                line_number = int(item.get("line_number") or 0)
+            except (TypeError, ValueError):
+                line_number = 0
+            row = {
+                "schema_version": REVISION_CORPUS_SCHEMA_VERSION,
+                "occurrence_id": identity_v2,
+                "identity_v2": identity_v2,
+                "file_rel_path": file_rel_path,
+                "locator": {
+                    "line": int(item.get("line") or 0),
+                    "line_number": line_number,
+                    "start": int(item.get("start") or 0),
+                    "end": int(item.get("end") or 0),
+                    "ordinal": ordinal,
+                },
+                "display_line": line_number,
+                "speaker_id": str(item.get("speaker_id") or ""),
+                "source": source,
+                "current_translation": current_translation,
+                "snapshot_digest": item_snapshot_digest(
+                    source,
+                    current_translation,
+                ),
+            }
+            items.append(row)
+    return items
+
+
+def render_corpus_markdown(
+    items: Sequence[Mapping[str, Any]],
+    *,
+    project_slug: str,
+) -> str:
+    """Render a linear human-review report; one section per file."""
+    lines = [
+        f"# 润色语料：{project_slug}",
+        "",
+        f"- 条目数：{len(items)}",
+        f"- schema：revision-corpus v{REVISION_CORPUS_SCHEMA_VERSION}",
+        "",
+    ]
+    current_file: str | None = None
+    for row in items:
+        file_rel_path = str(row.get("file_rel_path") or "")
+        if file_rel_path != current_file:
+            if current_file is not None:
+                lines.append("")
+            current_file = file_rel_path
+            lines.append(f"## {file_rel_path}")
+            lines.append("")
+        locator = row.get("locator") or {}
+        try:
+            line_number = int(locator.get("line_number") or 0)
+        except (TypeError, ValueError):
+            line_number = 0
+        speaker = str(row.get("speaker_id") or "").strip()
+        speaker_label = f" [{speaker}]" if speaker else ""
+        lines.append(f"- L{line_number}{speaker_label}：{row.get('source') or ''}")
+        lines.append(f"  → {row.get('current_translation') or ''}")
+    return "\n".join(lines) + "\n"
+
+
+def export_revision_corpus(
+    output_dir: str,
+    file_jobs: Sequence[Mapping[str, Any]],
+    *,
+    project_slug: str,
+    game_root: str,
+    tl_dir: str,
+    tl_subdir: str,
+    include_files: Sequence[str] = (),
+    include_prefixes: Sequence[str] = (),
+    source_digests_before: Mapping[str, str] | None = None,
+    source_digests_after: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Write JSONL + Markdown + manifest into ``output_dir``; return the manifest.
+
+    The manifest carries project identity, scanner/schema identity, the source
+    snapshot digest (per-file and aggregate), scope counts, and whether source
+    files changed while the scan was running. ``_output_dir`` / ``_manifest_path``
+    are CLI-facing conveniences and are not persisted inside the manifest file.
+    """
+    items = build_corpus_items(file_jobs)
+    os.makedirs(output_dir, exist_ok=True)
+    jsonl_path = os.path.abspath(os.path.join(output_dir, CORPUS_JSONL_NAME))
+    markdown_path = os.path.abspath(os.path.join(output_dir, CORPUS_MARKDOWN_NAME))
+    manifest_path = os.path.abspath(os.path.join(output_dir, CORPUS_MANIFEST_NAME))
+
+    atomic_write_jsonl(jsonl_path, items, ensure_ascii=False)
+    atomic_write_text(
+        markdown_path,
+        render_corpus_markdown(items, project_slug=project_slug),
+    )
+
+    source_digests = dict(source_digests_before or {})
+    source_changed = source_digests_after is not None and (
+        source_digests_after != source_digests
+    )
+    manifest = {
+        "schema_version": REVISION_CORPUS_SCHEMA_VERSION,
+        "kind": "revision_corpus",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "project": {
+            "slug": project_slug,
+            "game_root": os.path.abspath(game_root) if game_root else "",
+            "tl_dir": os.path.abspath(tl_dir) if tl_dir else "",
+            "tl_subdir": tl_subdir,
+            "include_files": sorted(include_files),
+            "include_prefixes": sorted(include_prefixes),
+        },
+        "scanner": {
+            "engine": SCANNER_ENGINE,
+            "identity_schema": IDENTITY_SCHEMA,
+        },
+        "source": {
+            "snapshot_digest": aggregate_digest(source_digests),
+            "file_digests": dict(sorted(source_digests.items())),
+            "source_changed_during_scan": bool(source_changed),
+        },
+        "scope": {
+            "file_count": len({str(row.get("file_rel_path") or "") for row in items}),
+            "item_count": len(items),
+        },
+        "paths": {
+            "output_dir": os.path.abspath(output_dir),
+            "jsonl": jsonl_path,
+            "markdown": markdown_path,
+            "manifest": manifest_path,
+        },
+    }
+    atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+    manifest["_output_dir"] = os.path.abspath(output_dir)
+    manifest["_manifest_path"] = manifest_path
+    return manifest

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1019,6 +1019,14 @@ class BatchCliContractTests(unittest.TestCase):
                                 batch, "export_keyword_candidates", return_value=None
                             )
                         )
+                    elif command == "export-revision-corpus":
+                        handler_patches.append(
+                            mock.patch.object(
+                                batch,
+                                "run_revision_corpus_export",
+                                return_value={"paths": {}, "scope": {}},
+                            )
+                        )
                     elif command == "merge-keywords-to-glossary":
                         handler_patches.extend(
                             [
@@ -1047,6 +1055,8 @@ class BatchCliContractTests(unittest.TestCase):
                             argv = ["merge-retry", "parent.json", "retry.json"]
                         elif command == "merge-keywords-to-glossary":
                             argv = ["merge-keywords-to-glossary", "candidates.jsonl", "--yes"]
+                        elif command == "export-revision-corpus":
+                            argv = ["export-revision-corpus"]
                         else:
                             argv = [command, "manifest.json"]
                         exit_code = batch.main(argv)

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -1062,7 +1062,12 @@ class BatchCliContractTests(unittest.TestCase):
                         exit_code = batch.main(argv)
 
                 self.assertEqual(exit_code, 0)
-                load_config.assert_called_once_with(require_api_key=False)
+                if command == "export-revision-corpus":
+                    # Read-only export takes an early dispatch path that must
+                    # not load (or rewrite) API-key / translator config.
+                    load_config.assert_not_called()
+                else:
+                    load_config.assert_called_once_with(require_api_key=False)
 
     def test_remote_batch_commands_still_require_api_key(self):
         load_config = mock.Mock()

--- a/tests/test_revision_corpus.py
+++ b/tests/test_revision_corpus.py
@@ -156,6 +156,28 @@ class RevisionCorpusExportTests(unittest.TestCase):
         self.assertEqual(comment[0]["current_translation"], "这扇门通向虚空。")
         self.assertEqual(comment[0]["file_rel_path"], "chapter03/comments.rpy")
 
+    def test_crlf_files_parse_like_universal_newlines(self):
+        chapter = self.tl_dir / "chapter05"
+        chapter.mkdir(parents=True, exist_ok=True)
+        (chapter / "crlf.rpy").write_bytes(
+            (
+                "translate schinese chapter05_terms:\r\n"
+                "    old \"CRLF Gate\"\r\n"
+                "    new \"回车门\"\r\n"
+            ).encode("utf-8")
+        )
+        jobs = batch.collect_revision_file_jobs(include_empty_files=True)
+        rows, _ = revision_corpus.build_corpus_items(jobs)
+        crlf = [row for row in rows if row["file_rel_path"] == "chapter05/crlf.rpy"]
+        self.assertEqual(len(crlf), 1)
+        self.assertEqual(crlf[0]["source"], "CRLF Gate")
+        self.assertEqual(crlf[0]["current_translation"], "回车门")
+        self.assertEqual(crlf[0]["locator"]["line_number"], 3)
+        crlf_job = next(
+            job for job in jobs if job["file_rel_path"] == "chapter05/crlf.rpy"
+        )
+        self.assertEqual(crlf_job["line_count"], 3)
+
     def test_empty_files_appear_in_coverage_summary(self):
         self._write_tl("chapter04/empty.rpy", "# only a comment, no entries\n")
         jobs = batch.collect_revision_file_jobs(include_empty_files=True)

--- a/tests/test_revision_corpus.py
+++ b/tests/test_revision_corpus.py
@@ -68,8 +68,9 @@ class RevisionCorpusExportTests(unittest.TestCase):
         target.write_text(text, encoding="utf-8")
         return target
 
-    def _export(self, output_dir: Path, **kwargs):
-        jobs = batch.collect_revision_file_jobs()
+    def _export(self, output_dir: Path, *, jobs=None, **kwargs):
+        if jobs is None:
+            jobs = batch.collect_revision_file_jobs()
         defaults = {
             "project_slug": "demo",
             "game_root": str(self.root),
@@ -81,7 +82,14 @@ class RevisionCorpusExportTests(unittest.TestCase):
 
     def test_export_writes_jsonl_markdown_and_manifest(self):
         out = self.root / "out"
-        manifest = self._export(out)
+        jobs = batch.collect_revision_file_jobs()
+        manifest = self._export(
+            out,
+            jobs=jobs,
+            file_line_counts={
+                job["file_rel_path"]: job["line_count"] for job in jobs
+            },
+        )
 
         jsonl_path = out / "revision_corpus.jsonl"
         md_path = out / "revision_corpus.md"
@@ -98,6 +106,13 @@ class RevisionCorpusExportTests(unittest.TestCase):
         self.assertGreaterEqual(len(rows), 3)
         self.assertEqual(manifest["scope"]["item_count"], len(rows))
         self.assertEqual(manifest["scope"]["file_count"], 1)
+        self.assertIn("file_summaries", manifest)
+        first_summary = manifest["file_summaries"]["chapter01/revisions.rpy"]
+        self.assertEqual(first_summary["item_count"], 3)
+        self.assertGreaterEqual(first_summary["line_count"], 1)
+        self.assertEqual(manifest["coverage"]["mode"], "revision_recognized_only")
+        self.assertEqual(manifest["coverage"]["recognized_item_count"], len(rows))
+        self.assertEqual(manifest["coverage"]["scanned_file_count"], 1)
         md = md_path.read_text(encoding="utf-8")
         self.assertEqual(md.count("- L"), len(rows))
         for row in rows:
@@ -140,6 +155,28 @@ class RevisionCorpusExportTests(unittest.TestCase):
         self.assertEqual(len(comment), 1)
         self.assertEqual(comment[0]["current_translation"], "这扇门通向虚空。")
         self.assertEqual(comment[0]["file_rel_path"], "chapter03/comments.rpy")
+
+    def test_empty_files_appear_in_coverage_summary(self):
+        self._write_tl("chapter04/empty.rpy", "# only a comment, no entries\n")
+        jobs = batch.collect_revision_file_jobs(include_empty_files=True)
+        rows, _ = revision_corpus.build_corpus_items(jobs)
+        line_counts = {
+            job["file_rel_path"]: job["line_count"] for job in jobs
+        }
+        manifest = revision_corpus.export_revision_corpus(
+            str(self.root / "out"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            file_line_counts=line_counts,
+        )
+        summary = manifest["file_summaries"]["chapter04/empty.rpy"]
+        self.assertEqual(summary["item_count"], 0)
+        self.assertGreaterEqual(summary["line_count"], 1)
+        self.assertEqual(manifest["coverage"]["scanned_file_count"], 2)
+        self.assertEqual(len(rows), 3)  # empty file contributes no items
 
     def test_export_is_deterministic(self):
         out1 = self.root / "out1"
@@ -495,6 +532,9 @@ class RevisionCorpusExportTests(unittest.TestCase):
         with open(manifest_path, encoding="utf-8") as handle:
             persisted = json.load(handle)
         self.assertEqual(persisted["kind"], "revision_corpus")
+        self.assertIn("file_summaries", persisted)
+        self.assertIn("coverage", persisted)
+        self.assertGreaterEqual(persisted["coverage"]["scanned_file_count"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_revision_corpus.py
+++ b/tests/test_revision_corpus.py
@@ -1,0 +1,319 @@
+"""Read-only revision corpus export tests (#320 / Epic #318 P1)."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch
+import revision_corpus
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "golden_revision_minimal" / "tl"
+
+
+class RevisionCorpusExportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.tl_dir = self.root / "game" / "tl" / "schinese"
+        self.tl_dir.mkdir(parents=True)
+        shutil.copytree(FIXTURE, self.tl_dir, dirs_exist_ok=True)
+        self.old = {
+            "base": batch.legacy.BASE_DIR,
+            "tl": batch.legacy.TL_DIR,
+            "files": set(batch.legacy.INCLUDE_FILES),
+            "prefixes": set(batch.legacy.INCLUDE_PREFIXES),
+            "log": batch.LOG_DIR,
+            "jobs": batch.BATCH_JOBS_DIR,
+            "latest": batch.LATEST_MANIFEST_FILE,
+            "progress": batch.PROGRESS_LOG,
+            "rag": batch.RAG_ENABLED,
+            "story": batch.STORY_MEMORY_ENABLED,
+        }
+        log_dir = self.root / "logs"
+        batch.legacy.BASE_DIR = str(self.root)
+        batch.legacy.TL_DIR = str(self.tl_dir)
+        batch.legacy.INCLUDE_FILES = set()
+        batch.legacy.INCLUDE_PREFIXES = set()
+        batch.LOG_DIR = str(log_dir)
+        batch.BATCH_JOBS_DIR = str(log_dir / "batch_jobs")
+        batch.LATEST_MANIFEST_FILE = str(log_dir / "batch_jobs" / "latest_manifest.txt")
+        batch.PROGRESS_LOG = str(log_dir / "translation_progress_batch.json")
+        batch.RAG_ENABLED = False
+        batch.STORY_MEMORY_ENABLED = False
+
+    def tearDown(self):
+        batch.legacy.BASE_DIR = self.old["base"]
+        batch.legacy.TL_DIR = self.old["tl"]
+        batch.legacy.INCLUDE_FILES = self.old["files"]
+        batch.legacy.INCLUDE_PREFIXES = self.old["prefixes"]
+        batch.LOG_DIR = self.old["log"]
+        batch.BATCH_JOBS_DIR = self.old["jobs"]
+        batch.LATEST_MANIFEST_FILE = self.old["latest"]
+        batch.PROGRESS_LOG = self.old["progress"]
+        batch.RAG_ENABLED = self.old["rag"]
+        batch.STORY_MEMORY_ENABLED = self.old["story"]
+        self.temp.cleanup()
+
+    def _write_tl(self, rel_path: str, text: str) -> Path:
+        target = self.tl_dir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+        return target
+
+    def _export(self, output_dir: Path, **kwargs):
+        jobs = batch.collect_revision_file_jobs()
+        defaults = {
+            "project_slug": "demo",
+            "game_root": str(self.root),
+            "tl_dir": str(self.tl_dir),
+            "tl_subdir": "game/tl/schinese",
+        }
+        defaults.update(kwargs)
+        return revision_corpus.export_revision_corpus(str(output_dir), jobs, **defaults)
+
+    def test_export_writes_jsonl_markdown_and_manifest(self):
+        out = self.root / "out"
+        manifest = self._export(out)
+
+        jsonl_path = out / "revision_corpus.jsonl"
+        md_path = out / "revision_corpus.md"
+        manifest_path = out / "revision_corpus_manifest.json"
+        self.assertTrue(jsonl_path.is_file())
+        self.assertTrue(md_path.is_file())
+        self.assertTrue(manifest_path.is_file())
+
+        rows = [
+            json.loads(line)
+            for line in jsonl_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.assertGreaterEqual(len(rows), 3)
+        self.assertEqual(manifest["scope"]["item_count"], len(rows))
+        self.assertEqual(manifest["scope"]["file_count"], 1)
+        md = md_path.read_text(encoding="utf-8")
+        self.assertEqual(md.count("- L"), len(rows))
+        for row in rows:
+            self.assertEqual(
+                row["schema_version"],
+                revision_corpus.REVISION_CORPUS_SCHEMA_VERSION,
+            )
+            self.assertTrue(row["occurrence_id"])
+            self.assertEqual(row["file_rel_path"], "chapter01/revisions.rpy")
+            self.assertGreaterEqual(row["locator"]["line_number"], 1)
+            self.assertGreaterEqual(row["locator"]["ordinal"], 1)
+            self.assertTrue(row["snapshot_digest"])
+
+    def test_duplicate_source_keeps_distinct_occurrences(self):
+        self._write_tl(
+            "chapter02/dups.rpy",
+            'translate schinese chapter02_terms:\n'
+            '    old "Repeat Me"\n'
+            '    new "重复我"\n'
+            '\n'
+            '    old "Repeat Me"\n'
+            '    new "重复我二号"\n',
+        )
+        rows = revision_corpus.build_corpus_items(batch.collect_revision_file_jobs())
+        repeats = [row for row in rows if row["source"] == "Repeat Me"]
+        self.assertEqual(len(repeats), 2)
+        self.assertNotEqual(repeats[0]["occurrence_id"], repeats[1]["occurrence_id"])
+
+    def test_comment_translations_are_exported(self):
+        self._write_tl(
+            "chapter03/comments.rpy",
+            '# 艾琳 "这扇门通往虚空。"\n"这扇门通向虚空。"\n',
+        )
+        rows = revision_corpus.build_corpus_items(batch.collect_revision_file_jobs())
+        comment = [row for row in rows if row["source"] == "这扇门通往虚空。"]
+        self.assertEqual(len(comment), 1)
+        self.assertEqual(comment[0]["current_translation"], "这扇门通向虚空。")
+        self.assertEqual(comment[0]["file_rel_path"], "chapter03/comments.rpy")
+
+    def test_export_is_deterministic(self):
+        out1 = self.root / "out1"
+        out2 = self.root / "out2"
+        self._export(out1)
+        self._export(out2)
+        self.assertEqual(
+            (out1 / "revision_corpus.jsonl").read_bytes(),
+            (out2 / "revision_corpus.jsonl").read_bytes(),
+        )
+        self.assertEqual(
+            (out1 / "revision_corpus.md").read_bytes(),
+            (out2 / "revision_corpus.md").read_bytes(),
+        )
+
+    def test_manifest_contains_project_and_snapshot_identity(self):
+        file_paths = {
+            rel_path: file_path
+            for rel_path, file_path in batch.collect_files_to_process()
+        }
+        digests = revision_corpus.collect_file_digests(file_paths)
+        manifest = self._export(
+            self.root / "out",
+            include_files=["a.rpy"],
+            include_prefixes=["chapter"],
+            source_digests_before=digests,
+            source_digests_after=digests,
+        )
+        self.assertEqual(manifest["kind"], "revision_corpus")
+        self.assertEqual(manifest["project"]["slug"], "demo")
+        self.assertEqual(manifest["project"]["game_root"], str(self.root))
+        self.assertEqual(manifest["project"]["tl_dir"], str(self.tl_dir))
+        self.assertEqual(manifest["project"]["tl_subdir"], "game/tl/schinese")
+        self.assertEqual(manifest["project"]["include_files"], ["a.rpy"])
+        self.assertEqual(manifest["project"]["include_prefixes"], ["chapter"])
+        self.assertEqual(
+            manifest["source"]["snapshot_digest"],
+            revision_corpus.aggregate_digest(digests),
+        )
+        self.assertEqual(
+            manifest["source"]["file_digests"],
+            dict(sorted(digests.items())),
+        )
+        self.assertFalse(manifest["source"]["source_changed_during_scan"])
+        self.assertEqual(
+            manifest["scanner"]["engine"],
+            revision_corpus.SCANNER_ENGINE,
+        )
+
+    def test_source_changed_during_scan_is_flagged(self):
+        jobs = []
+        changed = revision_corpus.export_revision_corpus(
+            str(self.root / "out1"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            source_digests_before={"a.rpy": "digest-1"},
+            source_digests_after={"a.rpy": "digest-2"},
+        )
+        self.assertTrue(changed["source"]["source_changed_during_scan"])
+
+        stable = revision_corpus.export_revision_corpus(
+            str(self.root / "out2"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            source_digests_before={"a.rpy": "digest-1"},
+            source_digests_after={"a.rpy": "digest-1"},
+        )
+        self.assertFalse(stable["source"]["source_changed_during_scan"])
+
+    def test_build_corpus_items_preserves_speaker_and_locator_fields(self):
+        jobs = [
+            {
+                "file_rel_path": "a.rpy",
+                "items": [
+                    {
+                        "id": "fallback-id",
+                        "identity_v2": "id-1",
+                        "source": "Hello",
+                        "current_translation": "你好",
+                        "line_number": 3,
+                        "line": 2,
+                        "start": 4,
+                        "end": 11,
+                        "speaker_id": "alice",
+                    }
+                ],
+            }
+        ]
+        rows = revision_corpus.build_corpus_items(jobs)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["identity_v2"], "id-1")
+        self.assertEqual(row["occurrence_id"], "id-1")
+        self.assertEqual(row["speaker_id"], "alice")
+        self.assertEqual(row["locator"]["line_number"], 3)
+        self.assertEqual(row["locator"]["ordinal"], 1)
+        self.assertEqual(row["display_line"], 3)
+        self.assertEqual(row["source"], "Hello")
+        self.assertEqual(row["current_translation"], "你好")
+
+    def test_cli_registers_offline_machine_command(self):
+        self.assertIn("export-revision-corpus", batch.MACHINE_OUTPUT_COMMANDS)
+        self.assertIn("export-revision-corpus", batch.OFFLINE_BATCH_COMMANDS)
+        parser = batch.build_arg_parser()
+        args = parser.parse_args(
+            ["export-revision-corpus", "--output-dir", "x", "--output", "json"]
+        )
+        self.assertEqual(args.command, "export-revision-corpus")
+        self.assertEqual(args.output_dir, "x")
+        self.assertEqual(args.output, "json")
+
+    def test_cli_machine_envelope_reports_artifacts(self):
+        manifest_value = {
+            "paths": {
+                "output_dir": "C:/out",
+                "jsonl": "C:/out/revision_corpus.jsonl",
+                "markdown": "C:/out/revision_corpus.md",
+                "manifest": "C:/out/revision_corpus_manifest.json",
+            },
+            "scope": {"file_count": 2, "item_count": 5},
+            "source": {"source_changed_during_scan": False},
+        }
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest_value),
+            redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(["export-revision-corpus", "--output", "json"])
+
+        self.assertEqual(exit_code, 0)
+        envelope = json.loads(stdout.getvalue())
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["command"], "export-revision-corpus")
+        self.assertEqual(envelope["status"], "completed")
+        self.assertEqual(envelope["result"]["item_count"], 5)
+        self.assertEqual(envelope["result"]["file_count"], 2)
+        self.assertEqual(
+            envelope["artifacts"]["corpus_jsonl"],
+            "C:/out/revision_corpus.jsonl",
+        )
+        self.assertEqual(
+            envelope["artifacts"]["corpus_manifest"],
+            "C:/out/revision_corpus_manifest.json",
+        )
+
+    def test_end_to_end_cli_export(self):
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "initialize_batch_logging"),
+            redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(["export-revision-corpus", "--output", "json"])
+
+        self.assertEqual(exit_code, 0)
+        envelope = json.loads(stdout.getvalue())
+        self.assertTrue(envelope["ok"])
+        jsonl_path = envelope["result"]["corpus_jsonl"]
+        self.assertTrue(os.path.isfile(jsonl_path))
+        with open(jsonl_path, encoding="utf-8") as handle:
+            rows = [
+                json.loads(line) for line in handle if line.strip()
+            ]
+        self.assertEqual(envelope["result"]["item_count"], len(rows))
+        self.assertGreaterEqual(len(rows), 3)
+        manifest_path = envelope["result"]["corpus_manifest"]
+        with open(manifest_path, encoding="utf-8") as handle:
+            persisted = json.load(handle)
+        self.assertEqual(persisted["kind"], "revision_corpus")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_revision_corpus.py
+++ b/tests/test_revision_corpus.py
@@ -121,7 +121,9 @@ class RevisionCorpusExportTests(unittest.TestCase):
             '    old "Repeat Me"\n'
             '    new "重复我二号"\n',
         )
-        rows = revision_corpus.build_corpus_items(batch.collect_revision_file_jobs())
+        rows, _ = revision_corpus.build_corpus_items(
+            batch.collect_revision_file_jobs()
+        )
         repeats = [row for row in rows if row["source"] == "Repeat Me"]
         self.assertEqual(len(repeats), 2)
         self.assertNotEqual(repeats[0]["occurrence_id"], repeats[1]["occurrence_id"])
@@ -131,7 +133,9 @@ class RevisionCorpusExportTests(unittest.TestCase):
             "chapter03/comments.rpy",
             '# 艾琳 "这扇门通往虚空。"\n"这扇门通向虚空。"\n',
         )
-        rows = revision_corpus.build_corpus_items(batch.collect_revision_file_jobs())
+        rows, _ = revision_corpus.build_corpus_items(
+            batch.collect_revision_file_jobs()
+        )
         comment = [row for row in rows if row["source"] == "这扇门通往虚空。"]
         self.assertEqual(len(comment), 1)
         self.assertEqual(comment[0]["current_translation"], "这扇门通向虚空。")
@@ -211,6 +215,126 @@ class RevisionCorpusExportTests(unittest.TestCase):
         )
         self.assertFalse(stable["source"]["source_changed_during_scan"])
 
+    def test_scanned_files_without_digest_are_flagged(self):
+        jobs = [
+            {
+                "file_rel_path": "chapter01/revisions.rpy",
+                "items": [
+                    {
+                        "id": "id-1",
+                        "source": "S",
+                        "current_translation": "T",
+                        "line_number": 1,
+                    }
+                ],
+            }
+        ]
+        manifest = revision_corpus.export_revision_corpus(
+            str(self.root / "out"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            source_digests_before={},
+            source_digests_after={},
+        )
+        self.assertTrue(manifest["source"]["source_changed_during_scan"])
+        self.assertEqual(
+            manifest["source"]["scanned_files_missing_digest"],
+            ["chapter01/revisions.rpy"],
+        )
+
+    def test_locator_non_numeric_produces_diagnostic(self):
+        jobs = [
+            {
+                "file_rel_path": "a.rpy",
+                "items": [
+                    {
+                        "id": "id-1",
+                        "source": "S",
+                        "current_translation": "T",
+                        "line": "oops",
+                        "line_number": 3,
+                        "start": 1,
+                        "end": "x",
+                    }
+                ],
+            }
+        ]
+        rows, diagnostics = revision_corpus.build_corpus_items(jobs)
+        self.assertEqual(rows[0]["locator"]["line"], 0)
+        self.assertEqual(rows[0]["locator"]["end"], 0)
+        self.assertEqual(rows[0]["locator"]["line_number"], 3)
+        self.assertEqual(
+            {entry["field"] for entry in diagnostics},
+            {"line", "end"},
+        )
+        self.assertTrue(
+            all(entry["code"] == "LOCATOR_NON_NUMERIC" for entry in diagnostics)
+        )
+
+    def test_context_links_adjacent_items(self):
+        jobs = [
+            {
+                "file_rel_path": "a.rpy",
+                "items": [
+                    {
+                        "id": "id-1",
+                        "source": "First",
+                        "current_translation": "第一",
+                        "line_number": 1,
+                    },
+                    {
+                        "id": "id-2",
+                        "source": "Second",
+                        "current_translation": "第二",
+                        "line_number": 2,
+                    },
+                ],
+            }
+        ]
+        rows, _ = revision_corpus.build_corpus_items(jobs)
+        self.assertIsNone(rows[0]["context"]["previous"])
+        self.assertEqual(
+            rows[0]["context"]["next"],
+            {"source": "Second", "current_translation": "第二"},
+        )
+        self.assertEqual(
+            rows[1]["context"]["previous"],
+            {"source": "First", "current_translation": "第一"},
+        )
+        self.assertIsNone(rows[1]["context"]["next"])
+
+    def test_build_corpus_items_sorts_files_explicitly(self):
+        jobs = [
+            {
+                "file_rel_path": "z.rpy",
+                "items": [
+                    {
+                        "id": "z-1",
+                        "source": "Z",
+                        "current_translation": "Z译",
+                    }
+                ],
+            },
+            {
+                "file_rel_path": "a.rpy",
+                "items": [
+                    {
+                        "id": "a-1",
+                        "source": "A",
+                        "current_translation": "A译",
+                    }
+                ],
+            },
+        ]
+        rows, _ = revision_corpus.build_corpus_items(jobs)
+        self.assertEqual(
+            [row["file_rel_path"] for row in rows],
+            ["a.rpy", "z.rpy"],
+        )
+
     def test_build_corpus_items_preserves_speaker_and_locator_fields(self):
         jobs = [
             {
@@ -230,7 +354,7 @@ class RevisionCorpusExportTests(unittest.TestCase):
                 ],
             }
         ]
-        rows = revision_corpus.build_corpus_items(jobs)
+        rows, _ = revision_corpus.build_corpus_items(jobs)
         self.assertEqual(len(rows), 1)
         row = rows[0]
         self.assertEqual(row["identity_v2"], "id-1")

--- a/tests/test_revision_corpus.py
+++ b/tests/test_revision_corpus.py
@@ -245,6 +245,64 @@ class RevisionCorpusExportTests(unittest.TestCase):
             ["chapter01/revisions.rpy"],
         )
 
+    def test_scanned_digest_mismatch_is_flagged(self):
+        jobs = [
+            {
+                "file_rel_path": "a.rpy",
+                "items": [
+                    {
+                        "id": "id-1",
+                        "source": "S",
+                        "current_translation": "T",
+                        "line_number": 1,
+                    }
+                ],
+            }
+        ]
+        manifest = revision_corpus.export_revision_corpus(
+            str(self.root / "out"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            source_digests_before={"a.rpy": "digest-1"},
+            source_digests_after={"a.rpy": "digest-1"},
+            source_digests_scanned={"a.rpy": "digest-mid-scan"},
+        )
+        self.assertTrue(manifest["source"]["source_changed_during_scan"])
+        self.assertEqual(
+            manifest["source"]["scanned_files_digest_mismatch"],
+            ["a.rpy"],
+        )
+
+        stable = revision_corpus.export_revision_corpus(
+            str(self.root / "out2"),
+            jobs,
+            project_slug="demo",
+            game_root="",
+            tl_dir="",
+            tl_subdir="",
+            source_digests_before={"a.rpy": "digest-1"},
+            source_digests_after={"a.rpy": "digest-1"},
+            source_digests_scanned={"a.rpy": "digest-1"},
+        )
+        self.assertFalse(stable["source"]["source_changed_during_scan"])
+        self.assertEqual(
+            stable["source"]["scanned_files_digest_mismatch"],
+            [],
+        )
+
+    def test_revision_jobs_record_scanned_source_digest(self):
+        jobs = batch.collect_revision_file_jobs()
+        self.assertTrue(jobs)
+        self.assertTrue(all(job.get("source_digest") for job in jobs))
+        first = jobs[0]
+        expected = revision_corpus.collect_file_digests(
+            {first["file_rel_path"]: first["file_path"]}
+        )[first["file_rel_path"]]
+        self.assertEqual(first["source_digest"], expected)
+
     def test_locator_non_numeric_produces_diagnostic(self):
         jobs = [
             {


### PR DESCRIPTION
Closes #320

## 交付内容

只读润色语料导出 `export-revision-corpus`（Epic #318 P1），复用现有 revision 扫描与 `identity_v2` occurrence，不新建扫描器、不修改 `.rpy` / manifest / glossary / RAG。

### 核心（新模块 `revision_corpus.py`）

- 稳定 item schema：`schema_version`、`occurrence_id` / `identity_v2`、`file_rel_path`、`locator`（line / line_number / start / end / ordinal）、`display_line`、`speaker_id`（可得时）、`source`、`current_translation`、`snapshot_digest`（old/new 快照）。
- 每个 item 的 `snapshot_digest` 是后续 #321 提案写回安全的基础锚点。
- 源快照：per-file SHA-256 + aggregate digest 写入 manifest；导出前后重算，扫描期间源变化显式标记 `source_changed_during_scan`，绝不静默混入。
- 确定性：文件按相对路径排序、item 保持文件内顺序；重复原文通过 `identity_v2` 保持不同 occurrence，不按文本去重。

### CLI

- `python gemini_translate_batch.py export-revision-corpus [--output-dir DIR] [--output json]`
- 默认写入 `logs/batch_jobs/<timestamp>_<project>_revision_corpus/`，产物：
  - `revision_corpus.jsonl`（权威合同）
  - `revision_corpus.md`（人工线性通读）
  - `revision_corpus_manifest.json`（项目身份、scanner/schema、源快照 digest、范围）
- 已注册到 `MACHINE_OUTPUT_COMMANDS` 与 `OFFLINE_BATCH_COMMANDS`；JSON envelope 返回三个产物路径与 file/item 计数。

### 验收对照

- [x] 最小 old/new、注释译文、speaker、字符串块和重复原文 fixture 均能导出（测试覆盖）
- [x] 重复原文保持不同 occurrence，不按文本去重
- [x] 文件与 item 顺序跨运行稳定（确定性测试：两次导出 JSONL/MD 字节一致）
- [x] source/current snapshot 和项目身份进入 corpus manifest
- [x] 扫描期间源变化有明确状态（`source_changed_during_scan`）
- [x] JSONL/Markdown 内容数一致
- [x] CLI help、机器输出/退出码、文档（docs/batch_workflows.md）和测试同步
- [x] 不改变现有 translation/revision/final-review 行为（CLI 全量 942 测试通过）

### 验证

- 新增 `tests/test_revision_corpus.py` 10 项：导出产物、重复原文 occurrence、注释译文、确定性、manifest 身份/digest、变更标记、speaker/locator 字段、机器 envelope、端到端 CLI 导出。
- 适配 `test_gemini_translate_batch_cli_contract`（离线命令遍历新增命令的 argv/handler）。
- `python -B tests/run_cli_tests.py -q`：942 tests OK。
- ruff critical（E9/F63/F7/F82）通过；`git diff --check` 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only revision corpus export command.
  * Exports revision comparisons, project and source metadata, entry locations, speaker details, and contextual information.
  * Generates JSONL, Markdown, and manifest files with deterministic ordering and integrity digests.
  * Supports custom output directories and machine-readable JSON output.
  * Reports source files that change during scanning without modifying project files or configuration.

* **Documentation**
  * Added usage guidance for the revision corpus export workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->