### PR TITLE
fix(gui): 首次打开 LiteLLM 设置页不再卡顿 + 自定义 Provider 表格布局优化

### DIFF
--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -670,6 +670,7 @@ class MainWindow(QMainWindow):
         self._litellm_catalog_worker: LiteLLMModelCatalogWorker | None = None
         self._litellm_version_worker: LiteLLMVersionWorker | None = None
         self._litellm_module_warmup_worker: LiteLLMModuleWarmupWorker | None = None
+        self._retired_litellm_warmup_workers: set[LiteLLMModuleWarmupWorker] = set()
         self._litellm_latest_version = ""
         self._litellm_latest_compatible_version = ""
         self._litellm_latest_requires_python = ""
@@ -4493,12 +4494,22 @@ class MainWindow(QMainWindow):
             return ()
         current_doctor = getattr(self, "_doctor_worker", None)
         doctor_is_foreground = bool(getattr(self, "_task_running", False))
+        # The LiteLLM module warmup import is local, not user-cancellable and
+        # fully owned by the settings page; it must not gate window shutdown
+        # with a confirmation dialog.  Retired workers are already detached
+        # and only kept alive until their import finishes.
+        warmup_worker = getattr(self, "_litellm_module_warmup_worker", None)
+        retired_workers = (
+            getattr(self, "_retired_litellm_warmup_workers", None) or set()
+        )
         active: list[QThread] = []
         for thread in threads:
             try:
                 if not thread.isRunning():
                     continue
             except RuntimeError:
+                continue
+            if thread is warmup_worker or thread in retired_workers:
                 continue
             if doctor_is_foreground and thread is current_doctor:
                 continue
@@ -8206,37 +8217,65 @@ class MainWindow(QMainWindow):
         if worker is not None:
             self._litellm_module_warmup_worker = None
             worker.deleteLater()
+        # A worker detached during shutdown finishes in the background; drop
+        # it once the thread is no longer running so teardown stays safe.
+        retired = getattr(self, "_retired_litellm_warmup_workers", None)
+        if retired:
+            for retired_worker in tuple(retired):
+                if not getattr(retired_worker, "isRunning", lambda: False)():
+                    retired.discard(retired_worker)
+                    retired_worker.deleteLater()
         if getattr(self, "_shutdown_requested", False):
             return
-        # Re-read the LiteLLM page with the now-complete reserved set so the
-        # custom-provider table and validation reflect installed LiteLLM
-        # prefixes.  Skip when the user already edited providers unsaved, or
-        # when the page was never opened.
+        # Skip when the user already edited providers unsaved, or when the
+        # page was never opened.
         if getattr(self, "_custom_litellm_providers_modified", False):
             return
         if "litellm" not in self.__dict__.get("_settings_pages_built", ()):
             return
+        # Re-validate the registry with the now-complete reserved set, then
+        # refresh table/dropdowns/status while preserving the current page
+        # selection.  A full _load_config_to_ui would silently reset any
+        # unsaved edits the user made during the ~10s warmup window.
         try:
-            self._load_config_to_ui(refresh_task_gates=False, pages={"litellm"})
+            config = self.state.load_translator_config()
+            sync_config = self._config_section(config, "sync")
+            self._custom_litellm_providers = custom_provider_registry(
+                sync_config.get("custom_litellm_providers"),
+                allow_import=False,
+            )
+            self._custom_litellm_providers_load_error = ""
         except Exception:
-            self._append_log("后台预热 LiteLLM 后刷新设置页失败。")
+            self._custom_litellm_providers = {}
+            self._custom_litellm_providers_load_error = (
+                "后台预热 LiteLLM 后重新校验自定义 Provider 失败，"
+                "请重新加载设置页。"
+            )
+            self._append_log("后台预热 LiteLLM 后重新校验自定义 Provider 失败。")
+        self._after_custom_providers_changed()
 
     def _detach_litellm_module_warmup(self) -> None:
         """Detach a still-running warmup thread from window teardown.
 
         A QThread destroyed while its import is still running aborts the
         process, so on shutdown the worker is released from the window's
-        ownership; the completed signal still fires and cleans it up after the
-        import finishes (the thread ends right before the signal is delivered).
+        ownership but kept alive in the retired set until the import finishes;
+        the completed signal still fires and cleans it up afterwards.
         """
         worker = getattr(self, "_litellm_module_warmup_worker", None)
-        if worker is None or not getattr(worker, "isRunning", lambda: False)():
+        if worker is None:
+            return
+        self._litellm_module_warmup_worker = None
+        if not getattr(worker, "isRunning", lambda: False)():
+            worker.deleteLater()
             return
         try:
             worker.setParent(None)
         except RuntimeError:
             pass
-        self._litellm_module_warmup_worker = None
+        retired = getattr(self, "_retired_litellm_warmup_workers", None)
+        if retired is not None:
+            retired.add(worker)
 
     def _on_litellm_network_progress(
         self,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -408,6 +408,13 @@ _BATCH_STAGE_RESULT = 2  # 写回 / 结果
 _LOG_FLUSH_INTERVAL_MS = 80
 _LAYOUT_SYNC_DEBOUNCE_MS = 32
 _LITELLM_MODEL_SELECTION_SAVE_DEBOUNCE_MS = 400
+
+# Application-level ownership for warmup workers detached from a closing
+# window: MainWindow teardown must never destroy a QThread whose import is
+# still running (Qt aborts the process).  Workers are removed once their
+# thread finished; entries left behind after the window itself is gone are
+# harmless process-exit cleanup.
+_RETIRED_LITELLM_WARMUP_WORKERS: set[LiteLLMModuleWarmupWorker] = set()
 _UI_PROGRESS_FLUSH_INTERVAL_MS = 100
 _CONTEXT_STATUS_CACHE_TTL_S = 2.0
 
@@ -670,7 +677,6 @@ class MainWindow(QMainWindow):
         self._litellm_catalog_worker: LiteLLMModelCatalogWorker | None = None
         self._litellm_version_worker: LiteLLMVersionWorker | None = None
         self._litellm_module_warmup_worker: LiteLLMModuleWarmupWorker | None = None
-        self._retired_litellm_warmup_workers: set[LiteLLMModuleWarmupWorker] = set()
         self._litellm_latest_version = ""
         self._litellm_latest_compatible_version = ""
         self._litellm_latest_requires_python = ""
@@ -4499,9 +4505,7 @@ class MainWindow(QMainWindow):
         # with a confirmation dialog.  Retired workers are already detached
         # and only kept alive until their import finishes.
         warmup_worker = getattr(self, "_litellm_module_warmup_worker", None)
-        retired_workers = (
-            getattr(self, "_retired_litellm_warmup_workers", None) or set()
-        )
+        retired_workers = _RETIRED_LITELLM_WARMUP_WORKERS
         active: list[QThread] = []
         for thread in threads:
             try:
@@ -8219,12 +8223,10 @@ class MainWindow(QMainWindow):
             worker.deleteLater()
         # A worker detached during shutdown finishes in the background; drop
         # it once the thread is no longer running so teardown stays safe.
-        retired = getattr(self, "_retired_litellm_warmup_workers", None)
-        if retired:
-            for retired_worker in tuple(retired):
-                if not getattr(retired_worker, "isRunning", lambda: False)():
-                    retired.discard(retired_worker)
-                    retired_worker.deleteLater()
+        for retired_worker in tuple(_RETIRED_LITELLM_WARMUP_WORKERS):
+            if not getattr(retired_worker, "isRunning", lambda: False)():
+                _RETIRED_LITELLM_WARMUP_WORKERS.discard(retired_worker)
+                retired_worker.deleteLater()
         if getattr(self, "_shutdown_requested", False):
             return
         # Skip when the user already edited providers unsaved, or when the
@@ -8259,8 +8261,10 @@ class MainWindow(QMainWindow):
 
         A QThread destroyed while its import is still running aborts the
         process, so on shutdown the worker is released from the window's
-        ownership but kept alive in the retired set until the import finishes;
-        the completed signal still fires and cleans it up afterwards.
+        ownership but kept alive in the application-level retired set until
+        the import finishes; the completed signal still fires and cleans it up
+        afterwards.  The set lives at module scope so window destruction can
+        never drop the last reference to a running thread.
         """
         worker = getattr(self, "_litellm_module_warmup_worker", None)
         if worker is None:
@@ -8273,9 +8277,7 @@ class MainWindow(QMainWindow):
             worker.setParent(None)
         except RuntimeError:
             pass
-        retired = getattr(self, "_retired_litellm_warmup_workers", None)
-        if retired is not None:
-            retired.add(worker)
+        _RETIRED_LITELLM_WARMUP_WORKERS.add(worker)
 
     def _on_litellm_network_progress(
         self,

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -247,6 +247,7 @@ from .work_bootstrap_report import (
 from .litellm_worker import (
     LiteLLMConnectionTestWorker,
     LiteLLMModelCatalogWorker,
+    LiteLLMModuleWarmupWorker,
     LiteLLMProviderCatalogWorker,
     LiteLLMVersionWorker,
     is_cancelled_message,
@@ -277,6 +278,7 @@ from litellm_provider_config import (
     custom_provider_from_mapping,
     custom_provider_registry,
     installed_litellm_version,
+    litellm_install_probe,
     load_provider_key_store,
     native_catalog_endpoint,
     provider_display_label,
@@ -667,6 +669,7 @@ class MainWindow(QMainWindow):
         self._litellm_provider_catalog_worker: LiteLLMProviderCatalogWorker | None = None
         self._litellm_catalog_worker: LiteLLMModelCatalogWorker | None = None
         self._litellm_version_worker: LiteLLMVersionWorker | None = None
+        self._litellm_module_warmup_worker: LiteLLMModuleWarmupWorker | None = None
         self._litellm_latest_version = ""
         self._litellm_latest_compatible_version = ""
         self._litellm_latest_requires_python = ""
@@ -3929,11 +3932,22 @@ class MainWindow(QMainWindow):
             QAbstractItemView.SelectionMode.SingleSelection
         )
         self.custom_provider_table.verticalHeader().setVisible(False)
+        # Long URLs/ids elide instead of forcing a horizontal scrollbar; hover
+        # tooltips keep the full value readable (set while filling rows).
+        self.custom_provider_table.setWordWrap(False)
+        self.custom_provider_table.setTextElideMode(Qt.TextElideMode.ElideRight)
         header = self.custom_provider_table.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setStretchLastSection(False)
+        header.setMinimumSectionSize(60)
+        # id / label / env columns stay user-resizable; API Base absorbs the
+        # leftover width so a long endpoint never collapses the other columns.
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Interactive)
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
-        header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
+        self.custom_provider_table.setColumnWidth(0, 110)
+        self.custom_provider_table.setColumnWidth(1, 110)
+        self.custom_provider_table.setColumnWidth(3, 150)
         self.custom_provider_table.setMinimumHeight(120)
         self.custom_provider_table.itemSelectionChanged.connect(
             self._refresh_custom_provider_actions
@@ -4017,6 +4031,10 @@ class MainWindow(QMainWindow):
         self._refresh_litellm_catalog_status()
         self._refresh_litellm_credential_status()
         self._refresh_custom_provider_table()
+        # Warm the heavy litellm import in the background so the installed
+        # provider table can be merged into the reserved-id check without
+        # blocking this (or any later) page visit.
+        self._start_litellm_module_warmup()
         layout.addStretch(1)
         return page
 
@@ -4627,6 +4645,7 @@ class MainWindow(QMainWindow):
             event.ignore()
             return
         self._shutdown_requested = True
+        self._detach_litellm_module_warmup()
         if active_labels:
             event.ignore()
             self._lock_ui_for_shutdown()
@@ -7775,9 +7794,12 @@ class MainWindow(QMainWindow):
         # registry. Historical catalog cache ids are intentionally excluded:
         # they are user-level state with no UI to clear, and including them
         # would block re-adding a deleted provider under the same id.
+        # allow_import=False keeps this call off the ~10s synchronous litellm
+        # import; the background warmup worker merges the installed provider
+        # table into the reserved set as soon as it finishes.
         return frozenset(
             {
-                *reserved_litellm_provider_ids(),
+                *reserved_litellm_provider_ids(allow_import=False),
                 *self.__dict__.get("_custom_litellm_providers", {}),
             }
         )
@@ -7801,6 +7823,10 @@ class MainWindow(QMainWindow):
             ):
                 item = QTableWidgetItem(text)
                 item.setData(Qt.ItemDataRole.UserRole, provider.id)
+                if len(text) > 20:
+                    # Long API Base URLs and labels are elided in the cell;
+                    # keep the full value readable on hover.
+                    item.setToolTip(text)
                 table.setItem(row, column, item)
             if previous and provider.id == previous:
                 table.selectRow(row)
@@ -7874,7 +7900,7 @@ class MainWindow(QMainWindow):
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return
         entry = dialog.result_provider()
-        provider = custom_provider_from_mapping(entry)
+        provider = custom_provider_from_mapping(entry, allow_import=False)
         if provider.id in self._custom_litellm_providers:
             message_box_warning(
                 self,
@@ -7921,7 +7947,7 @@ class MainWindow(QMainWindow):
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return
         entry = dialog.result_provider()
-        updated = custom_provider_from_mapping(entry)
+        updated = custom_provider_from_mapping(entry, allow_import=False)
         self._custom_litellm_providers[provider.id] = updated
         self._custom_litellm_providers_modified = True
         self._after_custom_providers_changed()
@@ -8151,6 +8177,66 @@ class MainWindow(QMainWindow):
             button.setText("正在取消…")
         self.statusBar().showMessage(status_message, 4000)
         return True
+
+    def _start_litellm_module_warmup(self) -> None:
+        """Preload the heavy litellm package in a background thread.
+
+        ``import litellm`` can take ~10s cold; running it off the main thread
+        keeps the first LiteLLM settings visit and the custom-provider dialogs
+        responsive.  When the import finishes, the installed provider table is
+        merged into the reserved-id set and any open LiteLLM page is re-read.
+        Idempotent and cheap when litellm is not installed (probe only).
+        """
+        if getattr(self, "_shutdown_requested", False):
+            return
+        if os.environ.get("RTL_DISABLE_LITELLM_WARMUP"):
+            return
+        if getattr(self, "_litellm_module_warmup_worker", None) is not None:
+            return
+        if not litellm_install_probe():
+            return
+        worker = LiteLLMModuleWarmupWorker(self)
+        worker.setPriority(QThread.Priority.LowPriority)
+        worker.completed.connect(self._on_litellm_module_warmed)
+        self._litellm_module_warmup_worker = worker
+        worker.start()
+
+    def _on_litellm_module_warmed(self, _module: object) -> None:
+        worker = getattr(self, "_litellm_module_warmup_worker", None)
+        if worker is not None:
+            self._litellm_module_warmup_worker = None
+            worker.deleteLater()
+        if getattr(self, "_shutdown_requested", False):
+            return
+        # Re-read the LiteLLM page with the now-complete reserved set so the
+        # custom-provider table and validation reflect installed LiteLLM
+        # prefixes.  Skip when the user already edited providers unsaved, or
+        # when the page was never opened.
+        if getattr(self, "_custom_litellm_providers_modified", False):
+            return
+        if "litellm" not in self.__dict__.get("_settings_pages_built", ()):
+            return
+        try:
+            self._load_config_to_ui(refresh_task_gates=False, pages={"litellm"})
+        except Exception:
+            self._append_log("后台预热 LiteLLM 后刷新设置页失败。")
+
+    def _detach_litellm_module_warmup(self) -> None:
+        """Detach a still-running warmup thread from window teardown.
+
+        A QThread destroyed while its import is still running aborts the
+        process, so on shutdown the worker is released from the window's
+        ownership; the completed signal still fires and cleans it up after the
+        import finishes (the thread ends right before the signal is delivered).
+        """
+        worker = getattr(self, "_litellm_module_warmup_worker", None)
+        if worker is None or not getattr(worker, "isRunning", lambda: False)():
+            return
+        try:
+            worker.setParent(None)
+        except RuntimeError:
+            pass
+        self._litellm_module_warmup_worker = None
 
     def _on_litellm_network_progress(
         self,
@@ -10986,7 +11072,8 @@ class MainWindow(QMainWindow):
                                     converted := self._mapping_from_entry(entry)
                                 )
                                 is not None
-                            ]
+                            ],
+                            allow_import=False,
                         )
                         self._custom_litellm_providers_load_error = ""
                     except ValueError as exc:
@@ -14191,7 +14278,8 @@ class MainWindow(QMainWindow):
                 if need_litellm:
                     try:
                         self._custom_litellm_providers = custom_provider_registry(
-                            sync_config.get("custom_litellm_providers")
+                            sync_config.get("custom_litellm_providers"),
+                            allow_import=False,
                         )
                         self._custom_litellm_providers_load_error = ""
                         self._custom_litellm_providers_modified = False

--- a/gui_qt/litellm_worker.py
+++ b/gui_qt/litellm_worker.py
@@ -26,6 +26,7 @@ from litellm_provider_config import (
     models_from_remote_catalog,
     native_catalog_endpoint,
     providers_from_remote_catalog,
+    warm_litellm_module,
 )
 from litellm_sync_backend import LiteLLMSyncBackend
 from sync_model_backend import SyncGenerationRequest
@@ -339,6 +340,25 @@ class LiteLLMProviderCatalogWorker(_CancellableNetworkWorker):
                 self.completed.emit((), "", f"{CANCELLED_MESSAGE_PREFIX}供应商列表加载。")
             else:
                 self.completed.emit((), "", f"联网加载供应商失败：{exc}")
+
+
+class LiteLLMModuleWarmupWorker(QThread):
+    """Import the heavy litellm package in the background.
+
+    `import litellm` can take ~10s cold; running it off the GUI main thread lets
+    the settings form open immediately while the reserved-provider table is
+    being prepared.  ``completed`` fires with the cached module (or None) once
+    the probe finished, so the window can refresh validation state afterwards.
+    """
+
+    completed = Signal(object)
+
+    def run(self) -> None:
+        try:
+            module = warm_litellm_module()
+        except Exception:
+            module = None
+        self.completed.emit(module)
 
 
 class LiteLLMVersionWorker(_CancellableNetworkWorker):

--- a/litellm_provider_config.py
+++ b/litellm_provider_config.py
@@ -105,17 +105,26 @@ _CUSTOM_PROVIDER_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 _ENVIRONMENT_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-def reserved_litellm_provider_ids(litellm_module: Any = None) -> frozenset[str]:
+def reserved_litellm_provider_ids(
+    litellm_module: Any = None,
+    *,
+    allow_import: bool = True,
+) -> frozenset[str]:
     """Return provider prefixes that custom ids must not shadow.
 
     The static reserve covers built-in choices and common LiteLLM prefixes;
     when litellm is installed its ``models_by_provider`` table is merged in too,
     so GUI validation and config loading always agree on the same reserved set.
     The import is probed once per process and cached (callers that already hold
-    a litellm module may pass it explicitly to skip the probe).
+    a litellm module may pass it explicitly to skip the probe).  Pass
+    ``allow_import=False`` from GUI main-thread paths: the check then uses only
+    the static reserve plus any module already cached by a background
+    ``warm_litellm_module`` call, and never blocks on the slow litellm import.
     """
     if litellm_module is None:
-        litellm_module = _installed_litellm_module()
+        litellm_module = (
+            _installed_litellm_module() if allow_import else cached_litellm_module()
+        )
     reserved = set(_RESERVED_PROVIDER_IDS)
     if litellm_module is not None:
         by_provider = getattr(litellm_module, "models_by_provider", {})
@@ -151,6 +160,7 @@ def validate_custom_provider_id(
     value: object,
     *,
     reserved: frozenset[str] | None = None,
+    allow_import: bool = True,
 ) -> str:
     """Validate a custom provider id (lowercase, ``[a-z0-9_-]+``, no shadowing)."""
     provider = str(value or "").strip().lower()
@@ -158,7 +168,11 @@ def validate_custom_provider_id(
         raise ValueError("自定义 Provider id 不能为空。")
     if not _CUSTOM_PROVIDER_ID_PATTERN.fullmatch(provider):
         raise ValueError("自定义 Provider id 只能包含小写字母、数字、- 和 _。")
-    reserved_ids = reserved_litellm_provider_ids() if reserved is None else reserved
+    reserved_ids = (
+        reserved_litellm_provider_ids(allow_import=allow_import)
+        if reserved is None
+        else reserved
+    )
     if provider in reserved_ids:
         raise ValueError(
             f"自定义 Provider id 与 LiteLLM 已知前缀冲突：{provider}。"
@@ -182,11 +196,16 @@ def custom_provider_from_mapping(
     *,
     index: int = 0,
     reserved: frozenset[str] | None = None,
+    allow_import: bool = True,
 ) -> CustomLiteLLMProvider:
     """Parse and validate one ``custom_litellm_providers`` config entry."""
     if not isinstance(entry, Mapping):
         raise ValueError(f"custom_litellm_providers[{index}] 必须是对象。")
-    provider_id = validate_custom_provider_id(entry.get("id"), reserved=reserved)
+    provider_id = validate_custom_provider_id(
+        entry.get("id"),
+        reserved=reserved,
+        allow_import=allow_import,
+    )
     label = str(entry.get("label") or "").strip() or provider_id
     base_url = validate_custom_provider_url(
         entry.get("base_url"),
@@ -218,6 +237,7 @@ def parse_custom_litellm_providers(
     raw: object,
     *,
     litellm_module: Any = None,
+    allow_import: bool = True,
 ) -> tuple[CustomLiteLLMProvider, ...]:
     """Parse ``sync.custom_litellm_providers`` into validated provider entries.
 
@@ -226,15 +246,21 @@ def parse_custom_litellm_providers(
     on structural errors, invalid ids/URLs, non-boolean ``requires_key`` or
     duplicate ids. When *litellm_module* is omitted but the optional litellm
     dependency is installed, its provider table is merged into the reserved-id
-    check (the import result is cached per process).
+    check (the import result is cached per process).  GUI callers pass
+    ``allow_import=False`` so parsing never blocks the UI thread on the slow
+    litellm import; the cached module is still merged in when already warmed.
     """
     if raw is None:
         return ()
     if not isinstance(raw, list):
         raise ValueError("custom_litellm_providers 必须是列表。")
     if litellm_module is None:
-        litellm_module = _installed_litellm_module()
-    reserved = reserved_litellm_provider_ids(litellm_module)
+        litellm_module = (
+            _installed_litellm_module() if allow_import else cached_litellm_module()
+        )
+    # litellm_module was already resolved above; passing None here must not
+    # re-trigger the import (allow_import=False keeps the GUI path non-blocking).
+    reserved = reserved_litellm_provider_ids(litellm_module, allow_import=False)
     providers: list[CustomLiteLLMProvider] = []
     seen: set[str] = set()
     for index, entry in enumerate(raw):
@@ -254,11 +280,16 @@ def custom_provider_registry(
     raw: object,
     *,
     litellm_module: Any = None,
+    allow_import: bool = True,
 ) -> dict[str, CustomLiteLLMProvider]:
     """Build the id → provider lookup used by backend/GUI/CLI paths."""
     return {
         provider.id: provider
-        for provider in parse_custom_litellm_providers(raw, litellm_module=litellm_module)
+        for provider in parse_custom_litellm_providers(
+            raw,
+            litellm_module=litellm_module,
+            allow_import=allow_import,
+        )
     }
 
 
@@ -266,22 +297,66 @@ _INSTALLED_LITELLM_MODULE: Any = None
 _INSTALLED_LITELLM_PROBED = False
 
 
-def _installed_litellm_module() -> Any:
-    """Return the installed litellm module, or None (probed once per process)."""
-    global _INSTALLED_LITELLM_MODULE, _INSTALLED_LITELLM_PROBED
+def cached_litellm_module() -> Any:
+    """Return the already-probed litellm module, or None.
+
+    Never imports litellm, so it is safe for the GUI main thread.  The module
+    is present only after :func:`warm_litellm_module` (or a synchronous
+    ``_installed_litellm_module`` call) completed in this process.
+    """
     if _INSTALLED_LITELLM_PROBED:
         return _INSTALLED_LITELLM_MODULE
-    _INSTALLED_LITELLM_PROBED = True
+    return None
+
+
+def litellm_install_probe() -> bool:
+    """Cheap ``find_spec`` check for litellm without importing it.
+
+    GUI callers use this before starting a background warmup thread so that
+    machines without the optional dependency never spin up a thread at all.
+    """
+    if _INSTALLED_LITELLM_PROBED:
+        return _INSTALLED_LITELLM_MODULE is not None
     try:
         from importlib.util import find_spec
 
-        if find_spec("litellm") is None:
-            return None
-        import litellm as litellm_module
+        return find_spec("litellm") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def warm_litellm_module() -> Any:
+    """Probe and import litellm once, caching the result for the process.
+
+    The import is expensive — the package pulls in many dependencies and can
+    take ~10s cold — so GUI callers run this in a background thread and read
+    the result later via :func:`cached_litellm_module`.  Idempotent: repeated
+    calls return the cached module without re-importing.
+    """
+    global _INSTALLED_LITELLM_MODULE, _INSTALLED_LITELLM_PROBED
+    if _INSTALLED_LITELLM_PROBED and _INSTALLED_LITELLM_MODULE is not None:
+        return _INSTALLED_LITELLM_MODULE
+    litellm_module = None
+    try:
+        from importlib.util import find_spec
+
+        if find_spec("litellm") is not None:
+            import litellm as litellm_module
     except (ImportError, ModuleNotFoundError, ValueError):
-        return None
+        litellm_module = None
     _INSTALLED_LITELLM_MODULE = litellm_module
+    _INSTALLED_LITELLM_PROBED = True
     return litellm_module
+
+
+def _installed_litellm_module() -> Any:
+    """Return the installed litellm module, or None (synchronous import).
+
+    Kept for CLI/backend callers where a blocking import is acceptable; GUI
+    main-thread paths pass ``allow_import=False`` and use the cached module
+    instead (see :func:`cached_litellm_module` and :func:`warm_litellm_module`).
+    """
+    return warm_litellm_module()
 
 
 def _custom_registry_lookup(

--- a/tests/gui_test_support.py
+++ b/tests/gui_test_support.py
@@ -17,12 +17,18 @@ Use in test modules::
 """
 from __future__ import annotations
 
+import os
 import unittest
 from collections.abc import Callable
 from typing import Any, TypeVar
 from unittest import mock
 
 _T = TypeVar("_T", bound=type)
+
+# Headless GUI tests must not spin up the background LiteLLM import warmup
+# thread: the import takes ~10s on machines with the optional dependency and a
+# QThread destroyed while still importing aborts the process.
+os.environ.setdefault("RTL_DISABLE_LITELLM_WARMUP", "1")
 
 
 def skip_unless_gui(

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -10,9 +10,10 @@ try:
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QCompleter, QGroupBox, QLineEdit
 
-    from gui_qt.app import MainWindow
+    from gui_qt.app import _RETIRED_LITELLM_WARMUP_WORKERS, MainWindow
 except ImportError as exc:
     MainWindow = None
+    _RETIRED_LITELLM_WARMUP_WORKERS = None
     QApplication = None
     IMPORT_ERROR = exc
 else:
@@ -56,6 +57,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         cls._temp_dir.cleanup()
 
     def setUp(self):
+        _RETIRED_LITELLM_WARMUP_WORKERS.clear()
         self.cache = LiteLLMCatalogCache(
             Path(self._temp_dir.name) / f"{self._testMethodName}.json"
         )
@@ -1302,7 +1304,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.window._detach_litellm_module_warmup()
 
         self.assertIsNone(self.window._litellm_module_warmup_worker)
-        self.assertIn(worker, self.window._retired_litellm_warmup_workers)
+        self.assertIn(worker, _RETIRED_LITELLM_WARMUP_WORKERS)
         worker.setParent.assert_called_once_with(None)
         worker.deleteLater.assert_not_called()
 
@@ -1316,7 +1318,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
 
         self.assertIsNone(self.window._litellm_module_warmup_worker)
         worker.deleteLater.assert_called_once_with()
-        self.assertNotIn(worker, self.window._retired_litellm_warmup_workers)
+        self.assertNotIn(worker, _RETIRED_LITELLM_WARMUP_WORKERS)
 
     def test_module_warmup_refreshes_without_full_reload(self):
         """Warmup revalidation must not reset unsaved page selections."""
@@ -1393,7 +1395,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.window._ensure_settings_page("litellm")
         retired = mock.Mock()
         retired.isRunning.return_value = False
-        self.window._retired_litellm_warmup_workers = {retired}
+        _RETIRED_LITELLM_WARMUP_WORKERS.add(retired)
         config = {"sync": {"backend": "gemini"}, "batch": {}}
         with (
             mock.patch.object(
@@ -1408,7 +1410,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         ):
             self.window._on_litellm_module_warmed(None)
 
-        self.assertNotIn(retired, self.window._retired_litellm_warmup_workers)
+        self.assertNotIn(retired, _RETIRED_LITELLM_WARMUP_WORKERS)
         retired.deleteLater.assert_called_once_with()
 
     def test_warmup_worker_is_not_a_background_task(self):
@@ -1426,7 +1428,7 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
 
         # A retired (detached, still importing) worker is excluded as well.
         self.window._litellm_module_warmup_worker = None
-        self.window._retired_litellm_warmup_workers = {worker}
+        _RETIRED_LITELLM_WARMUP_WORKERS.add(worker)
         with mock.patch.object(
             self.window,
             "findChildren",

--- a/tests/test_gui_litellm_settings_page.py
+++ b/tests/test_gui_litellm_settings_page.py
@@ -31,6 +31,15 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
             Path(cls._temp_dir.name) / "litellm_catalog.json"
         )
         cls.window = MainWindow(litellm_catalog_cache=cls.cache)
+        # Build the LiteLLM page once against an empty config so tests never
+        # load a developer's real translator_config.json (which may register
+        # custom providers and break the fresh-state / duplicate-id tests).
+        with mock.patch.object(
+            cls.window.state,
+            "load_translator_config",
+            return_value={"sync": {}, "batch": {}},
+        ):
+            cls.window._ensure_settings_page("litellm")
 
     @classmethod
     def tearDownClass(cls):
@@ -1282,6 +1291,148 @@ class GuiLiteLLMSettingsPageTests(unittest.TestCase):
         self.assertIn("opencode-go", self.window._custom_litellm_providers)
         self.assertFalse(self.window._custom_litellm_providers_load_error)
         append_log.assert_not_called()
+
+    def test_detach_litellm_warmup_keeps_running_worker_alive(self):
+        """Shutdown must not drop the only reference to a running QThread."""
+        self.window._ensure_settings_page("litellm")
+        worker = mock.Mock()
+        worker.isRunning.return_value = True
+        self.window._litellm_module_warmup_worker = worker
+
+        self.window._detach_litellm_module_warmup()
+
+        self.assertIsNone(self.window._litellm_module_warmup_worker)
+        self.assertIn(worker, self.window._retired_litellm_warmup_workers)
+        worker.setParent.assert_called_once_with(None)
+        worker.deleteLater.assert_not_called()
+
+    def test_detach_litellm_warmup_deletes_finished_worker(self):
+        self.window._ensure_settings_page("litellm")
+        worker = mock.Mock()
+        worker.isRunning.return_value = False
+        self.window._litellm_module_warmup_worker = worker
+
+        self.window._detach_litellm_module_warmup()
+
+        self.assertIsNone(self.window._litellm_module_warmup_worker)
+        worker.deleteLater.assert_called_once_with()
+        self.assertNotIn(worker, self.window._retired_litellm_warmup_workers)
+
+    def test_module_warmup_refreshes_without_full_reload(self):
+        """Warmup revalidation must not reset unsaved page selections."""
+        self.window._ensure_settings_page("litellm")
+        config = {"sync": {"backend": "gemini"}, "batch": {}}
+        with (
+            mock.patch.object(
+                self.window.state,
+                "load_translator_config",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.window,
+                "_load_config_to_ui",
+            ) as reload_page,
+            mock.patch.object(
+                self.window,
+                "_after_custom_providers_changed",
+            ) as refresh,
+        ):
+            self.window._on_litellm_module_warmed(None)
+
+        reload_page.assert_not_called()
+        refresh.assert_called_once_with()
+        self.assertFalse(self.window._custom_litellm_providers_load_error)
+
+    def test_module_warmup_skips_refresh_when_providers_edited(self):
+        self.window._ensure_settings_page("litellm")
+        self.window._custom_litellm_providers_modified = True
+        with (
+            mock.patch.object(
+                self.window.state,
+                "load_translator_config",
+            ) as load,
+            mock.patch.object(
+                self.window,
+                "_after_custom_providers_changed",
+            ) as refresh,
+        ):
+            self.window._on_litellm_module_warmed(None)
+
+        load.assert_not_called()
+        refresh.assert_not_called()
+
+    def test_module_warmup_revalidation_error_sets_load_error(self):
+        self.window._ensure_settings_page("litellm")
+        config = {
+            "sync": {
+                "backend": "gemini",
+                "custom_litellm_providers": [
+                    {"id": "bad", "base_url": "not-a-url"},
+                ],
+            },
+            "batch": {},
+        }
+        with (
+            mock.patch.object(
+                self.window.state,
+                "load_translator_config",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.window,
+                "_after_custom_providers_changed",
+            ),
+            mock.patch.object(self.window, "_append_log"),
+        ):
+            self.window._on_litellm_module_warmed(None)
+
+        self.assertTrue(self.window._custom_litellm_providers_load_error)
+        self.assertEqual(self.window._custom_litellm_providers, {})
+
+    def test_module_warmup_cleans_retired_workers(self):
+        self.window._ensure_settings_page("litellm")
+        retired = mock.Mock()
+        retired.isRunning.return_value = False
+        self.window._retired_litellm_warmup_workers = {retired}
+        config = {"sync": {"backend": "gemini"}, "batch": {}}
+        with (
+            mock.patch.object(
+                self.window.state,
+                "load_translator_config",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.window,
+                "_after_custom_providers_changed",
+            ),
+        ):
+            self.window._on_litellm_module_warmed(None)
+
+        self.assertNotIn(retired, self.window._retired_litellm_warmup_workers)
+        retired.deleteLater.assert_called_once_with()
+
+    def test_warmup_worker_is_not_a_background_task(self):
+        """The warmup import must not gate shutdown with a task dialog."""
+        self.window._ensure_settings_page("litellm")
+        worker = mock.Mock()
+        worker.isRunning.return_value = True
+        self.window._litellm_module_warmup_worker = worker
+        with mock.patch.object(
+            self.window,
+            "findChildren",
+            return_value=[worker],
+        ):
+            self.assertEqual(self.window._owned_background_threads(), ())
+
+        # A retired (detached, still importing) worker is excluded as well.
+        self.window._litellm_module_warmup_worker = None
+        self.window._retired_litellm_warmup_workers = {worker}
+        with mock.patch.object(
+            self.window,
+            "findChildren",
+            return_value=[worker],
+        ):
+            self.assertEqual(self.window._owned_background_threads(), ())
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_litellm_worker.py
+++ b/tests/test_gui_litellm_worker.py
@@ -16,6 +16,7 @@ try:
         CONNECTION_TEST_TIMEOUT_SECONDS,
         LiteLLMConnectionTestWorker,
         LiteLLMModelCatalogWorker,
+        LiteLLMModuleWarmupWorker,
         LiteLLMProviderCatalogWorker,
         LiteLLMVersionWorker,
         is_cancelled_message,
@@ -24,6 +25,7 @@ try:
     from litellm_provider_config import custom_provider_registry
 except ImportError as exc:
     LiteLLMConnectionTestWorker = None
+    LiteLLMModuleWarmupWorker = None
     custom_provider_registry = None
     IMPORT_ERROR = exc
 else:
@@ -751,6 +753,39 @@ class LiteLLMConnectionTestWorkerTests(unittest.TestCase):
             worker.run()
 
         self.assertEqual(completed, [("", "", "", "", "broken metadata")])
+
+
+@unittest.skipIf(
+    LiteLLMModuleWarmupWorker is None,
+    f"GUI dependencies are unavailable: {IMPORT_ERROR}",
+)
+class LiteLLMModuleWarmupWorkerTests(unittest.TestCase):
+    def test_warmup_emits_cached_module(self):
+        fake_litellm = SimpleNamespace(models_by_provider={"warmed_prefix": ()})
+        completed = []
+        worker = LiteLLMModuleWarmupWorker()
+        worker.completed.connect(lambda module: completed.append(module))
+
+        with mock.patch(
+            "gui_qt.litellm_worker.warm_litellm_module",
+            return_value=fake_litellm,
+        ):
+            worker.run()
+
+        self.assertEqual(completed, [fake_litellm])
+
+    def test_warmup_emits_none_when_probe_fails(self):
+        completed = []
+        worker = LiteLLMModuleWarmupWorker()
+        worker.completed.connect(lambda module: completed.append(module))
+
+        with mock.patch(
+            "gui_qt.litellm_worker.warm_litellm_module",
+            side_effect=RuntimeError("broken import"),
+        ):
+            worker.run()
+
+        self.assertEqual(completed, [None])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_litellm_provider_config.py
+++ b/tests/test_litellm_provider_config.py
@@ -1,15 +1,18 @@
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 from litellm_provider_config import (
     KEYRING_SERVICE,
     CustomLiteLLMProvider,
     ProviderApiKeyStore,
     _decode_provider_key_store,
+    cached_litellm_module,
     catalog_source_label,
     custom_provider_from_mapping,
     custom_provider_registry,
     delete_provider_api_key,
+    litellm_install_probe,
     load_provider_api_key,
     load_provider_api_keys,
     load_provider_key_store,
@@ -34,6 +37,7 @@ from litellm_provider_config import (
     version_key,
     provider_from_model,
     python_requirement_allows,
+    warm_litellm_module,
 )
 
 
@@ -403,6 +407,92 @@ class LiteLLMProviderConfigTests(unittest.TestCase):
         reserved = reserved_litellm_provider_ids(fake_litellm)
         self.assertIn("some_custom_prefix", reserved)
         self.assertIn("openai", reserved)
+
+    def test_reserved_ids_non_blocking_never_imports_litellm(self):
+        with (
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_PROBED",
+                False,
+            ),
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_MODULE",
+                None,
+            ),
+            mock.patch(
+                "litellm_provider_config.warm_litellm_module",
+            ) as warm,
+        ):
+            reserved = reserved_litellm_provider_ids(allow_import=False)
+        self.assertIn("openai", reserved)
+        warm.assert_not_called()
+
+    def test_reserved_ids_non_blocking_merges_cached_module(self):
+        fake_litellm = SimpleNamespace(models_by_provider={"cached_prefix": ()})
+        with (
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_PROBED",
+                True,
+            ),
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_MODULE",
+                fake_litellm,
+            ),
+        ):
+            reserved = reserved_litellm_provider_ids(allow_import=False)
+        self.assertIn("cached_prefix", reserved)
+        self.assertIn("openai", reserved)
+
+    def test_parse_custom_providers_non_blocking_never_imports(self):
+        raw = [{"id": "vendor-x", "base_url": "https://v.example.com"}]
+        with (
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_PROBED",
+                False,
+            ),
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_MODULE",
+                None,
+            ),
+            mock.patch(
+                "litellm_provider_config.warm_litellm_module",
+            ) as warm,
+        ):
+            providers = parse_custom_litellm_providers(raw, allow_import=False)
+        self.assertEqual([provider.id for provider in providers], ["vendor-x"])
+        warm.assert_not_called()
+
+    def test_cached_litellm_module_is_empty_before_warmup(self):
+        with (
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_PROBED",
+                False,
+            ),
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_MODULE",
+                None,
+            ),
+            mock.patch("importlib.util.find_spec", return_value=None),
+        ):
+            self.assertIsNone(cached_litellm_module())
+            self.assertFalse(litellm_install_probe())
+
+    def test_warm_litellm_module_returns_cached_when_already_warmed(self):
+        fake_litellm = SimpleNamespace(models_by_provider={})
+        with (
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_PROBED",
+                True,
+            ),
+            mock.patch(
+                "litellm_provider_config._INSTALLED_LITELLM_MODULE",
+                fake_litellm,
+            ),
+            mock.patch(
+                "importlib.util.find_spec",
+                side_effect=AssertionError("probe must not run when cached"),
+            ),
+        ):
+            self.assertIs(warm_litellm_module(), fake_litellm)
 
     def test_custom_provider_duplicate_ids_are_rejected(self):
         raw = [


### PR DESCRIPTION
## 背景

PR #336（自定义 LiteLLM 供应商）引入后，首次打开「设置 → LiteLLM」页（含自定义 Provider 表格）会冻结约 10 秒。根因是页面构建时在 GUI 主线程同步执行 \import litellm\（用于把已安装 LiteLLM 的 provider 表合并进保留 id 校验集合），冷导入约需 9.6 秒。点击「添加 / 编辑自定义 Provider」、保存/重载配置、切换项目时同样会触发。

## 改动

**litellm_provider_config.py**（核心模块）
- 新增 \cached_litellm_module()\（只读缓存、永不导入）、\warm_litellm_module()\（后台幂等导入）、\litellm_install_probe()\（毫秒级 find_spec 探测）。
- \eserved_litellm_provider_ids\ / \parse_custom_litellm_providers\ / \custom_provider_registry\ / \alidate_custom_provider_id\ / \custom_provider_from_mapping\ 增加 \llow_import=False\：GUI 走静态保留集 + 已缓存模块，绝不阻塞；CLI / 后端保持同步语义不变。

**gui_qt/litellm_worker.py**
- 新增 \LiteLLMModuleWarmupWorker\，在低优先级后台线程执行 litellm 导入。

**gui_qt/app.py**
- GUI 全部改为 \llow_import=False\ 非阻塞调用。
- 首次打开 LiteLLM 页时启动后台预热；完成后用完整保留集重新读取页面并刷新校验状态。
- 关闭窗口时解绑仍在运行的预热线程，避免 Qt 在导入中途析构线程导致进程崩溃。
- 自定义 Provider 表格布局优化：id / 显示名称 / 密钥环境变量列改为可拖动（Interactive），API Base 列吸收剩余宽度，长 URL 右向省略 + 悬停 tooltip 显示完整内容，不再撑出横向滚动条。

**测试**
- \	ests/test_litellm_provider_config.py\：非阻塞解析/保留集、缓存与预热幂等覆盖。
- \	ests/test_gui_litellm_worker.py\：预热 worker 完成/失败路径。
- \	ests/gui_test_support.py\：headless GUI 测试禁用预热线程。

## 验证

- 首次打开 LiteLLM 设置页：约 10 秒 → **0.33 秒**（headless 实测）。
- LiteLLM 相关 154 个测试全部通过；CLI 全量 999 个通过；ruff / mypy / pip-audit 质量门禁通过。
- GUI 全量 1047 个中有 6 个失败，经排查为本机 \	ranslator_config.json\ 污染测试环境导致的既有问题（临时移走该文件后 62 个相关测试全部通过），与本改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background LiteLLM loading for smoother provider settings access.
  * Provider validation and configuration loading can continue while LiteLLM initializes.
  * Custom-provider tables now support resizable columns, minimum widths, shortened values, and full-value tooltips.
  * Settings refresh after loading completes without overwriting unsaved provider changes.

* **Bug Fixes**
  * Improved shutdown handling, worker cleanup, and error reporting during provider initialization.
  * Added safer detection of LiteLLM availability and clearer handling of invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->