### PR TITLE
test(final-review): add result failure fixture spike

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -212,6 +212,8 @@ python gemini_translate_batch.py apply-revisions logs/batch_jobs/<revision-packa
 
 `final-review-resume` 会**重新采集 live 共享上下文**（而非只读冻结 snapshot）来判断 skip / stale，只为 pending / stale / failed 重建 `requests.jsonl`；`--force` 才重审全部。有待跑 unit 时会清空 `job_name` / 下载字段，并把旧 `results.jsonl` 改名为 `results.jsonl.pre_resume_*`，避免 `download` 短路复用上一轮结果。`final-review-ingest-results` 解析 Batch 结果：成功（含空 findings）→ `done`，并在成功时写回本次 live `input_digest`；解析失败 / 缺响应 → `failed`（**不会**记成「零问题 done」）。resume 之后若尚未重新 download，默认**拒绝**用 resume 前的 `results.jsonl`（可用 `--result` 或 `--allow-stale-results` 显式覆盖）。
 
+当前 ingest 的固定 fixture 基线发现两个现行误接受边界：finding 缺 response schema 必填字段、完全重复 finding；另单列一个未来 completion receipt 数量不符的假设性探针。它们尚未进入生产 parser；本阶段也不启用宽松 JSON repair。现状对比、候选稳定码、unit 级 targeted resume 合约和 receipt 暂缓结论见 [Final Review 结果失败分类 fixture spike](plans/final_review_result_failure_spike.md)。
+
 ### 产物布局
 
 ```text

--- a/docs/plans/final_review_result_failure_spike.md
+++ b/docs/plans/final_review_result_failure_spike.md
@@ -1,0 +1,118 @@
+# Final Review 结果失败分类与 targeted resume fixture spike（#309）
+
+状态：P0 fixture spike，2026-08-09。本文记录现状，不实现激进 JSON repair、
+unit 内 adaptive split 或完整恢复器。
+
+## 范围与方法
+
+固定 fixture 位于
+[`tests/fixtures/final_review_result_cases.json`](../../tests/fixtures/final_review_result_cases.json)，
+并由
+[`tests/test_final_review_result_spike.py`](../../tests/test_final_review_result_spike.py)
+直接走 `ingest_result_rows()`。每个 case 使用含两个 item 的同一 review unit，避免
+把 parser 结果与不同 unit shape 混在一起。
+
+“接受”指 unit 被记为 `done`；“拒绝”指 unit 被记为 `failed`。误接受 / 误拒绝只
+评价决策，不表示当前自由文本 `error` 已提供稳定分类。
+
+## Fixture 对比
+
+| Fixture | 响应要点 | 当前行为 | 期望分类与决策 | 结果 |
+|---|---|---|---|---|
+| `truncated_json` | finding 内部截断，缺闭合括号 | `failed`；`failed_to_parse_model_json: ...` | `truncate`；拒绝 | 正确拒绝，但分类不稳定 |
+| `missing_findings` | 根对象只有 `issues_count` | `failed`；提示缺 `findings` array | `missing_findings`；拒绝 | 正确拒绝 |
+| `schema_missing_reason` | finding 缺 response schema 必填的 `reason` | `done`，生成 1 条空 reason finding | `schema`；拒绝 | **误接受** |
+| `duplicate_item` | 同一 item 的同一 finding 完全重复 | `done`，保留 2 条同 ID finding | `duplicate_item`；拒绝 | **误接受** |
+| `refusal` | provider `promptFeedback.blockReason=SAFETY`，无文本 | `failed`；`missing_response_text` | `refusal`；拒绝 | 正确拒绝，但拒答原因丢失 |
+| `empty_ok` | `{"findings":[]}` | `done`，0 findings | `empty_ok`；接受 | 正确接受 |
+| `reviewed_count_mismatch` | unit 有 2 项，假设回执声称只审 1 项 | `done`，忽略 `complete` / count | `schema`；若存在回执则拒绝矛盾值 | **假设性 receipt 缺口** |
+
+现行合同的 6 类基线合计：2/6 误接受，0/6 误拒绝。截断、缺 `findings` 和无文本已经
+fail closed；已有直接证据的收益集中在客户端 schema 校验和精确重复项校验，不在
+宽松 JSON repair。第 7 个数量不符 case 是尚不存在的 receipt 合同探针，单独记录，
+不计入当前 parser bug 比例。
+
+## 候选稳定码
+
+候选集合固定为：
+
+- `truncate`：JSON 在可识别容器内部结束，语法外壳不完整；
+- `missing_findings`：合法 JSON 对象没有规范的 `findings` 字段；
+- `schema`：root / finding shape、必填字段、item 引用或完成数量违反 schema；
+- `duplicate_item`：同一 item 的同一规范化 finding 完全重复；同一 item 的不同问题
+  类型仍允许并存，不能只按 `item_id` 去重；
+- `refusal`：provider 明确返回 block / refusal metadata；不建议只靠自然语言猜测；
+- `empty_ok`：结构与完成合同都成立且 findings 为空，这是成功分类，不是失败。
+
+数量不符映射为 `schema`，避免在尚未确定回执字段前新增只服务一种校验的错误码。
+若后续进入实现，parser 应返回结构化分类与 detail；失败 unit artifact 可新增可选
+`error_code`，保留现有 `error` 作为人类可读细节。`empty_ok` 是成功分类，不写入
+`error_code`。与 #296 接入机器 envelope 时，失败可展示为
+`final_review.<code>`，无需等待所有 final-review 命令迁移完成。
+
+## Targeted resume 结论
+
+现有 unit 级 resume **不需要新 artifact/schema 字段**。当前字段已经足够：
+
+- `unit_id` 定位重跑单位；
+- `status` 区分 `failed` / `done`；
+- `items`、`items_digest`、`context_digest`、model、prompt schema 共同重算
+  `input_digest`；
+- digest 匹配的 `done` unit 被 skip，`failed` unit 单独写入新的 `requests.jsonl`；
+- 未重跑 unit 的 findings 由 `merge_findings_preserve_selection()` 保留。
+
+新增合约测试使用一个 matching-digest `done` unit 和一个 `failed` unit，证明只有失败
+unit 进入 request；done unit 的状态、digest、完成时间、items、finding count 和 finding
+均保持不变。resume 目前会给已跳过行附加 `live_input_digest` / `live_context_digest`
+审计字段；这不改变上述完成语义，也不是 targeted resume 的新依赖。
+
+## Completion receipt 结论
+
+结论：**暂缓把 completion receipt 设为强制合同。**
+
+证据是 `reviewed_count_mismatch` 与 `empty_ok` 在当前 ingest 中得到完全相同的
+`done + 0 findings` 结果。仅靠 Batch row key、unit digest 和一个合法空 findings 数组，
+无法证明模型实际看完 unit 的全部 item；但 `reviewed_item_count` 和 `complete` 仍然只是
+同一个模型的自报值，也不能独立证明完成。该 fixture 证明“若响应已经带回执，内部数量
+矛盾不能被忽略”，并没有证明“强制模型增加回执”能降低真实误接受率。
+
+当前有直接 fixture 证据的收益是客户端 schema 与精确重复项校验，应先实现这两项。
+只有收集到真实 provider 的“语法和 schema 均合法、但实际只覆盖部分 item”样本，并能
+证明 receipt 与该失败相关时，再把 `complete: true` 与
+`reviewed_item_count == unit.item_count` 设为 response schema 必填。届时必须升级
+`prompt_schema_version`，让旧 done unit 按现有 digest 机制自动 stale；receipt 仍不是
+targeted resume 的依赖，也不要求复制进 campaign manifest。
+
+实施顺序应为：
+
+1. 客户端按原 response schema 严格校验，拒绝缺必填字段和未知 item 引用；
+2. 仅拒绝“同 item + 同规范化 finding”的精确重复，保留同 item 多类问题；
+3. 收集真实 provider 的部分覆盖样本，再决定是否加入 completion receipt 并升级
+   prompt schema；
+4. 再评估是否需要仅修语法外壳的 JSON repair。
+
+任何 repair 都必须在修复后重新通过相同 schema、重复项以及已启用的 receipt 校验；不得补造
+`findings`、`reason`、`complete` 或数量字段。本 spike 不支持 unit 内 adaptive split；
+失败仍按现有稳定 unit 整体重跑。
+
+## 验证记录
+
+2026-08-09 在独立 `codex/issue-309-final-review-spike` worktree 验证：
+
+- `python -m unittest tests.test_final_review_result_spike tests.test_final_review_llm -q`：
+  25 项通过；
+- `python -B tests/run_cli_tests.py -q`：953 项通过，1 项跳过；
+- `python -m unittest tests.test_gui_final_review_workflow -q`：8 项通过；
+- `python scripts/run_quality_gates.py all`：ruff、mypy、pip-audit blocking gate 全通过；
+- 39 个 Markdown 文件的 201 个本地链接目标均存在；
+- `git diff --check` 通过。
+
+## 风险与非目标
+
+- fixture 是确定性的合成基线，不代表真实 provider 各类失败的发生率；
+- `refusal` 的可靠分类需要保留 response metadata，纯文本启发式可能误判正常内容；
+- response schema 当前未设置 `additionalProperties: false`；receipt 落地时应明确兼容
+  策略，而不是静默接收拼错字段；
+- 本 spike 故意钉住当前合同的 2 个误接受，并单列 1 个假设性 receipt 缺口；后续
+  修复或引入新合同时必须同步更新 fixture 的 `current_*`、`evidence_scope` 与
+  assessment，不能用放宽测试掩盖行为变化。

--- a/tests/fixtures/final_review_result_cases.json
+++ b/tests/fixtures/final_review_result_cases.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": 1,
+  "unit_item_count": 2,
+  "candidate_codes": [
+    "truncate",
+    "missing_findings",
+    "schema",
+    "duplicate_item",
+    "refusal",
+    "empty_ok"
+  ],
+  "cases": [
+    {
+      "id": "truncated_json",
+      "description": "JSON is cut off inside the first finding.",
+      "result_row": {
+        "response_text": "{\"findings\":[{\"item_id\":\"id-a\",\"finding_type\":\"omission\",\"severity\":\"high\",\"reason\":\"cut off\"}"
+      },
+      "candidate_code": "truncate",
+      "evidence_scope": "current_contract",
+      "expected_decision": "reject",
+      "current_status": "failed",
+      "current_finding_count": 0,
+      "current_error_contains": "failed_to_parse_model_json",
+      "decision_assessment": "correct_reject"
+    },
+    {
+      "id": "missing_findings",
+      "description": "The root object has no findings member.",
+      "result_row": {
+        "response_text": "{\"issues_count\":0}"
+      },
+      "candidate_code": "missing_findings",
+      "evidence_scope": "current_contract",
+      "expected_decision": "reject",
+      "current_status": "failed",
+      "current_finding_count": 0,
+      "current_error_contains": "missing findings array",
+      "decision_assessment": "correct_reject"
+    },
+    {
+      "id": "schema_missing_reason",
+      "description": "A finding omits the response schema's required reason field.",
+      "result_row": {
+        "response_text": "{\"findings\":[{\"item_id\":\"id-a\",\"finding_type\":\"omission\",\"severity\":\"high\"}]}"
+      },
+      "candidate_code": "schema",
+      "evidence_scope": "current_contract",
+      "expected_decision": "reject",
+      "current_status": "done",
+      "current_finding_count": 1,
+      "current_error_contains": "",
+      "decision_assessment": "false_accept"
+    },
+    {
+      "id": "duplicate_item",
+      "description": "The same normalized finding for one input item is repeated exactly.",
+      "result_row": {
+        "response_text": "{\"findings\":[{\"item_id\":\"id-a\",\"finding_type\":\"terminology\",\"severity\":\"medium\",\"reason\":\"term mismatch\"},{\"item_id\":\"id-a\",\"finding_type\":\"terminology\",\"severity\":\"medium\",\"reason\":\"term mismatch\"}]}"
+      },
+      "candidate_code": "duplicate_item",
+      "evidence_scope": "current_contract",
+      "expected_decision": "reject",
+      "current_status": "done",
+      "current_finding_count": 2,
+      "current_error_contains": "",
+      "decision_assessment": "false_accept"
+    },
+    {
+      "id": "refusal",
+      "description": "Provider metadata reports a safety block and contains no candidate text.",
+      "result_row": {
+        "response": {
+          "promptFeedback": {
+            "blockReason": "SAFETY"
+          },
+          "candidates": []
+        }
+      },
+      "candidate_code": "refusal",
+      "evidence_scope": "current_contract",
+      "expected_decision": "reject",
+      "current_status": "failed",
+      "current_finding_count": 0,
+      "current_error_contains": "missing_response_text",
+      "decision_assessment": "correct_reject"
+    },
+    {
+      "id": "empty_ok",
+      "description": "A complete response reports no findings.",
+      "result_row": {
+        "response_text": "{\"findings\":[]}"
+      },
+      "candidate_code": "empty_ok",
+      "evidence_scope": "current_contract",
+      "expected_decision": "accept",
+      "current_status": "done",
+      "current_finding_count": 0,
+      "current_error_contains": "",
+      "decision_assessment": "correct_accept"
+    },
+    {
+      "id": "reviewed_count_mismatch",
+      "description": "A hypothetical receipt says only one of the unit's two items was reviewed.",
+      "result_row": {
+        "response_text": "{\"findings\":[],\"complete\":true,\"reviewed_item_count\":1}"
+      },
+      "candidate_code": "schema",
+      "evidence_scope": "hypothetical_receipt",
+      "expected_decision": "reject",
+      "current_status": "done",
+      "current_finding_count": 0,
+      "current_error_contains": "",
+      "decision_assessment": "false_accept"
+    }
+  ]
+}

--- a/tests/test_final_review_result_spike.py
+++ b/tests/test_final_review_result_spike.py
@@ -1,0 +1,248 @@
+import copy
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import final_review as fr
+import final_review_llm as frl
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "final_review_result_cases.json"
+)
+
+
+def _review_items() -> list[dict]:
+    return [
+        {
+            "id": "id-a",
+            "identity_v2": "id-a",
+            "file_rel_path": "tl/script.rpy",
+            "source": "Hello.",
+            "current_translation": "你好。",
+        },
+        {
+            "id": "id-b",
+            "identity_v2": "id-b",
+            "file_rel_path": "tl/script.rpy",
+            "source": "Goodbye.",
+            "current_translation": "再见。",
+        },
+    ]
+
+
+def _fixture_unit() -> dict:
+    items = _review_items()
+    items_digest = fr.digest_translation_items(items)
+    context_digest = "fixture-context"
+    return {
+        "unit_id": "fixture-unit",
+        "status": fr.STATUS_RUNNING,
+        "file_rel_path": "tl/script.rpy",
+        "chunk_index": 1,
+        "item_ids": [item["id"] for item in items],
+        "item_count": len(items),
+        "items": items,
+        "items_digest": items_digest,
+        "input_digest": fr.compute_unit_input_digest(
+            item_ids=[item["id"] for item in items],
+            items_digest=items_digest,
+            context_digest=context_digest,
+            model="fixture-model",
+            chunk_index=1,
+            file_rel_path="tl/script.rpy",
+        ),
+        "context_digest": context_digest,
+        "model": "fixture-model",
+        "prompt_schema_version": fr.PROMPT_SCHEMA_VERSION,
+        "error": "",
+        "finding_count": 0,
+        "completed_at": "",
+    }
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+class ResultFixtureSpikeTests(unittest.TestCase):
+    def test_fixed_fixtures_characterize_current_ingest_decisions(self):
+        fixture = _load_fixture()
+        self.assertEqual(fixture["schema_version"], 1)
+        self.assertEqual(fixture["unit_item_count"], len(_fixture_unit()["items"]))
+
+        for case in fixture["cases"]:
+            with self.subTest(case=case["id"]):
+                row = {"key": "fixture-unit", **case["result_row"]}
+                result = frl.ingest_result_rows([_fixture_unit()], [row])
+                unit = result["units"][0]
+
+                self.assertEqual(unit["status"], case["current_status"])
+                self.assertEqual(
+                    unit["finding_count"], case["current_finding_count"]
+                )
+                current_error = str(unit.get("error") or "")
+                if case["current_error_contains"]:
+                    self.assertIn(case["current_error_contains"], current_error)
+                else:
+                    self.assertEqual(current_error, "")
+
+                current_decision = (
+                    "accept" if unit["status"] == fr.STATUS_DONE else "reject"
+                )
+                if current_decision == case["expected_decision"]:
+                    assessment = (
+                        "correct_accept"
+                        if current_decision == "accept"
+                        else "correct_reject"
+                    )
+                else:
+                    assessment = (
+                        "false_accept"
+                        if current_decision == "accept"
+                        else "false_reject"
+                    )
+                self.assertEqual(assessment, case["decision_assessment"])
+
+    def test_candidate_codes_and_evidence_scopes_are_explicit(self):
+        fixture = _load_fixture()
+        mapped_codes = {case["candidate_code"] for case in fixture["cases"]}
+        self.assertEqual(mapped_codes, set(fixture["candidate_codes"]))
+        self.assertEqual(
+            {
+                case["id"]
+                for case in fixture["cases"]
+                if case["evidence_scope"] == "current_contract"
+                if case["decision_assessment"] == "false_accept"
+            },
+            {
+                "schema_missing_reason",
+                "duplicate_item",
+            },
+        )
+        self.assertEqual(
+            {
+                case["id"]
+                for case in fixture["cases"]
+                if case["evidence_scope"] == "hypothetical_receipt"
+            },
+            {"reviewed_count_mismatch"},
+        )
+        self.assertFalse(
+            any(
+                case["decision_assessment"] == "false_reject"
+                and case["evidence_scope"] == "current_contract"
+                for case in fixture["cases"]
+            )
+        )
+
+
+class TargetedResumeContractTests(unittest.TestCase):
+    def test_resume_requeues_only_failed_unit_and_preserves_done_semantics(self):
+        items = _review_items()
+        snapshot = fr.build_context_snapshot(
+            translation_items=items,
+            glossary_enabled=False,
+        )
+        units = fr.build_review_units(
+            items,
+            chunk_size=1,
+            context_digest=snapshot["context_digest"],
+            snapshot_digest=snapshot["snapshot_digest"],
+            model="fixture-model",
+        )
+        by_item_id = {unit["item_ids"][0]: unit for unit in units}
+        done = fr.mark_unit_done(by_item_id["id-a"], finding_count=1)
+        failed = fr.mark_unit_failed(by_item_id["id-b"], "fixture_parse_error")
+        done_before = copy.deepcopy(done)
+
+        finding = fr.normalize_finding(
+            {
+                "identity_v2": "id-a",
+                "file_rel_path": done["file_rel_path"],
+                "source": done["items"][0]["source"],
+                "current_translation": done["items"][0]["current_translation"],
+                "finding_type": "terminology",
+                "severity": "medium",
+                "reason": "fixture finding retained across targeted resume",
+            },
+            review_unit_id=done["unit_id"],
+            review_unit_digest=done["input_digest"],
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = os.path.join(tmp, "final_review_spike")
+            readiness = fr.evaluate_readiness(
+                pending_task_count=0,
+                review_item_count=len(items),
+            )
+            manifest = fr.build_campaign_manifest(
+                package_dir=package_dir,
+                display_name="issue-309-fixture",
+                snapshot=snapshot,
+                units=[done, failed],
+                readiness=readiness,
+                model="fixture-model",
+                chunk_size=1,
+            )
+            fr.write_campaign_package(
+                package_dir,
+                manifest=manifest,
+                snapshot=snapshot,
+                units=[done, failed],
+                findings=[finding],
+            )
+
+            result = frl.prepare_resume_requests(
+                package_dir,
+                live_context_digest=snapshot["context_digest"],
+                model="fixture-model",
+            )
+            self.assertEqual(result["run_count"], 1)
+            self.assertEqual(result["skip_count"], 1)
+            self.assertEqual(result["to_run_unit_ids"], [failed["unit_id"]])
+
+            request_rows = [
+                json.loads(line)
+                for line in (
+                    Path(package_dir) / fr.REQUESTS_JSONL_FILENAME
+                ).read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            self.assertEqual(
+                [row["key"] for row in request_rows], [failed["unit_id"]]
+            )
+
+            package = fr.load_campaign_package(package_dir)
+            units_after = {
+                unit["unit_id"]: unit for unit in package["units"]
+            }
+            done_after = units_after[done["unit_id"]]
+            for field in (
+                "unit_id",
+                "status",
+                "input_digest",
+                "context_digest",
+                "items_digest",
+                "item_ids",
+                "items",
+                "finding_count",
+                "completed_at",
+                "error",
+            ):
+                with self.subTest(field=field):
+                    self.assertEqual(done_after[field], done_before[field])
+
+            self.assertEqual(
+                units_after[failed["unit_id"]]["status"], fr.STATUS_RUNNING
+            )
+            self.assertEqual(len(package["findings"]), 1)
+            self.assertEqual(
+                package["findings"][0]["finding_id"], finding["finding_id"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add seven fixed Final Review ingest fixtures for truncation, missing `findings`, schema violations, duplicate findings, refusal metadata, valid empty results, and a hypothetical receipt count mismatch
- characterize current accept/reject behavior and pin unit-level targeted resume semantics
- document the candidate result taxonomy, artifact-field decision, completion-receipt evidence, and JSON-repair boundary
- link the spike conclusions from the active Batch workflow documentation

## Findings

- the current contract has two false accepts across six applicable cases: a finding missing required `reason`, and an exact duplicate finding
- failed units can already be resumed independently while matching-digest completed units and their findings remain unchanged; no new resume artifact field is required
- completion receipts remain deferred because model-reported `complete` / item counts are not independent completion evidence
- this PR does not change production parser, CLI, GUI, JSON repair, or adaptive split behavior

## Validation

- `python -m unittest tests.test_final_review_result_spike tests.test_final_review_llm -q` — 25 passed
- `python -B tests/run_cli_tests.py -q` — 953 passed, 1 skipped
- `python -m unittest tests.test_gui_final_review_workflow -q` — 8 passed
- `python scripts/run_quality_gates.py all` — ruff, mypy, and pip-audit passed
- 39 tracked Markdown files / 201 local links checked
- `git diff --check`

Closes #309
Related to #296