### PR TITLE
Enlarge project notes editor

### DIFF
--- a/gui_qt/games_registry_panel.py
+++ b/gui_qt/games_registry_panel.py
@@ -34,6 +34,8 @@ from PySide6.QtWidgets import (
 # Prefer giving the overview table real height inside the settings viewport.
 _REGISTRY_TABLE_MIN_HEIGHT = 280
 _REGISTRY_DETAIL_DEFAULT_HEIGHT = 260
+_REGISTRY_NOTES_MIN_HEIGHT = 112
+_REGISTRY_NOTES_MAX_HEIGHT = 220
 
 from games_registry import (
     PLAY_STATUSES,
@@ -574,9 +576,12 @@ class GamesRegistryPanel(QWidget):
 
         self._notes_edit = QPlainTextEdit()
         self._notes_edit.setPlaceholderText("备注 / 下一步")
-        self._notes_edit.setFixedHeight(72)
-        self._notes_edit.setMinimumHeight(56)
-        self._notes_edit.setMaximumHeight(120)
+        self._notes_edit.setMinimumHeight(_REGISTRY_NOTES_MIN_HEIGHT)
+        self._notes_edit.setMaximumHeight(_REGISTRY_NOTES_MAX_HEIGHT)
+        self._notes_edit.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.MinimumExpanding,
+        )
         edit_layout.addRow("备注", self._notes_edit)
 
         edit_actions_host = QWidget()

--- a/tests/test_gui_games_registry_panel_layout.py
+++ b/tests/test_gui_games_registry_panel_layout.py
@@ -161,8 +161,10 @@ class GuiGamesRegistryPanelLayoutTests(unittest.TestCase):
             self._app.processEvents()
 
         notes = panel._notes_edit
-        self.assertGreaterEqual(notes.minimumHeight(), 112)
-        self.assertGreater(notes.maximumHeight(), notes.minimumHeight())
+        notes.setPlainText("第一行\n第二行\n第三行")
+        self.assertEqual(notes.minimumHeight(), 112)
+        self.assertEqual(notes.maximumHeight(), 220)
+        self.assertGreaterEqual(notes.document().blockCount(), 3)
         self.assertGreaterEqual(notes.height(), notes.minimumHeight())
 
     def test_table_column_path_is_last_stretch_and_drag_clamps_eui_min(self) -> None:

--- a/tests/test_gui_games_registry_panel_layout.py
+++ b/tests/test_gui_games_registry_panel_layout.py
@@ -147,6 +147,24 @@ class GuiGamesRegistryPanelLayoutTests(unittest.TestCase):
                 self._app.processEvents()
             self.assertTrue(panel._detail_host.isHidden())
 
+    def test_project_notes_editor_has_room_for_multiple_lines(self) -> None:
+        self.window.resize(1200, 800)
+        self.window.show()
+        self.window._focus_settings_section("workspace")
+        for _ in range(12):
+            self._app.processEvents()
+
+        panel = self.window._games_registry_panel
+        assert panel is not None
+        panel._set_detail_visible(True)
+        for _ in range(4):
+            self._app.processEvents()
+
+        notes = panel._notes_edit
+        self.assertGreaterEqual(notes.minimumHeight(), 112)
+        self.assertGreater(notes.maximumHeight(), notes.minimumHeight())
+        self.assertGreaterEqual(notes.height(), notes.minimumHeight())
+
     def test_table_column_path_is_last_stretch_and_drag_clamps_eui_min(self) -> None:
         from PySide6.QtCore import Qt
         from PySide6.QtWidgets import QHeaderView


### PR DESCRIPTION
## What changed

- Increase the project notes editor minimum height from the effective 56 px to 112 px.
- Allow the editor to expand up to 220 px with the detail pane.
- Add a GUI layout regression test for multi-line note editing space.

## Why

The notes field under Settings → Project List was compressed to its previous minimum height when the detail pane shared limited vertical space with the project table, making multi-line notes awkward to review and edit.

## Impact

Project notes now have a more comfortable multi-line editing area while preserving the resizable table/detail splitter behavior.

## Validation

- `python -m unittest tests.test_gui_games_registry_panel_layout.GuiGamesRegistryPanelLayoutTests.test_project_notes_editor_has_room_for_multiple_lines tests.test_gui_games_registry_dialog`
- `python -m unittest tests.test_gui_games_registry_actions`
- `git diff --check`

All targeted checks passed. The full panel-layout module also reached the unrelated existing preference-persistence test, which cannot write `C:\RenPy_Workspace\games_registry.json` under the current sandbox permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the project notes editor layout so it expands for multi-line content while remaining within a suitable height range.
  * Preserved the current game context when switching projects if no refresh is required.

* **Tests**
  * Added coverage to verify the notes editor remains adequately sized when the details panel is visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->