### PR TITLE
Improve reasoning-aware sync recovery

### DIFF
--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -127,7 +127,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 - **密钥**：
   - **Gemini**：读取 / 保存 `api_keys.json`；可添加多把 Key；环境变量 Key 只读提示。
   - **LiteLLM Provider**：按供应商保存在操作系统凭据管理器（与 Gemini 分离）。密钥页 Provider 列表含常用供应商（OpenAI / Anthropic / Gemini / OpenRouter / DeepSeek / xAI / Azure / Vertex 等），并合并 LiteLLM 页**已联网加载**的供应商；可搜索或手填自定义 id。每个 Provider 可用与 Gemini 相同的多 Key 对话框管理（添加 / 删除 / 显示明文核对 / **设为当前使用**），状态显示全部脱敏后缀与当前 Key。
-- **LiteLLM**：按“联网加载供应商 → 选择 Provider → **在密钥页或凭据区管理并保存 API Key** → 联网加载模型 → 选择模型 → 保存设置”配置同步替代后端。DeepSeek / OpenAI / Anthropic / xAI 等官方模型列表需要**先保存至少一把 API Key**；未保存时会提示，可取消或显式选择仅用 LiteLLM 子集目录（可能依赖 GitHub）。加载供应商 / 模型、检查更新、测试连接运行中可**再次点击同一按钮停止**；过程中状态栏会显示阶段（如「正在请求官方列表」「官方失败，正在改用子集」）。连接测试使用有界的最小 JSON 请求，只有收到非空且符合合同的响应才会成功；空正文、不可解析 JSON 或字段不匹配均会报告失败。模型列表整次操作有约 **35 秒**总时限，单次 HTTP 约 **20 秒**上限，避免官方+回退叠成近一分钟无反馈。首次打开不会默认选择 OpenAI 或模型，也不会静默联网；Provider 下拉列表优先显示常用供应商，输入任意片段可搜索，也可手动填写自定义 Provider / 模型。
+- **LiteLLM**：按“联网加载供应商 → 选择 Provider → **在密钥页或凭据区管理并保存 API Key** → 联网加载模型 → 选择模型 → 保存设置”配置同步替代后端。DeepSeek / OpenAI / Anthropic / xAI 等官方模型列表需要**先保存至少一把 API Key**；未保存时会提示，可取消或显式选择仅用 LiteLLM 子集目录（可能依赖 GitHub）。加载供应商 / 模型、检查更新、测试连接运行中可**再次点击同一按钮停止**；过程中状态栏会显示阶段（如「正在请求官方列表」「官方失败，正在改用子集」）。连接测试使用 64 Token 上限、有界 timeout 与最小 JSON 合同，只有收到非空且精确匹配 `{"ok":true}` 的响应才会成功；空正文、不可解析 JSON 或字段不匹配均会报告失败，结果和错误文案不回显 Provider 原始异常或凭据。模型列表整次操作有约 **35 秒**总时限，单次 HTTP 约 **20 秒**上限，避免官方+回退叠成近一分钟无反馈。首次打开不会默认选择 OpenAI 或模型，也不会静默联网；Provider 下拉列表优先显示常用供应商，输入任意片段可搜索，也可手动填写自定义 Provider / 模型。
 - **自定义 OpenAI 兼容 Provider**：LiteLLM 设置页的「自定义 OpenAI 兼容 Provider」区域可**添加 / 编辑 / 删除** OpenCode Go、中转站、本地 vLLM 等 LiteLLM 未内置但兼容 OpenAI 的服务，持久化到 `translator_config.json` 的 `sync.custom_litellm_providers`。添加时填写 `id`（创建后不可改，同时用作模型前缀与密钥用户名）、显示名称、API Base、模型列表 URL（可留空）、可选密钥环境变量，以及「需要 API Key」开关（默认开启；本地无鉴权网关可关闭）。非法 URL 或与内置前缀冲突的 id 会被拒绝。注册后 Provider 下拉与密钥页列表自动合并该条目，选择后即可像内置 provider 一样保存密钥、加载模型与测试连接。实际请求改写为 `openai/<模型>` + `api_base`，`api_key_env` 仅在系统凭据为空时生效；需要密钥但两者均缺失时请求会直接失败，不会把 `OPENAI_API_KEY` 静默发给第三方端点。
 - **扩展**：按需安装 / 修复 / 更新关系分析器的独立依赖。安装状态来自当前 Python 环境，不另存“已启用”开关；安装在后台运行，普通翻译不会加载这些科学计算与图像依赖。关系分析器的运行入口和边界见 [关系与语义分析](relation_analysis.md)。
 - **项目**：术语表、翻译目录、include filters，以及准备流程的 source game、Ren'Py SDK、Python、launcher 和自定义命令。Ren'Py SDK 须显式配置： **查找 SDK**（用户点击后才扫描附近）、**浏览…**，或确认后 **下载推荐 SDK…**（官方固定版本）；留空不会自动搜其它目录或联网。结果写入 `prepare.renpy_sdk_dir`，保存设置后生效。当前 `game_root` 只读展示；需换项目请用「项目与环境」或「项目列表」。
@@ -168,7 +168,7 @@ doctor -> build -> submit -> status -> download -> check -> apply
 - **任务上下文**：任务记录路径、翻译包、云端任务状态、最近检查结果、是否已写回；报告路径逐行展示并支持复制。
 - **命令参考**：按当前任务记录生成可复制的手动命令（`doctor`、`submit`、`status`、`download`、`check`、`apply` 等）；提交 journal 已记录远端 job、但 manifest 尚未落盘时会显示 `recover-submit`。#265 P3 还提供 `export-project-snapshot` 与 `reconcile-project-snapshots` 模板，用于导出 source-only 版本快照和只读版本差异；P6 之前这里只提供高级命令，不提供快照浏览或匹配确认界面。GUI 保留人类可读文本模式；Agent、脚本或 CI 可在这些核心命令后追加 `--output json`，让 stdout 只返回版本化结果 envelope，并可再追加 `--strict-exit-codes` 获得稳定的语义退出码。需要禁止 stdin 与 latest-manifest 回退时，Agent 可使用 `--non-interactive`；只禁止 target 回退时使用 `--require-explicit-target`。机器结果还可用 `--compact`、`--fields` 和 `--output-file` 限制终端上下文或原子落盘。Agent 可通过 `capabilities` 和 `schema <command>` 直接读取当前 argparse 生成的机器命令索引、参数 schema 和这些能力标记，GUI 不复制维护另一份命令定义。批量翻译任务记录还会显示 `compare-variants` 试跑命令模板。当最近一次检查为「需处理」时，也会补出补译相关命令（底层为 `build-retry`、`merge-retry` 等）。提交前的 `estimate-cost` 与异常恢复语义见 [Batch 工作流](batch_workflows.md#提交前估算与异常恢复)。
 - **任务记录**：只读 JSON 预览（省略 `chunks` / `files` 大字段）。
-- **实际模型用量**：任务上下文显示当前项目累计调用、已知 token、未知记录数、最近运行及可用成本摘要；命令参考提供 `usage-import` 和 `usage-report`。缺失 usage 不显示成 0，完整字段与成本语义见 [实际模型用量账本](model_usage_ledger.md)。
+- **实际模型用量**：任务上下文显示当前项目累计调用、completion / reasoning / 正文输出 Token、reasoning 占已知输出比例、空正文/截断告警、未知记录数、最近运行及可用成本摘要；命令参考提供 `usage-import` 和 `usage-report`。Provider 没有明确正文计数时显示 `unknown`，不会用 completion 减 reasoning 猜测，也不会把缺失 usage 显示成 0。完整字段与成本语义见 [实际模型用量账本](model_usage_ledger.md)。
 
 **下方（原始输出）**：始终可见，显示 CLI 的 stdout/stderr。
 
@@ -270,7 +270,7 @@ build -> submit -> status -> download -> check
 
 ### 同步翻译
 
-在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；若模型结果仍有缺失/无效 ID，或部分文件未通过 adapter 写回计划校验，GUI 显示「部分完成」警告和结果完整率、定点重试、未解决项，只允许写回 manifest 中其余已生成的安全预览。用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；其中 `timeout_seconds` 是单请求上限并会写入同步 manifest 的设置诊断。Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
+在左导航选择 **同步翻译**，点击「**开始同步翻译**」。GUI 先无参数调用 `gemini_translate.py`，在 `logs/sync_runs/` 生成绑定当前项目的 manifest、源文件快照、候选文件和 `preview.diff`，此时不会修改项目脚本。预览包含变更时，页面启用「**确认并写回预览**」；若模型结果仍有缺失/无效 ID，或部分文件未通过 adapter 写回计划校验，GUI 显示「部分完成」警告和结果完整率、定点重试、未解决项，只允许写回 manifest 中其余已生成的安全预览。同步摘要还区分 completion、reasoning 和 Provider 可提供时的正文输出 Token；reasoning 吃满输出预算造成空正文或截断时会显示告警。用户确认后 GUI 调用 `gemini_translate.py --apply MANIFEST`，写回前重新核对当前项目、翻译目录、manifest 中所有预览文件对应的源快照哈希和预览制品哈希。任何项目切换、源文件变化或制品篡改都会阻止写回。配置仍来自 `translator_config.json` 的 `sync.*` 段；其中 `timeout_seconds` 是单请求上限并会写入同步 manifest 的设置诊断。Gemini 后端使用现有 Gemini API Key，LiteLLM 后端使用「设置 → LiteLLM」中保存的供应商凭据或 LiteLLM 约定的环境变量。
 
 模型返回先经过统一命名对象合同（翻译 `translations`、订正 `revisions`、关键词 `candidates`）。旧任务中的裸数组可继续读取；新请求只使用命名对象。有效结果会立即保留，只对缺失或无效 ID 做定点重试；重试仍不完整时 GUI 明确显示部分完成，不会把不完整结果误报为全部成功。详细合同与 Provider 降级策略见 [同步翻译工作流](sync_workflow.md#模型结果合同与定点重试)。
 
@@ -279,6 +279,8 @@ build -> submit -> status -> download -> check
 - **默认与回退**：Gemini Batch 始终是推荐的批量主路径。要停止使用 LiteLLM，在「设置 → LiteLLM」把同步执行后端切回「Gemini 同步（推荐）」并保存；这不会改动 Batch 模型或 RAG Embedding 配置。
 - **目录与运行配置**：用户级目录缓存只帮助恢复 GUI 选择；项目实际运行仍以 `translator_config.json` 的 `sync.backend` / `sync.litellm_model` 为准，已保存模型优先于 GUI 历史。只选择 Provider 而不选择模型时不能保存为可运行的 LiteLLM 配置。取消 Provider 不会清除目录缓存或系统凭据。
 - **费用与吞吐**：LiteLLM 同步请求按所选供应商和模型计费，不具有 Gemini Batch 的远程排队、恢复或 Batch 折扣语义；大项目可能更贵且吞吐量更低。工具不为任意供应商提供统一价格保证，正式运行前应查看供应商定价并先做小样本。
+- **Reasoning 参数**：项目不把 Gemini 的 `thinking_level` / `thinking_config` 伪装成跨 Provider 通用选项；LiteLLM 请求会忽略该 Gemini 专属字段并留下安全能力诊断。需要供应商专属 reasoning 参数时，应等待显式 capability/provider options 支持。
+- **恢复与多 Key**：429 可在当前 LiteLLM Provider 已保存的 Key 中按脱敏后缀有界轮换；401/403 不重试，timeout/503 只做有界退避，同步恢复不会触碰 Gemini keyring。点击停止后，迟到的子进程成功不会继续进入 preview 或写回。
 - **隐私**：本项目直接调用 LiteLLM Python SDK，不经过本项目自建代理。待译文本、提示词和必要上下文会发送给所选模型供应商；应按该供应商的日志、训练和数据保留政策评估敏感内容。供应商密钥保存到操作系统凭据管理器或由环境变量提供，不写入 `translator_config.json`。
 - **安全边界**：同步翻译默认只生成预览，显式 apply 才会写入当前项目；仍应先备份并小范围验证。同步 manifest 使用独立的项目绑定、源文件快照和制品哈希复核，不复用 Batch manifest 的 `check=safe` 状态。
 
@@ -391,7 +393,7 @@ bootstrap-source-index
 project-analysis-status
 ```
 
-预建和项目分析结果以普通语言摘要显示；项目分析生成完成后还会显示场景摘要 / 路线摘要进度、请求数、输入/输出 Token 和按当前价格表估算的成本。失败细节可在「诊断与运行日志」的原始输出查看。任务运行中，上下文库内其他动作会禁用并提供与当前任务对应的停止按钮，避免叠跑。项目分析状态还会明确显示功能是否启用，以及当前发布摘要是否实际用于翻译。
+预建和项目分析结果以普通语言摘要显示；项目分析生成完成后还会显示场景摘要 / 路线摘要进度、请求数、输入 Token、completion / reasoning / 正文输出 Token 和按当前价格表估算的成本；Provider 未提供的正文计数显示 `unknown`。失败细节可在「诊断与运行日志」的原始输出查看。任务运行中，上下文库内其他动作会禁用并提供与当前任务对应的停止按钮，避免叠跑。项目分析状态还会明确显示功能是否启用，以及当前发布摘要是否实际用于翻译。
 
 若开启了 build 时自动补建，后续 `build` 仍可能自动补建；图形预建入口适合在首次翻译前手动确认 store 状态。
 

--- a/docs/model_usage_ledger.md
+++ b/docs/model_usage_ledger.md
@@ -23,12 +23,18 @@
 - `stage`：例如 `batch_translation`、`sync_revision`、`compare_variants`、`label`、`route`、`brief`
 - `provider` / `model` / `thinking_level` / `execution_mode`
 - `calls`
-- `prompt_tokens` / `completion_tokens` / `total_tokens` / `thoughts_tokens` / `cached_tokens`
+- `prompt_tokens` / `completion_tokens` / `reasoning_tokens` / `text_output_tokens` / `total_tokens` / `cached_tokens`
+- `output_diagnostics`：只保存空正文、截断、输出预算耗尽、reasoning 预算压力与稳定原因码等安全摘要
+- `request_metadata`：只保存 Provider、能力降级和脱敏后的凭据后缀；不保存 API Key
 - `provider_usage`：provider 返回的原始 usage 摘要，不保存响应正文
 - `estimated_cost` 与 `actual_cost`
 - `recorded_at` / `dedupe_key` / 响应与来源 identity
 
 缺失 token 或 cost 保持 `null`。聚合报告同时给出 `*_known_records` 与 `*_unknown_records`，不会把未知值伪造成 0。
+
+`completion_tokens` 沿用 Provider 的完成/输出计数；`reasoning_tokens` 是 Provider 明确报告的推理计数；`text_output_tokens` 只在 Provider 明确给出正文计数时记录。不同 OpenAI-compatible Provider 对 `completion_tokens` 是否包含 reasoning 的定义并不一致，因此账本不会用 `completion - reasoning` 猜测正文 Token。Gemini 的 `candidatesTokenCount` 是明确的正文计数，可以直接归入 `text_output_tokens`；无法确认时 GUI 与 CLI 显示 `unknown`。
+
+当正文为空或 finish reason 表示长度截断时，账本会结合 `max_output_tokens`、completion/reasoning/正文计数判断 `reasoning_budget_exhausted`、`reasoning_without_text_output` 或 `truncated_output`。该诊断不保存响应正文，也不会把单纯“模型返回空文本”自动归因给 reasoning；只有 Provider 计数与输出预算证据同时支持时才标记 reasoning 预算压力。
 
 ## 数据来源与自动记录
 
@@ -89,6 +95,8 @@ python gemini_translate_batch.py usage-report --group-by task,stage,provider,mod
 「诊断与运行日志」的任务上下文会显示：
 
 - 当前项目累计调用数和已知 total token
+- completion、reasoning 与 Provider 可提供时的正文输出 Token；未知字段明确显示 `unknown`
+- reasoning 占已知输出的比例，以及 reasoning 预算压力/截断响应计数
 - token 不完整时的未知记录数
 - 最近一次运行的 task / stage / provider / model 与 token 摘要
 - 存在时的估算成本和 provider 报告成本
@@ -107,7 +115,7 @@ python gemini_translate_batch.py usage-report --group-by task,stage,provider,mod
 
 ## 隐私与版本控制
 
-账本保存 provider usage 摘要、模型/阶段 identity 和响应 fingerprint，不保存 prompt、译文或完整响应正文。它仍属于项目本地运行数据；不要把真实游戏项目账本、Batch 结果或日志提交到公开仓库。
+账本保存 provider usage 摘要、模型/阶段 identity、稳定输出诊断、脱敏凭据 identity 和响应 fingerprint，不保存 prompt、译文、完整响应正文或 API Key。它仍属于项目本地运行数据；不要把真实游戏项目账本、Batch 结果或日志提交到公开仓库。
 
 ## 设计来源
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -199,6 +199,7 @@ LiteLLM 没有内置的 OpenCode Go 等第三方 OpenAI 兼容端点。任何提
 
 - 界面与配置中模型保持 `<id>/<模型>` 形式（如 `opencode-go/gpt-4o-mini`）；实际请求改写为 `openai/<模型>` + `api_base`，按请求传参，不使用进程级 `OPENAI_API_KEY` / `OPENAI_API_BASE` 环境变量。
 - 密钥优先使用系统凭据管理器（GUI「管理密钥…」多 Key 对话框），与内置 provider 一致。
+- 同步请求遇到 429 时可在**同一 Provider** 的已保存 Key 集合内有界尝试下一把，并只记录脱敏后缀；401/403 不轮换。该机制与 Gemini keyring 完全分离。
 - 模型列表走 `GET {models_url}`（Bearer 认证），解析 OpenAI 风格 `{data:[{id:...}]}` 响应。
 - `requires_key=true` 且 keyring 与 `api_key_env` 均无密钥时，请求会在发送前失败，杜绝 `OPENAI_API_KEY` 被静默发送到第三方端点。
 - 非法 `base_url`、非法字符或与内置前缀冲突的 `id` 会被拒绝；GUI 保存或 CLI 加载配置时均会报错。

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -43,7 +43,7 @@
 | `unsupported_capability` / `missing_dependency` | 立即失败，由用户修正 Provider、模型或依赖 |
 | 未分类 Provider 错误（`provider_error`） | 不重试，但保留拆包兜底：多行 batch 失败时拆成两半继续，把可能由单行引起的问题隔离，健康行仍可产出；单行仍未解决时按既有合同记录失败 |
 
-LiteLLM 多 Key 轮换只发生在当前 Provider 的凭据集合内，记录形如 `openai#2:****abcd` 的脱敏 identity；不会调用或修改 Gemini keyring。401/403 不会尝试下一把 Key。所有退避与重试均受固定次数和单请求 `timeout_seconds` 约束。
+LiteLLM 多 Key 轮换只发生在当前 Provider 的凭据集合内，记录形如 `openai#2:key:3f9a2c1b4e` 的**不可逆** identity（密钥 SHA-256 摘要前缀，不含任何原始密钥字符）；不会调用或修改 Gemini keyring。401/403 不会尝试下一把 Key。所有退避与重试均受固定次数和单请求 `timeout_seconds` 约束。
 
 后端错误在 UI 与结果文件中只显示安全摘要（如 `provider request failed [provider_error]`），不回显 Provider 异常正文或凭据。为保留排障线索，backend 会以 `raise ... from exc` 保留原始异常链，翻译流程的本地失败日志（`logs/`）会在未分类 Provider 错误时附上截断的原始消息；这些原始文本不会进入 GUI 或任何结果/manifest 文件。
 

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -24,6 +24,28 @@
 
 选择 LiteLLM 后端时，可通过 `sync.custom_litellm_providers` 注册 OpenAI 兼容但 LiteLLM 未内置的服务（OpenCode Go、中转站、本地 vLLM 等）：每项配置 `id` / `label` / `base_url` / `models_url` / `api_key_env`，请求会改写为 `openai/<模型>` 并逐请求透传 `api_base`，密钥优先使用系统凭据管理器。字段与示例见 [安装与本地配置 · 自定义 OpenAI 兼容 Provider](setup.md#自定义-openai-兼容-providerlitellm-同步)。
 
+## Reasoning 与输出预算诊断
+
+同步结果和实际模型用量账本会分别记录 Provider 可提供的 `completion_tokens`、`reasoning_tokens` 与正文输出 Token。正文计数缺失时显示 `unknown`，不会跨 Provider 假定 `completion - reasoning` 就是正文。若空正文/截断同时伴随 reasoning 计数和输出预算耗尽，结果会记录稳定原因码（例如 `reasoning_budget_exhausted`），GUI 摘要会显示 reasoning 预算告警和截断次数。结果、日志和 GUI 只显示计数与原因码，不回显 Provider 异常正文或凭据。
+
+项目没有增加伪装成通用能力的 reasoning 配置。`thinking_level` / `thinking_config` 仍是 Gemini 专属语义：Gemini 原生后端可消费它；LiteLLM 后端不会把该字段发送给 OpenAI-compatible Provider，而是在安全的 `request_metadata.ignored_provider_options` 中记录该能力未应用。未来某个 Provider 若要支持专属 reasoning 参数，应通过显式 capability/provider options 接入并独立测试。
+
+## 错误分类与有界恢复
+
+生产同步入口优先读取 backend 提供的结构化错误分类；只有 Google SDK 未提供分类时才使用状态码、异常类型和窄化的兼容判断。恢复规则固定为：
+
+| 分类 | 行为 |
+|---|---|
+| `authentication` | 立即失败；不重试、不拆包、不轮换模型 |
+| `rate_limit` | 有界退避；Gemini 只使用 Gemini 自己的轮换策略，LiteLLM 可在同一 Provider 的保存密钥集合内尝试下一把 Key |
+| `service_unavailable` / `timeout` | 在同一请求上有界重试；耗尽后失败，不用拆包制造更多请求 |
+| `invalid_response` | 翻译请求可按现有合同做定点重试/拆包；不会当作网络故障无限重试 |
+| `unsupported_capability` / `missing_dependency` / 未分类 Provider 错误 | 立即失败，由用户修正 Provider、模型或依赖 |
+
+LiteLLM 多 Key 轮换只发生在当前 Provider 的凭据集合内，记录形如 `openai#2:****abcd` 的脱敏 identity；不会调用或修改 Gemini keyring。401/403 不会尝试下一把 Key。所有退避与重试均受固定次数和单请求 `timeout_seconds` 约束。
+
+GUI 的停止操作会使当前 CLI 任务以失败/取消状态收尾；即使子进程在终止竞态中返回 0，也不会接受其迟到成功状态或继续进入 preview/apply 流程。
+
 ## 模型结果合同与定点重试
 
 同步翻译、同步订正和关键词提取共用同一条 provider-neutral 校验边界。新请求要求模型返回带名称的 JSON 对象：翻译为 `{"translations":[...]}`，订正为 `{"revisions":[...]}`，关键词为 `{"candidates":[...]}`。旧任务中的裸数组结果仍可读取，但只作为迁移兼容；新提示词和 schema 不再生成裸数组合同。
@@ -41,7 +63,7 @@ python scripts/run_provider_contract_smoke.py --provider gemini
 python scripts/run_provider_contract_smoke.py --provider deepseek
 ```
 
-脚本每个 Provider 最多发送一次、限制输出 token 和超时；未配置对应凭据会跳过，不会修改项目文件。正式项目仍应先用小范围同步任务验证实际翻译/订正 envelope。
+脚本每个 Provider 最多发送一次、限制输出 token 和超时；通过后只打印 completion/reasoning/正文 Token 的安全摘要，失败时只打印分类与安全错误文案。未配置对应凭据会跳过，不会修改项目文件。正式项目仍应先用小范围同步任务验证实际翻译/订正 envelope。
 
 ## 预览后写回
 

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -40,9 +40,12 @@
 | `rate_limit` | 有界退避；Gemini 只使用 Gemini 自己的轮换策略，LiteLLM 可在同一 Provider 的保存密钥集合内尝试下一把 Key |
 | `service_unavailable` / `timeout` | 在同一请求上有界重试；耗尽后失败，不用拆包制造更多请求 |
 | `invalid_response` | 翻译请求可按现有合同做定点重试/拆包；不会当作网络故障无限重试 |
-| `unsupported_capability` / `missing_dependency` / 未分类 Provider 错误 | 立即失败，由用户修正 Provider、模型或依赖 |
+| `unsupported_capability` / `missing_dependency` | 立即失败，由用户修正 Provider、模型或依赖 |
+| 未分类 Provider 错误（`provider_error`） | 不重试，但保留拆包兜底：多行 batch 失败时拆成两半继续，把可能由单行引起的问题隔离，健康行仍可产出；单行仍未解决时按既有合同记录失败 |
 
 LiteLLM 多 Key 轮换只发生在当前 Provider 的凭据集合内，记录形如 `openai#2:****abcd` 的脱敏 identity；不会调用或修改 Gemini keyring。401/403 不会尝试下一把 Key。所有退避与重试均受固定次数和单请求 `timeout_seconds` 约束。
+
+后端错误在 UI 与结果文件中只显示安全摘要（如 `provider request failed [provider_error]`），不回显 Provider 异常正文或凭据。为保留排障线索，backend 会以 `raise ... from exc` 保留原始异常链，翻译流程的本地失败日志（`logs/`）会在未分类 Provider 错误时附上截断的原始消息；这些原始文本不会进入 GUI 或任何结果/manifest 文件。
 
 GUI 的停止操作会使当前 CLI 任务以失败/取消状态收尾；即使子进程在终止竞态中返回 0，也不会接受其迟到成功状态或继续进入 preview/apply 流程。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -6244,20 +6244,16 @@ def _sync_token_summary_value(summary, field):
 
 def print_sync_output_summary(summary):
     """Print the stable CLI token/diagnostic contract consumed by the GUI."""
-    print(
-        'Sync output tokens: '
-        f"completion={_sync_token_summary_value(summary, 'completion_tokens')} "
-        f"reasoning={_sync_token_summary_value(summary, 'reasoning_tokens')} "
-        f"text={_sync_token_summary_value(summary, 'text_output_tokens')}"
-    )
-    print(
-        'Reasoning budget warnings: '
-        f"{int(summary.get('reasoning_budget_pressure_count') or 0)}"
-    )
-    print(
-        'Truncated sync responses: '
-        f"{int(summary.get('truncated_output_count') or 0)}"
-    )
+    for line in model_usage_ledger.format_sync_output_lines(
+        completion=_sync_token_summary_value(summary, 'completion_tokens'),
+        reasoning=_sync_token_summary_value(summary, 'reasoning_tokens'),
+        text_output=_sync_token_summary_value(summary, 'text_output_tokens'),
+        reasoning_budget_pressure=int(
+            summary.get('reasoning_budget_pressure_count') or 0
+        ),
+        truncated=int(summary.get('truncated_output_count') or 0),
+    ):
+        print(line)
 
 
 def contract_diagnostics_counts(diagnostics, field_name):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -70,10 +70,14 @@ from gemini_model_catalog import (
 )
 from project_version import __version__
 from sync_model_backend import (
+    DEFAULT_SYNC_RETRY_ATTEMPTS,
     DEFAULT_SYNC_TIMEOUT_SECONDS,
     GeminiSyncBackend,
     SyncGenerationRequest,
     normalize_sync_timeout_seconds,
+    sync_recovery_decision,
+    sync_error_category,
+    sync_error_summary,
 )
 
 try:
@@ -6162,6 +6166,8 @@ def record_generation_usage_best_effort(
             execution_mode=str(result.get('execution_mode') or 'sync'),
             source_key=source_key,
             source=source or {},
+            response_diagnostics=result.get('output_diagnostics') or {},
+            request_metadata=result.get('request_metadata') or {},
             pricing_config=pricing_config,
         )
     except (OSError, ValueError, model_usage_ledger.UsageLedgerError) as exc:
@@ -6191,6 +6197,67 @@ def record_contract_reasons(summary, report):
     diagnostic_bucket = summary.setdefault('diagnostic_counts', {})
     for reason_code, count in report.diagnostic_counts().items():
         bump_counter(diagnostic_bucket, reason_code, count)
+
+
+def sync_output_diagnostics(result, request_payload=None):
+    """Return safe output-budget diagnostics for one synchronous response."""
+    diagnostics = result.get('output_diagnostics')
+    if isinstance(diagnostics, dict) and diagnostics:
+        return model_usage_ledger.normalize_response_diagnostics(diagnostics)
+    request_payload = request_payload if isinstance(request_payload, dict) else {}
+    generation_config = request_payload.get('generation_config')
+    generation_config = generation_config if isinstance(generation_config, dict) else {}
+    return model_usage_ledger.response_budget_diagnostics(
+        response_text=result.get('response_text') or '',
+        finish_reason=result.get('finish_reason') or '',
+        usage_metadata=result.get('usage_metadata') or {},
+        max_output_tokens=generation_config.get('max_output_tokens'),
+    )
+
+
+def record_sync_output_summary(summary, diagnostics):
+    """Add one safe response diagnostic to a sync manifest summary."""
+    diagnostics = model_usage_ledger.normalize_response_diagnostics(diagnostics)
+    for field in ('completion_tokens', 'reasoning_tokens', 'text_output_tokens'):
+        value = diagnostics.get(field)
+        if isinstance(value, int) and not isinstance(value, bool):
+            summary[field] = int(summary.get(field) or 0) + value
+            known_key = f'{field}_known_requests'
+            summary[known_key] = int(summary.get(known_key) or 0) + 1
+    summary['reasoning_budget_pressure_count'] = int(
+        summary.get('reasoning_budget_pressure_count') or 0
+    ) + int(diagnostics.get('reasoning_budget_pressure') is True)
+    summary['truncated_output_count'] = int(
+        summary.get('truncated_output_count') or 0
+    ) + int(diagnostics.get('truncated') is True)
+    reason_code = str(diagnostics.get('reason_code') or '').strip()
+    if reason_code:
+        bump_counter(summary.setdefault('output_reason_counts', {}), reason_code)
+
+
+def _sync_token_summary_value(summary, field):
+    """Format an aggregate only when at least one provider reported it."""
+    if int(summary.get(f'{field}_known_requests') or 0) <= 0:
+        return 'unknown'
+    return str(int(summary.get(field) or 0))
+
+
+def print_sync_output_summary(summary):
+    """Print the stable CLI token/diagnostic contract consumed by the GUI."""
+    print(
+        'Sync output tokens: '
+        f"completion={_sync_token_summary_value(summary, 'completion_tokens')} "
+        f"reasoning={_sync_token_summary_value(summary, 'reasoning_tokens')} "
+        f"text={_sync_token_summary_value(summary, 'text_output_tokens')}"
+    )
+    print(
+        'Reasoning budget warnings: '
+        f"{int(summary.get('reasoning_budget_pressure_count') or 0)}"
+    )
+    print(
+        'Truncated sync responses: '
+        f"{int(summary.get('truncated_output_count') or 0)}"
+    )
 
 
 def contract_diagnostics_counts(diagnostics, field_name):
@@ -10449,7 +10516,7 @@ def build_repair_request(job, model=None):
     }
 
 def _sync_result_to_dict(result):
-    return {
+    response = {
         'response_payload': result.response_payload,
         'response_text': result.response_text,
         'finish_reason': result.finish_reason,
@@ -10458,6 +10525,37 @@ def _sync_result_to_dict(result):
         'model': result.model,
         'execution_mode': result.execution_mode,
     }
+    request_metadata = dict(getattr(result, 'request_metadata', None) or {})
+    if request_metadata:
+        response['request_metadata'] = request_metadata
+    output_diagnostics = dict(getattr(result, 'output_diagnostics', None) or {})
+    if output_diagnostics:
+        response['output_diagnostics'] = output_diagnostics
+    return response
+
+
+def _run_sync_backend_with_retry(
+    backend,
+    request,
+    *,
+    attempts=DEFAULT_SYNC_RETRY_ATTEMPTS,
+):
+    """Retry only transient structured categories on the same backend."""
+    limit = max(1, int(attempts or 1))
+    for attempt in range(1, limit + 1):
+        try:
+            return backend.generate(request)
+        except Exception as exc:
+            decision = sync_recovery_decision(exc)
+            if not decision.retry_same_request or attempt >= limit:
+                raise
+            print(
+                f'Sync request {decision.category}; retrying '
+                f'({attempt}/{limit})...',
+            )
+            if decision.backoff:
+                time.sleep(min(attempt, 2))
+    raise RuntimeError('Sync request failed without a captured exception.')
 
 
 def run_sync_request(request_payload, model_name, api_key_index=None):
@@ -10477,21 +10575,30 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
             raise SystemExit('--api-key-index is only supported by the Gemini sync backend.')
         from litellm_sync_backend import LiteLLMSyncBackend
 
-        result = LiteLLMSyncBackend(
+        backend = LiteLLMSyncBackend(
             custom_providers=legacy.CUSTOM_LITELLM_PROVIDERS,
-        ).generate(SyncGenerationRequest(
+        )
+        request = SyncGenerationRequest(
             model=effective_model,
             contents=request_payload.get('contents') or [],
             config=config,
-        ))
-        return _sync_result_to_dict(result)
+        )
+        result = _run_sync_backend_with_retry(backend, request)
+        response = _sync_result_to_dict(result)
+        response['output_diagnostics'] = model_usage_ledger.response_budget_diagnostics(
+            response_text=result.response_text,
+            finish_reason=result.finish_reason,
+            usage_metadata=result.usage_metadata,
+            max_output_tokens=config.get('max_output_tokens'),
+        )
+        return response
 
-    if api_key_index is not None:
-        attempts = 1
-    elif hasattr(legacy, 'api_key_rotation_attempts'):
-        attempts = legacy.api_key_rotation_attempts()
-    else:
-        attempts = max(1, len(getattr(legacy, 'API_KEYS', []) or []))
+    key_attempts = (
+        legacy.api_key_rotation_attempts()
+        if api_key_index is None and hasattr(legacy, 'api_key_rotation_attempts')
+        else 1
+    )
+    attempts = max(DEFAULT_SYNC_RETRY_ATTEMPTS, key_attempts)
     last_error = None
 
     for attempt in range(1, attempts + 1):
@@ -10509,15 +10616,32 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
                 contents=request_payload.get('contents') or [],
                 config=config,
             ))
-            return _sync_result_to_dict(result)
+            response = _sync_result_to_dict(result)
+            response['output_diagnostics'] = model_usage_ledger.response_budget_diagnostics(
+                response_text=result.response_text,
+                finish_reason=result.finish_reason,
+                usage_metadata=result.usage_metadata,
+                max_output_tokens=config.get('max_output_tokens'),
+            )
+            return response
 
         except Exception as exc:
             last_error = exc
-            retryable = is_quota_error(exc) or is_unavailable_error(exc)
-            if api_key_index is None and retryable and attempt < attempts and legacy.rotate_api_key():
-                label = 'quota' if is_quota_error(exc) else 'service unavailable'
-                print(f'Sync request hit {label}. Retrying with next API key ({attempt}/{attempts})...')
-                time.sleep(min(attempt, 2))
+            decision = sync_recovery_decision(exc)
+            if decision.retry_same_request and attempt < attempts:
+                rotated = bool(
+                    decision.rotate_credentials
+                    and api_key_index is None
+                    and legacy.rotate_api_key()
+                )
+                label = decision.category.replace('_', ' ')
+                key_action = 'next API key' if rotated else 'same API key'
+                print(
+                    f'Sync request hit {label}. Retrying with {key_action} '
+                    f'({attempt}/{attempts})...'
+                )
+                if decision.backoff:
+                    time.sleep(min(attempt, 2))
                 continue
             raise
 
@@ -10759,6 +10883,16 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
         'contract_partial_requests': 0,
         'targeted_retry_requests': 0,
         'targeted_retry_items': 0,
+        'completion_tokens': 0,
+        'completion_tokens_known_requests': 0,
+        'reasoning_tokens': 0,
+        'reasoning_tokens_known_requests': 0,
+        'text_output_tokens': 0,
+        'text_output_tokens_known_requests': 0,
+        'reasoning_budget_pressure_count': 0,
+        'truncated_output_count': 0,
+        'output_reason_counts': {},
+        'error_category_counts': {},
         'reason_counts': {},
     }
     if keyword_contract:
@@ -10794,6 +10928,17 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
             }
             result_row['finish_reason'] = result.get('finish_reason', '')
             result_row['usage_metadata'] = result.get('usage_metadata') or {}
+            result_row['output_diagnostics'] = sync_output_diagnostics(
+                result,
+                row.get('request') or {},
+            )
+            record_sync_output_summary(summary, result_row['output_diagnostics'])
+            if result.get('request_metadata'):
+                result_row['request_metadata'] = (
+                    model_usage_ledger.normalize_request_metadata(
+                        result.get('request_metadata') or {}
+                    )
+                )
             result_row['provider'] = result.get('provider') or SYNC_BACKEND
             result_row['model'] = result.get('model') or SYNC_MODEL or BATCH_MODEL
             result_row['execution_mode'] = result.get('execution_mode') or 'sync'
@@ -10802,6 +10947,8 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                 'kind': 'first_pass',
                 'finish_reason': result.get('finish_reason', ''),
                 'usage_metadata': result.get('usage_metadata') or {},
+                'output_diagnostics': result_row['output_diagnostics'],
+                'request_metadata': result_row.get('request_metadata') or {},
             }]
             if result.get('finish_reason') == 'MAX_TOKENS':
                 summary['max_tokens_count'] += 1
@@ -10877,7 +11024,22 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                         'response': retry_result.get('response_payload') or {},
                         'finish_reason': retry_result.get('finish_reason', ''),
                         'usage_metadata': retry_result.get('usage_metadata') or {},
+                        'output_diagnostics': sync_output_diagnostics(
+                            retry_result,
+                            retry_row.get('request') or {},
+                        ),
+                        'request_metadata': (
+                            model_usage_ledger.normalize_request_metadata(
+                                retry_result.get('request_metadata') or {}
+                            )
+                        ),
                     })
+                    record_sync_output_summary(
+                        summary,
+                        result_row['provider_response_attempts'][-1][
+                            'output_diagnostics'
+                        ],
+                    )
                     retry_contract = _contract_from_sync_result(
                         retry_result,
                         retry_chunk,
@@ -10898,13 +11060,24 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                         )
                     )
                 except Exception as exc:
+                    error_category = sync_error_category(exc)
                     result_row['provider_response_attempts'].append({
                         'kind': 'targeted_retry',
                         'item_ids': [
                             item.get('id') for item in retry_chunk.get('items') or []
                         ],
-                        'error': str(exc),
+                        'error_category': error_category,
+                        'error': sync_error_summary(exc),
+                        'request_metadata': (
+                            model_usage_ledger.normalize_request_metadata(
+                                getattr(exc, 'request_metadata', None) or {}
+                            )
+                        ),
                     })
+                    bump_counter(
+                        summary['error_category_counts'],
+                        error_category,
+                    )
                     bump_counter(
                         summary['reason_counts'],
                         contract_error_reason(
@@ -10947,10 +11120,18 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                     },
                 }
         except Exception as exc:
+            error_category = sync_error_category(exc)
             summary['failed_request_count'] += 1
-            bump_counter(summary['reason_counts'], 'request_error')
-            result_row['error'] = str(exc)
-            print(f'  error: {str(exc)[:160]}')
+            bump_counter(summary['reason_counts'], error_category)
+            bump_counter(summary['error_category_counts'], error_category)
+            result_row['error_category'] = error_category
+            result_row['error'] = sync_error_summary(exc)
+            request_metadata = model_usage_ledger.normalize_request_metadata(
+                getattr(exc, 'request_metadata', None) or {}
+            )
+            if request_metadata:
+                result_row['request_metadata'] = request_metadata
+            print(f"  error: {result_row['error']}")
         result_rows.append(result_row)
 
     atomic_write_jsonl(result_path, result_rows, ensure_ascii=False)
@@ -11012,6 +11193,7 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
     if not keyword_contract:
         print(f'Unresolved contract items: {unresolved_items}')
     print(f"Contract partial requests: {summary['contract_partial_requests']}")
+    print_sync_output_summary(summary)
     import_manifest_usage_best_effort(manifest)
     return manifest
 
@@ -11244,6 +11426,7 @@ def print_repair_summary(summary):
     print(f"Validation failures: {summary['validation_failures']}")
     print(f"Missing item ids: {summary['missing_item_ids']}")
     print(f"Unresolved items: {summary['unresolved_items']}")
+    print_sync_output_summary(summary)
     if summary.get('story_memory_enabled'):
         story_summary = summary.get('story_memory_summary') or {}
         print(
@@ -11309,6 +11492,16 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
         'story_memory_enabled': STORY_MEMORY_ENABLED,
         'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
         'story_memory_summary': summarize_batch_story_memory(jobs) if STORY_MEMORY_ENABLED else {},
+        'completion_tokens': 0,
+        'completion_tokens_known_requests': 0,
+        'reasoning_tokens': 0,
+        'reasoning_tokens_known_requests': 0,
+        'text_output_tokens': 0,
+        'text_output_tokens_known_requests': 0,
+        'reasoning_budget_pressure_count': 0,
+        'truncated_output_count': 0,
+        'output_reason_counts': {},
+        'error_category_counts': {},
         'reason_counts': reason_counts,
     }
 
@@ -11333,6 +11526,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
         usage_metadata = {}
         response_text = ''
         parse_error = ''
+        output_diagnostics = {}
+        request_metadata = {}
         result_items = []
         parse_ok = False
         try:
@@ -11344,10 +11539,23 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
             finish_reason = response_data['finish_reason']
             usage_metadata = response_data['usage_metadata']
             response_text = response_data['response_text']
+            output_diagnostics = sync_output_diagnostics(
+                response_data,
+                request_row.get('request') or {},
+            )
+            request_metadata = model_usage_ledger.normalize_request_metadata(
+                response_data.get('request_metadata') or {}
+            )
+            record_sync_output_summary(summary, output_diagnostics)
         except Exception as exc:
+            error_category = sync_error_category(exc)
             summary['request_errors'] += 1
-            bump_counter(reason_counts, 'request_error')
-            parse_error = str(exc)
+            bump_counter(reason_counts, error_category)
+            bump_counter(summary['error_category_counts'], error_category)
+            parse_error = sync_error_summary(exc)
+            request_metadata = model_usage_ledger.normalize_request_metadata(
+                getattr(exc, 'request_metadata', None) or {}
+            )
             for item in job['items']:
                 failure_entries.append(
                     {
@@ -11357,6 +11565,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                         'source': item['text'],
                         'id': item['id'],
                         'error': parse_error,
+                        'error_category': error_category,
+                        'request_metadata': request_metadata,
                     }
                 )
             result_entries.append(
@@ -11368,8 +11578,10 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                     'parsed_items': 0,
                     'parse_ok': False,
                     'parse_error': parse_error,
+                    'error_category': error_category,
                     'finish_reason': finish_reason,
                     'usage_metadata': usage_metadata,
+                    'request_metadata': request_metadata,
                     'response_preview': '',
                 }
             )
@@ -11411,12 +11623,13 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                     contract_error_reason(exc, 'parse_error'),
                 )
         else:
-            parse_error = 'Missing text in response payload'
-            summary['parse_errors'] += 1
-            bump_counter(
-                reason_counts,
-                translation_core.CONTRACT_EMPTY_RESPONSE_TEXT,
+            reason_code = str(
+                output_diagnostics.get('reason_code')
+                or translation_core.CONTRACT_EMPTY_RESPONSE_TEXT
             )
+            parse_error = f'Missing text in response payload [{reason_code}]'
+            summary['parse_errors'] += 1
+            bump_counter(reason_counts, reason_code)
 
         if not parse_ok:
             for item in job['items']:
@@ -11430,6 +11643,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                         'error': parse_error,
                         'finish_reason': finish_reason,
                         'usage_metadata': usage_metadata,
+                        'output_diagnostics': output_diagnostics,
+                        'request_metadata': request_metadata,
                         'response_preview': response_text[:500],
                     }
                 )
@@ -11444,6 +11659,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                     'parse_error': parse_error,
                     'finish_reason': finish_reason,
                     'usage_metadata': usage_metadata,
+                    'output_diagnostics': output_diagnostics,
+                    'request_metadata': request_metadata,
                     'response_preview': response_text[:500],
                 }
             )
@@ -11521,6 +11738,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
                 'parse_error': '',
                 'finish_reason': finish_reason,
                 'usage_metadata': usage_metadata,
+                'output_diagnostics': output_diagnostics,
+                'request_metadata': request_metadata,
                 'response_preview': response_text[:500],
             }
         )
@@ -13840,6 +14059,8 @@ def dispatch_command(parser, args):
                         response_text=str(raw.get('response_text') or ''),
                         finish_reason=str(raw.get('finish_reason') or ''),
                         usage_metadata=dict(raw.get('usage_metadata') or {}),
+                        output_diagnostics=dict(raw.get('output_diagnostics') or {}),
+                        request_metadata=dict(raw.get('request_metadata') or {}),
                     )
 
                 pricing_config = batch_cost_estimate.load_pricing_config(
@@ -13853,10 +14074,17 @@ def dispatch_command(parser, args):
                     result = event.get('result')
                     if result is None:
                         return
+                    usage_result = _sync_result_to_dict(result)
+                    usage_result['output_diagnostics'] = (
+                        event.get('output_diagnostics') or {}
+                    )
+                    usage_result['request_metadata'] = (
+                        event.get('request_metadata') or {}
+                    )
                     record_generation_usage_best_effort(
                         task_mode='analysis',
                         stage=str(event.get('stage') or 'project_analysis'),
-                        result=_sync_result_to_dict(result),
+                        result=usage_result,
                         operation_id=analysis_usage_operation_id,
                         run_id=analysis_usage_run_id,
                         source_key=str(event.get('artifact_id') or ''),
@@ -14203,6 +14431,7 @@ def dispatch_command(parser, args):
         print(f"- dry_run: {summary['dry_run']}")
         print(f"- report: {summary['report_path']}")
         print(f"- results: {summary['results_path']}")
+        print_sync_output_summary(summary.get('output_summary') or {})
         return
 
     if command == 'preview-revisions':

--- a/gui_qt/ab_experiment_report.py
+++ b/gui_qt/ab_experiment_report.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from .bootstrap_report import coerce_bool
 from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry
 from .user_copy import format_manifest_path_fact
+from .sync_usage_report import collect_sync_usage_facts
 
 _MANIFEST_MODE_TRANSLATION = "translation"
 _COMPARE_VARIANTS_LINE_RE = re.compile(
@@ -307,6 +308,7 @@ def summarize_compare_variants_output(
         facts.append(format_manifest_path_fact(manifest_path))
     if variant_names:
         facts.append(f"对比变体：{variant_names}")
+    facts.extend(collect_sync_usage_facts(output))
 
     if exit_code != 0:
         return AbExperimentSummary(

--- a/gui_qt/cli_runner.py
+++ b/gui_qt/cli_runner.py
@@ -135,7 +135,7 @@ class CliRunner(QObject):
     def request_stop(self, *, grace_ms: int = 2000) -> bool:
         """Ask the child to terminate, then asynchronously fall back to kill."""
         process = self._proc
-        if process is None or process.state() == QProcess.ProcessState.NotRunning:
+        if process is None:
             return False
         if self._stop_requested:
             return True
@@ -143,6 +143,16 @@ class CliRunner(QObject):
         self._start_timeout_timer.stop()
         self.line_ready.emit("\n[GUI] 正在停止本地进程...\n")
         self.stopping.emit()
+        if process.state() == QProcess.ProcessState.NotRunning:
+            # Qt can expose NotRunning before the queued finished signal. The
+            # user stop still wins in that ownership window; drain/finalize now
+            # and ignore the later stale signal.
+            self._on_process_finished(
+                process,
+                -1,
+                QProcess.ExitStatus.CrashExit,
+            )
+            return True
         self._stop_timeout_timer.start(max(1, int(grace_ms)))
         process.terminate()
         return True
@@ -225,6 +235,7 @@ class CliRunner(QObject):
     ) -> None:
         if process is not self._proc:
             return
+        stop_requested = self._stop_requested
         self._start_timeout_timer.stop()
         self._stop_timeout_timer.stop()
         # QProcess may still hold final bytes when finished is delivered.
@@ -248,7 +259,11 @@ class CliRunner(QObject):
             delete_later()
         # Clear ownership before notifying consumers: workflow callbacks may
         # synchronously start the next process from ``finished``.
-        self.finished.emit(exit_code)
+        # Once the user requested stop, a racing zero exit must not be accepted
+        # as success by a workflow or enable a newly written preview. Use one
+        # stable non-zero terminal code even when the child exits cleanly while
+        # handling terminate().
+        self.finished.emit(-1 if stop_requested else exit_code)
 
     def _on_error(self, error: QProcess.ProcessError):
         process = self._proc

--- a/gui_qt/cli_runner.py
+++ b/gui_qt/cli_runner.py
@@ -133,7 +133,17 @@ class CliRunner(QObject):
         self.request_stop()
 
     def request_stop(self, *, grace_ms: int = 2000) -> bool:
-        """Ask the child to terminate, then asynchronously fall back to kill."""
+        """Ask the child to terminate, then asynchronously fall back to kill.
+
+        Returns ``True`` when a stop was issued or already requested for the
+        owned process; returns ``False`` when there is no owned process.
+
+        An owned process that is already in the ``NotRunning`` state is
+        finalized immediately (drained and emitted as finished) so the user
+        stop wins over a queued stale exit. A user stop always produces the
+        terminal ``finished`` signal with exit code ``-1``; any later stale
+        process result is ignored by the ownership check.
+        """
         process = self._proc
         if process is None:
             return False

--- a/gui_qt/keyword_report.py
+++ b/gui_qt/keyword_report.py
@@ -5,6 +5,7 @@ import re
 
 from .check_report import WritebackSummary
 from .translation_workflow import WorkflowUpdate
+from .sync_usage_report import collect_sync_usage_facts
 from .user_copy import MODEL_CONTRACT_COPY
 
 
@@ -204,6 +205,7 @@ def _collect_sync_facts(output: str) -> list[str]:
         facts.append(
             f"{MODEL_CONTRACT_COPY['partial_requests']}：{partial_requests} 个"
         )
+    facts.extend(collect_sync_usage_facts(output))
     return facts
 
 

--- a/gui_qt/litellm_worker.py
+++ b/gui_qt/litellm_worker.py
@@ -29,7 +29,7 @@ from litellm_provider_config import (
     warm_litellm_module,
 )
 from litellm_sync_backend import LiteLLMBackendError, LiteLLMSyncBackend
-from sync_model_backend import SyncGenerationRequest
+from sync_model_backend import SyncGenerationRequest, sync_error_category
 from .user_copy import CUSTOM_LITELLM_PROVIDER_COPY, LITELLM_CONNECTION_TEST_COPY
 
 
@@ -69,7 +69,7 @@ class BudgetExhausted(TimeoutError):
 
 
 def _connection_error_message(exc: Exception) -> str:
-    category = str(getattr(exc, "category", "provider_error") or "provider_error")
+    category = sync_error_category(exc)
     details = LITELLM_CONNECTION_TEST_COPY["errors"]
     return f"连接失败 [{category}]: {details.get(category, details['provider_error'])}"
 

--- a/gui_qt/project_analysis_workflow.py
+++ b/gui_qt/project_analysis_workflow.py
@@ -36,13 +36,30 @@ def generation_facts_from_output(output: str) -> list[str]:
     usage = latest.get("usage") if isinstance(latest.get("usage"), dict) else {}
     if not latest:
         return []
+    def token_value(field: str, *, legacy_field: str = "") -> str:
+        known_key = f"{field}_known_requests"
+        if known_key in usage and int(usage.get(known_key) or 0) <= 0:
+            return "unknown"
+        value = usage.get(field)
+        if value is None and legacy_field:
+            value = usage.get(legacy_field)
+        return "unknown" if value is None else str(int(value or 0))
+
     facts = [
         f"生成进度：{_generation_stage_label(str(latest.get('stage') or ''))} "
         f"{latest.get('completed', 0)}/{latest.get('total', 0)}",
         f"模型请求：{usage.get('requests', 0)} · "
         f"输入 Token {usage.get('input_tokens', 0)} · "
-        f"输出 Token {usage.get('output_tokens', 0)}",
+        f"completion {token_value('completion_tokens', legacy_field='output_tokens')} · "
+        f"reasoning {token_value('reasoning_tokens')} · "
+        f"正文 {token_value('text_output_tokens')}",
     ]
+    reasoning_warnings = int(usage.get("reasoning_budget_pressure_count") or 0)
+    truncated = int(usage.get("truncated_output_count") or 0)
+    if reasoning_warnings:
+        facts.append(f"Reasoning 预算告警：{reasoning_warnings} 次")
+    if truncated:
+        facts.append(f"输出截断：{truncated} 次")
     if usage.get("estimated_cost") is not None:
         facts.append(
             f"估算成本：{float(usage.get('estimated_cost') or 0.0):.6f} "

--- a/gui_qt/repair_report.py
+++ b/gui_qt/repair_report.py
@@ -20,6 +20,7 @@ from .check_failures_report import (
 from .diagnostics_context import DiagnosticsContext, DiagnosticsPathEntry, resolve_package_dir
 from .diagnostics_context import manifest_check_safety_level
 from .user_copy import format_manifest_path_fact
+from .sync_usage_report import collect_sync_usage_facts
 
 _DERIVED_REPAIR_REPORT_NAME = "repair_from_check_failures.jsonl"
 _REPAIR_RUN_DIR_RE = re.compile(r"^\s*Repair run dir:\s*(.+?)\s*$", re.MULTILINE)
@@ -317,6 +318,7 @@ def summarize_repair_output(
         facts.append(format_manifest_path_fact(manifest_path))
     if report_path:
         facts.append(f"修补报告：{report_path}")
+    facts.extend(collect_sync_usage_facts(output))
 
     if exit_code != 0:
         return RepairSummary(

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -5,6 +5,7 @@ import re
 
 from .check_report import WritebackSummary
 from .summary_helpers import extend_facts_with_notices
+from .sync_usage_report import collect_sync_usage_facts
 from .translation_workflow import WorkflowUpdate
 from .user_copy import MODEL_CONTRACT_COPY, format_manifest_path_fact
 
@@ -374,6 +375,7 @@ def _collect_sync_revision_facts(
         facts.append(
             f"{MODEL_CONTRACT_COPY['partial_requests']}：{partial_requests} 个"
         )
+    facts.extend(collect_sync_usage_facts(output))
     return facts
 
 

--- a/gui_qt/sync_translation_report.py
+++ b/gui_qt/sync_translation_report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import re
 
 from .translation_workflow import WorkflowUpdate
+from .sync_usage_report import collect_sync_usage_facts
 from .user_copy import MODEL_CONTRACT_COPY
 
 
@@ -173,4 +174,5 @@ def _collect_facts(output: str) -> list[str]:
             f"{MODEL_CONTRACT_COPY['targeted_retries']}："
             f"{retry_match.group(1)} 次请求 / {retry_match.group(2)} 项"
         )
+    facts.extend(collect_sync_usage_facts(output))
     return facts

--- a/gui_qt/sync_usage_report.py
+++ b/gui_qt/sync_usage_report.py
@@ -1,0 +1,40 @@
+"""Shared GUI parsing for provider-neutral synchronous output diagnostics."""
+from __future__ import annotations
+
+import re
+
+
+_TOKEN_SUMMARY_RE = re.compile(
+    r"^Sync output tokens:\s*"
+    r"completion=(\d+|unknown)\s+"
+    r"reasoning=(\d+|unknown)\s+"
+    r"text=(\d+|unknown)\s*$",
+    re.MULTILINE,
+)
+
+
+def collect_sync_usage_facts(output: str) -> list[str]:
+    """Return compact token and output-budget facts from stable CLI lines."""
+    facts: list[str] = []
+    token_match = _TOKEN_SUMMARY_RE.search(output)
+    if token_match:
+        completion, reasoning, text_output = token_match.groups()
+        facts.append(
+            "输出 Token："
+            f"completion {completion} / reasoning {reasoning} / 正文 {text_output}"
+        )
+    warning_match = re.search(
+        r"^Reasoning budget warnings:\s*(\d+)\s*$",
+        output,
+        re.MULTILINE,
+    )
+    if warning_match and int(warning_match.group(1)) > 0:
+        facts.append(f"Reasoning 预算告警：{warning_match.group(1)} 次")
+    truncated_match = re.search(
+        r"^Truncated sync responses:\s*(\d+)\s*$",
+        output,
+        re.MULTILINE,
+    )
+    if truncated_match and int(truncated_match.group(1)) > 0:
+        facts.append(f"输出截断：{truncated_match.group(1)} 次")
+    return facts

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -261,7 +261,8 @@ LITELLM_CONNECTION_TEST_COPY = {
     "errors": {
         "authentication": "身份验证失败，请检查供应商密钥。",
         "rate_limit": "供应商限流或配额不足，请稍后重试。",
-        "service_unavailable": "供应商服务暂时不可用或请求超时。",
+        "service_unavailable": "供应商服务暂时不可用，请稍后重试。",
+        "timeout": "连接测试已达到单请求超时上限。",
         "missing_dependency": "LiteLLM 尚未正确安装。",
         "invalid_response": (
             "模型未返回预期的 JSON 结果；请检查模型兼容性或 reasoning 输出预算。"
@@ -497,6 +498,34 @@ def format_usage_ledger_facts(report: Any) -> list[str]:
     facts = [
         f"{USAGE_LEDGER_COPY['total']}：累计 {calls} 次调用；{token_text}",
     ]
+
+    def token_metric(field: str) -> str:
+        value = totals.get(field)
+        unknown = int(totals.get(f"{field}_unknown_records") or 0)
+        text = "unknown" if value is None else f"{int(value):,}"
+        if unknown:
+            text += f"（{unknown} 条未知）"
+        return text
+
+    facts.append(
+        "输出 Token："
+        f"completion {token_metric('completion_tokens')} / "
+        f"reasoning {token_metric('reasoning_tokens')} / "
+        f"正文 {token_metric('text_output_tokens')}"
+    )
+    reasoning_share = totals.get("reasoning_share")
+    if reasoning_share is not None:
+        facts.append(f"Reasoning 占已知输出：{float(reasoning_share):.1%}")
+    diagnostics = totals.get("output_diagnostics")
+    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    reasoning_warnings = int(
+        diagnostics.get("reasoning_budget_pressure_records") or 0
+    )
+    truncated = int(diagnostics.get("truncated_records") or 0)
+    if reasoning_warnings:
+        facts.append(f"Reasoning 预算告警：{reasoning_warnings} 条响应")
+    if truncated:
+        facts.append(f"输出截断：{truncated} 条响应")
 
     recent = report.get("recent_run")
     if isinstance(recent, dict):

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -17,30 +17,55 @@ from sync_model_backend import (
     SyncGenerationRequest,
     SyncGenerationResult,
     normalize_sync_timeout_seconds,
+    sync_error_category,
 )
 
 
 class LiteLLMBackendError(RuntimeError):
+    """Backend failure whose message is whitelisted or explicitly internal.
+
+    ``message`` must be one of the safe per-category messages unless the caller
+    explicitly opts in with ``internal=True`` for intentional user-facing text.
+    Provider-derived text is never accepted as the message; it may only travel
+    in ``detail``, which is never rendered by :meth:`__str__` and exists for
+    local logs.
+    """
+
     def __init__(
         self,
         message: str,
         *,
         category: str = "provider_error",
         request_metadata: Mapping[str, Any] | None = None,
+        internal: bool = False,
+        detail: str | None = None,
     ) -> None:
+        normalized = str(category or "provider_error").strip().lower()
+        if normalized not in SYNC_ERROR_CATEGORIES:
+            normalized = "provider_error"
+        safe_message = _SAFE_ERROR_MESSAGES.get(
+            normalized,
+            _SAFE_ERROR_MESSAGES["provider_error"],
+        )
+        if not internal and message != safe_message:
+            # Whitelist enforcement: only known safe text may become the
+            # user-visible message; anything else is replaced by the category
+            # summary so a missed sanitization point cannot echo provider text.
+            message = safe_message
         super().__init__(message)
-        self.category = category
+        self.category = normalized
         self.request_metadata = dict(request_metadata or {})
+        self.detail = str(detail or "")[:500]
 
 
 class LiteLLMUnavailableError(LiteLLMBackendError):
     def __init__(self, message: str) -> None:
-        super().__init__(message, category="missing_dependency")
+        super().__init__(message, category="missing_dependency", internal=True)
 
 
 class LiteLLMCapabilityError(LiteLLMBackendError):
     def __init__(self, message: str) -> None:
-        super().__init__(message, category="unsupported_capability")
+        super().__init__(message, category="unsupported_capability", internal=True)
 
 
 _SAFE_ERROR_MESSAGES = {
@@ -50,6 +75,7 @@ _SAFE_ERROR_MESSAGES = {
     "timeout": "LiteLLM request timed out.",
     "invalid_response": "LiteLLM returned an invalid response.",
     "unsupported_capability": "LiteLLM provider does not support this request.",
+    "missing_dependency": "LiteLLM optional dependency is unavailable.",
     "provider_error": "LiteLLM provider request failed.",
 }
 
@@ -60,11 +86,12 @@ def _safe_backend_error(
     request_metadata: Mapping[str, Any] | None = None,
 ) -> LiteLLMBackendError:
     """Convert arbitrary provider failures without echoing provider text."""
-    category = _error_category(exc)
+    category = sync_error_category(exc)
     return LiteLLMBackendError(
         _SAFE_ERROR_MESSAGES.get(category, _SAFE_ERROR_MESSAGES["provider_error"]),
         category=category,
         request_metadata=request_metadata,
+        detail=str(exc),
     )
 
 
@@ -84,6 +111,7 @@ def _serialize_response(response: Any) -> Mapping[str, Any]:
         raise LiteLLMBackendError(
             f"LiteLLM returned unsupported response type: {type(response).__name__}",
             category="invalid_response",
+            internal=True,
         )
     hidden = getattr(response, "_hidden_params", None)
     if isinstance(hidden, Mapping) and "_hidden_params" not in payload:
@@ -124,52 +152,6 @@ def _messages(contents: Any, config: Mapping[str, Any]) -> List[Dict[str, str]]:
             ),
         })
     return messages
-
-
-def _error_category(exc: Exception) -> str:
-    explicit = str(getattr(exc, "category", "") or "").strip().lower()
-    if explicit in SYNC_ERROR_CATEGORIES:
-        return explicit
-    try:
-        import litellm
-
-        typed_categories = (
-            ("rate_limit", (getattr(litellm, "RateLimitError", None),)),
-            ("service_unavailable", (
-                getattr(litellm, "ServiceUnavailableError", None),
-                getattr(litellm, "APIConnectionError", None),
-            )),
-            ("timeout", (getattr(litellm, "Timeout", None),)),
-            ("authentication", (
-                getattr(litellm, "AuthenticationError", None),
-                getattr(litellm, "PermissionDeniedError", None),
-            )),
-        )
-        for category, candidates in typed_categories:
-            exception_types = tuple(
-                candidate for candidate in candidates if isinstance(candidate, type)
-            )
-            if exception_types and isinstance(exc, exception_types):
-                return category
-    except ImportError:
-        pass
-
-    status = getattr(exc, "status_code", getattr(exc, "code", None))
-    try:
-        status = int(status)
-    except (TypeError, ValueError, OverflowError):
-        status = None
-    if status == 429:
-        return "rate_limit"
-    if status == 408 or isinstance(exc, TimeoutError):
-        return "timeout"
-    if status in {500, 502, 503, 504}:
-        return "service_unavailable"
-    if status in {401, 403}:
-        return "authentication"
-    if status == 404:
-        return "unsupported_capability"
-    return "provider_error"
 
 
 def _masked_key_identity(provider: str, key: str, index: int | None = None) -> str:
@@ -381,7 +363,7 @@ class LiteLLMSyncBackend:
                 response = completion(**request_kwargs)
                 return response, credential, tuple(attempted_identities)
             except Exception as exc:
-                category = _error_category(exc)
+                category = sync_error_category(exc)
                 if category == "rate_limit" and index + 1 < len(attempts):
                     self._sleep(min(index + 1, 2))
                     continue
@@ -393,10 +375,11 @@ class LiteLLMSyncBackend:
                 raise _safe_backend_error(
                     exc,
                     request_metadata=failure_metadata,
-                ) from None
+                ) from exc
         raise LiteLLMBackendError(
             "LiteLLM request failed without a captured exception.",
             category="provider_error",
+            internal=True,
         )
 
     async def _run_with_credentials_async(
@@ -417,7 +400,7 @@ class LiteLLMSyncBackend:
                 response = await completion(**request_kwargs)
                 return response, credential, tuple(attempted_identities)
             except Exception as exc:
-                category = _error_category(exc)
+                category = sync_error_category(exc)
                 if category == "rate_limit" and index + 1 < len(attempts):
                     import asyncio
 
@@ -431,10 +414,11 @@ class LiteLLMSyncBackend:
                 raise _safe_backend_error(
                     exc,
                     request_metadata=failure_metadata,
-                ) from None
+                ) from exc
         raise LiteLLMBackendError(
             "LiteLLM request failed without a captured exception.",
             category="provider_error",
+            internal=True,
         )
 
     def _build_request_context(
@@ -503,6 +487,7 @@ class LiteLLMSyncBackend:
                 f"自定义 Provider {custom.label} 需要 API Key，"
                 "但系统凭据与 api_key_env 环境变量均未提供。",
                 category="authentication",
+                internal=True,
             )
         if custom is not None:
             kwargs["api_base"] = custom.base_url

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -1,6 +1,7 @@
 """Optional LiteLLM implementation of the synchronous model backend."""
 
 import os
+import hashlib
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional
@@ -95,7 +96,11 @@ def _safe_backend_error(
     )
 
 
-def _serialize_response(response: Any) -> Mapping[str, Any]:
+def _serialize_response(
+    response: Any,
+    *,
+    request_metadata: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
     payload: Dict[str, Any] | None = None
     if isinstance(response, Mapping):
         payload = dict(response)
@@ -111,6 +116,7 @@ def _serialize_response(response: Any) -> Mapping[str, Any]:
         raise LiteLLMBackendError(
             f"LiteLLM returned unsupported response type: {type(response).__name__}",
             category="invalid_response",
+            request_metadata=request_metadata,
             internal=True,
         )
     hidden = getattr(response, "_hidden_params", None)
@@ -155,10 +161,17 @@ def _messages(contents: Any, config: Mapping[str, Any]) -> List[Dict[str, str]]:
 
 
 def _masked_key_identity(provider: str, key: str, index: int | None = None) -> str:
-    """Return a log-safe provider/key identity without exposing the secret."""
-    suffix = str(key or "")[-4:] if len(str(key or "")) >= 4 else ""
+    """Return a non-reversible provider/key identity for logs and metadata.
+
+    Uses a SHA-256 digest prefix of the key instead of any raw key material
+    (including a final-character suffix), so the value cannot be reversed into
+    the secret while still identifying the same key across runs. The ordinal
+    (when known) keeps rotation attempts distinguishable within one provider.
+    """
+    raw = str(key or "")
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:10] if raw else "empty"
     ordinal = f"#{index + 1}" if index is not None else ""
-    return f"{provider}{ordinal}:****{suffix}"
+    return f"{provider}{ordinal}:key:{digest}"
 
 
 @dataclass(frozen=True)
@@ -257,6 +270,14 @@ class LiteLLMSyncBackend:
         provider: str,
         custom: CustomLiteLLMProvider | None,
     ) -> tuple[_ResolvedCredential, ...]:
+        """Resolve credentials in precedence order for one provider.
+
+        Precedence: the explicit constructor API key first; otherwise the
+        provider keyring with the active key ordered first (rotation only
+        considers keys belonging to this provider); then the custom-provider
+        environment variable; otherwise no credentials. Every ``identity`` is a
+        non-reversible digest, so metadata and logs never contain key material.
+        """
         if self._api_key:
             return (
                 _ResolvedCredential(
@@ -543,7 +564,7 @@ class LiteLLMSyncBackend:
         *,
         request_metadata: Mapping[str, Any] | None = None,
     ) -> SyncGenerationResult:
-        payload = _serialize_response(response)
+        payload = _serialize_response(response, request_metadata=request_metadata)
         choices = payload.get("choices") or []
         choice = choices[0] if choices and isinstance(choices[0], Mapping) else {}
         message = choice.get("message") or {}

--- a/litellm_sync_backend.py
+++ b/litellm_sync_backend.py
@@ -1,6 +1,8 @@
 """Optional LiteLLM implementation of the synchronous model backend."""
 
 import os
+import time
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from gemini_model_catalog import filter_gemini_generation_config
@@ -11,6 +13,7 @@ from litellm_provider_config import (
 )
 from sync_model_backend import (
     SYNC_EXECUTION_MODE,
+    SYNC_ERROR_CATEGORIES,
     SyncGenerationRequest,
     SyncGenerationResult,
     normalize_sync_timeout_seconds,
@@ -18,9 +21,16 @@ from sync_model_backend import (
 
 
 class LiteLLMBackendError(RuntimeError):
-    def __init__(self, message: str, *, category: str = "provider_error") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        category: str = "provider_error",
+        request_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
         super().__init__(message)
         self.category = category
+        self.request_metadata = dict(request_metadata or {})
 
 
 class LiteLLMUnavailableError(LiteLLMBackendError):
@@ -31,6 +41,31 @@ class LiteLLMUnavailableError(LiteLLMBackendError):
 class LiteLLMCapabilityError(LiteLLMBackendError):
     def __init__(self, message: str) -> None:
         super().__init__(message, category="unsupported_capability")
+
+
+_SAFE_ERROR_MESSAGES = {
+    "authentication": "LiteLLM authentication failed.",
+    "rate_limit": "LiteLLM request was rate limited.",
+    "service_unavailable": "LiteLLM service is temporarily unavailable.",
+    "timeout": "LiteLLM request timed out.",
+    "invalid_response": "LiteLLM returned an invalid response.",
+    "unsupported_capability": "LiteLLM provider does not support this request.",
+    "provider_error": "LiteLLM provider request failed.",
+}
+
+
+def _safe_backend_error(
+    exc: Exception,
+    *,
+    request_metadata: Mapping[str, Any] | None = None,
+) -> LiteLLMBackendError:
+    """Convert arbitrary provider failures without echoing provider text."""
+    category = _error_category(exc)
+    return LiteLLMBackendError(
+        _SAFE_ERROR_MESSAGES.get(category, _SAFE_ERROR_MESSAGES["provider_error"]),
+        category=category,
+        request_metadata=request_metadata,
+    )
 
 
 def _serialize_response(response: Any) -> Mapping[str, Any]:
@@ -92,6 +127,9 @@ def _messages(contents: Any, config: Mapping[str, Any]) -> List[Dict[str, str]]:
 
 
 def _error_category(exc: Exception) -> str:
+    explicit = str(getattr(exc, "category", "") or "").strip().lower()
+    if explicit in SYNC_ERROR_CATEGORIES:
+        return explicit
     try:
         import litellm
 
@@ -99,9 +137,9 @@ def _error_category(exc: Exception) -> str:
             ("rate_limit", (getattr(litellm, "RateLimitError", None),)),
             ("service_unavailable", (
                 getattr(litellm, "ServiceUnavailableError", None),
-                getattr(litellm, "Timeout", None),
                 getattr(litellm, "APIConnectionError", None),
             )),
+            ("timeout", (getattr(litellm, "Timeout", None),)),
             ("authentication", (
                 getattr(litellm, "AuthenticationError", None),
                 getattr(litellm, "PermissionDeniedError", None),
@@ -116,14 +154,37 @@ def _error_category(exc: Exception) -> str:
     except ImportError:
         pass
 
-    status = getattr(exc, "status_code", None)
+    status = getattr(exc, "status_code", getattr(exc, "code", None))
+    try:
+        status = int(status)
+    except (TypeError, ValueError, OverflowError):
+        status = None
     if status == 429:
         return "rate_limit"
-    if status in {502, 503, 504}:
+    if status == 408 or isinstance(exc, TimeoutError):
+        return "timeout"
+    if status in {500, 502, 503, 504}:
         return "service_unavailable"
     if status in {401, 403}:
         return "authentication"
+    if status == 404:
+        return "unsupported_capability"
     return "provider_error"
+
+
+def _masked_key_identity(provider: str, key: str, index: int | None = None) -> str:
+    """Return a log-safe provider/key identity without exposing the secret."""
+    suffix = str(key or "")[-4:] if len(str(key or "")) >= 4 else ""
+    ordinal = f"#{index + 1}" if index is not None else ""
+    return f"{provider}{ordinal}:****{suffix}"
+
+
+@dataclass(frozen=True)
+class _ResolvedCredential:
+    key: str
+    identity: str
+    source: str
+
 
 class LiteLLMSyncBackend:
     """Lazy optional adapter; importing this module does not import LiteLLM."""
@@ -136,6 +197,7 @@ class LiteLLMSyncBackend:
         api_key: Optional[str] = None,
         async_completion: Optional[Callable[..., Any]] = None,
         custom_providers: Optional[Mapping[str, CustomLiteLLMProvider]] = None,
+        sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         self._completion = completion
         self._async_completion = async_completion
@@ -143,6 +205,7 @@ class LiteLLMSyncBackend:
         self._custom_providers = (
             dict(custom_providers) if isinstance(custom_providers, Mapping) else {}
         )
+        self._sleep = sleep
 
     def _resolve_completion(self) -> Callable[..., Any]:
         if self._completion is not None:
@@ -158,16 +221,22 @@ class LiteLLMSyncBackend:
         return completion
 
     def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult:
-        kwargs = self._build_request_kwargs(request)
-        try:
-            response = self._resolve_completion()(**kwargs)
-        except LiteLLMBackendError:
-            raise
-        except Exception as exc:
-            raise LiteLLMBackendError(
-                f"LiteLLM request failed: {exc}", category=_error_category(exc)
-            ) from exc
-        return self._build_result(request, response)
+        kwargs, credentials, metadata = self._build_request_context(request)
+        response, credential, credential_attempts = self._run_with_credentials(
+            self._resolve_completion(),
+            kwargs,
+            credentials,
+            metadata,
+        )
+        return self._build_result(
+            request,
+            response,
+            request_metadata=self._result_request_metadata(
+                metadata,
+                credential,
+                credential_attempts,
+            ),
+        )
 
     def _resolve_async_completion(self) -> Callable[..., Any]:
         if self._async_completion is not None:
@@ -184,18 +253,218 @@ class LiteLLMSyncBackend:
 
     async def generate_async(self, request: SyncGenerationRequest) -> SyncGenerationResult:
         """Run a LiteLLM request through its async API so task cancellation reaches I/O."""
-        kwargs = self._build_request_kwargs(request)
-        try:
-            response = await self._resolve_async_completion()(**kwargs)
-        except LiteLLMBackendError:
-            raise
-        except Exception as exc:
-            raise LiteLLMBackendError(
-                f"LiteLLM request failed: {exc}", category=_error_category(exc)
-            ) from exc
-        return self._build_result(request, response)
+        kwargs, credentials, metadata = self._build_request_context(request)
+        response, credential, credential_attempts = await self._run_with_credentials_async(
+            self._resolve_async_completion(),
+            kwargs,
+            credentials,
+            metadata,
+        )
+        return self._build_result(
+            request,
+            response,
+            request_metadata=self._result_request_metadata(
+                metadata,
+                credential,
+                credential_attempts,
+            ),
+        )
 
-    def _build_request_kwargs(self, request: SyncGenerationRequest) -> Dict[str, Any]:
+    def _resolve_credentials(
+        self,
+        provider: str,
+        custom: CustomLiteLLMProvider | None,
+    ) -> tuple[_ResolvedCredential, ...]:
+        if self._api_key:
+            return (
+                _ResolvedCredential(
+                    self._api_key,
+                    _masked_key_identity(provider, self._api_key),
+                    "explicit",
+                ),
+            )
+        try:
+            from litellm_provider_config import (
+                load_provider_api_key,
+                load_provider_key_store,
+            )
+        except Exception:
+            load_provider_api_key = None
+            load_provider_key_store = None
+        try:
+            active_key = (
+                str(load_provider_api_key(provider) or "").strip()
+                if load_provider_api_key is not None
+                else ""
+            )
+        except Exception:
+            active_key = ""
+        if active_key:
+            try:
+                store = (
+                    load_provider_key_store(provider).normalized()
+                    if load_provider_key_store is not None
+                    else None
+                )
+            except Exception:
+                store = None
+        else:
+            store = None
+        if store is not None and active_key in store.keys:
+            ordered_indices = [
+                store.keys.index(active_key),
+                *(
+                    index
+                    for index in range(len(store.keys))
+                    if index != store.keys.index(active_key)
+                ),
+            ]
+            return tuple(
+                _ResolvedCredential(
+                    store.keys[index],
+                    _masked_key_identity(provider, store.keys[index], index),
+                    "keyring",
+                )
+                for index in ordered_indices
+            )
+        # Keep compatibility with older/injected credential readers that only
+        # implement the single-active-key helper.
+        if active_key:
+            return (
+                _ResolvedCredential(
+                    active_key,
+                    _masked_key_identity(provider, active_key),
+                    "keyring",
+                ),
+            )
+        if custom is not None and custom.api_key_env:
+            env_key = str(os.environ.get(custom.api_key_env) or "").strip()
+            if env_key:
+                return (
+                    _ResolvedCredential(
+                        env_key,
+                        _masked_key_identity(provider, env_key),
+                        f"env:{custom.api_key_env}",
+                    ),
+                )
+        return ()
+
+    @staticmethod
+    def _result_request_metadata(
+        metadata: Mapping[str, Any],
+        credential: _ResolvedCredential | None,
+        credential_attempts: tuple[str, ...],
+    ) -> Dict[str, Any]:
+        result = dict(metadata)
+        if credential is not None:
+            result["credential_identity"] = credential.identity
+            result["credential_source"] = credential.source
+        if credential_attempts:
+            result["credential_attempts"] = list(credential_attempts)
+        return result
+
+    def _run_with_credentials(
+        self,
+        completion: Callable[..., Any],
+        kwargs: Mapping[str, Any],
+        credentials: tuple[_ResolvedCredential, ...],
+        metadata: Mapping[str, Any],
+    ) -> tuple[Any, _ResolvedCredential | None, tuple[str, ...]]:
+        attempts = credentials or (None,)
+        attempted_identities: list[str] = []
+        for index, credential in enumerate(attempts):
+            request_kwargs = dict(kwargs)
+            if credential is not None:
+                request_kwargs["api_key"] = credential.key
+                attempted_identities.append(credential.identity)
+            try:
+                response = completion(**request_kwargs)
+                return response, credential, tuple(attempted_identities)
+            except Exception as exc:
+                category = _error_category(exc)
+                if category == "rate_limit" and index + 1 < len(attempts):
+                    self._sleep(min(index + 1, 2))
+                    continue
+                failure_metadata = self._result_request_metadata(
+                    metadata,
+                    credential,
+                    tuple(attempted_identities),
+                )
+                raise _safe_backend_error(
+                    exc,
+                    request_metadata=failure_metadata,
+                ) from None
+        raise LiteLLMBackendError(
+            "LiteLLM request failed without a captured exception.",
+            category="provider_error",
+        )
+
+    async def _run_with_credentials_async(
+        self,
+        completion: Callable[..., Any],
+        kwargs: Mapping[str, Any],
+        credentials: tuple[_ResolvedCredential, ...],
+        metadata: Mapping[str, Any],
+    ) -> tuple[Any, _ResolvedCredential | None, tuple[str, ...]]:
+        attempts = credentials or (None,)
+        attempted_identities: list[str] = []
+        for index, credential in enumerate(attempts):
+            request_kwargs = dict(kwargs)
+            if credential is not None:
+                request_kwargs["api_key"] = credential.key
+                attempted_identities.append(credential.identity)
+            try:
+                response = await completion(**request_kwargs)
+                return response, credential, tuple(attempted_identities)
+            except Exception as exc:
+                category = _error_category(exc)
+                if category == "rate_limit" and index + 1 < len(attempts):
+                    import asyncio
+
+                    await asyncio.sleep(min(index + 1, 2))
+                    continue
+                failure_metadata = self._result_request_metadata(
+                    metadata,
+                    credential,
+                    tuple(attempted_identities),
+                )
+                raise _safe_backend_error(
+                    exc,
+                    request_metadata=failure_metadata,
+                ) from None
+        raise LiteLLMBackendError(
+            "LiteLLM request failed without a captured exception.",
+            category="provider_error",
+        )
+
+    def _build_request_context(
+        self,
+        request: SyncGenerationRequest,
+    ) -> tuple[Dict[str, Any], tuple[_ResolvedCredential, ...], Dict[str, Any]]:
+        provider = provider_from_model(request.model)
+        custom = self._custom_providers.get(provider)
+        credentials = self._resolve_credentials(provider, custom)
+        kwargs = self._build_request_kwargs(
+            request,
+            credentials=credentials,
+        )
+        metadata: Dict[str, Any] = {
+            "provider": provider,
+            "credential_count": len(credentials),
+        }
+        if request.config.get("thinking_config"):
+            # Gemini's thinking_config has no provider-neutral LiteLLM meaning.
+            # It is intentionally not sent; preserve that capability decision
+            # in safe request metadata instead of pretending it was honored.
+            metadata["ignored_provider_options"] = ["thinking_config"]
+        return kwargs, credentials, metadata
+
+    def _build_request_kwargs(
+        self,
+        request: SyncGenerationRequest,
+        *,
+        credentials: tuple[_ResolvedCredential, ...] | None = None,
+    ) -> Dict[str, Any]:
         config = filter_gemini_generation_config(request.model, request.config)
         if config.get("safety_settings"):
             raise LiteLLMCapabilityError(
@@ -220,21 +489,12 @@ class LiteLLMSyncBackend:
             "model": model,
             "messages": _messages(request.contents, config),
         }
-        api_key = self._api_key
-        if not api_key:
-            try:
-                from litellm_provider_config import load_provider_api_key
-
-                api_key = load_provider_api_key(provider)
-            except Exception:
-                # keyring is optional; LiteLLM can still use environment variables.
-                api_key = ""
-        if not api_key and custom is not None and custom.api_key_env:
-            # Explicit opt-in env fallback: without a keyring entry, send the
-            # named environment variable's value instead of letting LiteLLM
-            # silently fall back to OPENAI_API_KEY for a third-party endpoint.
-            api_key = str(os.environ.get(custom.api_key_env) or "").strip()
-        if custom is not None and custom.requires_key and not api_key:
+        resolved_credentials = (
+            self._resolve_credentials(provider, custom)
+            if credentials is None
+            else credentials
+        )
+        if custom is not None and custom.requires_key and not resolved_credentials:
             # The model id has been rewritten to openai/<model>, so LiteLLM
             # would otherwise fall back to OPENAI_API_KEY and leak an unrelated
             # OpenAI key to the third-party api_base. Fail before dispatch
@@ -244,8 +504,6 @@ class LiteLLMSyncBackend:
                 "但系统凭据与 api_key_env 环境变量均未提供。",
                 category="authentication",
             )
-        if api_key:
-            kwargs["api_key"] = api_key
         if custom is not None:
             kwargs["api_base"] = custom.base_url
         kwargs["timeout"] = normalize_sync_timeout_seconds(config.get("timeout"))
@@ -294,7 +552,11 @@ class LiteLLMSyncBackend:
         return kwargs
 
     def _build_result(
-        self, request: SyncGenerationRequest, response: Any
+        self,
+        request: SyncGenerationRequest,
+        response: Any,
+        *,
+        request_metadata: Mapping[str, Any] | None = None,
     ) -> SyncGenerationResult:
         payload = _serialize_response(response)
         choices = payload.get("choices") or []
@@ -310,4 +572,5 @@ class LiteLLMSyncBackend:
             response_text=str(text or ""),
             finish_reason=str(choice.get("finish_reason") or ""),
             usage_metadata=dict(usage) if isinstance(usage, Mapping) else {},
+            request_metadata=dict(request_metadata or {}),
         )

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -52,10 +53,18 @@ GROUP_FIELD_ALIASES = {
 TOKEN_FIELDS = (
     "prompt_tokens",
     "completion_tokens",
+    "reasoning_tokens",
+    "text_output_tokens",
     "total_tokens",
     "thoughts_tokens",
     "cached_tokens",
 )
+OUTPUT_DIAGNOSTIC_REASON_CODES = frozenset({
+    "reasoning_budget_exhausted",
+    "reasoning_without_text_output",
+    "truncated_output",
+    "empty_response_text",
+})
 
 
 class UsageLedgerError(RuntimeError):
@@ -217,6 +226,24 @@ def normalize_usage_metadata(usage_metadata: Mapping[str, Any] | None) -> dict[s
             ("output_tokens_details", "reasoning_tokens"),
         ),
     )
+    text_output = _first_int(
+        usage,
+        (
+            # Gemini reports visible candidate tokens separately from thoughts.
+            ("candidatesTokenCount",),
+            ("candidates_token_count",),
+            # Provider-neutral / Responses-style explicit visible-output fields.
+            ("text_output_tokens",),
+            ("output_text_tokens",),
+            ("completion_tokens_details", "text_tokens"),
+            ("output_tokens_details", "text_tokens"),
+        ),
+    )
+    # Do not derive visible text by subtracting reasoning from completion:
+    # OpenAI-compatible providers disagree on whether completion already
+    # includes reasoning (xAI is one counterexample). LiteLLM often emits an
+    # explicit details.text_tokens value; otherwise the honest value is unknown.
+    text_output_derived = False
     cached = _first_int(
         usage,
         (
@@ -236,10 +263,13 @@ def normalize_usage_metadata(usage_metadata: Mapping[str, Any] | None) -> dict[s
             ("total_tokens",),
         ),
     )
+    gemini_candidate_counter = any(
+        key in usage for key in ("candidatesTokenCount", "candidates_token_count")
+    )
     total_derived = False
     if total is None and prompt is not None and completion is not None:
         total = prompt + completion
-        if "candidatesTokenCount" in usage and thoughts is not None:
+        if gemini_candidate_counter and thoughts is not None:
             total += thoughts
         total_derived = True
 
@@ -248,18 +278,177 @@ def normalize_usage_metadata(usage_metadata: Mapping[str, Any] | None) -> dict[s
         billable_output = max(0, total - prompt)
     elif completion is not None:
         billable_output = completion
-        if "candidatesTokenCount" in usage and thoughts is not None:
+        if gemini_candidate_counter and thoughts is not None:
             billable_output += thoughts
 
     return {
         "prompt_tokens": prompt,
         "completion_tokens": completion,
+        "reasoning_tokens": thoughts,
+        "text_output_tokens": text_output,
+        "text_output_tokens_derived": text_output_derived,
         "total_tokens": total,
         "thoughts_tokens": thoughts,
         "cached_tokens": cached,
         "billable_output_tokens": billable_output,
         "total_tokens_derived": total_derived,
     }
+
+
+def response_budget_diagnostics(
+    *,
+    response_text: Any,
+    finish_reason: Any,
+    usage_metadata: Mapping[str, Any] | None,
+    max_output_tokens: Any = None,
+) -> dict[str, Any]:
+    """Describe visible output, reasoning pressure, and truncation safely.
+
+    The result contains counters and stable reason codes only; it never embeds
+    provider response text. Unknown provider counters remain ``None``.
+    """
+    normalized = normalize_usage_metadata(usage_metadata)
+    completion = normalized["completion_tokens"]
+    reasoning = normalized["reasoning_tokens"]
+    text_output = normalized["text_output_tokens"]
+    try:
+        output_limit = int(max_output_tokens)
+        if output_limit <= 0:
+            output_limit = None
+    except (TypeError, ValueError, OverflowError):
+        output_limit = None
+
+    empty_text = not bool(str(response_text or "").strip())
+    normalized_finish = str(finish_reason or "").strip().upper()
+    truncated = normalized_finish in {
+        "MAX_TOKENS",
+        "MAX_TOKEN",
+        "LENGTH",
+        "TOKEN_LIMIT",
+        "OUTPUT_TOKEN_LIMIT",
+    }
+    output_budget_used = normalized["billable_output_tokens"]
+    budget_exhausted = bool(
+        output_limit is not None
+        and output_budget_used is not None
+        and output_budget_used >= output_limit
+    )
+    reasoning_ratio = None
+    if reasoning is not None and output_budget_used:
+        reasoning_ratio = reasoning / output_budget_used
+
+    reason_code = ""
+    reasoning_budget_pressure = False
+    if empty_text and reasoning and (text_output in {None, 0}):
+        reasoning_budget_pressure = bool(budget_exhausted or truncated)
+        reason_code = (
+            "reasoning_budget_exhausted"
+            if reasoning_budget_pressure
+            else "reasoning_without_text_output"
+        )
+    elif truncated:
+        reason_code = "truncated_output"
+        reasoning_budget_pressure = bool(
+            reasoning_ratio is not None and reasoning_ratio >= 0.5
+        )
+    elif empty_text:
+        reason_code = "empty_response_text"
+
+    return {
+        "completion_tokens": completion,
+        "reasoning_tokens": reasoning,
+        "text_output_tokens": text_output,
+        "text_output_tokens_derived": bool(
+            normalized["text_output_tokens_derived"]
+        ),
+        "max_output_tokens": output_limit,
+        "output_budget_used": output_budget_used,
+        "reasoning_ratio": reasoning_ratio,
+        "empty_text": empty_text,
+        "truncated": truncated,
+        "budget_exhausted": budget_exhausted,
+        "reasoning_budget_pressure": reasoning_budget_pressure,
+        "reason_code": reason_code,
+    }
+
+
+def normalize_response_diagnostics(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Keep only safe, provider-neutral output diagnostic fields."""
+    raw = dict(value or {})
+    normalized: dict[str, Any] = {}
+    for key in (
+        "completion_tokens",
+        "reasoning_tokens",
+        "text_output_tokens",
+        "max_output_tokens",
+        "output_budget_used",
+    ):
+        parsed = _nonnegative_int(raw.get(key))
+        if parsed is not None:
+            normalized[key] = parsed
+    ratio = _nonnegative_float(raw.get("reasoning_ratio"))
+    if ratio is not None:
+        normalized["reasoning_ratio"] = min(1.0, ratio)
+    for key in (
+        "text_output_tokens_derived",
+        "empty_text",
+        "truncated",
+        "budget_exhausted",
+        "reasoning_budget_pressure",
+    ):
+        if isinstance(raw.get(key), bool):
+            normalized[key] = raw[key]
+    reason_code = str(raw.get("reason_code") or "").strip()
+    if reason_code in OUTPUT_DIAGNOSTIC_REASON_CODES:
+        normalized["reason_code"] = reason_code
+    return normalized
+
+
+def normalize_request_metadata(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Keep only non-secret request routing/capability audit fields."""
+    raw = dict(value or {})
+    normalized: dict[str, Any] = {}
+    provider = str(raw.get("provider") or "").strip().lower()
+    if re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", provider):
+        normalized["provider"] = provider
+    credential_count = _nonnegative_int(raw.get("credential_count"))
+    if credential_count is not None:
+        normalized["credential_count"] = credential_count
+    identity = _safe_credential_identity(raw.get("credential_identity"))
+    if identity:
+        normalized["credential_identity"] = identity
+    source = str(raw.get("credential_source") or "").strip()
+    if source in {"explicit", "keyring"} or re.fullmatch(
+        r"env:[A-Z_][A-Z0-9_]{0,63}", source
+    ):
+        normalized["credential_source"] = source
+    attempts = raw.get("credential_attempts")
+    if isinstance(attempts, list):
+        normalized["credential_attempts"] = [
+            identity
+            for item in attempts
+            if (identity := _safe_credential_identity(item))
+        ]
+    ignored = raw.get("ignored_provider_options")
+    if isinstance(ignored, list):
+        normalized["ignored_provider_options"] = [
+            option
+            for item in ignored
+            if (option := str(item).strip()) in {"thinking_config"}
+        ]
+    return normalized
+
+
+def _safe_credential_identity(value: Any) -> str:
+    """Accept only the adapter's masked identity form, never a raw secret."""
+    identity = str(value or "").strip()
+    if not re.fullmatch(
+        r"[a-z0-9][a-z0-9._-]*(?:#\d+)?:\*{4}\S{0,4}",
+        identity,
+        flags=re.IGNORECASE,
+    ):
+        return ""
+    return identity
 
 
 def _nonnegative_float(value: Any) -> float | None:
@@ -345,6 +534,8 @@ def build_usage_record(
     execution_mode: str = "",
     source_key: str = "",
     source: Mapping[str, Any] | None = None,
+    response_diagnostics: Mapping[str, Any] | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
     pricing_config: Mapping[str, Any] | None = None,
     estimated_cost: float | None = None,
     estimated_cost_currency: str = "",
@@ -408,11 +599,18 @@ def build_usage_record(
         "calls": 1,
         "prompt_tokens": normalized["prompt_tokens"],
         "completion_tokens": normalized["completion_tokens"],
+        "reasoning_tokens": normalized["reasoning_tokens"],
+        "text_output_tokens": normalized["text_output_tokens"],
+        "text_output_tokens_derived": bool(
+            normalized["text_output_tokens_derived"]
+        ),
         "total_tokens": normalized["total_tokens"],
         "thoughts_tokens": normalized["thoughts_tokens"],
         "cached_tokens": normalized["cached_tokens"],
         "total_tokens_derived": bool(normalized["total_tokens_derived"]),
         "provider_usage": raw_usage,
+        "output_diagnostics": normalize_response_diagnostics(response_diagnostics),
+        "request_metadata": normalize_request_metadata(request_metadata),
         "estimated_cost": computed_estimate,
         "estimated_cost_currency": estimate_currency if computed_estimate is not None else None,
         "estimated_cost_basis": estimate_basis,
@@ -722,6 +920,34 @@ def import_manifest_results(
                                     "attempt_kind": attempt_kind,
                                     "item_ids": item_ids,
                                 },
+                                response_diagnostics=(
+                                    attempt.get("output_diagnostics")
+                                    if isinstance(
+                                        attempt.get("output_diagnostics"), Mapping
+                                    )
+                                    else (
+                                        row.get("output_diagnostics")
+                                        if attempt_kind == "first_pass"
+                                        and isinstance(
+                                            row.get("output_diagnostics"), Mapping
+                                        )
+                                        else None
+                                    )
+                                ),
+                                request_metadata=(
+                                    attempt.get("request_metadata")
+                                    if isinstance(
+                                        attempt.get("request_metadata"), Mapping
+                                    )
+                                    else (
+                                        row.get("request_metadata")
+                                        if attempt_kind == "first_pass"
+                                        and isinstance(
+                                            row.get("request_metadata"), Mapping
+                                        )
+                                        else None
+                                    )
+                                ),
                                 pricing_config=effective_pricing,
                             )
                         )
@@ -764,6 +990,16 @@ def import_manifest_results(
                             "row_key": row_key,
                             "row_index": row_index,
                         },
+                        response_diagnostics=(
+                            row.get("output_diagnostics")
+                            if isinstance(row.get("output_diagnostics"), Mapping)
+                            else None
+                        ),
+                        request_metadata=(
+                            row.get("request_metadata")
+                            if isinstance(row.get("request_metadata"), Mapping)
+                            else None
+                        ),
                         pricing_config=effective_pricing,
                     )
                 )
@@ -797,6 +1033,8 @@ def record_generation_usage(
     execution_mode: str = "sync",
     source_key: str = "",
     source: Mapping[str, Any] | None = None,
+    response_diagnostics: Mapping[str, Any] | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
     pricing_config: Mapping[str, Any] | None = None,
     ledger: UsageLedger | None = None,
 ) -> dict[str, Any]:
@@ -814,6 +1052,8 @@ def record_generation_usage(
         execution_mode=execution_mode,
         source_key=source_key,
         source=source,
+        response_diagnostics=response_diagnostics,
+        request_metadata=request_metadata,
         pricing_config=pricing_config,
     )
     store = ledger or UsageLedger(game_root)
@@ -871,14 +1111,68 @@ def aggregate_usage_records(records: Sequence[Mapping[str, Any]]) -> dict[str, A
         values = [
             parsed
             for record in records
-            if (parsed := _nonnegative_int(record.get(field))) is not None
+            if (parsed := _record_token_value(record, field)) is not None
         ]
         totals[field] = sum(values) if values else None
         totals[f"{field}_known_records"] = len(values)
         totals[f"{field}_unknown_records"] = len(records) - len(values)
+    reasoning_component = 0
+    text_component = 0
+    reasoning_share_records = 0
+    diagnostic_reason_counts: dict[str, int] = {}
+    empty_text_records = 0
+    truncated_records = 0
+    reasoning_pressure_records = 0
+    for record in records:
+        reasoning = _record_token_value(record, "reasoning_tokens")
+        text_output = _record_token_value(record, "text_output_tokens")
+        if reasoning is not None and text_output is not None:
+            reasoning_component += reasoning
+            text_component += text_output
+            reasoning_share_records += 1
+        diagnostics = record.get("output_diagnostics")
+        if not isinstance(diagnostics, Mapping):
+            continue
+        reason_code = str(diagnostics.get("reason_code") or "").strip()
+        if reason_code:
+            diagnostic_reason_counts[reason_code] = (
+                diagnostic_reason_counts.get(reason_code, 0) + 1
+            )
+        empty_text_records += int(diagnostics.get("empty_text") is True)
+        truncated_records += int(diagnostics.get("truncated") is True)
+        reasoning_pressure_records += int(
+            diagnostics.get("reasoning_budget_pressure") is True
+        )
+    denominator = reasoning_component + text_component
+    totals["reasoning_share"] = (
+        reasoning_component / denominator if denominator else None
+    )
+    totals["reasoning_share_known_records"] = reasoning_share_records
+    totals["output_diagnostics"] = {
+        "reason_counts": dict(sorted(diagnostic_reason_counts.items())),
+        "empty_text_records": empty_text_records,
+        "truncated_records": truncated_records,
+        "reasoning_budget_pressure_records": reasoning_pressure_records,
+    }
     totals["estimated_cost"] = _aggregate_cost(records, "estimated")
     totals["actual_cost"] = _aggregate_cost(records, "actual")
     return totals
+
+
+def _record_token_value(record: Mapping[str, Any], field: str) -> int | None:
+    """Read an additive token field while supporting pre-#340 records."""
+    direct = _nonnegative_int(record.get(field))
+    if direct is not None:
+        return direct
+    if field == "reasoning_tokens":
+        legacy = _nonnegative_int(record.get("thoughts_tokens"))
+        if legacy is not None:
+            return legacy
+    provider_usage = record.get("provider_usage")
+    if isinstance(provider_usage, Mapping):
+        normalized = normalize_usage_metadata(provider_usage)
+        return _nonnegative_int(normalized.get(field))
+    return None
 
 
 def _record_matches(record: Mapping[str, Any], field: str, expected: str) -> bool:
@@ -990,6 +1284,17 @@ def _format_cost_metric(metric: Mapping[str, Any]) -> str:
 def format_usage_report(report: Mapping[str, Any]) -> list[str]:
     totals = report.get("totals") if isinstance(report.get("totals"), Mapping) else {}
     project = report.get("project") if isinstance(report.get("project"), Mapping) else {}
+    reasoning_share = totals.get("reasoning_share")
+    reasoning_share_text = (
+        "unknown"
+        if reasoning_share is None
+        else f"{float(reasoning_share):.1%} "
+        f"({int(totals.get('reasoning_share_known_records') or 0)} record(s))"
+    )
+    output_diagnostics = totals.get("output_diagnostics")
+    output_diagnostics = (
+        output_diagnostics if isinstance(output_diagnostics, Mapping) else {}
+    )
     lines = [
         "Model usage ledger:",
         f"- Project: {project.get('game_root') or '(unknown)'}",
@@ -997,8 +1302,17 @@ def format_usage_report(report: Mapping[str, Any]) -> list[str]:
         f"- Records / calls: {int(totals.get('records') or 0)} / {int(totals.get('calls') or 0)}",
         f"- Prompt tokens: {_format_token_metric(totals, 'prompt_tokens')}",
         f"- Completion tokens: {_format_token_metric(totals, 'completion_tokens')}",
+        f"- Reasoning tokens: {_format_token_metric(totals, 'reasoning_tokens')}",
+        f"- Text output tokens: {_format_token_metric(totals, 'text_output_tokens')}",
+        f"- Reasoning share of known output: {reasoning_share_text}",
+        (
+            "- Output diagnostics: "
+            f"empty={int(output_diagnostics.get('empty_text_records') or 0)}, "
+            f"truncated={int(output_diagnostics.get('truncated_records') or 0)}, "
+            "reasoning_budget_pressure="
+            f"{int(output_diagnostics.get('reasoning_budget_pressure_records') or 0)}"
+        ),
         f"- Total tokens: {_format_token_metric(totals, 'total_tokens')}",
-        f"- Thoughts tokens: {_format_token_metric(totals, 'thoughts_tokens')}",
         f"- Cached tokens: {_format_token_metric(totals, 'cached_tokens')}",
         (
             "- Estimated cost (configured pricing, not provider billing): "

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -1348,3 +1348,25 @@ def format_usage_report(report: Mapping[str, Any]) -> list[str]:
             f"{_format_token_metric(recent_totals, 'total_tokens')} total tokens"
         )
     return lines
+
+
+def format_sync_output_lines(
+    *,
+    completion: str | int,
+    reasoning: str | int,
+    text_output: str | int,
+    reasoning_budget_pressure: int,
+    truncated: int,
+) -> list[str]:
+    """Return the stable CLI output-diagnostic lines consumed by the GUI.
+
+    Both synchronous consumers (ledger-backed runtime summaries and manifest
+    request summaries) resolve their workflow-specific totals and print these
+    identical lines so the GUI parser sees one contract.
+    """
+    return [
+        f"Sync output tokens: completion={completion} "
+        f"reasoning={reasoning} text={text_output}",
+        f"Reasoning budget warnings: {int(reasoning_budget_pressure)}",
+        f"Truncated sync responses: {int(truncated)}",
+    ]

--- a/model_usage_ledger.py
+++ b/model_usage_ledger.py
@@ -440,10 +440,15 @@ def normalize_request_metadata(value: Mapping[str, Any] | None) -> dict[str, Any
 
 
 def _safe_credential_identity(value: Any) -> str:
-    """Accept only the adapter's masked identity form, never a raw secret."""
+    """Accept only the adapter's masked identity forms, never a raw secret.
+
+    Two forms are accepted: the current non-reversible digest
+    (``provider#n:key:<hex>``) and the legacy masked suffix form
+    (``provider#n:****abcd``) so previously persisted records stay readable.
+    """
     identity = str(value or "").strip()
     if not re.fullmatch(
-        r"[a-z0-9][a-z0-9._-]*(?:#\d+)?:\*{4}\S{0,4}",
+        r"[a-z0-9][a-z0-9._-]*(?:#\d+)?:(?:\*{4}\S{0,4}|key:[a-f0-9]{10})",
         identity,
         flags=re.IGNORECASE,
     ):

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
+import model_usage_ledger
+
 from project_analysis import (
     KIND_LABEL,
     KIND_PROJECT_BRIEF,
@@ -42,6 +44,39 @@ from sync_model_backend import (
 PROMPT_SCHEMA_VERSION = "project-analysis-llm-v2"
 
 GenerateFn = Callable[[SyncGenerationRequest], SyncGenerationResult]
+
+
+class ProjectAnalysisResponseError(ProjectAnalysisError):
+    """A provider response failed the analysis text contract."""
+
+    category = "invalid_response"
+
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = str(reason_code or "empty_response_text")
+        super().__init__(
+            "analysis LLM returned no usable text "
+            f"[{self.reason_code}]"
+        )
+
+
+def _result_output_diagnostics(
+    result: SyncGenerationResult,
+    *,
+    max_output_tokens: Any,
+) -> dict[str, Any]:
+    """Return complete safe diagnostics even for a bare backend result."""
+    diagnostics = model_usage_ledger.response_budget_diagnostics(
+        response_text=getattr(result, "response_text", ""),
+        finish_reason=getattr(result, "finish_reason", ""),
+        usage_metadata=getattr(result, "usage_metadata", None) or {},
+        max_output_tokens=max_output_tokens,
+    )
+    diagnostics.update(
+        model_usage_ledger.normalize_response_diagnostics(
+            getattr(result, "output_diagnostics", None) or {}
+        )
+    )
+    return model_usage_ledger.normalize_response_diagnostics(diagnostics)
 
 
 class AnalysisLlmConfig(Protocol):
@@ -241,7 +276,13 @@ def complete_analysis_text(
     )
     text = str(getattr(result, "response_text", "") or "").strip()
     if not text:
-        raise ProjectAnalysisError("analysis LLM returned empty text")
+        diagnostics = _result_output_diagnostics(
+            result,
+            max_output_tokens=max_output_tokens,
+        )
+        raise ProjectAnalysisResponseError(
+            str(diagnostics.get("reason_code") or "empty_response_text")
+        )
     usage = dict(getattr(result, "usage_metadata", None) or {})
     return text, usage
 
@@ -558,50 +599,99 @@ def run_mapreduce_drafts(
         "requests": 0,
         "input_tokens": 0,
         "output_tokens": 0,
+        "completion_tokens": 0,
+        "reasoning_tokens": 0,
+        "reasoning_tokens_known_requests": 0,
+        "text_output_tokens": 0,
+        "text_output_tokens_known_requests": 0,
+        "completion_tokens_known_requests": 0,
+        "reasoning_budget_pressure_count": 0,
+        "truncated_output_count": 0,
         "total_tokens": 0,
         "by_stage": {},
     }
     current_request = {"stage": "", "artifact_id": ""}
     raw_generate = generate
 
-    def _usage_int(metadata: Mapping[str, Any], *keys: str) -> int:
-        for key in keys:
-            try:
-                value = int(metadata.get(key) or 0)
-            except (TypeError, ValueError):
-                continue
-            if value:
-                return value
-        return 0
-
     def _tracked_generate(request: SyncGenerationRequest) -> SyncGenerationResult:
         result = raw_generate(request)
         metadata = dict(getattr(result, "usage_metadata", None) or {})
-        input_tokens = _usage_int(
-            metadata, "promptTokenCount", "prompt_token_count", "prompt_tokens", "input_tokens"
+        normalized = model_usage_ledger.normalize_usage_metadata(metadata)
+        input_tokens = int(normalized.get("prompt_tokens") or 0)
+        completion_tokens = int(normalized.get("completion_tokens") or 0)
+        reasoning_tokens = int(normalized.get("reasoning_tokens") or 0)
+        text_output_tokens = int(normalized.get("text_output_tokens") or 0)
+        output_tokens = int(
+            normalized.get("billable_output_tokens") or completion_tokens
         )
-        output_tokens = _usage_int(
-            metadata,
-            "candidatesTokenCount", "candidates_token_count",
-            "completion_tokens", "output_tokens",
-        )
-        total_tokens = _usage_int(
-            metadata, "totalTokenCount", "total_token_count", "total_tokens"
-        )
+        total_tokens = int(normalized.get("total_tokens") or 0)
         if not total_tokens:
             total_tokens = input_tokens + output_tokens
         usage_summary["requests"] += 1
         usage_summary["input_tokens"] += input_tokens
         usage_summary["output_tokens"] += output_tokens
+        usage_summary["completion_tokens"] += completion_tokens
+        usage_summary["reasoning_tokens"] += reasoning_tokens
+        usage_summary["text_output_tokens"] += text_output_tokens
+        usage_summary["completion_tokens_known_requests"] += int(
+            normalized.get("completion_tokens") is not None
+        )
+        usage_summary["reasoning_tokens_known_requests"] += int(
+            normalized.get("reasoning_tokens") is not None
+        )
+        usage_summary["text_output_tokens_known_requests"] += int(
+            normalized.get("text_output_tokens") is not None
+        )
+        diagnostics = _result_output_diagnostics(
+            result,
+            max_output_tokens=(request.config or {}).get("max_output_tokens"),
+        )
+        usage_summary["reasoning_budget_pressure_count"] += int(
+            diagnostics.get("reasoning_budget_pressure") is True
+        )
+        usage_summary["truncated_output_count"] += int(
+            diagnostics.get("truncated") is True
+        )
         usage_summary["total_tokens"] += total_tokens
         stage = current_request["stage"] or "unknown"
         stage_usage = usage_summary["by_stage"].setdefault(
             stage,
-            {"requests": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            {
+                "requests": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "completion_tokens": 0,
+                "completion_tokens_known_requests": 0,
+                "reasoning_tokens": 0,
+                "reasoning_tokens_known_requests": 0,
+                "text_output_tokens": 0,
+                "text_output_tokens_known_requests": 0,
+                "reasoning_budget_pressure_count": 0,
+                "truncated_output_count": 0,
+                "total_tokens": 0,
+            },
         )
         stage_usage["requests"] += 1
         stage_usage["input_tokens"] += input_tokens
         stage_usage["output_tokens"] += output_tokens
+        stage_usage["completion_tokens"] += completion_tokens
+        stage_usage["reasoning_tokens"] += reasoning_tokens
+        stage_usage["text_output_tokens"] += text_output_tokens
+        stage_usage["completion_tokens_known_requests"] += int(
+            normalized.get("completion_tokens") is not None
+        )
+        stage_usage["reasoning_tokens_known_requests"] += int(
+            normalized.get("reasoning_tokens") is not None
+        )
+        stage_usage["text_output_tokens_known_requests"] += int(
+            normalized.get("text_output_tokens") is not None
+        )
+        stage_usage["reasoning_budget_pressure_count"] += int(
+            diagnostics.get("reasoning_budget_pressure") is True
+        )
+        stage_usage["truncated_output_count"] += int(
+            diagnostics.get("truncated") is True
+        )
         stage_usage["total_tokens"] += total_tokens
         if usage_recorder is not None:
             try:
@@ -611,6 +701,10 @@ def run_mapreduce_drafts(
                         "artifact_id": current_request["artifact_id"],
                         "result": result,
                         "usage_metadata": metadata,
+                        "output_diagnostics": diagnostics,
+                        "request_metadata": dict(
+                            getattr(result, "request_metadata", None) or {}
+                        ),
                     }
                 )
             except Exception:

--- a/project_analysis_llm.py
+++ b/project_analysis_llm.py
@@ -613,10 +613,18 @@ def run_mapreduce_drafts(
     current_request = {"stage": "", "artifact_id": ""}
     raw_generate = generate
 
-    def _tracked_generate(request: SyncGenerationRequest) -> SyncGenerationResult:
-        result = raw_generate(request)
-        metadata = dict(getattr(result, "usage_metadata", None) or {})
-        normalized = model_usage_ledger.normalize_usage_metadata(metadata)
+    def _accumulate_usage(
+        target: dict[str, Any],
+        *,
+        normalized: Mapping[str, Any],
+        diagnostics: Mapping[str, Any],
+        total_tokens: int,
+    ) -> None:
+        """Add one request's normalized usage fields to an aggregate mapping.
+
+        Keeps per-stage and aggregate accumulators identical; request counting
+        stays with the caller because aggregate and per-stage handling differ.
+        """
         input_tokens = int(normalized.get("prompt_tokens") or 0)
         completion_tokens = int(normalized.get("completion_tokens") or 0)
         reasoning_tokens = int(normalized.get("reasoning_tokens") or 0)
@@ -624,35 +632,50 @@ def run_mapreduce_drafts(
         output_tokens = int(
             normalized.get("billable_output_tokens") or completion_tokens
         )
-        total_tokens = int(normalized.get("total_tokens") or 0)
-        if not total_tokens:
-            total_tokens = input_tokens + output_tokens
-        usage_summary["requests"] += 1
-        usage_summary["input_tokens"] += input_tokens
-        usage_summary["output_tokens"] += output_tokens
-        usage_summary["completion_tokens"] += completion_tokens
-        usage_summary["reasoning_tokens"] += reasoning_tokens
-        usage_summary["text_output_tokens"] += text_output_tokens
-        usage_summary["completion_tokens_known_requests"] += int(
+        target["input_tokens"] += input_tokens
+        target["output_tokens"] += output_tokens
+        target["completion_tokens"] += completion_tokens
+        target["reasoning_tokens"] += reasoning_tokens
+        target["text_output_tokens"] += text_output_tokens
+        target["completion_tokens_known_requests"] += int(
             normalized.get("completion_tokens") is not None
         )
-        usage_summary["reasoning_tokens_known_requests"] += int(
+        target["reasoning_tokens_known_requests"] += int(
             normalized.get("reasoning_tokens") is not None
         )
-        usage_summary["text_output_tokens_known_requests"] += int(
+        target["text_output_tokens_known_requests"] += int(
             normalized.get("text_output_tokens") is not None
         )
+        target["reasoning_budget_pressure_count"] += int(
+            diagnostics.get("reasoning_budget_pressure") is True
+        )
+        target["truncated_output_count"] += int(
+            diagnostics.get("truncated") is True
+        )
+        target["total_tokens"] += total_tokens
+
+    def _tracked_generate(request: SyncGenerationRequest) -> SyncGenerationResult:
+        result = raw_generate(request)
+        metadata = dict(getattr(result, "usage_metadata", None) or {})
+        normalized = model_usage_ledger.normalize_usage_metadata(metadata)
+        completion_tokens = int(normalized.get("completion_tokens") or 0)
+        output_tokens = int(
+            normalized.get("billable_output_tokens") or completion_tokens
+        )
+        total_tokens = int(normalized.get("total_tokens") or 0)
+        if not total_tokens:
+            total_tokens = int(normalized.get("prompt_tokens") or 0) + output_tokens
         diagnostics = _result_output_diagnostics(
             result,
             max_output_tokens=(request.config or {}).get("max_output_tokens"),
         )
-        usage_summary["reasoning_budget_pressure_count"] += int(
-            diagnostics.get("reasoning_budget_pressure") is True
+        usage_summary["requests"] += 1
+        _accumulate_usage(
+            usage_summary,
+            normalized=normalized,
+            diagnostics=diagnostics,
+            total_tokens=total_tokens,
         )
-        usage_summary["truncated_output_count"] += int(
-            diagnostics.get("truncated") is True
-        )
-        usage_summary["total_tokens"] += total_tokens
         stage = current_request["stage"] or "unknown"
         stage_usage = usage_summary["by_stage"].setdefault(
             stage,
@@ -672,27 +695,12 @@ def run_mapreduce_drafts(
             },
         )
         stage_usage["requests"] += 1
-        stage_usage["input_tokens"] += input_tokens
-        stage_usage["output_tokens"] += output_tokens
-        stage_usage["completion_tokens"] += completion_tokens
-        stage_usage["reasoning_tokens"] += reasoning_tokens
-        stage_usage["text_output_tokens"] += text_output_tokens
-        stage_usage["completion_tokens_known_requests"] += int(
-            normalized.get("completion_tokens") is not None
+        _accumulate_usage(
+            stage_usage,
+            normalized=normalized,
+            diagnostics=diagnostics,
+            total_tokens=total_tokens,
         )
-        stage_usage["reasoning_tokens_known_requests"] += int(
-            normalized.get("reasoning_tokens") is not None
-        )
-        stage_usage["text_output_tokens_known_requests"] += int(
-            normalized.get("text_output_tokens") is not None
-        )
-        stage_usage["reasoning_budget_pressure_count"] += int(
-            diagnostics.get("reasoning_budget_pressure") is True
-        )
-        stage_usage["truncated_output_count"] += int(
-            diagnostics.get("truncated") is True
-        )
-        stage_usage["total_tokens"] += total_tokens
         if usage_recorder is not None:
             try:
                 usage_recorder(

--- a/scripts/run_provider_contract_smoke.py
+++ b/scripts/run_provider_contract_smoke.py
@@ -15,7 +15,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from litellm_provider_config import DEFAULT_MODELS, SUPPORTED_PROVIDERS
-from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
+import model_usage_ledger
+from sync_model_backend import (
+    GeminiSyncBackend,
+    SyncGenerationRequest,
+    sync_error_category,
+    sync_error_summary,
+)
 from translation_core import MODE_TRANSLATION, build_translation_schema, validate_model_response
 
 
@@ -88,12 +94,11 @@ def contract_request(spec: ProviderSpec) -> SyncGenerationRequest:
     config: dict[str, Any] = {
         "temperature": 0,
         "max_output_tokens": MAX_OUTPUT_TOKENS,
+        "timeout": REQUEST_TIMEOUT_SECONDS,
         "response_json_schema": schema,
     }
     if spec.backend == "gemini":
         config["response_mime_type"] = "application/json"
-    else:
-        config["timeout"] = REQUEST_TIMEOUT_SECONDS
     return SyncGenerationRequest(
         model=spec.model,
         contents=(
@@ -166,29 +171,32 @@ def validate_result(spec: ProviderSpec, result: Any) -> dict[str, Any]:
 
 
 def classify_error(exc: Exception) -> str:
-    category = str(getattr(exc, "category", "") or "").strip()
-    if category:
-        return category
-    status = getattr(exc, "status_code", None)
-    if status in {401, 403}:
-        return "authentication"
-    if status == 429:
-        return "rate_limit"
-    if status in {408, 502, 503, 504} or isinstance(exc, TimeoutError):
-        return "service_unavailable"
-    return "provider_error"
+    return sync_error_category(exc)
 
 
 def run_provider(spec: ProviderSpec, api_key: str, backend: Any = None) -> None:
     backend = backend or create_backend(spec, api_key)
     result = backend.generate(contract_request(spec))
     validate_result(spec, result)
-    usage = dict(result.usage_metadata or {})
+    diagnostics = model_usage_ledger.response_budget_diagnostics(
+        response_text=result.response_text,
+        finish_reason=getattr(result, "finish_reason", ""),
+        usage_metadata=result.usage_metadata or {},
+        max_output_tokens=MAX_OUTPUT_TOKENS,
+    )
+
+    def token_value(field: str) -> str:
+        value = diagnostics.get(field)
+        return "unknown" if value is None else str(int(value))
+
     print(
         "PASS "
         f"provider={spec.name} backend={spec.backend} model={spec.model} "
         f"requests={MAX_REQUESTS_PER_PROVIDER} "
-        f"max_output_tokens={MAX_OUTPUT_TOKENS} usage={json.dumps(usage, sort_keys=True)}"
+        f"max_output_tokens={MAX_OUTPUT_TOKENS} "
+        f"completion_tokens={token_value('completion_tokens')} "
+        f"reasoning_tokens={token_value('reasoning_tokens')} "
+        f"text_output_tokens={token_value('text_output_tokens')}"
     )
 
 
@@ -213,7 +221,8 @@ def run_selected(
         except Exception as exc:
             failed += 1
             print(
-                f"FAIL provider={spec.name} category={classify_error(exc)}: {exc}",
+                f"FAIL provider={spec.name} category={classify_error(exc)}: "
+                f"{sync_error_summary(exc)}",
                 file=sys.stderr,
             )
     print(

--- a/sync_model_backend.py
+++ b/sync_model_backend.py
@@ -70,6 +70,10 @@ def sync_error_category(exc: BaseException) -> str:
     ``LiteLLMBackendError.category`` (and any future backend category) is the
     authoritative source. Status/type/text fallbacks exist for SDK exceptions
     that do not expose the shared category contract yet.
+
+    google-genai reports invalid API keys as ``400 + "API key not valid..."``
+    without a typed exception, so the text fallback also recognizes key-related
+    markers as ``authentication`` instead of a generic provider error.
     """
     explicit = str(getattr(exc, "category", "") or "").strip().lower()
     if explicit in SYNC_ERROR_CATEGORIES:
@@ -140,7 +144,16 @@ def sync_error_category(exc: BaseException) -> str:
         )
     ):
         return "service_unavailable"
-    if "UNAUTHENTICATED" in text or "PERMISSION_DENIED" in text:
+    if any(
+        marker in text
+        for marker in (
+            "UNAUTHENTICATED",
+            "PERMISSION_DENIED",
+            "API KEY NOT VALID",
+            "API KEY INVALID",
+            "INVALID API KEY",
+        )
+    ):
         return "authentication"
     return "provider_error"
 
@@ -174,6 +187,32 @@ def sync_error_summary(exc: BaseException) -> str:
         _SYNC_SAFE_ERROR_MESSAGES["provider_error"],
     )
     return f"{message} [{category}]"
+
+
+def sync_error_detail(exc: BaseException, limit: int = 300) -> str:
+    """Return the original provider message for local logs only.
+
+    Backend errors intentionally hide provider text behind safe summaries, so
+    the original message is recovered by walking the ``__cause__``/``__context__``
+    chain (or the explicit ``detail`` attribute) and returning the first
+    non-backend message. Callers must never render this value in UI or result
+    files; it exists so local logs keep a diagnosable trail.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        explicit_detail = str(getattr(current, "detail", "") or "")
+        if explicit_detail:
+            return explicit_detail[:limit]
+        if isinstance(current, SyncBackendError):
+            current = current.__cause__ or current.__context__
+            continue
+        text = str(current).strip()
+        if text:
+            return text[:limit]
+        current = current.__cause__ or current.__context__
+    return ""
 
 
 def normalize_sync_timeout_seconds(
@@ -260,7 +299,7 @@ class GeminiSyncBackend:
             raise SyncBackendError(
                 sync_error_category(exc),
                 request_metadata={"provider": self.provider},
-            ) from None
+            ) from exc
         try:
             payload = self._serialize_response(response)
             usage: Dict[str, Any] = {}
@@ -269,11 +308,11 @@ class GeminiSyncBackend:
             response_text = self._extract_text(payload) or ""
             finish_reason = self._extract_finish_reason(payload) or ""
             parsed = getattr(response, "parsed", None)
-        except Exception:
+        except Exception as exc:
             raise SyncBackendError(
                 "invalid_response",
                 request_metadata={"provider": self.provider},
-            ) from None
+            ) from exc
         return SyncGenerationResult(
             provider=self.provider, model=request.model,
             execution_mode=SYNC_EXECUTION_MODE, response_payload=payload,

--- a/sync_model_backend.py
+++ b/sync_model_backend.py
@@ -13,6 +13,167 @@ SYNC_EXECUTION_MODE = "sync"
 DEFAULT_SYNC_TIMEOUT_SECONDS = 120
 MIN_SYNC_TIMEOUT_SECONDS = 5
 MAX_SYNC_TIMEOUT_SECONDS = 600
+DEFAULT_SYNC_RETRY_ATTEMPTS = 3
+SYNC_ERROR_CATEGORIES = frozenset({
+    "authentication",
+    "rate_limit",
+    "service_unavailable",
+    "timeout",
+    "invalid_response",
+    "unsupported_capability",
+    "missing_dependency",
+    "provider_error",
+})
+_SYNC_SAFE_ERROR_MESSAGES = {
+    "authentication": "authentication failed",
+    "rate_limit": "rate limited or quota exhausted",
+    "service_unavailable": "service temporarily unavailable",
+    "timeout": "request timed out",
+    "invalid_response": "provider returned an invalid response",
+    "unsupported_capability": "provider does not support this capability",
+    "missing_dependency": "optional provider dependency is unavailable",
+    "provider_error": "provider request failed",
+}
+
+
+class SyncBackendError(RuntimeError):
+    """Provider-neutral failure that never stores the raw provider message."""
+
+    def __init__(
+        self,
+        category: str = "provider_error",
+        *,
+        request_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        normalized = str(category or "provider_error").strip().lower()
+        if normalized not in SYNC_ERROR_CATEGORIES:
+            normalized = "provider_error"
+        self.category = normalized
+        self.request_metadata = dict(request_metadata or {})
+        super().__init__(_SYNC_SAFE_ERROR_MESSAGES[normalized])
+
+
+@dataclass(frozen=True)
+class SyncRecoveryDecision:
+    """Provider-neutral recovery action derived from a structured category."""
+
+    category: str
+    retry_same_request: bool = False
+    split_request: bool = False
+    backoff: bool = False
+    rotate_credentials: bool = False
+
+
+def sync_error_category(exc: BaseException) -> str:
+    """Classify a synchronous request failure without overriding provider data.
+
+    ``LiteLLMBackendError.category`` (and any future backend category) is the
+    authoritative source. Status/type/text fallbacks exist for SDK exceptions
+    that do not expose the shared category contract yet.
+    """
+    explicit = str(getattr(exc, "category", "") or "").strip().lower()
+    if explicit in SYNC_ERROR_CATEGORIES:
+        return explicit
+
+    reason_code = str(getattr(exc, "reason_code", "") or "").strip().lower()
+    if reason_code and (
+        reason_code in {
+            "empty_response_text",
+            "invalid_json",
+            "truncated_output",
+            "reasoning_budget_exhausted",
+            "reasoning_without_text_output",
+        }
+        or reason_code.startswith(("response_", "result_"))
+    ):
+        return "invalid_response"
+
+    status = getattr(exc, "status_code", getattr(exc, "code", None))
+    try:
+        status = int(status)
+    except (TypeError, ValueError, OverflowError):
+        status = None
+    if status in {401, 403}:
+        return "authentication"
+    if status == 408:
+        return "timeout"
+    if status == 429:
+        return "rate_limit"
+    if status in {500, 502, 503, 504}:
+        return "service_unavailable"
+    if status == 404:
+        return "unsupported_capability"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+
+    type_name = type(exc).__name__.lower()
+    if any(marker in type_name for marker in ("authentication", "permissiondenied")):
+        return "authentication"
+    if any(marker in type_name for marker in ("ratelimit", "resourceexhausted")):
+        return "rate_limit"
+    if "timeout" in type_name:
+        return "timeout"
+    if any(
+        marker in type_name
+        for marker in ("serviceunavailable", "apiconnection", "connecterror", "readerror")
+    ):
+        return "service_unavailable"
+    if "notfound" in type_name:
+        return "unsupported_capability"
+
+    # google-genai does not consistently expose typed categories/status across
+    # versions. Keep this fallback narrow and use it only after structured data.
+    text = str(exc).upper()
+    if "RESOURCE_EXHAUSTED" in text or "429" in text:
+        return "rate_limit"
+    if any(marker in text for marker in ("CONNECTTIMEOUT", "READTIMEOUT", "TIMED OUT")):
+        return "timeout"
+    if any(
+        marker in text
+        for marker in (
+            "UNAVAILABLE",
+            "UNEXPECTED_EOF_WHILE_READING",
+            "REMOTEPROTOCOLERROR",
+            " 502",
+            " 503",
+            " 504",
+        )
+    ):
+        return "service_unavailable"
+    if "UNAUTHENTICATED" in text or "PERMISSION_DENIED" in text:
+        return "authentication"
+    return "provider_error"
+
+
+def sync_recovery_decision(exc: BaseException) -> SyncRecoveryDecision:
+    """Return the only retry/split actions allowed for *exc*."""
+    category = sync_error_category(exc)
+    if category == "rate_limit":
+        return SyncRecoveryDecision(
+            category,
+            retry_same_request=True,
+            backoff=True,
+            rotate_credentials=True,
+        )
+    if category in {"service_unavailable", "timeout"}:
+        return SyncRecoveryDecision(
+            category,
+            retry_same_request=True,
+            backoff=True,
+        )
+    if category == "invalid_response":
+        return SyncRecoveryDecision(category, split_request=True)
+    return SyncRecoveryDecision(category)
+
+
+def sync_error_summary(exc: BaseException) -> str:
+    """Return a log-safe summary that never includes provider exception text."""
+    category = sync_error_category(exc)
+    message = _SYNC_SAFE_ERROR_MESSAGES.get(
+        category,
+        _SYNC_SAFE_ERROR_MESSAGES["provider_error"],
+    )
+    return f"{message} [{category}]"
 
 
 def normalize_sync_timeout_seconds(
@@ -28,11 +189,13 @@ def normalize_sync_timeout_seconds(
         timeout = int(default)
     return max(MIN_SYNC_TIMEOUT_SECONDS, min(MAX_SYNC_TIMEOUT_SECONDS, timeout))
 
+
 @dataclass(frozen=True)
 class SyncGenerationRequest:
     model: str
     contents: Any
     config: Mapping[str, Any] = field(default_factory=dict)
+
 
 @dataclass(frozen=True)
 class SyncGenerationResult:
@@ -44,11 +207,16 @@ class SyncGenerationResult:
     parsed: Any = None
     finish_reason: str = ""
     usage_metadata: Mapping[str, Any] = field(default_factory=dict)
+    output_diagnostics: Mapping[str, Any] = field(default_factory=dict)
+    request_metadata: Mapping[str, Any] = field(default_factory=dict)
+
 
 @runtime_checkable
 class SyncModelBackend(Protocol):
     provider: str
+
     def generate(self, request: SyncGenerationRequest) -> SyncGenerationResult: ...
+
 
 class GeminiSyncBackend:
     """Adapter for the existing google-genai synchronous client."""
@@ -82,19 +250,35 @@ class GeminiSyncBackend:
         # final boundary even if a future caller forgets to set it.
         http_options["timeout"] = normalize_sync_timeout_seconds(timeout) * 1000
         config["http_options"] = http_options
-        response = self._client.models.generate_content(
-            model=request.model,
-            contents=request.contents,
-            config=config,
-        )
-        payload = self._serialize_response(response)
-        usage: Dict[str, Any] = {}
-        if self._extract_usage is not None:
-            usage = dict(self._extract_usage(payload) or {})
+        try:
+            response = self._client.models.generate_content(
+                model=request.model,
+                contents=request.contents,
+                config=config,
+            )
+        except Exception as exc:
+            raise SyncBackendError(
+                sync_error_category(exc),
+                request_metadata={"provider": self.provider},
+            ) from None
+        try:
+            payload = self._serialize_response(response)
+            usage: Dict[str, Any] = {}
+            if self._extract_usage is not None:
+                usage = dict(self._extract_usage(payload) or {})
+            response_text = self._extract_text(payload) or ""
+            finish_reason = self._extract_finish_reason(payload) or ""
+            parsed = getattr(response, "parsed", None)
+        except Exception:
+            raise SyncBackendError(
+                "invalid_response",
+                request_metadata={"provider": self.provider},
+            ) from None
         return SyncGenerationResult(
             provider=self.provider, model=request.model,
             execution_mode=SYNC_EXECUTION_MODE, response_payload=payload,
-            response_text=self._extract_text(payload) or "",
-            parsed=getattr(response, "parsed", None),
-            finish_reason=self._extract_finish_reason(payload) or "",
-            usage_metadata=usage)
+            response_text=response_text,
+            parsed=parsed,
+            finish_reason=finish_reason,
+            usage_metadata=usage,
+            request_metadata={"provider": self.provider})

--- a/tests/test_gui_cli_runner.py
+++ b/tests/test_gui_cli_runner.py
@@ -186,6 +186,39 @@ class CliRunnerChannelTests(unittest.TestCase):
         self.runner._force_kill()
         self.assertEqual(process.kill_count, 1)
 
+    def test_stop_discards_racing_zero_exit(self):
+        process = _LifecycleFakeProcess(state=QProcess.ProcessState.Running)
+        self.runner._proc = process
+        self.runner._start_timeout_timer = _FakeTimer()
+        self.runner._stop_timeout_timer = _FakeTimer()
+
+        self.assertTrue(self.runner.request_stop())
+        process._state = QProcess.ProcessState.NotRunning
+        self.runner._on_process_finished(
+            process,
+            0,
+            QProcess.ExitStatus.NormalExit,
+        )
+
+        self.assertEqual(self.finished_codes, [-1])
+        self.assertIsNone(self.runner._proc)
+
+    def test_stop_wins_when_process_is_already_not_running(self):
+        process = _LifecycleFakeProcess(
+            state=QProcess.ProcessState.NotRunning,
+            stdout=(b"Sync preview manifest: stale.json",),
+        )
+        self.runner._proc = process
+        self.runner._start_timeout_timer = _FakeTimer()
+        self.runner._stop_timeout_timer = _FakeTimer()
+
+        self.assertTrue(self.runner.request_stop())
+
+        self.assertEqual(self.finished_codes, [-1])
+        self.assertEqual(self.stdout_lines, ["Sync preview manifest: stale.json"])
+        self.assertIsNone(self.runner._proc)
+        self.assertEqual(process.terminate_count, 0)
+
     def test_stale_process_completion_cannot_finish_current_process(self):
         stale = _LifecycleFakeProcess(state=QProcess.ProcessState.NotRunning)
         current = _LifecycleFakeProcess(state=QProcess.ProcessState.Running)

--- a/tests/test_gui_project_analysis.py
+++ b/tests/test_gui_project_analysis.py
@@ -71,12 +71,19 @@ class ProjectAnalysisWorkflowTests(unittest.TestCase):
             'PROJECT_ANALYSIS_PROGRESS '
             '{"stage":"complete","completed":1,"total":1,'
             '"usage":{"requests":4,"input_tokens":40,"output_tokens":16,'
+            '"completion_tokens":16,"reasoning_tokens":10,'
+            '"text_output_tokens":6,"completion_tokens_known_requests":4,'
+            '"reasoning_tokens_known_requests":4,'
+            '"text_output_tokens_known_requests":4,'
             '"estimated_cost":0.000104,"currency":"USD"}}\n'
         )
         facts = generation_facts_from_output(output)
 
         self.assertIn("全部完成 1/1", facts[0])
         self.assertIn("模型请求：4", facts[1])
+        self.assertIn("completion 16", facts[1])
+        self.assertIn("reasoning 10", facts[1])
+        self.assertIn("正文 6", facts[1])
         self.assertIn("0.000104 USD", facts[2])
 
         unknown = generation_facts_from_output(

--- a/tests/test_gui_sync_translation_report.py
+++ b/tests/test_gui_sync_translation_report.py
@@ -151,6 +151,22 @@ class GuiSyncTranslationReportTests(unittest.TestCase):
         self.assertIn("定点重试：1 次请求 / 1 项", update.facts)
         self.assertIn("未解决结果：1 个", update.facts)
 
+    def test_summarize_surfaces_reasoning_and_text_output_diagnostics(self):
+        update = summarize_sync_translation_output(
+            SUCCESS_OUTPUT
+            + "Sync output tokens: completion=23 reasoning=17 text=6\n"
+            + "Reasoning budget warnings: 1\n"
+            + "Truncated sync responses: 2\n",
+            0,
+        )
+
+        self.assertIn(
+            "输出 Token：completion 23 / reasoning 17 / 正文 6",
+            update.facts,
+        )
+        self.assertIn("Reasoning 预算告警：1 次", update.facts)
+        self.assertIn("输出截断：2 次", update.facts)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_litellm_error_classification.py
+++ b/tests/test_litellm_error_classification.py
@@ -1,13 +1,12 @@
-import sys
-import types
 import unittest
-from unittest import mock
 
-from litellm_sync_backend import _error_category
+from sync_model_backend import sync_error_category
 
 
 class LiteLLMErrorClassificationTests(unittest.TestCase):
-    def test_prefers_litellm_typed_exceptions(self):
+    def test_litellm_typed_exception_names_classify_via_shared_category(self):
+        """LiteLLM typed errors are covered by the shared type-name fallback."""
+
         class RateLimitError(Exception):
             pass
 
@@ -17,17 +16,18 @@ class LiteLLMErrorClassificationTests(unittest.TestCase):
         class AuthenticationError(Exception):
             pass
 
-        fake_litellm = types.SimpleNamespace(
-            RateLimitError=RateLimitError,
-            ServiceUnavailableError=ServiceUnavailableError,
-            AuthenticationError=AuthenticationError,
+        self.assertEqual(
+            sync_error_category(RateLimitError()),
+            "rate_limit",
         )
-        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
-            self.assertEqual(_error_category(RateLimitError()), "rate_limit")
-            self.assertEqual(
-                _error_category(ServiceUnavailableError()), "service_unavailable"
-            )
-            self.assertEqual(_error_category(AuthenticationError()), "authentication")
+        self.assertEqual(
+            sync_error_category(ServiceUnavailableError()),
+            "service_unavailable",
+        )
+        self.assertEqual(
+            sync_error_category(AuthenticationError()),
+            "authentication",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -340,6 +340,48 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
             ["openai#1:****1111"],
         )
 
+    def test_backend_error_keeps_chain_and_detail_for_local_logs(self):
+        original = RuntimeError("provider echoed stored-secret-1111")
+        original.status_code = 400
+
+        def completion(**_kwargs):
+            raise original
+
+        backend = LiteLLMSyncBackend(completion=completion)
+        with self.assertRaises(LiteLLMBackendError) as captured:
+            backend.generate(SyncGenerationRequest("openai/test", "hello"))
+
+        self.assertIs(captured.exception.__cause__, original)
+        self.assertEqual(captured.exception.category, "provider_error")
+        self.assertEqual(str(captured.exception), "LiteLLM provider request failed.")
+        self.assertNotIn("stored-secret", str(captured.exception))
+        self.assertEqual(captured.exception.detail, str(original))
+
+    def test_litellm_backend_error_whitelists_non_internal_messages(self):
+        error = LiteLLMBackendError(
+            "provider echoed arbitrary text",
+            category="authentication",
+        )
+        self.assertEqual(
+            str(error),
+            "LiteLLM authentication failed.",
+        )
+        self.assertEqual(error.category, "authentication")
+
+        internal = LiteLLMBackendError(
+            "intentional user-facing message",
+            category="invalid_response",
+            internal=True,
+        )
+        self.assertEqual(str(internal), "intentional user-facing message")
+
+    def test_litellm_backend_error_normalizes_unknown_category(self):
+        error = LiteLLMBackendError(
+            "LiteLLM provider request failed.",
+            category="not-a-real-category",
+        )
+        self.assertEqual(error.category, "provider_error")
+
     def test_gemini_thinking_config_is_not_forwarded_to_litellm(self):
         calls = []
         backend = LiteLLMSyncBackend(

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -295,14 +295,17 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
         self.assertEqual([call["api_key"] for call in calls], list(store.keys))
         self.assertEqual(
             result.request_metadata["credential_attempts"],
-            ["openai#1:****1111", "openai#2:****2222"],
+            ["openai#1:key:c8c5267554", "openai#2:key:785abd44b6"],
         )
         self.assertEqual(
             result.request_metadata["credential_identity"],
-            "openai#2:****2222",
+            "openai#2:key:785abd44b6",
         )
-        self.assertNotIn("first-key-1111", repr(result.request_metadata))
-        self.assertNotIn("second-key-2222", repr(result.request_metadata))
+        metadata_repr = repr(result.request_metadata)
+        self.assertNotIn("first-key-1111", metadata_repr)
+        self.assertNotIn("second-key-2222", metadata_repr)
+        self.assertNotIn("1111", metadata_repr)
+        self.assertNotIn("2222", metadata_repr)
 
     def test_authentication_failure_does_not_retry_or_rotate(self):
         calls = []
@@ -337,7 +340,45 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
         self.assertNotIn("stored-secret", str(captured.exception))
         self.assertEqual(
             captured.exception.request_metadata["credential_attempts"],
-            ["openai#1:****1111"],
+            ["openai#1:key:fc1a1e7ee5"],
+        )
+
+    def test_credential_identity_is_non_reversible_and_stable(self):
+        from litellm_sync_backend import _masked_key_identity
+
+        identity = _masked_key_identity("openai", "first-key-1111", index=0)
+        self.assertEqual(identity, "openai#1:key:c8c5267554")
+        self.assertNotIn("first-key", identity)
+        self.assertNotIn("1111", identity)
+        self.assertEqual(
+            _masked_key_identity("openai", "first-key-1111", index=0),
+            identity,
+        )
+        self.assertNotEqual(
+            _masked_key_identity("openai", "second-key-2222", index=1),
+            identity,
+        )
+        self.assertEqual(
+            _masked_key_identity("openai", "second-key-2222", index=1),
+            "openai#2:key:785abd44b6",
+        )
+        self.assertEqual(
+            _masked_key_identity("openai", ""),
+            "openai:key:empty",
+        )
+
+    def test_serialize_failure_keeps_request_metadata(self):
+        backend = LiteLLMSyncBackend(
+            completion=lambda **_kwargs: object(),
+        )
+        with self.assertRaises(LiteLLMBackendError) as captured:
+            backend.generate(SyncGenerationRequest("openai/test", "hello"))
+
+        self.assertEqual(captured.exception.category, "invalid_response")
+        self.assertEqual(captured.exception.request_metadata["provider"], "openai")
+        self.assertEqual(
+            captured.exception.request_metadata["credential_count"],
+            0,
         )
 
     def test_backend_error_keeps_chain_and_detail_for_local_logs(self):

--- a/tests/test_litellm_sync_backend.py
+++ b/tests/test_litellm_sync_backend.py
@@ -10,7 +10,7 @@ from litellm_sync_backend import (
     LiteLLMSyncBackend,
     LiteLLMUnavailableError,
 )
-from litellm_provider_config import custom_provider_registry
+from litellm_provider_config import ProviderApiKeyStore, custom_provider_registry
 from sync_model_backend import SyncGenerationRequest, SyncModelBackend
 
 
@@ -253,6 +253,112 @@ class LiteLLMSyncBackendTests(unittest.TestCase):
         with self.assertRaises(LiteLLMBackendError) as captured:
             backend.generate(SyncGenerationRequest("openai/test", "hello"))
         self.assertEqual(captured.exception.category, "rate_limit")
+
+    def test_rate_limit_rotates_only_within_same_provider_keyring(self):
+        calls = []
+
+        class RateLimitError(RuntimeError):
+            category = "rate_limit"
+
+        def completion(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RateLimitError("provider echoed first-key-1111")
+            return {
+                "choices": [{"message": {"content": "OK"}}],
+                "usage": {},
+            }
+
+        backend = LiteLLMSyncBackend(completion=completion, sleep=lambda _delay: None)
+        store = ProviderApiKeyStore(
+            keys=("first-key-1111", "second-key-2222"),
+            active_index=0,
+        )
+        with (
+            mock.patch(
+                "litellm_provider_config.load_provider_api_key",
+                return_value="first-key-1111",
+            ),
+            mock.patch(
+                "litellm_provider_config.load_provider_key_store",
+                return_value=store,
+            ) as load_store,
+            mock.patch.object(
+                __import__("translator_runtime"),
+                "rotate_api_key",
+                side_effect=AssertionError("must not touch Gemini keyring"),
+            ),
+        ):
+            result = backend.generate(SyncGenerationRequest("openai/test", "hello"))
+
+        load_store.assert_called_once_with("openai")
+        self.assertEqual([call["api_key"] for call in calls], list(store.keys))
+        self.assertEqual(
+            result.request_metadata["credential_attempts"],
+            ["openai#1:****1111", "openai#2:****2222"],
+        )
+        self.assertEqual(
+            result.request_metadata["credential_identity"],
+            "openai#2:****2222",
+        )
+        self.assertNotIn("first-key-1111", repr(result.request_metadata))
+        self.assertNotIn("second-key-2222", repr(result.request_metadata))
+
+    def test_authentication_failure_does_not_retry_or_rotate(self):
+        calls = []
+
+        class AuthenticationError(RuntimeError):
+            category = "authentication"
+
+        def completion(**kwargs):
+            calls.append(kwargs)
+            raise AuthenticationError("provider echoed stored-secret-1111")
+
+        backend = LiteLLMSyncBackend(completion=completion, sleep=lambda _delay: None)
+        store = ProviderApiKeyStore(
+            keys=("stored-secret-1111", "stored-secret-2222"),
+            active_index=0,
+        )
+        with (
+            mock.patch(
+                "litellm_provider_config.load_provider_api_key",
+                return_value="stored-secret-1111",
+            ),
+            mock.patch(
+                "litellm_provider_config.load_provider_key_store",
+                return_value=store,
+            ),
+        ):
+            with self.assertRaises(LiteLLMBackendError) as captured:
+                backend.generate(SyncGenerationRequest("openai/test", "hello"))
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(captured.exception.category, "authentication")
+        self.assertNotIn("stored-secret", str(captured.exception))
+        self.assertEqual(
+            captured.exception.request_metadata["credential_attempts"],
+            ["openai#1:****1111"],
+        )
+
+    def test_gemini_thinking_config_is_not_forwarded_to_litellm(self):
+        calls = []
+        backend = LiteLLMSyncBackend(
+            completion=lambda **kwargs: calls.append(kwargs) or {"choices": []}
+        )
+
+        result = backend.generate(
+            SyncGenerationRequest(
+                "openai/test",
+                "hello",
+                {"thinking_config": {"thinking_level": "high"}},
+            )
+        )
+
+        self.assertNotIn("thinking_config", calls[0])
+        self.assertEqual(
+            result.request_metadata["ignored_provider_options"],
+            ["thinking_config"],
+        )
 
     def test_custom_provider_rewrites_model_and_passes_api_base(self):
         calls = []

--- a/tests/test_litellm_sync_integration.py
+++ b/tests/test_litellm_sync_integration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
+from litellm_sync_backend import LiteLLMBackendError
 
 
 class LiteLLMSyncIntegrationTests(unittest.TestCase):
@@ -106,6 +107,49 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
             manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
 
         self.assertEqual(manifest["settings"]["timeout_seconds"], 45)
+
+    def test_litellm_authentication_failure_is_not_retried(self):
+        fake_backend = mock.Mock()
+        fake_backend.generate.side_effect = LiteLLMBackendError(
+            "provider echoed secret-value",
+            category="authentication",
+        )
+        with (
+            mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch(
+                "litellm_sync_backend.LiteLLMSyncBackend",
+                return_value=fake_backend,
+            ),
+        ):
+            with self.assertRaises(LiteLLMBackendError):
+                batch_mod.run_sync_request({"contents": []}, "gemini-default")
+
+        self.assertEqual(fake_backend.generate.call_count, 1)
+
+    def test_litellm_timeout_retry_is_bounded(self):
+        fake_backend = mock.Mock()
+        fake_backend.generate.side_effect = [
+            LiteLLMBackendError("timeout one", category="timeout"),
+            LiteLLMBackendError("timeout two", category="timeout"),
+            self._fake_result(),
+        ]
+        with (
+            mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod.time, "sleep"),
+            mock.patch(
+                "litellm_sync_backend.LiteLLMSyncBackend",
+                return_value=fake_backend,
+            ),
+        ):
+            result = batch_mod.run_sync_request(
+                {"contents": []},
+                "gemini-default",
+            )
+
+        self.assertEqual(fake_backend.generate.call_count, 3)
+        self.assertEqual(result["provider"], "litellm")
 
 
 if __name__ == "__main__":

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -348,7 +348,11 @@ class ModelUsageLedgerTests(unittest.TestCase):
                 "provider": "openai",
                 "credential_identity": "raw-secret-key",
                 "credential_source": "secret-value",
-                "credential_attempts": ["openai#1:****1234", "raw-secret-key"],
+                "credential_attempts": [
+                    "openai#1:****1234",
+                    "openai#2:key:785abd44b6",
+                    "raw-secret-key",
+                ],
                 "ignored_provider_options": ["thinking_config", "secret-value"],
             }
         )
@@ -357,7 +361,7 @@ class ModelUsageLedgerTests(unittest.TestCase):
         self.assertNotIn("credential_source", normalized)
         self.assertEqual(
             normalized["credential_attempts"],
-            ["openai#1:****1234"],
+            ["openai#1:****1234", "openai#2:key:785abd44b6"],
         )
         self.assertEqual(
             normalized["ignored_provider_options"],

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -1062,6 +1062,36 @@ class ModelUsageLedgerTests(unittest.TestCase):
             output.getvalue(),
         )
 
+    def test_format_sync_output_lines_is_stable_contract(self):
+        self.assertEqual(
+            usage.format_sync_output_lines(
+                completion="23",
+                reasoning="17",
+                text_output="unknown",
+                reasoning_budget_pressure=1,
+                truncated=2,
+            ),
+            [
+                "Sync output tokens: completion=23 reasoning=17 text=unknown",
+                "Reasoning budget warnings: 1",
+                "Truncated sync responses: 2",
+            ],
+        )
+        self.assertEqual(
+            usage.format_sync_output_lines(
+                completion=0,
+                reasoning=0,
+                text_output=0,
+                reasoning_budget_pressure=0,
+                truncated=0,
+            ),
+            [
+                "Sync output tokens: completion=0 reasoning=0 text=0",
+                "Reasoning budget warnings: 0",
+                "Truncated sync responses: 0",
+            ],
+        )
+
     def test_import_best_effort_does_not_swallow_system_exit(self):
         with self.assertRaises(SystemExit):
             with mock.patch.object(

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -219,7 +219,10 @@ class ModelUsageLedgerTests(unittest.TestCase):
                             "completion_tokens": 4,
                             "total_tokens": 12,
                             "prompt_tokens_details": {"cached_tokens": 3},
-                            "completion_tokens_details": {"reasoning_tokens": 2},
+                            "completion_tokens_details": {
+                                "reasoning_tokens": 2,
+                                "text_tokens": 2,
+                            },
                         },
                         "response": {
                             "id": "chatcmpl-fixture-1",
@@ -243,6 +246,8 @@ class ModelUsageLedgerTests(unittest.TestCase):
 
             self.assertEqual(report["totals"]["prompt_tokens"], 8)
             self.assertEqual(report["totals"]["completion_tokens"], 4)
+            self.assertEqual(report["totals"]["reasoning_tokens"], 2)
+            self.assertEqual(report["totals"]["text_output_tokens"], 2)
             self.assertEqual(report["totals"]["thoughts_tokens"], 2)
             self.assertEqual(report["totals"]["cached_tokens"], 3)
             self.assertEqual(
@@ -252,6 +257,112 @@ class ModelUsageLedgerTests(unittest.TestCase):
             self.assertIsNone(record["estimated_cost"])
             self.assertEqual(record["actual_cost_source"], "_hidden_params.response_cost")
             self.assertEqual(record["stage"], "sync_keyword")
+
+    def test_reasoning_budget_diagnostics_detect_empty_exhausted_output(self):
+        diagnostics = usage.response_budget_diagnostics(
+            response_text="",
+            finish_reason="length",
+            usage_metadata={
+                "completion_tokens": 64,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 64,
+                    "text_tokens": 0,
+                },
+            },
+            max_output_tokens=64,
+        )
+
+        self.assertTrue(diagnostics["empty_text"])
+        self.assertTrue(diagnostics["truncated"])
+        self.assertTrue(diagnostics["reasoning_budget_pressure"])
+        self.assertEqual(diagnostics["reason_code"], "reasoning_budget_exhausted")
+
+        record = usage.build_usage_record(
+            game_root="C:/fixture",
+            task_mode="translation",
+            stage="sync_translation",
+            provider="litellm",
+            model="openai/test",
+            usage_metadata={
+                "completion_tokens": 64,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 64,
+                    "text_tokens": 0,
+                },
+            },
+            response_diagnostics=diagnostics,
+        )
+        totals = usage.aggregate_usage_records([record])
+        lines = usage.format_usage_report(
+            {
+                "project": {"game_root": "C:/fixture"},
+                "ledger_path": "C:/fixture/usage.json",
+                "totals": totals,
+            }
+        )
+        self.assertTrue(any("Reasoning share" in line and "100.0%" in line for line in lines))
+        self.assertTrue(
+            any("reasoning_budget_pressure=1" in line for line in lines)
+        )
+
+    def test_visible_text_is_not_derived_for_ambiguous_provider_counters(self):
+        normalized = usage.normalize_usage_metadata(
+            {
+                "completion_tokens": 20,
+                "completion_tokens_details": {"reasoning_tokens": 5},
+            }
+        )
+
+        self.assertEqual(normalized["completion_tokens"], 20)
+        self.assertEqual(normalized["reasoning_tokens"], 5)
+        self.assertIsNone(normalized["text_output_tokens"])
+
+    def test_snake_case_gemini_usage_includes_thoughts_in_output_budget(self):
+        normalized = usage.normalize_usage_metadata(
+            {
+                "prompt_token_count": 10,
+                "candidates_token_count": 4,
+                "thoughts_token_count": 6,
+            }
+        )
+
+        self.assertEqual(normalized["completion_tokens"], 4)
+        self.assertEqual(normalized["reasoning_tokens"], 6)
+        self.assertEqual(normalized["text_output_tokens"], 4)
+        self.assertEqual(normalized["billable_output_tokens"], 10)
+        self.assertEqual(normalized["total_tokens"], 20)
+
+    def test_safe_diagnostic_metadata_rejects_unstructured_or_secret_fields(self):
+        self.assertEqual(
+            usage.normalize_response_diagnostics(
+                {"reason_code": "provider said secret value"}
+            ),
+            {},
+        )
+        self.assertEqual(
+            usage.normalize_response_diagnostics({"reason_code": "secret-value"}),
+            {},
+        )
+        normalized = usage.normalize_request_metadata(
+            {
+                "provider": "openai",
+                "credential_identity": "raw-secret-key",
+                "credential_source": "secret-value",
+                "credential_attempts": ["openai#1:****1234", "raw-secret-key"],
+                "ignored_provider_options": ["thinking_config", "secret-value"],
+            }
+        )
+        self.assertEqual(normalized["provider"], "openai")
+        self.assertNotIn("credential_identity", normalized)
+        self.assertNotIn("credential_source", normalized)
+        self.assertEqual(
+            normalized["credential_attempts"],
+            ["openai#1:****1234"],
+        )
+        self.assertEqual(
+            normalized["ignored_provider_options"],
+            ["thinking_config"],
+        )
 
     def test_usage_response_cost_without_currency_stays_unknown_currency(self):
         with tempfile.TemporaryDirectory() as game_root, tempfile.TemporaryDirectory() as package:
@@ -916,6 +1027,40 @@ class ModelUsageLedgerTests(unittest.TestCase):
             finally:
                 runtime.BASE_DIR = previous_base
                 runtime.SYNC_BACKEND = previous_backend
+
+    def test_runtime_sync_usage_summary_preserves_unknown_text_tokens(self):
+        import translator_runtime as runtime
+
+        records = [
+            usage.build_usage_record(
+                game_root="C:/fixture",
+                task_mode="translation",
+                stage="sync_translation",
+                provider="litellm",
+                model="openai/test",
+                usage_metadata={
+                    "prompt_tokens": 3,
+                    "completion_tokens": 23,
+                    "completion_tokens_details": {"reasoning_tokens": 17},
+                    "total_tokens": 26,
+                },
+                response_diagnostics={
+                    "completion_tokens": 23,
+                    "reasoning_tokens": 17,
+                    "empty_text": False,
+                    "truncated": False,
+                    "reasoning_budget_pressure": False,
+                },
+            )
+        ]
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            runtime.print_sync_usage_summary(records)
+
+        self.assertIn(
+            "Sync output tokens: completion=23 reasoning=17 text=unknown",
+            output.getvalue(),
+        )
 
     def test_import_best_effort_does_not_swallow_system_exit(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_project_analysis_llm.py
+++ b/tests/test_project_analysis_llm.py
@@ -76,6 +76,39 @@ class MapReduceTests(unittest.TestCase):
         )
         self.assertEqual(request.config["timeout"], 45)
 
+    def test_empty_reasoning_exhausted_response_has_stable_reason_code(self):
+        def generate(_request):
+            return SyncGenerationResult(
+                provider="fake",
+                model="fake-model",
+                execution_mode=SYNC_EXECUTION_MODE,
+                response_payload={},
+                response_text="",
+                finish_reason="length",
+                usage_metadata={
+                    "completion_tokens": 64,
+                    "completion_tokens_details": {
+                        "reasoning_tokens": 64,
+                        "text_tokens": 0,
+                    },
+                },
+            )
+
+        with self.assertRaises(llm.ProjectAnalysisResponseError) as captured:
+            llm.complete_analysis_text(
+                generate,
+                model="fake-model",
+                system="system",
+                user="user",
+                max_output_tokens=64,
+            )
+
+        self.assertEqual(captured.exception.category, "invalid_response")
+        self.assertEqual(
+            captured.exception.reason_code,
+            "reasoning_budget_exhausted",
+        )
+
     def test_mapreduce_refines_labels_routes_brief(self):
         with tempfile.TemporaryDirectory() as tmp:
             store_dir = os.path.join(tmp, "pa")
@@ -141,6 +174,58 @@ class MapReduceTests(unittest.TestCase):
             self.assertGreaterEqual(result["labels_refined"], 1)
             self.assertGreaterEqual(result["routes_refined"], 1)
             self.assertGreater(len(backend.calls), 0)
+
+    def test_usage_summary_derives_reasoning_diagnostics_from_bare_backend(self):
+        class ReasoningBackend(FakeBackend):
+            def generate(self, request):
+                base = super().generate(request)
+                return SyncGenerationResult(
+                    provider=base.provider,
+                    model=base.model,
+                    execution_mode=base.execution_mode,
+                    response_payload=base.response_payload,
+                    response_text=base.response_text,
+                    finish_reason="length",
+                    usage_metadata={
+                        "prompt_tokens": 10,
+                        "completion_tokens": 8,
+                        "total_tokens": 18,
+                        "completion_tokens_details": {
+                            "reasoning_tokens": 6,
+                            "text_tokens": 2,
+                        },
+                    },
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store_dir = os.path.join(tmp, "pa")
+            gen.ingest_keyword_summaries(str(KEYWORDS), store_dir=store_dir)
+            gen.build_structure_drafts(
+                store_dir=store_dir,
+                base_dir=str(FIXTURE_DIR),
+                script_roots=[str(FIXTURE_DIR)],
+                entry_labels=["start"],
+            )
+            events = []
+            result = llm.run_mapreduce_drafts(
+                store_dir=store_dir,
+                backend=ReasoningBackend(),
+                config={"model": "fake-model", "max_output_tokens": 8},
+                force=True,
+                usage_recorder=events.append,
+            )
+
+        self.assertEqual(
+            result["usage"]["reasoning_budget_pressure_count"],
+            result["usage"]["requests"],
+        )
+        self.assertEqual(result["usage"]["truncated_output_count"], result["usage"]["requests"])
+        self.assertTrue(
+            all(
+                event["output_diagnostics"]["reasoning_budget_pressure"]
+                for event in events
+            )
+        )
 
     def test_optional_inputs_are_prompted_persisted_and_invalidate_cache(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_provider_contract_smoke.py
+++ b/tests/test_provider_contract_smoke.py
@@ -34,12 +34,22 @@ class ProviderContractSmokeTests(unittest.TestCase):
             response_text=(
                 '{"translations":[{"id":"smoke-1","translation":"你好"}]}'
             ),
-            usage_metadata={"total_tokens": 9},
+            usage_metadata={
+                "prompt_tokens": 3,
+                "completion_tokens": 6,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 2,
+                    "text_tokens": 4,
+                },
+                "total_tokens": 9,
+            },
         )
         backend = mock.Mock()
         backend.generate.return_value = result
 
-        smoke.run_provider(spec, "secret", backend=backend)
+        output = io.StringIO()
+        with redirect_stdout(output):
+            smoke.run_provider(spec, "secret", backend=backend)
 
         request = backend.generate.call_args.args[0]
         self.assertEqual(request.model, spec.model)
@@ -52,6 +62,9 @@ class ProviderContractSmokeTests(unittest.TestCase):
             smoke.REQUEST_TIMEOUT_SECONDS,
         )
         self.assertIn("translations", request.config["response_json_schema"]["properties"])
+        self.assertIn("completion_tokens=6", output.getvalue())
+        self.assertIn("reasoning_tokens=2", output.getvalue())
+        self.assertIn("text_output_tokens=4", output.getvalue())
 
     def test_invalid_response_fails_with_provider_name_and_category(self):
         spec = smoke.PROVIDER_BY_NAME["openai"]
@@ -93,11 +106,31 @@ class ProviderContractSmokeTests(unittest.TestCase):
         for status, expected in (
             (401, "authentication"),
             (429, "rate_limit"),
+            (408, "timeout"),
             (503, "service_unavailable"),
         ):
             error = RuntimeError("provider failed")
             error.status_code = status
             self.assertEqual(smoke.classify_error(error), expected)
+
+    def test_failure_output_does_not_echo_provider_exception_text(self):
+        spec = smoke.PROVIDER_BY_NAME["openai"]
+        backend = mock.Mock()
+        error = RuntimeError("provider echoed secret-value")
+        error.status_code = 401
+        backend.generate.side_effect = error
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(smoke, "create_backend", return_value=backend),
+            redirect_stderr(stderr),
+            redirect_stdout(io.StringIO()),
+        ):
+            code = smoke.run_selected([spec], {"OPENAI_API_KEY": "secret"})
+
+        self.assertEqual(code, 1)
+        self.assertIn("category=authentication", stderr.getvalue())
+        self.assertNotIn("secret-value", stderr.getvalue())
+        self.assertNotIn("provider echoed", stderr.getvalue())
 
     def test_workflow_is_scheduled_manual_and_not_a_pr_gate(self):
         workflow = (

--- a/tests/test_sync_model_backend.py
+++ b/tests/test_sync_model_backend.py
@@ -9,6 +9,7 @@ from sync_model_backend import (
     SyncBackendError,
     SyncModelBackend,
     normalize_sync_timeout_seconds,
+    sync_error_detail,
     sync_error_category,
     sync_error_summary,
     sync_recovery_decision,
@@ -256,6 +257,60 @@ class SyncModelBackendTests(unittest.TestCase):
 
         error.category = "secret-value"
         self.assertEqual(sync_error_category(error), "rate_limit")
+
+    def test_gemini_invalid_api_key_text_is_authentication(self):
+        for message in (
+            "400 API key not valid. Please pass a valid API key.",
+            "API key invalid: 400 INVALID_ARGUMENT",
+            "Invalid API key provided.",
+        ):
+            with self.subTest(message=message):
+                error = RuntimeError(message)
+                error.status_code = 400
+                self.assertEqual(sync_error_category(error), "authentication")
+                self.assertEqual(
+                    sync_error_summary(error),
+                    "authentication failed [authentication]",
+                )
+
+    def test_sync_backend_error_keeps_original_exception_chain(self):
+        original = RuntimeError("provider echoed secret-value")
+        original.status_code = 400
+        client = _Client(_Response())
+
+        def fail(**_kwargs):
+            raise original
+
+        client.models.generate_content = fail
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=lambda response: {},
+            extract_text=lambda payload: "",
+            extract_finish_reason=lambda payload: "",
+        )
+
+        with self.assertRaises(SyncBackendError) as captured:
+            backend.generate(SyncGenerationRequest("gemini-test", [], {}))
+
+        self.assertIs(captured.exception.__cause__, original)
+        self.assertEqual(captured.exception.category, "provider_error")
+        self.assertNotIn("secret-value", str(captured.exception))
+        self.assertEqual(sync_error_detail(captured.exception), "provider echoed secret-value")
+
+    def test_sync_error_detail_prefers_explicit_detail_then_chain(self):
+        error = RuntimeError("raw provider text")
+        self.assertEqual(sync_error_detail(error), "raw provider text")
+
+        wrapped = SyncBackendError("authentication")
+        try:
+            raise wrapped from error
+        except SyncBackendError:
+            pass
+        self.assertEqual(sync_error_detail(wrapped), "raw provider text")
+
+        with_detail = RuntimeError("detail wins")
+        with_detail.detail = "kept for local logs"
+        self.assertEqual(sync_error_detail(with_detail), "kept for local logs")
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_model_backend.py
+++ b/tests/test_sync_model_backend.py
@@ -6,8 +6,12 @@ from sync_model_backend import (
     MIN_SYNC_TIMEOUT_SECONDS,
     GeminiSyncBackend,
     SyncGenerationRequest,
+    SyncBackendError,
     SyncModelBackend,
     normalize_sync_timeout_seconds,
+    sync_error_category,
+    sync_error_summary,
+    sync_recovery_decision,
 )
 
 
@@ -136,6 +140,48 @@ class SyncModelBackendTests(unittest.TestCase):
         )
         self.assertNotIn("timeout", client.models.calls[0]["config"])
 
+    def test_gemini_provider_failure_is_classified_without_secret_text(self):
+        client = _Client(_Response())
+        error = RuntimeError("provider echoed fake-secret-value")
+        error.status_code = 401
+
+        def fail(**_kwargs):
+            raise error
+
+        client.models.generate_content = fail
+        backend = GeminiSyncBackend(
+            client,
+            serialize_response=lambda response: {},
+            extract_text=lambda payload: "",
+            extract_finish_reason=lambda payload: "",
+        )
+
+        with self.assertRaises(SyncBackendError) as captured:
+            backend.generate(SyncGenerationRequest("gemini-test", [], {}))
+
+        self.assertEqual(captured.exception.category, "authentication")
+        self.assertEqual(
+            captured.exception.request_metadata,
+            {"provider": "gemini"},
+        )
+        self.assertNotIn("fake-secret-value", str(captured.exception))
+
+    def test_gemini_response_extraction_failure_is_invalid_response(self):
+        backend = GeminiSyncBackend(
+            _Client(_Response()),
+            serialize_response=lambda _response: (_ for _ in ()).throw(
+                ValueError("provider response contained fake-secret-value")
+            ),
+            extract_text=lambda payload: "",
+            extract_finish_reason=lambda payload: "",
+        )
+
+        with self.assertRaises(SyncBackendError) as captured:
+            backend.generate(SyncGenerationRequest("gemini-test", [], {}))
+
+        self.assertEqual(captured.exception.category, "invalid_response")
+        self.assertNotIn("fake-secret-value", str(captured.exception))
+
     def test_sync_timeout_normalization_has_finite_bounds(self):
         self.assertEqual(
             normalize_sync_timeout_seconds(None),
@@ -174,6 +220,42 @@ class SyncModelBackendTests(unittest.TestCase):
             },
         )
         self.assertIn("temperature", config)
+
+    def test_recovery_decisions_are_category_driven(self):
+        cases = (
+            (401, "authentication", False, False),
+            (429, "rate_limit", True, False),
+            (408, "timeout", True, False),
+            (503, "service_unavailable", True, False),
+        )
+        for status, category, retry, split in cases:
+            with self.subTest(status=status):
+                error = RuntimeError("provider details")
+                error.status_code = status
+                decision = sync_recovery_decision(error)
+                self.assertEqual(decision.category, category)
+                self.assertEqual(decision.retry_same_request, retry)
+                self.assertEqual(decision.split_request, split)
+
+        invalid = RuntimeError("bad payload")
+        invalid.reason_code = "empty_response_text"
+        decision = sync_recovery_decision(invalid)
+        self.assertEqual(decision.category, "invalid_response")
+        self.assertTrue(decision.split_request)
+        self.assertFalse(decision.retry_same_request)
+
+    def test_explicit_category_wins_and_safe_summary_hides_details(self):
+        error = RuntimeError("provider echoed secret-value")
+        error.category = "authentication"
+        error.status_code = 429
+
+        self.assertEqual(sync_error_category(error), "authentication")
+        summary = sync_error_summary(error)
+        self.assertIn("authentication", summary)
+        self.assertNotIn("secret-value", summary)
+
+        error.category = "secret-value"
+        self.assertEqual(sync_error_category(error), "rate_limit")
 
 
 if __name__ == "__main__":

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -348,7 +348,15 @@ class TranslationAbExperimentTests(unittest.TestCase):
             self.assertEqual(len(row['variants']), 2)
             errors = {variant['name']: variant.get('error', '') for variant in row['variants']}
             self.assertEqual(errors['baseline'], '')
-            self.assertIn('sync failed', errors['story_memory'])
+            self.assertEqual(
+                errors['story_memory'],
+                'provider request failed [provider_error]',
+            )
+            categories = {
+                variant['name']: variant.get('error_category', '')
+                for variant in row['variants']
+            }
+            self.assertEqual(categories['story_memory'], 'provider_error')
 
     def test_run_translation_ab_experiment_writes_partial_outputs_on_experiment_failure(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -1667,6 +1667,80 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
             },
         }])
 
+    def test_authentication_failure_is_not_retried_or_split(self):
+        batch = [
+            {
+                'id': f'file:{index}:1',
+                'text': 'Hello',
+                'line': index,
+                'start': 1,
+                'end': 8,
+                'prefix': '',
+                'quote': '"',
+                'progress_entry': f'task:{index}:1',
+            }
+            for index in range(2)
+        ]
+        error = RuntimeError('provider echoed secret-value')
+        error.category = 'authentication'
+        diagnostics = runtime.new_sync_contract_diagnostics()
+        failures = []
+        with (
+            mock.patch.object(runtime, 'call_gemini_sdk', side_effect=error) as call,
+            mock.patch.object(runtime, 'get_random_delay', return_value=0),
+            mock.patch.object(runtime.time, 'sleep'),
+            mock.patch.object(runtime, 'log_failure') as log_failure,
+        ):
+            successful = runtime.process_batch_with_retry(
+                batch,
+                {},
+                contract_diagnostics=diagnostics,
+                contract_failures=failures,
+            )
+
+        self.assertEqual(successful, [])
+        self.assertEqual(call.call_count, 1)
+        self.assertEqual(diagnostics['split_retry_requests'], 0)
+        self.assertEqual(
+            diagnostics['terminal_reason_counts'],
+            {'authentication': 1},
+        )
+        self.assertTrue(all(item['reason_code'] == 'authentication' for item in failures))
+        self.assertTrue(all('secret-value' not in item['message'] for item in failures))
+        self.assertNotIn('secret-value', log_failure.call_args.args[1])
+
+    def test_timeout_retries_are_bounded_and_do_not_split(self):
+        batch = [
+            {
+                'id': f'file:{index}:1',
+                'text': 'Hello',
+                'line': index,
+                'start': 1,
+                'end': 8,
+                'prefix': '',
+                'quote': '"',
+                'progress_entry': f'task:{index}:1',
+            }
+            for index in range(2)
+        ]
+        error = TimeoutError('provider timeout details')
+        diagnostics = runtime.new_sync_contract_diagnostics()
+        with (
+            mock.patch.object(runtime, 'call_gemini_sdk', side_effect=error) as call,
+            mock.patch.object(runtime, 'get_random_delay', return_value=0),
+            mock.patch.object(runtime.time, 'sleep'),
+            mock.patch.object(runtime, 'log_failure'),
+        ):
+            successful = runtime.process_batch_with_retry(
+                batch,
+                {},
+                contract_diagnostics=diagnostics,
+            )
+
+        self.assertEqual(successful, [])
+        self.assertEqual(call.call_count, runtime.BATCH_RETRIES)
+        self.assertEqual(diagnostics['split_retry_requests'], 0)
+
     def test_contract_completeness_excludes_adapter_rejected_items(self):
         batch = [
             {

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -1741,6 +1741,102 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(call.call_count, runtime.BATCH_RETRIES)
         self.assertEqual(diagnostics['split_retry_requests'], 0)
 
+    def test_provider_error_splits_batch_to_rescue_healthy_rows(self):
+        batch = [
+            {
+                'id': f'file:{index}:1',
+                'text': 'Hello',
+                'line': index,
+                'start': 1,
+                'end': 8,
+                'prefix': '',
+                'quote': '"',
+                'progress_entry': f'task:{index}:1',
+            }
+            for index in range(2)
+        ]
+        seen_batches = []
+
+        def fake_call(_prompt, items, **_kwargs):
+            seen_batches.append([item['id'] for item in items])
+            if len(items) > 1:
+                error = RuntimeError('provider content-policy detail')
+                error.status_code = 400
+                raise error
+            return translation_core.validate_model_response(
+                {'translations': [{
+                    'id': items[0]['id'],
+                    'translation': '你好',
+                }]},
+                expected_units=items,
+            )
+
+        diagnostics = runtime.new_sync_contract_diagnostics()
+        failures = []
+        with (
+            mock.patch.object(runtime, 'call_gemini_sdk', side_effect=fake_call),
+            mock.patch.object(runtime, 'get_random_delay', return_value=0),
+            mock.patch.object(runtime.time, 'sleep'),
+            mock.patch.object(runtime, 'log_failure'),
+        ):
+            successful = runtime.process_batch_with_retry(
+                batch,
+                {},
+                contract_diagnostics=diagnostics,
+                contract_failures=failures,
+            )
+
+        self.assertEqual(
+            seen_batches,
+            [['file:0:1', 'file:1:1'], ['file:0:1'], ['file:1:1']],
+        )
+        self.assertEqual(successful, ['task:0:1', 'task:1:1'])
+        self.assertEqual(failures, [])
+        self.assertEqual(diagnostics['split_retry_requests'], 2)
+        self.assertEqual(diagnostics['terminal_reason_counts'], {})
+
+    def test_provider_error_single_row_keeps_safe_manifest_and_log_detail(self):
+        batch = [{
+            'id': 'file:0:1',
+            'text': 'Hello',
+            'line': 0,
+            'start': 1,
+            'end': 8,
+            'prefix': '',
+            'quote': '"',
+            'progress_entry': 'task:0:1',
+        }]
+        error = RuntimeError('provider echoed fixable-detail')
+        error.status_code = 400
+        diagnostics = runtime.new_sync_contract_diagnostics()
+        failures = []
+        with (
+            mock.patch.object(runtime, 'call_gemini_sdk', side_effect=error) as call,
+            mock.patch.object(runtime, 'get_random_delay', return_value=0),
+            mock.patch.object(runtime.time, 'sleep'),
+            mock.patch.object(runtime, 'log_failure') as log_failure,
+        ):
+            successful = runtime.process_batch_with_retry(
+                batch,
+                {},
+                contract_diagnostics=diagnostics,
+                contract_failures=failures,
+            )
+
+        self.assertEqual(successful, [])
+        self.assertEqual(call.call_count, 1)
+        self.assertEqual(diagnostics['split_retry_requests'], 0)
+        self.assertEqual(
+            diagnostics['terminal_reason_counts'],
+            {'request_or_contract_failure': 1},
+        )
+        self.assertTrue(
+            all(item['reason_code'] == 'request_or_contract_failure' for item in failures)
+        )
+        self.assertTrue(all('fixable-detail' not in item['message'] for item in failures))
+        self.assertIn('provider request failed [provider_error]', log_failure.call_args.args[1])
+        self.assertIn('fixable-detail', log_failure.call_args.args[1])
+
     def test_contract_completeness_excludes_adapter_rejected_items(self):
         batch = [
             {

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -15,6 +15,7 @@ from typing import Callable
 import model_usage_ledger
 import story_memory
 import translator_runtime as legacy
+from sync_model_backend import sync_error_category, sync_error_summary
 
 _TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
 EXPERIMENTS_DIR = os.path.join(_TOOL_DIR, 'logs', 'experiments')
@@ -343,7 +344,10 @@ class VariantRunResult:
     settings: dict
     translations: dict[str, str] = field(default_factory=dict)
     usage_metadata: dict = field(default_factory=dict)
+    output_diagnostics: dict = field(default_factory=dict)
+    request_metadata: dict = field(default_factory=dict)
     finish_reason: str = ''
+    error_category: str = ''
     error: str = ''
     dry_run: bool = False
 
@@ -444,6 +448,13 @@ def render_markdown_report(
                 f'finish_reason={result.finish_reason or "(none)"}',
                 f'usage={json.dumps(result.usage_metadata, ensure_ascii=False)}',
             ]
+            if result.output_diagnostics:
+                meta_bits.append(
+                    'output_diagnostics='
+                    + json.dumps(result.output_diagnostics, ensure_ascii=False)
+                )
+            if result.error_category:
+                meta_bits.append(f'error_category={result.error_category}')
             if result.error:
                 meta_bits.append(f'error={result.error}')
             if result.dry_run:
@@ -499,7 +510,10 @@ def write_experiment_outputs(
                                 'settings': result.settings,
                                 'translations': result.translations,
                                 'usage_metadata': result.usage_metadata,
+                                'output_diagnostics': result.output_diagnostics,
+                                'request_metadata': result.request_metadata,
                                 'finish_reason': result.finish_reason,
+                                'error_category': result.error_category,
                                 'error': result.error,
                                 'dry_run': result.dry_run,
                             }
@@ -546,6 +560,13 @@ def run_variant_for_chunk(
 
         runner = sync_runner or _batch().run_sync_request
         response = runner(request_payload, model_name, api_key_index=api_key_index)
+        output_diagnostics = _batch().sync_output_diagnostics(
+            response,
+            request_payload,
+        )
+        request_metadata = model_usage_ledger.normalize_request_metadata(
+            response.get('request_metadata') or {}
+        )
         game_root = str((usage_context or {}).get('game_root') or legacy.BASE_DIR or '')
         if usage_context and game_root:
             try:
@@ -569,6 +590,8 @@ def run_variant_for_chunk(
                         'chunk_key': str(chunk.get('key') or ''),
                         'variant': variant_name,
                     },
+                    response_diagnostics=output_diagnostics,
+                    request_metadata=request_metadata,
                 )
             except Exception as exc:
                 # Accounting must not turn a successful variant into a failure.
@@ -582,14 +605,21 @@ def run_variant_for_chunk(
             settings=settings,
             translations=translations,
             usage_metadata=response.get('usage_metadata') or {},
+            output_diagnostics=output_diagnostics,
+            request_metadata=request_metadata,
             finish_reason=response.get('finish_reason') or '',
             error=parse_error,
+            error_category='invalid_response' if parse_error else '',
         )
     except Exception as exc:
         return VariantRunResult(
             variant_name=variant_name,
             settings=settings,
-            error=str(exc),
+            error=sync_error_summary(exc),
+            error_category=sync_error_category(exc),
+            request_metadata=model_usage_ledger.normalize_request_metadata(
+                getattr(exc, 'request_metadata', None) or {}
+            ),
         )
 
 
@@ -680,6 +710,25 @@ def run_translation_ab_experiment(
         'dry_run': dry_run,
         **output_paths,
     }
+    output_summary = {
+        'completion_tokens': 0,
+        'completion_tokens_known_requests': 0,
+        'reasoning_tokens': 0,
+        'reasoning_tokens_known_requests': 0,
+        'text_output_tokens': 0,
+        'text_output_tokens_known_requests': 0,
+        'reasoning_budget_pressure_count': 0,
+        'truncated_output_count': 0,
+        'output_reason_counts': {},
+    }
+    for chunk_result in chunk_results:
+        for variant_result in chunk_result.variant_results:
+            if variant_result.output_diagnostics:
+                batch_mod.record_sync_output_summary(
+                    output_summary,
+                    variant_result.output_diagnostics,
+                )
+    result['output_summary'] = output_summary
     if experiment_error:
         result['experiment_error'] = experiment_error
     if usage_context.get('errors'):

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -340,6 +340,17 @@ def extract_translation_map(response_text: str, items: list[dict]) -> tuple[dict
 
 @dataclass
 class VariantRunResult:
+    """Store one variant result and its safe synchronization metadata.
+
+    ``output_diagnostics`` holds provider-neutral response-budget facts
+    normalized via ``model_usage_ledger.normalize_response_diagnostics`` and is
+    empty when no response was produced. ``request_metadata`` holds normalized
+    non-secret routing metadata (provider, masked credential identity) and is
+    empty when unavailable. ``error_category`` is set only for categorized
+    request or response failures and is empty on success; the JSONL result
+    contract persists these fields with the same empty-value semantics.
+    """
+
     variant_name: str
     settings: dict
     translations: dict[str, str] = field(default_factory=dict)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -71,6 +71,7 @@ from sync_model_backend import (
     GeminiSyncBackend,
     SyncGenerationRequest,
     normalize_sync_timeout_seconds,
+    sync_error_detail,
     sync_error_summary,
     sync_recovery_decision,
 )
@@ -4689,22 +4690,18 @@ def print_sync_usage_summary(records):
             return 'unknown'
         return str(int(totals.get(field) or 0))
 
-    print(
-        'Sync output tokens: '
-        f"completion={token_value('completion_tokens')} "
-        f"reasoning={token_value('reasoning_tokens')} "
-        f"text={token_value('text_output_tokens')}"
-    )
     diagnostics = totals.get('output_diagnostics')
     diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
-    print(
-        'Reasoning budget warnings: '
-        f"{int(diagnostics.get('reasoning_budget_pressure_records') or 0)}"
-    )
-    print(
-        'Truncated sync responses: '
-        f"{int(diagnostics.get('truncated_records') or 0)}"
-    )
+    for line in model_usage_ledger.format_sync_output_lines(
+        completion=token_value('completion_tokens'),
+        reasoning=token_value('reasoning_tokens'),
+        text_output=token_value('text_output_tokens'),
+        reasoning_budget_pressure=int(
+            diagnostics.get('reasoning_budget_pressure_records') or 0
+        ),
+        truncated=int(diagnostics.get('truncated_records') or 0),
+    ):
+        print(line)
 
 
 def process_batch_with_retry(
@@ -4740,6 +4737,7 @@ def process_batch_with_retry(
     error_str = "" # Initialize variable to be safe
     error_reason_code = ''
     split_reason_counts = {}
+    error_detail = ''
     allow_split = True
 
     for attempt in range(1, BATCH_RETRIES + 1):
@@ -4850,6 +4848,10 @@ def process_batch_with_retry(
             error_reason_code = str(getattr(e, 'reason_code', '') or '')
             if not error_reason_code and recovery.category != 'provider_error':
                 error_reason_code = recovery.category
+            if recovery.category == 'provider_error':
+                # Unknown provider failures keep the original message in the
+                # local failure log; the printed/manifest text stays safe.
+                error_detail = sync_error_detail(e)
             split_reason_code = error_reason_code
             if not split_reason_code and 'Finish reason: 2' in error_str:
                 split_reason_code = 'truncated_output'
@@ -4883,15 +4885,21 @@ def process_batch_with_retry(
             if recovery.split_request or error_reason_code == 'truncated_output':
                 print("  ! Invalid or truncated output. Splitting batch...")
                 break
-            # Authentication, unsupported capability, and unknown provider
-            # errors are not made safer by repeating or splitting the request.
+            # Authentication, unsupported capability, and missing dependency
+            # errors are deterministic; repeating or splitting cannot help.
             if recovery.category in {
                 'authentication',
                 'unsupported_capability',
                 'missing_dependency',
-                'provider_error',
             }:
                 allow_split = False
+                break
+            # Unknown provider errors may be caused by a single problematic
+            # row (400 content policy, gateway hiccup). Splitting isolates the
+            # failing row so healthy lines can still produce output; this
+            # preserves the pre-#340 split rescue for unclassified failures.
+            if recovery.category == 'provider_error':
+                allow_split = True
                 break
 
     # If batch failed after retries, try splitting
@@ -4942,7 +4950,10 @@ def process_batch_with_retry(
         )
         return r1 + r2
 
-    log_failure(batch, f"Failed after retries: {error_str}")
+    log_message = f"Failed after retries: {error_str}"
+    if error_detail and error_detail != error_str:
+        log_message = f"{log_message} | original: {error_detail}"
+    log_failure(batch, log_message)
     if contract_diagnostics is not None:
         terminal_code = error_reason_code or 'request_or_contract_failure'
         terminal_counts = contract_diagnostics.setdefault(

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -71,6 +71,8 @@ from sync_model_backend import (
     GeminiSyncBackend,
     SyncGenerationRequest,
     normalize_sync_timeout_seconds,
+    sync_error_summary,
+    sync_recovery_decision,
 )
 
 # Configuration
@@ -4360,13 +4362,9 @@ def call_gemini_sdk(
     if SYNC_BACKEND == "litellm":
         from litellm_sync_backend import LiteLLMSyncBackend
 
-        result = LiteLLMSyncBackend(
+        backend = LiteLLMSyncBackend(
             custom_providers=CUSTOM_LITELLM_PROVIDERS
-        ).generate(SyncGenerationRequest(
-            model=model_name,
-            contents=prompt,
-            config=generation_config,
-        ))
+        )
     else:
         configure_genai()
         backend = GeminiSyncBackend(
@@ -4376,11 +4374,18 @@ def call_gemini_sdk(
             extract_finish_reason=extract_finish_reason,
             extract_usage=model_usage_ledger.extract_provider_usage,
         )
-        result = backend.generate(SyncGenerationRequest(
+    request = SyncGenerationRequest(
             model=model_name,
             contents=prompt,
             config=generation_config,
-        ))
+        )
+    result = backend.generate(request)
+    output_diagnostics = model_usage_ledger.response_budget_diagnostics(
+        response_text=getattr(result, 'response_text', ''),
+        finish_reason=getattr(result, 'finish_reason', ''),
+        usage_metadata=getattr(result, 'usage_metadata', None) or {},
+        max_output_tokens=generation_config.get("max_output_tokens"),
+    )
 
     if usage_run_id and BASE_DIR:
         item_ids = [str(item.get('id') or '') for item in items]
@@ -4391,7 +4396,7 @@ def call_gemini_sdk(
                 stage='sync_translation',
                 provider=result.provider,
                 model=result.model,
-                usage_metadata=result.usage_metadata,
+                usage_metadata=getattr(result, 'usage_metadata', None) or {},
                 response_payload=result.response_payload,
                 operation_id=usage_operation_id or usage_run_id,
                 run_id=usage_run_id,
@@ -4401,6 +4406,10 @@ def call_gemini_sdk(
                     'kind': 'sync_translation_response',
                     'item_ids': item_ids,
                 },
+                response_diagnostics=output_diagnostics,
+                request_metadata=dict(
+                    getattr(result, 'request_metadata', None) or {}
+                ),
             )
             if usage_buffer is not None:
                 usage_buffer.append(record)
@@ -4442,8 +4451,12 @@ def call_gemini_sdk(
     if result.finish_reason:
         diagnostics.append(f"Finish reason: {result.finish_reason}")
     detail = f" ({'; '.join(diagnostics)})" if diagnostics else ""
+    reason_code = str(
+        output_diagnostics.get('reason_code')
+        or translation_core.CONTRACT_EMPTY_RESPONSE_TEXT
+    )
     raise translation_core.ModelResponseContractError(
-        translation_core.CONTRACT_EMPTY_RESPONSE_TEXT,
+        reason_code,
         f"Invalid response from API. Missing structured text{detail}.",
     )
 
@@ -4667,6 +4680,33 @@ def finalize_sync_contract_diagnostics(diagnostics):
     }
 
 
+def print_sync_usage_summary(records):
+    """Print the stable usage facts consumed by synchronous GUI reports."""
+    totals = model_usage_ledger.aggregate_usage_records(list(records or ()))
+
+    def token_value(field):
+        if int(totals.get(f'{field}_known_records') or 0) <= 0:
+            return 'unknown'
+        return str(int(totals.get(field) or 0))
+
+    print(
+        'Sync output tokens: '
+        f"completion={token_value('completion_tokens')} "
+        f"reasoning={token_value('reasoning_tokens')} "
+        f"text={token_value('text_output_tokens')}"
+    )
+    diagnostics = totals.get('output_diagnostics')
+    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    print(
+        'Reasoning budget warnings: '
+        f"{int(diagnostics.get('reasoning_budget_pressure_records') or 0)}"
+    )
+    print(
+        'Truncated sync responses: '
+        f"{int(diagnostics.get('truncated_records') or 0)}"
+    )
+
+
 def process_batch_with_retry(
     batch,
     replacements,
@@ -4700,6 +4740,7 @@ def process_batch_with_retry(
     error_str = "" # Initialize variable to be safe
     error_reason_code = ''
     split_reason_counts = {}
+    allow_split = True
 
     for attempt in range(1, BATCH_RETRIES + 1):
         try:
@@ -4795,8 +4836,20 @@ def process_batch_with_retry(
             return successful + retried
 
         except Exception as e:
-            error_str = str(e)
+            recovery = sync_recovery_decision(e)
+            is_structured_provider_failure = bool(
+                getattr(e, 'category', '')
+                or getattr(e, 'status_code', None) is not None
+                or recovery.category != 'provider_error'
+            )
+            error_str = (
+                sync_error_summary(e)
+                if is_structured_provider_failure
+                else str(e)
+            )
             error_reason_code = str(getattr(e, 'reason_code', '') or '')
+            if not error_reason_code and recovery.category != 'provider_error':
+                error_reason_code = recovery.category
             split_reason_code = error_reason_code
             if not split_reason_code and 'Finish reason: 2' in error_str:
                 split_reason_code = 'truncated_output'
@@ -4805,48 +4858,44 @@ def process_batch_with_retry(
             }
             print(f"  [Attempt {attempt}] Error: {error_str[:100]}...", flush=True)
 
-            # Handle Specific Errors
-
-            # 1. 429 Resource Exhausted -> Rotate Key AND Model if needed
-            if "429" in error_str or "ResourceExhausted" in error_str:
+            # Handle provider failures by structured recovery category.
+            if recovery.category == 'rate_limit':
                 print("  ! Rate limit hit.")
-
-                # First try rotating key
-                key_rotated = rotate_api_key()
-
-                # If we have retried multiple times (meaning keys are likely all exhausted for this model)
-                # OR we only have 1 key, switch the model.
-                if attempt > 1 or not key_rotated:
-                    print("  ! Persistent rate limit. Switching model...")
-                    if rotate_model():
+                if SYNC_BACKEND == 'gemini':
+                    key_rotated = rotate_api_key()
+                    if attempt > 1 or not key_rotated:
+                        print("  ! Persistent rate limit. Switching model...")
+                        if rotate_model():
+                            continue
+                    if key_rotated:
                         continue
-
-                if key_rotated:
+                if attempt < BATCH_RETRIES:
+                    time.sleep(min(2 ** attempt, 10))
                     continue
-                else:
-                    # No more keys, wait longer
-                    time.sleep(10)
-
-            # 2. 404 Not Found -> Rotate Model (Invalid model name)
-            elif "404" in error_str or "NotFound" in error_str:
-                print("  ! Model not found.")
-                if rotate_model():
+                allow_split = False
+                break
+            if recovery.category in {'service_unavailable', 'timeout'}:
+                if attempt < BATCH_RETRIES:
+                    time.sleep(min(2 ** attempt, 5))
                     continue
-
-            # 3. 500/503 Server Errors -> Just wait
-            elif "500" in error_str or "503" in error_str:
-                time.sleep(5)
-
-            # 4. Truncated/Finish Reason 2 -> Break loop to split batch immediately
-            elif "Finish reason: 2" in error_str:
-                print("  ! Output truncated. Splitting batch...")
-                break # Break retry loop to trigger batch splitting
-
-            # Generic retry backoff
-            time.sleep(2 ** attempt)
+                allow_split = False
+                break
+            if recovery.split_request or error_reason_code == 'truncated_output':
+                print("  ! Invalid or truncated output. Splitting batch...")
+                break
+            # Authentication, unsupported capability, and unknown provider
+            # errors are not made safer by repeating or splitting the request.
+            if recovery.category in {
+                'authentication',
+                'unsupported_capability',
+                'missing_dependency',
+                'provider_error',
+            }:
+                allow_split = False
+                break
 
     # If batch failed after retries, try splitting
-    if len(batch) > 1:
+    if allow_split and len(batch) > 1:
         print("  > Splitting batch...", flush=True)
         mid = len(batch) // 2
         left_batch = batch[:mid]
@@ -5652,6 +5701,7 @@ def run_translation(*, prepare=False):
             "Unresolved contract items: "
             f"{len(finalized_contract.get('unresolved_ids') or [])}"
         )
+        print_sync_usage_summary(usage_buffer)
         contract_partial = bool(
             finalized_contract.get('unresolved_ids')
             or finalized_contract.get('terminal_reason_counts')


### PR DESCRIPTION
## Summary

- make LiteLLM connection checks reasoning-aware with a bounded 64-token JSON contract and safe result reporting
- add provider-neutral sync error categories, bounded recovery, same-provider key rotation, and cancellation race protection
- surface completion, reasoning, and visible-text token diagnostics across the usage ledger, CLI, GUI, project analysis, repair, and A/B flows
- keep Gemini-only thinking options out of incompatible LiteLLM requests and sanitize provider failures at backend boundaries
- update provider smoke coverage and synchronous workflow documentation

## Root cause

The previous connection probe treated any non-throwing request as success and allowed only eight output tokens. Reasoning models could consume that budget without returning visible text. Production sync paths also lacked one shared category-driven recovery contract and could not consistently explain reasoning-heavy empty or truncated responses.

## User impact

- empty, invalid, or mismatched connection responses are now failures instead of false positives
- authentication failures stop immediately; transient failures retry within fixed bounds
- LiteLLM rate limits can rotate only through keys saved for the same provider, with masked identities in diagnostics
- GUI and usage reports distinguish completion, reasoning, and provider-reported visible output tokens
- stopping a CLI-backed task wins over a racing zero exit, so late success cannot enable preview or writeback

## Validation

- `python -B tests/run_cli_tests.py -q` — 1091 passed, 1 skipped
- changed-scope GUI suite — 121 passed
- `python scripts/run_quality_gates.py all` — ruff, mypy, and all configured dependency audits passed
- `git diff --check`
- 205 local links checked across 39 tracked Markdown files

The full GUI runner has seven unrelated environment/baseline failures: six are triggered by the ignored local project configuration auto-starting doctor checks and pass in a clean worktree; the remaining settings-layout assertion also fails on clean `main@a74fd19`.

Closes #340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added completion, reasoning, and text-output token reporting across synchronization, analysis, repair, revision, and experiment summaries.
  - Added warnings for reasoning-budget exhaustion, truncated or empty responses, and unavailable token counts.
  - Improved LiteLLM recovery with bounded retries and limited same-provider key rotation.
- **Bug Fixes**
  - Safer categorized diagnostics now avoid exposing credentials or provider details.
  - Stopping a completed process reliably reports the requested stop.
  - Connection tests distinguish timeouts from service outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->