### PR TITLE
fix(sync): add bounded request timeouts

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -132,6 +132,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 - **扩展**：按需安装 / 修复 / 更新关系分析器的独立依赖。安装状态来自当前 Python 环境，不另存“已启用”开关；安装在后台运行，普通翻译不会加载这些科学计算与图像依赖。关系分析器的运行入口和边界见 [关系与语义分析](relation_analysis.md)。
 - **项目**：术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。Ren'Py SDK 须显式配置： **查找 SDK**（用户点击后才扫描附近）、**浏览…**，或确认后 **下载推荐 SDK…**（官方固定版本）；留空不会自动搜其它目录或联网。结果写入 `prepare.renpy_sdk_dir`，保存设置后生效。当前 `game_root` 只读展示；需换项目请用「项目与环境」或「项目列表」。
 - **模型**：同步 / 批量翻译模型、embedding model、批量 thinking level。
+- **高级 · 翻译吞吐**：`同步单请求超时` 统一控制同步翻译、项目分析、关键词、订正、修补和 A/B 对比的每次模型请求等待上限；默认 120 秒，可设 5–600 秒，不是整次任务总时限。
 - **上下文**：
   - **按当前项目保存**（`work/project_context_settings.json`）：启用批量 RAG、启用原文索引、开始翻译时自动暖 RAG，以及项目分析的启用 / 用于翻译。切换游戏互不影响。
   - **工具全局**（`translator_config.json`）：上下文库保存位置（工具 `logs/` 或游戏旁 `translation_context/`）；以及 **同步 RAG / 同步·批量剧情记忆主开关**（仅在本分区编辑，高级页不重复）。
@@ -269,7 +270,7 @@ build -> submit -> status -> download -> check
 
 ### 同步翻译
 
-在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；若部分文件未通过 adapter 写回计划校验，GUI 显示「部分完成」警告，只允许写回 manifest 中其余已生成的安全预览。用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
+在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；若部分文件未通过 adapter 写回计划校验，GUI 显示「部分完成」警告，只允许写回 manifest 中其余已生成的安全预览。用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；其中 `timeout_seconds` 是单请求上限并会写入同步 manifest 的设置诊断。Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
 
 #### LiteLLM 同步替代边界
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -157,7 +157,7 @@ python gemini_translate_batch.py doctor
 
 ## 运行模式
 
-当前更推荐优先使用 Gemini Batch 模式；同步模式可显式选择 Gemini 原生调用或可选 LiteLLM 后端。同步模式的 `backend/model/chunk_size/max_source_chars/max_output_tokens` 和可选 RAG 滚动记忆都通过 `translator_config.json` 的 `sync` 配置读取。LiteLLM 未安装或未启用时，不影响 Gemini Batch、doctor 或 GUI 启动。
+当前更推荐优先使用 Gemini Batch 模式；同步模式可显式选择 Gemini 原生调用或可选 LiteLLM 后端。同步模式的 `backend/model/chunk_size/max_source_chars/max_output_tokens/timeout_seconds` 和可选 RAG 滚动记忆都通过 `translator_config.json` 的 `sync` 配置读取。`timeout_seconds` 默认 120，允许 5–600 秒，表示单次模型请求上限而非整次任务总时限，并统一用于同步翻译、项目分析、关键词、订正、修补和 A/B 对比。LiteLLM 未安装或未启用时，不影响 Gemini Batch、doctor 或 GUI 启动。
 
 ### 自定义 OpenAI 兼容 Provider（LiteLLM 同步）
 

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -18,7 +18,9 @@
 3. Gemini 后端需要本地 `api_keys.json` 或 `GEMINI_API_KEY*` 环境变量；LiteLLM 后端需要在操作系统凭据管理器或供应商约定的环境变量中保存凭据。
 4. 先备份项目，并用 `include_files` / `include_prefixes` 把第一次运行限制在少量文件。
 
-同步设置来自 `translator_config.json` 的 `sync` 段，主要包括 `backend`、`model`、`chunk_size`、`max_source_chars` 和 `max_output_tokens`。完整字段和模型目录见 [安装与本地配置](setup.md#运行模式)。
+同步设置来自 `translator_config.json` 的 `sync` 段，主要包括 `backend`、`model`、`chunk_size`、`max_source_chars`、`max_output_tokens` 和 `timeout_seconds`。完整字段和模型目录见 [安装与本地配置](setup.md#运行模式)。
+
+`timeout_seconds` 默认 120 秒，可设为 5–600 秒。它是每一次模型请求的等待上限，不是整次任务的总时限；普通同步翻译、项目分析、同步关键词、同步订正、同步修补和翻译 A/B 对比均读取同一字段。Gemini backend 会把秒转换为 SDK 的毫秒级 `http_options.timeout`，LiteLLM backend 则按秒透传。手工配置超出范围时 runtime 会收敛到最近边界，避免异常值形成无界等待。
 
 选择 LiteLLM 后端时，可通过 `sync.custom_litellm_providers` 注册 OpenAI 兼容但 LiteLLM 未内置的服务（OpenCode Go、中转站、本地 vLLM 等）：每项配置 `id` / `label` / `base_url` / `models_url` / `api_key_env`，请求会改写为 `openai/<模型>` 并逐请求透传 `api_base`，密钥优先使用系统凭据管理器。字段与示例见 [安装与本地配置 · 自定义 OpenAI 兼容 Provider](setup.md#自定义-openai-兼容-providerlitellm-同步)。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -392,6 +392,11 @@ def normalize_batch_safety_settings(value):
 
 
 def load_batch_settings():
+    """Load persisted settings, normalizing sync timeouts to the shared contract.
+
+    ``sync.timeout_seconds`` is a per-model-request limit in seconds. Missing or
+    invalid values default to 120 seconds, and effective values stay within 5-600.
+    """
     global BATCH_MODEL, BATCH_TARGET_SIZE, BATCH_CONTEXT_BEFORE, BATCH_CONTEXT_AFTER
     global BATCH_TARGET_CHARS, BATCH_RETRY_TARGET_SIZE, BATCH_RETRY_TARGET_CHARS
     global BATCH_MAX_OUTPUT_TOKENS, BATCH_TEMPERATURE, BATCH_THINKING_LEVEL

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -69,7 +69,12 @@ from gemini_model_catalog import (
     is_gemini_3_model,
 )
 from project_version import __version__
-from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
+from sync_model_backend import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
+    GeminiSyncBackend,
+    SyncGenerationRequest,
+    normalize_sync_timeout_seconds,
+)
 
 try:
     from google import genai
@@ -92,6 +97,7 @@ PROJECT_SNAPSHOTS_DIR = os.path.join(LOG_DIR, 'project_snapshots')
 PROJECT_RECONCILIATIONS_DIR = os.path.join(LOG_DIR, 'project_reconciliations')
 SYNC_BACKEND = 'gemini'
 SYNC_MODEL = ''
+SYNC_TIMEOUT_SECONDS = DEFAULT_SYNC_TIMEOUT_SECONDS
 MACHINE_OUTPUT_COMMANDS = frozenset(
     {
         'doctor',
@@ -410,7 +416,7 @@ def load_batch_settings():
     global FINAL_REVIEW_ENABLED, FINAL_REVIEW_REQUIRE_ZERO_PENDING, FINAL_REVIEW_CHUNK_SIZE
     global FINAL_REVIEW_PROMPT_SCHEMA_VERSION, FINAL_REVIEW_MODEL
     global FINAL_REVIEW_DISPLAY_NAME_PREFIX
-    global BATCH_NON_CHINESE_RULES, SYNC_BACKEND, SYNC_MODEL
+    global BATCH_NON_CHINESE_RULES, SYNC_BACKEND, SYNC_MODEL, SYNC_TIMEOUT_SECONDS
 
     config = load_json_file(legacy.CONFIG_FILE)
     translator_config = load_json_file(legacy.TRANSLATOR_CONFIG)
@@ -476,6 +482,10 @@ def load_batch_settings():
         SYNC_MODEL = sync_model.strip()
     else:
         SYNC_MODEL = ''
+    SYNC_TIMEOUT_SECONDS = normalize_sync_timeout_seconds(
+        sync.get('timeout_seconds'),
+        DEFAULT_SYNC_TIMEOUT_SECONDS,
+    )
     model_name = batch.get('model')
     if isinstance(model_name, str) and model_name.strip():
         BATCH_MODEL = model_name.strip()
@@ -8253,6 +8263,7 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
             model_name,
             request_payload.get('generation_config') or {},
         )
+        config['timeout'] = SYNC_TIMEOUT_SECONDS
         system_instruction = request_payload.get('system_instruction')
         if system_instruction:
             config['system_instruction'] = system_instruction
@@ -9854,6 +9865,7 @@ def _sync_result_to_dict(result):
 
 def run_sync_request(request_payload, model_name, api_key_index=None):
     config = dict(request_payload.get('generation_config') or {})
+    config['timeout'] = SYNC_TIMEOUT_SECONDS
     system_instruction = request_payload.get('system_instruction')
     if system_instruction:
         config['system_instruction'] = system_instruction
@@ -10016,6 +10028,8 @@ def make_sync_manifest(
     settings,
     extra_fields=None,
 ):
+    settings = dict(settings or {})
+    settings.setdefault('timeout_seconds', SYNC_TIMEOUT_SECONDS)
     input_jsonl_path = os.path.join(package_dir, 'requests.jsonl')
     result_jsonl_path = os.path.join(package_dir, 'results.jsonl')
     write_request_rows(input_jsonl_path, request_rows)
@@ -12854,6 +12868,7 @@ def dispatch_command(parser, args):
                     config={
                         'model': model,
                         'thinking_level': PROJECT_ANALYSIS_THINKING_LEVEL,
+                        'timeout_seconds': SYNC_TIMEOUT_SECONDS,
                         'max_label_summary_chars': PROJECT_ANALYSIS_MAX_LABEL_SUMMARY_CHARS,
                         'max_route_summary_chars': PROJECT_ANALYSIS_MAX_ROUTE_SUMMARY_CHARS,
                         'max_brief_chars': PROJECT_ANALYSIS_MAX_BRIEF_CHARS,

--- a/gui_qt/settings_schema.py
+++ b/gui_qt/settings_schema.py
@@ -24,6 +24,12 @@ from gemini_model_catalog import (
     extras_beyond_builtins,
     filter_gemini_rotation_models,
 )
+from sync_model_backend import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
+    MAX_SYNC_TIMEOUT_SECONDS,
+    MIN_SYNC_TIMEOUT_SECONDS,
+)
+from .user_copy import SYNC_TIMEOUT_COPY
 
 
 SettingKind = Literal[
@@ -171,6 +177,17 @@ ADVANCED_SETTING_FIELDS: tuple[SettingField, ...] = (
         24576,
         "翻译吞吐",
         minimum=1,
+    ),
+    SettingField(
+        "sync_timeout_seconds",
+        ("sync", "timeout_seconds"),
+        SYNC_TIMEOUT_COPY["label"],
+        SYNC_TIMEOUT_COPY["description"],
+        "int",
+        DEFAULT_SYNC_TIMEOUT_SECONDS,
+        "翻译吞吐",
+        minimum=MIN_SYNC_TIMEOUT_SECONDS,
+        maximum=MAX_SYNC_TIMEOUT_SECONDS,
     ),
     SettingField(
         "batch_chunk_size",

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import doctor_recommendations as doctor_rec
+from sync_model_backend import MAX_SYNC_TIMEOUT_SECONDS, MIN_SYNC_TIMEOUT_SECONDS
 
 SAFETY_LEVEL_LABELS = {
     "safe": "可写回",
@@ -91,6 +92,15 @@ USAGE_LEDGER_COPY = {
     "recent": "最近一次运行",
     "estimated_cost": "估算成本（非 provider 账单）",
     "actual_cost": "Provider 报告成本",
+}
+
+SYNC_TIMEOUT_COPY = {
+    "label": "同步单请求超时",
+    "description": (
+        "普通翻译、项目分析、关键词、订正、补译与 A/B 对比中，每次模型请求的等待上限；"
+        "不是整次任务的总时限。允许范围 "
+        f"{MIN_SYNC_TIMEOUT_SECONDS}–{MAX_SYNC_TIMEOUT_SECONDS} 秒。"
+    ),
 }
 
 PROJECT_ANALYSIS_COPY = {

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -8,7 +8,12 @@ from litellm_provider_config import (
     CustomLiteLLMProvider,
     provider_from_model,
 )
-from sync_model_backend import SYNC_EXECUTION_MODE, SyncGenerationRequest, SyncGenerationResult
+from sync_model_backend import (
+    SYNC_EXECUTION_MODE,
+    SyncGenerationRequest,
+    SyncGenerationResult,
+    normalize_sync_timeout_seconds,
+)
 
 
 class LiteLLMBackendError(RuntimeError):
@@ -242,8 +247,7 @@ class LiteLLMSyncBackend:
             kwargs["api_key"] = api_key
         if custom is not None:
             kwargs["api_base"] = custom.base_url
-        if "timeout" in config:
-            kwargs["timeout"] = config["timeout"]
+        kwargs["timeout"] = normalize_sync_timeout_seconds(config.get("timeout"))
         if "temperature" in config:
             kwargs["temperature"] = config["temperature"]
         if "max_output_tokens" in config:

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -31,7 +31,13 @@ from project_analysis import (
     utc_now_iso,
 )
 from gemini_model_catalog import filter_gemini_generation_config
-from sync_model_backend import SyncGenerationRequest, SyncModelBackend, SyncGenerationResult
+from sync_model_backend import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
+    SyncGenerationRequest,
+    SyncGenerationResult,
+    SyncModelBackend,
+    normalize_sync_timeout_seconds,
+)
 
 PROMPT_SCHEMA_VERSION = "project-analysis-llm-v2"
 
@@ -46,6 +52,7 @@ class AnalysisLlmConfig(Protocol):
     max_brief_chars: int
     max_input_chars_per_request: int
     max_output_tokens: int
+    timeout_seconds: int
 
 
 def default_llm_config(
@@ -57,6 +64,7 @@ def default_llm_config(
     max_brief_chars: int = 4000,
     max_input_chars_per_request: int = 12000,
     max_output_tokens: int = 2048,
+    timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     return {
         "model": str(model or "").strip(),
@@ -66,6 +74,7 @@ def default_llm_config(
         "max_brief_chars": int(max_brief_chars),
         "max_input_chars_per_request": int(max_input_chars_per_request),
         "max_output_tokens": int(max_output_tokens),
+        "timeout_seconds": normalize_sync_timeout_seconds(timeout_seconds),
     }
 
 
@@ -79,6 +88,10 @@ def merge_llm_config(config: Mapping[str, Any] | None = None) -> dict[str, Any]:
         max_brief_chars=int(raw.get("max_brief_chars") or 4000),
         max_input_chars_per_request=int(raw.get("max_input_chars_per_request") or 12000),
         max_output_tokens=int(raw.get("max_output_tokens") or 2048),
+        timeout_seconds=normalize_sync_timeout_seconds(
+            raw.get("timeout_seconds"),
+            DEFAULT_SYNC_TIMEOUT_SECONDS,
+        ),
     )
 
 
@@ -177,11 +190,13 @@ def _build_request(
     user: str,
     thinking_level: str = "",
     max_output_tokens: int = 2048,
+    timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> SyncGenerationRequest:
     config: dict[str, Any] = {
         "system_instruction": system,
         "max_output_tokens": max_output_tokens,
         "temperature": 0.2,
+        "timeout": normalize_sync_timeout_seconds(timeout_seconds),
     }
     if thinking_level:
         config["thinking_config"] = {"thinking_level": thinking_level}
@@ -200,6 +215,7 @@ def complete_analysis_text(
     user: str,
     thinking_level: str = "",
     max_output_tokens: int = 2048,
+    timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> tuple[str, Mapping[str, Any]]:
     """Call backend; return (text, usage_metadata)."""
     if not model:
@@ -211,6 +227,7 @@ def complete_analysis_text(
             user=user,
             thinking_level=thinking_level,
             max_output_tokens=max_output_tokens,
+            timeout_seconds=timeout_seconds,
         )
     )
     text = str(getattr(result, "response_text", "") or "").strip()
@@ -284,6 +301,7 @@ def refine_label_record(
         user=user,
         thinking_level=cfg["thinking_level"],
         max_output_tokens=cfg["max_output_tokens"],
+        timeout_seconds=cfg["timeout_seconds"],
     )
     text = _clip(text, cfg["max_label_summary_chars"])
     out = dict(rec)
@@ -347,6 +365,7 @@ def refine_route_record(
         user=user,
         thinking_level=cfg["thinking_level"],
         max_output_tokens=cfg["max_output_tokens"],
+        timeout_seconds=cfg["timeout_seconds"],
     )
     text = _clip(text, cfg["max_route_summary_chars"])
     out = dict(rec)
@@ -405,6 +424,7 @@ def refine_project_brief(
         user=user,
         thinking_level=cfg["thinking_level"],
         max_output_tokens=cfg["max_output_tokens"],
+        timeout_seconds=cfg["timeout_seconds"],
     )
     return _clip(text, cfg["max_brief_chars"])
 

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -45,6 +45,12 @@ GenerateFn = Callable[[SyncGenerationRequest], SyncGenerationResult]
 
 
 class AnalysisLlmConfig(Protocol):
+    """Project-analysis request settings with a bounded per-request timeout.
+
+    ``timeout_seconds`` follows the shared synchronous contract: it defaults to
+    120 seconds and is normalized to the inclusive 5-600 second range.
+    """
+
     model: str
     thinking_level: str
     max_label_summary_chars: int
@@ -66,6 +72,7 @@ def default_llm_config(
     max_output_tokens: int = 2048,
     timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
+    """Build normalized analysis settings, including the bounded request timeout."""
     return {
         "model": str(model or "").strip(),
         "thinking_level": str(thinking_level or "").strip(),
@@ -79,6 +86,7 @@ def default_llm_config(
 
 
 def merge_llm_config(config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Merge partial analysis settings while restoring timeout defaults and bounds."""
     raw = dict(config or {})
     return default_llm_config(
         model=str(raw.get("model") or ""),
@@ -192,6 +200,7 @@ def _build_request(
     max_output_tokens: int = 2048,
     timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> SyncGenerationRequest:
+    """Build one backend request with a normalized per-request timeout in seconds."""
     config: dict[str, Any] = {
         "system_instruction": system,
         "max_output_tokens": max_output_tokens,
@@ -217,7 +226,7 @@ def complete_analysis_text(
     max_output_tokens: int = 2048,
     timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
 ) -> tuple[str, Mapping[str, Any]]:
-    """Call backend; return (text, usage_metadata)."""
+    """Call the backend with the bounded timeout and return text plus usage metadata."""
     if not model:
         raise ProjectAnalysisError("analysis LLM model is not configured")
     result = generate(

--- a/sync_model_backend.py
+++ b/sync_model_backend.py
@@ -10,6 +10,23 @@ from typing import Any, Callable, Dict, Mapping, Optional, Protocol, runtime_che
 from gemini_model_catalog import filter_gemini_generation_config
 
 SYNC_EXECUTION_MODE = "sync"
+DEFAULT_SYNC_TIMEOUT_SECONDS = 120
+MIN_SYNC_TIMEOUT_SECONDS = 5
+MAX_SYNC_TIMEOUT_SECONDS = 600
+
+
+def normalize_sync_timeout_seconds(
+    value: Any,
+    default: int = DEFAULT_SYNC_TIMEOUT_SECONDS,
+) -> int:
+    """Return a finite per-request timeout constrained to safe sync bounds."""
+    try:
+        if isinstance(value, bool):
+            raise TypeError("boolean is not a timeout")
+        timeout = int(value)
+    except (TypeError, ValueError, OverflowError):
+        timeout = int(default)
+    return max(MIN_SYNC_TIMEOUT_SECONDS, min(MAX_SYNC_TIMEOUT_SECONDS, timeout))
 
 @dataclass(frozen=True)
 class SyncGenerationRequest:
@@ -48,10 +65,23 @@ class GeminiSyncBackend:
         self._extract_usage = extract_usage
 
     def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult:
+        config = filter_gemini_generation_config(request.model, request.config)
+        timeout = config.pop("timeout", DEFAULT_SYNC_TIMEOUT_SECONDS)
+        raw_http_options = config.get("http_options")
+        http_options = (
+            dict(raw_http_options)
+            if isinstance(raw_http_options, Mapping)
+            else {}
+        )
+        # google-genai HttpOptions uses milliseconds; the public sync request
+        # contract and LiteLLM both use seconds. Apply the default here as a
+        # final boundary even if a future caller forgets to set it.
+        http_options["timeout"] = normalize_sync_timeout_seconds(timeout) * 1000
+        config["http_options"] = http_options
         response = self._client.models.generate_content(
             model=request.model,
             contents=request.contents,
-            config=filter_gemini_generation_config(request.model, request.config),
+            config=config,
         )
         payload = self._serialize_response(response)
         usage: Dict[str, Any] = {}

--- a/tests/test_gui_settings_schema.py
+++ b/tests/test_gui_settings_schema.py
@@ -15,6 +15,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
     def test_user_visible_setting_titles_use_chinese_copy(self):
         expected_labels = {
             "sync_chunk_size": "同步分块条数",
+            "sync_timeout_seconds": "同步单请求超时",
             "batch_chunk_size": "批量分块条数",
             "batch_retry_chunk_size": "补译分块条数",
             "keyword_chunk_size": "关键词分块条数",
@@ -74,6 +75,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
         values = read_advanced_settings({})
 
         self.assertEqual(values["sync_chunk_size"], 40)
+        self.assertEqual(values["sync_timeout_seconds"], 120)
         self.assertEqual(values["batch_chunk_size"], 60)
         self.assertEqual(values["batch_temperature"], 0.2)
         self.assertEqual(values["batch_source_index_min_similarity"], 0.72)
@@ -85,6 +87,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
             {
                 "sync": {
                     "chunk_size": "7",
+                    "timeout_seconds": "45",
                     "rag": {
                         "enabled": True,
                         "min_similarity": "0.5",
@@ -100,6 +103,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
         )
 
         self.assertEqual(values["sync_chunk_size"], 7)
+        self.assertEqual(values["sync_timeout_seconds"], 45)
         self.assertTrue(values["sync_rag_enabled"])
         self.assertEqual(values["sync_rag_min_similarity"], 0.5)
         self.assertEqual(values["sync_rag_store_dir"], "logs/sync_rag")
@@ -112,6 +116,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
         values["batch_chunk_size"] = 0
         values["batch_temperature"] = 2.5
         values["sync_rag_min_similarity"] = -0.1
+        values["sync_timeout_seconds"] = 601
         values["context_storage_game_dir_name"] = ""
 
         errors = validate_advanced_settings(values)
@@ -119,6 +124,7 @@ class GuiSettingsSchemaTests(unittest.TestCase):
         self.assertIn("batch_chunk_size", errors)
         self.assertIn("batch_temperature", errors)
         self.assertIn("sync_rag_min_similarity", errors)
+        self.assertIn("sync_timeout_seconds", errors)
         self.assertIn("context_storage_game_dir_name", errors)
 
     def test_list_and_json_fields_round_trip_from_text(self):

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -8,18 +8,30 @@ class LiteLLMConfigTests(unittest.TestCase):
     def test_batch_settings_load_explicit_sync_backend_and_model(self):
         previous_backend = batch_mod.SYNC_BACKEND
         previous_model = batch_mod.SYNC_MODEL
+        previous_timeout = batch_mod.SYNC_TIMEOUT_SECONDS
         try:
             with mock.patch.object(
                 batch_mod,
                 "load_json_file",
-                side_effect=[{}, {"sync": {"backend": "litellm", "model": "openai/test"}}],
+                side_effect=[
+                    {},
+                    {
+                        "sync": {
+                            "backend": "litellm",
+                            "model": "openai/test",
+                            "timeout_seconds": 45,
+                        }
+                    },
+                ],
             ):
                 batch_mod.load_batch_settings()
             self.assertEqual(batch_mod.SYNC_BACKEND, "litellm")
             self.assertEqual(batch_mod.SYNC_MODEL, "openai/test")
+            self.assertEqual(batch_mod.SYNC_TIMEOUT_SECONDS, 45)
         finally:
             batch_mod.SYNC_BACKEND = previous_backend
             batch_mod.SYNC_MODEL = previous_model
+            batch_mod.SYNC_TIMEOUT_SECONDS = previous_timeout
 
     def test_batch_settings_reject_unknown_sync_backend(self):
         with mock.patch.object(

--- a/tests/test_litellm_runtime_integration.py
+++ b/tests/test_litellm_runtime_integration.py
@@ -80,6 +80,7 @@ class LiteLLMRuntimeIntegrationTests(unittest.TestCase):
 
         with (
             mock.patch.object(runtime, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(runtime, "SYNC_TIMEOUT_SECONDS", 45),
             mock.patch.object(runtime, "get_current_model", return_value="openai/test"),
             mock.patch.object(runtime, "create_genai_client") as create_gemini,
             mock.patch("litellm_sync_backend.LiteLLMSyncBackend", return_value=fake_backend),
@@ -89,6 +90,7 @@ class LiteLLMRuntimeIntegrationTests(unittest.TestCase):
         create_gemini.assert_not_called()
         request = fake_backend.generate.call_args.args[0]
         self.assertEqual(request.model, "openai/test")
+        self.assertEqual(request.config["timeout"], 45)
         self.assertEqual(result, [{"id": "a", "translation": "你好"}])
 
     def test_sync_settings_default_to_gemini_and_accept_litellm(self):
@@ -108,6 +110,33 @@ class LiteLLMRuntimeIntegrationTests(unittest.TestCase):
         with self.assertRaises(ValueError) as captured:
             runtime.load_sync_translation_settings({"sync": {"backend": "automatic"}})
         self.assertIn("Unsupported sync backend", str(captured.exception))
+
+    def test_sync_timeout_settings_are_bounded(self):
+        previous = runtime.SYNC_TIMEOUT_SECONDS
+        try:
+            runtime.load_sync_translation_settings(
+                {"sync": {"timeout_seconds": 1}}
+            )
+            self.assertEqual(
+                runtime.SYNC_TIMEOUT_SECONDS,
+                runtime.MIN_SYNC_TIMEOUT_SECONDS,
+            )
+            runtime.load_sync_translation_settings(
+                {"sync": {"timeout_seconds": 9999}}
+            )
+            self.assertEqual(
+                runtime.SYNC_TIMEOUT_SECONDS,
+                runtime.MAX_SYNC_TIMEOUT_SECONDS,
+            )
+            runtime.load_sync_translation_settings(
+                {"sync": {"timeout_seconds": "invalid"}}
+            )
+            self.assertEqual(
+                runtime.SYNC_TIMEOUT_SECONDS,
+                runtime.DEFAULT_SYNC_TIMEOUT_SECONDS,
+            )
+        finally:
+            runtime.SYNC_TIMEOUT_SECONDS = previous
 
     def test_sync_settings_load_custom_providers_into_runtime(self):
         previous_backend = runtime.SYNC_BACKEND

--- a/tests/test_litellm_sync_integration.py
+++ b/tests/test_litellm_sync_integration.py
@@ -1,26 +1,34 @@
+import json
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
 
 
 class LiteLLMSyncIntegrationTests(unittest.TestCase):
-    def test_sync_runner_uses_litellm_only_when_explicitly_selected(self):
-        fake_result = type("Result", (), {
+    @staticmethod
+    def _fake_result(provider="litellm", model="openai/test"):
+        return type("Result", (), {
             "response_payload": {"choices": []},
             "response_text": "[]",
             "finish_reason": "stop",
             "usage_metadata": {"total_tokens": 3},
-            "provider": "litellm",
-            "model": "openai/test",
+            "provider": provider,
+            "model": model,
             "execution_mode": "sync",
         })()
+
+    def test_sync_runner_uses_litellm_only_when_explicitly_selected(self):
+        fake_result = self._fake_result()
         fake_backend = mock.Mock()
         fake_backend.generate.return_value = fake_result
 
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
             mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod, "SYNC_TIMEOUT_SECONDS", 45),
             mock.patch.object(batch_mod, "create_batch_client") as create_client,
             mock.patch("litellm_sync_backend.LiteLLMSyncBackend", return_value=fake_backend),
         ):
@@ -32,8 +40,31 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
         create_client.assert_not_called()
         request = fake_backend.generate.call_args.args[0]
         self.assertEqual(request.model, "openai/test")
+        self.assertEqual(request.config["timeout"], 45)
         self.assertEqual(result["provider"], "litellm")
         self.assertEqual(result["execution_mode"], "sync")
+
+    def test_sync_runner_passes_timeout_to_gemini_backend(self):
+        fake_backend = mock.Mock()
+        fake_backend.generate.return_value = self._fake_result(
+            provider="gemini",
+            model="gemini-test",
+        )
+        with (
+            mock.patch.object(batch_mod, "SYNC_BACKEND", "gemini"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "gemini-test"),
+            mock.patch.object(batch_mod, "SYNC_TIMEOUT_SECONDS", 45),
+            mock.patch.object(batch_mod, "create_batch_client"),
+            mock.patch.object(
+                batch_mod,
+                "GeminiSyncBackend",
+                return_value=fake_backend,
+            ),
+        ):
+            batch_mod.run_sync_request({"contents": []}, "gemini-default")
+
+        request = fake_backend.generate.call_args.args[0]
+        self.assertEqual(request.config["timeout"], 45)
 
     def test_litellm_rejects_gemini_api_key_index(self):
         with (
@@ -43,6 +74,25 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
             with self.assertRaises(SystemExit) as captured:
                 batch_mod.run_sync_request({}, "gemini-default", api_key_index=0)
         self.assertIn("only supported by the Gemini", str(captured.exception))
+
+    def test_sync_manifest_records_effective_request_timeout(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            batch_mod,
+            "SYNC_TIMEOUT_SECONDS",
+            45,
+        ):
+            manifest_path = batch_mod.make_sync_manifest(
+                package_dir=tmp,
+                mode=batch_mod.MANIFEST_MODE_TRANSLATION,
+                display_name="timeout-test",
+                chunks=[],
+                request_rows=[],
+                settings={"max_output_tokens": 64},
+            )
+
+            manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["settings"]["timeout_seconds"], 45)
 
 
 if __name__ == "__main__":

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -62,6 +62,19 @@ class MapReduceTests(unittest.TestCase):
         )
         self.assertNotIn("temperature", request.config)
         self.assertEqual(request.config["max_output_tokens"], 2048)
+        self.assertEqual(
+            request.config["timeout"],
+            llm.DEFAULT_SYNC_TIMEOUT_SECONDS,
+        )
+
+    def test_analysis_request_uses_configured_sync_timeout(self):
+        request = llm._build_request(
+            model="fake-model",
+            system="system",
+            user="user",
+            timeout_seconds=45,
+        )
+        self.assertEqual(request.config["timeout"], 45)
 
     def test_mapreduce_refines_labels_routes_brief(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -32,6 +32,7 @@ def _snapshot_sensitive_runtime():
         "MAX_ITEMS": runtime.MAX_ITEMS,
         "MAX_CHARS": runtime.MAX_CHARS,
         "SYNC_MAX_OUTPUT_TOKENS": runtime.SYNC_MAX_OUTPUT_TOKENS,
+        "SYNC_TIMEOUT_SECONDS": runtime.SYNC_TIMEOUT_SECONDS,
         "SYNC_BACKEND": runtime.SYNC_BACKEND,
         "INCLUDE_FILES": set(runtime.INCLUDE_FILES),
         "INCLUDE_PREFIXES": set(runtime.INCLUDE_PREFIXES),
@@ -70,21 +71,43 @@ class RuntimeConfigObjectTests(unittest.TestCase):
             cfg.tl_dir = "C:/games/Example/work/game/tl/japanese"
             cfg.work_game_dir = "C:/games/Example/work/game"
             cfg.max_items = 11
+            cfg.sync_timeout_seconds = 45
             applied = runtime.apply_runtime_config(cfg)
             self.assertEqual(runtime.API_KEYS, ["key-a"])
             self.assertEqual(runtime.PREP_LANGUAGE, "japanese")
             self.assertEqual(runtime.TL_SUBDIR, "game/tl/japanese")
             self.assertEqual(runtime.MAX_ITEMS, 11)
+            self.assertEqual(runtime.SYNC_TIMEOUT_SECONDS, 45)
 
             snapped = runtime.snapshot_runtime_config()
             self.assertEqual(snapped.api_keys, ["key-a"])
             self.assertEqual(snapped.prep_language, "japanese")
             self.assertEqual(snapped.tl_subdir, "game/tl/japanese")
             self.assertEqual(snapped.max_items, 11)
+            self.assertEqual(snapped.sync_timeout_seconds, 45)
             self.assertIsInstance(applied, runtime.RuntimeConfig)
             self.assertIs(runtime.ProjectContext, runtime.RuntimeConfig)
             got = runtime.get_runtime_config()
             self.assertEqual(got.api_keys, ["key-a"])
+        finally:
+            _restore_sensitive_runtime(snapshot)
+
+    def test_apply_runtime_config_normalizes_timeout_in_active_snapshot(self):
+        snapshot = _snapshot_sensitive_runtime()
+        try:
+            cfg = runtime.default_runtime_config()
+            cfg.sync_timeout_seconds = 9999
+
+            applied = runtime.apply_runtime_config(cfg)
+
+            self.assertEqual(
+                applied.sync_timeout_seconds,
+                runtime.MAX_SYNC_TIMEOUT_SECONDS,
+            )
+            self.assertEqual(
+                runtime.get_runtime_config().sync_timeout_seconds,
+                runtime.MAX_SYNC_TIMEOUT_SECONDS,
+            )
         finally:
             _restore_sensitive_runtime(snapshot)
 
@@ -236,6 +259,10 @@ class DefaultsFirstReloadTests(unittest.TestCase):
                     self.assertEqual(cfg_b.prep_language, runtime.DEFAULT_PREP_LANGUAGE)
                     self.assertEqual(cfg_b.tl_subdir, runtime.DEFAULT_TL_SUBDIR)
                     self.assertEqual(cfg_b.sync_backend, runtime.DEFAULT_SYNC_BACKEND)
+                    self.assertEqual(
+                        cfg_b.sync_timeout_seconds,
+                        runtime.DEFAULT_SYNC_TIMEOUT_SECONDS,
+                    )
                     self.assertEqual(runtime.API_KEYS, ["key-b"])
                     self.assertEqual(runtime.PREP_LANGUAGE, runtime.DEFAULT_PREP_LANGUAGE)
                     # With model rotation off (default), the active list pins to

--- a/tests/test_sync_model_backend.py
+++ b/tests/test_sync_model_backend.py
@@ -1,6 +1,14 @@
 import unittest
 
-from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest, SyncModelBackend
+from sync_model_backend import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
+    MAX_SYNC_TIMEOUT_SECONDS,
+    MIN_SYNC_TIMEOUT_SECONDS,
+    GeminiSyncBackend,
+    SyncGenerationRequest,
+    SyncModelBackend,
+    normalize_sync_timeout_seconds,
+)
 
 
 class _Models:
@@ -39,7 +47,14 @@ class SyncModelBackendTests(unittest.TestCase):
             model="gemini-test", contents="prompt", config={"temperature": 0.2},
         ))
         self.assertEqual(client.models.calls, [{
-            "model": "gemini-test", "contents": "prompt", "config": {"temperature": 0.2},
+            "model": "gemini-test",
+            "contents": "prompt",
+            "config": {
+                "temperature": 0.2,
+                "http_options": {
+                    "timeout": DEFAULT_SYNC_TIMEOUT_SECONDS * 1000,
+                },
+            },
         }])
         self.assertEqual(result.provider, "gemini")
         self.assertEqual(result.model, "gemini-test")
@@ -60,7 +75,51 @@ class SyncModelBackendTests(unittest.TestCase):
         )
         backend.generate(SyncGenerationRequest("gemini-test", [], config))
         self.assertIsNot(client.models.calls[0]["config"], config)
-        self.assertEqual(client.models.calls[0]["config"], config)
+        self.assertEqual(config, {"nested": {"enabled": True}})
+        self.assertEqual(
+            client.models.calls[0]["config"],
+            {
+                "nested": {"enabled": True},
+                "http_options": {
+                    "timeout": DEFAULT_SYNC_TIMEOUT_SECONDS * 1000,
+                },
+            },
+        )
+
+    def test_gemini_timeout_seconds_becomes_http_options_milliseconds(self):
+        config = {
+            "timeout": 12,
+            "http_options": {"headers": {"X-Test": "yes"}},
+        }
+        client = _Client(_Response())
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=lambda response: {},
+            extract_text=lambda payload: "",
+            extract_finish_reason=lambda payload: "",
+        )
+
+        backend.generate(SyncGenerationRequest("gemini-test", [], config))
+
+        self.assertEqual(config["timeout"], 12)
+        self.assertEqual(
+            client.models.calls[0]["config"]["http_options"],
+            {"headers": {"X-Test": "yes"}, "timeout": 12_000},
+        )
+        self.assertNotIn("timeout", client.models.calls[0]["config"])
+
+    def test_sync_timeout_normalization_has_finite_bounds(self):
+        self.assertEqual(
+            normalize_sync_timeout_seconds(None),
+            DEFAULT_SYNC_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            normalize_sync_timeout_seconds(True),
+            DEFAULT_SYNC_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(normalize_sync_timeout_seconds(1), MIN_SYNC_TIMEOUT_SECONDS)
+        self.assertEqual(normalize_sync_timeout_seconds(9999), MAX_SYNC_TIMEOUT_SECONDS)
+        self.assertEqual(normalize_sync_timeout_seconds("45"), 45)
 
     def test_new_gemini_model_omits_sampling_before_sdk_call(self):
         config = {
@@ -79,7 +138,12 @@ class SyncModelBackendTests(unittest.TestCase):
         backend.generate(SyncGenerationRequest("gemini-3.5-flash-lite", [], config))
         self.assertEqual(
             client.models.calls[0]["config"],
-            {"max_output_tokens": 1024},
+            {
+                "max_output_tokens": 1024,
+                "http_options": {
+                    "timeout": DEFAULT_SYNC_TIMEOUT_SECONDS * 1000,
+                },
+            },
         )
         self.assertIn("temperature", config)
 

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -92,6 +92,11 @@ class TranslationAbExperimentTests(unittest.TestCase):
             self.assertTrue(batch_mod.RAG_ENABLED)
         self.assertFalse(batch_mod.RAG_ENABLED)
 
+    def test_variant_settings_report_effective_sync_timeout(self):
+        with mock.patch.object(batch_mod, 'SYNC_TIMEOUT_SECONDS', 45):
+            settings = ab_mod.summarize_variant_settings()
+        self.assertEqual(settings['timeout_seconds'], 45)
+
     def test_variant_overrides_win_over_project_context_without_clearing_base_dir(self):
         """compare-variants must keep BASE_DIR for project paths, but still honor RAG overrides."""
         import translator_runtime as runtime

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -874,6 +874,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             'max_items': runtime.MAX_ITEMS,
             'max_chars': runtime.MAX_CHARS,
             'max_output_tokens': runtime.SYNC_MAX_OUTPUT_TOKENS,
+            'timeout_seconds': runtime.SYNC_TIMEOUT_SECONDS,
             'include_files': runtime.INCLUDE_FILES,
             'include_prefixes': runtime.INCLUDE_PREFIXES,
         }
@@ -893,6 +894,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                             'chunk_size': 7,
                             'max_source_chars': 1234,
                             'max_output_tokens': 5678,
+                            'timeout_seconds': 45,
                         },
                     }),
                     encoding='utf-8',
@@ -907,6 +909,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                     runtime.MAX_ITEMS = 40
                     runtime.MAX_CHARS = 12000
                     runtime.SYNC_MAX_OUTPUT_TOKENS = 24576
+                    runtime.SYNC_TIMEOUT_SECONDS = runtime.DEFAULT_SYNC_TIMEOUT_SECONDS
                     runtime.INCLUDE_FILES = set()
                     runtime.INCLUDE_PREFIXES = set()
                     runtime.load_translator_settings()
@@ -917,6 +920,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
                 self.assertEqual(runtime.MAX_ITEMS, 7)
                 self.assertEqual(runtime.MAX_CHARS, 1234)
                 self.assertEqual(runtime.SYNC_MAX_OUTPUT_TOKENS, 5678)
+                self.assertEqual(runtime.SYNC_TIMEOUT_SECONDS, 45)
                 self.assertEqual(runtime.INCLUDE_FILES, {'game/tl/schinese/script.rpy'})
                 self.assertEqual(runtime.INCLUDE_PREFIXES, {'game/tl/schinese/chapter1'})
         finally:
@@ -925,6 +929,7 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             runtime.MAX_ITEMS = old_values['max_items']
             runtime.MAX_CHARS = old_values['max_chars']
             runtime.SYNC_MAX_OUTPUT_TOKENS = old_values['max_output_tokens']
+            runtime.SYNC_TIMEOUT_SECONDS = old_values['timeout_seconds']
             runtime.INCLUDE_FILES = old_values['include_files']
             runtime.INCLUDE_PREFIXES = old_values['include_prefixes']
 

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -108,6 +108,7 @@ def summarize_variant_settings() -> dict:
         'macro_setting_preview': _macro_preview(batch_mod.BATCH_MACRO_SETTING),
         'temperature': batch_mod.BATCH_TEMPERATURE,
         'max_output_tokens': batch_mod.BATCH_MAX_OUTPUT_TOKENS,
+        'timeout_seconds': batch_mod.SYNC_TIMEOUT_SECONDS,
         'thinking_level': batch_mod.BATCH_THINKING_LEVEL,
     }
 
@@ -155,6 +156,7 @@ _BATCH_GLOBAL_KEYS = (
     'STORY_MEMORY_TOP_K_TERMS',
     'STORY_MEMORY_INCLUDE_SCENE_SUMMARY',
     'BATCH_NON_CHINESE_RULES',
+    'SYNC_TIMEOUT_SECONDS',
     '_RAG_STORE',
     '_SOURCE_INDEX_STORE',
     '_STORY_GRAPH',

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -49,6 +49,7 @@
     "chunk_size": 40,
     "max_source_chars": 12000,
     "max_output_tokens": 24576,
+    "timeout_seconds": 120,
     "rag": {
       "enabled": false,
       "embedding_model": "gemini-embedding-001",

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -64,7 +64,14 @@ import prompt_context
 import story_memory
 import sync_translation_preview
 import translation_core
-from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
+from sync_model_backend import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
+    MAX_SYNC_TIMEOUT_SECONDS,
+    MIN_SYNC_TIMEOUT_SECONDS,
+    GeminiSyncBackend,
+    SyncGenerationRequest,
+    normalize_sync_timeout_seconds,
+)
 
 # Configuration
 TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -169,6 +176,7 @@ PRESERVE_TERMS = [
 MAX_CHARS = DEFAULT_MAX_CHARS
 MAX_ITEMS = DEFAULT_MAX_ITEMS
 SYNC_MAX_OUTPUT_TOKENS = DEFAULT_SYNC_MAX_OUTPUT_TOKENS
+SYNC_TIMEOUT_SECONDS = DEFAULT_SYNC_TIMEOUT_SECONDS
 SYNC_BACKEND = DEFAULT_SYNC_BACKEND
 # Custom OpenAI-compatible LiteLLM providers parsed from sync.custom_litellm_providers.
 CUSTOM_LITELLM_PROVIDERS: dict[str, object] = {}
@@ -1030,7 +1038,8 @@ def load_rotation_settings(config):
 
 
 def load_sync_translation_settings(config):
-    global MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS, SYNC_BACKEND
+    global MAX_ITEMS, MAX_CHARS, SYNC_MAX_OUTPUT_TOKENS, SYNC_TIMEOUT_SECONDS
+    global SYNC_BACKEND
     global CUSTOM_LITELLM_PROVIDERS
 
     sync = config.get("sync")
@@ -1100,6 +1109,7 @@ def load_sync_translation_settings(config):
     previous_items = MAX_ITEMS
     previous_chars = MAX_CHARS
     previous_output_tokens = SYNC_MAX_OUTPUT_TOKENS
+    previous_timeout = SYNC_TIMEOUT_SECONDS
 
     MAX_ITEMS = _coerce_positive_int(sync.get("chunk_size"), MAX_ITEMS)
     MAX_CHARS = _coerce_positive_int(
@@ -1110,6 +1120,10 @@ def load_sync_translation_settings(config):
         sync.get("max_output_tokens"),
         SYNC_MAX_OUTPUT_TOKENS,
     )
+    SYNC_TIMEOUT_SECONDS = normalize_sync_timeout_seconds(
+        sync.get("timeout_seconds"),
+        DEFAULT_SYNC_TIMEOUT_SECONDS,
+    )
 
     if MAX_ITEMS != previous_items:
         print(f"Using sync chunk size: {MAX_ITEMS}")
@@ -1117,6 +1131,8 @@ def load_sync_translation_settings(config):
         print(f"Using sync max source chars: {MAX_CHARS}")
     if SYNC_MAX_OUTPUT_TOKENS != previous_output_tokens:
         print(f"Using sync max output tokens: {SYNC_MAX_OUTPUT_TOKENS}")
+    if SYNC_TIMEOUT_SECONDS != previous_timeout:
+        print(f"Using sync request timeout: {SYNC_TIMEOUT_SECONDS} seconds")
 
 
 def coerce_normalized_rel_path_set(value):
@@ -1209,6 +1225,7 @@ class RuntimeConfig:
     max_chars: int = DEFAULT_MAX_CHARS
     max_items: int = DEFAULT_MAX_ITEMS
     sync_max_output_tokens: int = DEFAULT_SYNC_MAX_OUTPUT_TOKENS
+    sync_timeout_seconds: int = DEFAULT_SYNC_TIMEOUT_SECONDS
     sync_backend: str = DEFAULT_SYNC_BACKEND
     custom_litellm_providers: dict = field(default_factory=dict)
 
@@ -1283,6 +1300,7 @@ def default_runtime_config() -> RuntimeConfig:
         max_chars=DEFAULT_MAX_CHARS,
         max_items=DEFAULT_MAX_ITEMS,
         sync_max_output_tokens=DEFAULT_SYNC_MAX_OUTPUT_TOKENS,
+        sync_timeout_seconds=DEFAULT_SYNC_TIMEOUT_SECONDS,
         sync_backend=DEFAULT_SYNC_BACKEND,
         custom_litellm_providers={},
         prep_language=DEFAULT_PREP_LANGUAGE,
@@ -1332,6 +1350,7 @@ def snapshot_runtime_config() -> RuntimeConfig:
         max_chars=MAX_CHARS,
         max_items=MAX_ITEMS,
         sync_max_output_tokens=SYNC_MAX_OUTPUT_TOKENS,
+        sync_timeout_seconds=SYNC_TIMEOUT_SECONDS,
         sync_backend=SYNC_BACKEND,
         custom_litellm_providers=dict(CUSTOM_LITELLM_PROVIDERS),
         include_files=set(INCLUDE_FILES),
@@ -1367,7 +1386,8 @@ def apply_runtime_config(config: RuntimeConfig) -> RuntimeConfig:
     global CONTEXT_STORAGE_LOCATION, CONTEXT_STORAGE_GAME_DIR_NAME
     global API_KEYS, MODELS, CURRENT_KEY_INDEX, CURRENT_MODEL_INDEX
     global API_KEY_ROTATION_ENABLED, MODEL_ROTATION_ENABLED, MODEL_ROTATION_MODELS
-    global MAX_CHARS, MAX_ITEMS, SYNC_MAX_OUTPUT_TOKENS, SYNC_BACKEND
+    global MAX_CHARS, MAX_ITEMS, SYNC_MAX_OUTPUT_TOKENS, SYNC_TIMEOUT_SECONDS
+    global SYNC_BACKEND
     global CUSTOM_LITELLM_PROVIDERS
     global INCLUDE_FILES, INCLUDE_PREFIXES
     global SYNC_RAG_ENABLED, SYNC_RAG_STORE_DIR, SYNC_RAG_EMBEDDING_MODEL
@@ -1419,6 +1439,11 @@ def apply_runtime_config(config: RuntimeConfig) -> RuntimeConfig:
         MAX_CHARS = int(applied.max_chars)
         MAX_ITEMS = int(applied.max_items)
         SYNC_MAX_OUTPUT_TOKENS = int(applied.sync_max_output_tokens)
+        applied.sync_timeout_seconds = normalize_sync_timeout_seconds(
+            applied.sync_timeout_seconds,
+            DEFAULT_SYNC_TIMEOUT_SECONDS,
+        )
+        SYNC_TIMEOUT_SECONDS = applied.sync_timeout_seconds
         SYNC_BACKEND = applied.sync_backend or DEFAULT_SYNC_BACKEND
         CUSTOM_LITELLM_PROVIDERS = dict(applied.custom_litellm_providers or {})
 
@@ -1569,7 +1594,7 @@ def _reset_project_settings_to_defaults():
     global PREP_RENPY_SDK_DIR, PREP_LAUNCHER_PY, PREP_PYTHON_EXE
     global PREP_UNPACK_COMMAND, PREP_TEMPLATE_COMMAND, PREP_ALLOW_SHELL_COMMANDS
     global CONTEXT_STORAGE_LOCATION, CONTEXT_STORAGE_GAME_DIR_NAME
-    global SYNC_BACKEND
+    global SYNC_BACKEND, SYNC_TIMEOUT_SECONDS
     global SYNC_RAG_ENABLED, SYNC_RAG_STORE_DIR, SYNC_RAG_EMBEDDING_MODEL
     global SYNC_RAG_QUERY_TASK_TYPE, SYNC_RAG_DOCUMENT_TASK_TYPE
     global SYNC_RAG_OUTPUT_DIMENSIONALITY, SYNC_RAG_TOP_K_HISTORY, SYNC_RAG_TOP_K_TERMS
@@ -1606,6 +1631,7 @@ def _reset_project_settings_to_defaults():
 
     # RAG / story memory always recompute from translator_config.sync defaults.
     SYNC_BACKEND = DEFAULT_SYNC_BACKEND
+    SYNC_TIMEOUT_SECONDS = DEFAULT_SYNC_TIMEOUT_SECONDS
     SYNC_RAG_ENABLED = False
     SYNC_RAG_STORE_DIR = ""
     SYNC_RAG_EMBEDDING_MODEL = DEFAULT_SYNC_RAG_EMBEDDING_MODEL
@@ -4339,6 +4365,7 @@ def call_gemini_sdk(
     generation_config = {
         "temperature": 0.2,
         "max_output_tokens": SYNC_MAX_OUTPUT_TOKENS,
+        "timeout": SYNC_TIMEOUT_SECONDS,
         "response_mime_type": "application/json",
         "response_json_schema": build_response_json_schema(items),
     }


### PR DESCRIPTION
## Summary

- add `sync.timeout_seconds` with a 120-second default and a bounded 5–600 second range
- apply the same effective timeout to ordinary sync translation, Project Analysis, keyword extraction, revisions, repair, A/B comparisons, and probe requests
- translate the provider-neutral seconds contract into Gemini `http_options.timeout` milliseconds while keeping LiteLLM in seconds
- surface the setting in the GUI advanced page, sync manifests, the example config, user copy, and current documentation
- enforce the default again at both sync backend boundaries so future callers cannot accidentally create an unbounded request

## Why

The connection smoke now has a bounded request, but production synchronous calls still relied on provider or SDK defaults. A stalled provider could therefore leave translation and analysis workflows waiting far longer than the user intended.

This is the production-timeout slice of #340. Reasoning-token diagnostics and category-driven retry/key-rotation policy remain separate follow-up work.

## User impact

Users can configure one per-request timeout for both Gemini and LiteLLM. The GUI explains that this is not a whole-task deadline, out-of-range manual values are constrained safely, and sync manifests/A/B reports record the effective value for diagnostics.

## Validation

- `python -B tests/run_cli_tests.py -q` — 1,011 passed, 1 skipped
- focused runtime/backend/Project Analysis/GUI schema/workflow suites — 294 passed
- `python scripts/run_quality_gates.py all` — ruff, mypy, and all dependency audits passed
- `git diff --check` and `translator_config.example.json` JSON parse — passed
- full GUI runner completed 1,056 tests without modal-guard rejection; the same 7 pre-existing local-project-state assertions remain outside this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an advanced synchronous translation timeout setting.
  - Defaults to 120 seconds and supports values from 5 to 600 seconds.
  - Applies consistently to translation, analysis, and related synchronous operations.
  - Effective timeout settings are preserved in runtime configuration and synchronization diagnostics.
  - Added configuration example and GUI guidance.

- **Documentation**
  - Updated setup, workflow, and GUI documentation with timeout behavior, limits, and applicability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->