### PR TITLE
CLI: Add machine-readable parser errors for #296 P0

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -53,7 +53,7 @@ JSON 模式下 stdout 只包含结果文档，原有 banner、进度、prepare �
 
 如果原始参数中包含精确的 `--output json` 或 `--output=json`，但 argparse 在生成参数 Namespace 前失败（例如未知参数、缺少参数值或非法 choice），CLI 会在 stdout 输出一个 schema v1 的错误 envelope：`error.code=ARGUMENT_PARSE_ERROR`，退出码为 `2`，并把原生 argparse usage / error 诊断保留在 stderr。若已识别出合法子命令，envelope 的 `command` 使用该名称；最早期无法识别子命令时使用 `command=cli`。
 
-这种失败发生在 workflow、`--output-file` 安全探测和字段投影之前，因此错误 envelope 始终回退到 stdout，不会尝试写入不完整参数中的输出路径。机器模式的识别边界是有意收窄的：未出现精确 JSON 输出标记（包括 `--strict-exit-codes` 单独出现）、`--output` 缺少值，或 `--output` 使用非 `json` 值时，继续使用普通 argparse 文本错误和退出码 `2`。
+这种失败发生在 workflow、`--output-file` 安全探测和字段投影之前，因此错误 envelope 始终回退到 stdout，不会尝试写入不完整参数中的输出路径。机器模式的识别边界是有意收窄的：未出现精确 JSON 输出标记（包括 `--strict-exit-codes` 单独出现）、`--output` 缺少值，或 `--output` 使用非 `json` 值时，继续使用普通 argparse 文本错误和退出码 `2`。扫描遇到 `--` 后停止；其后的参数全部按 positional 数据处理，不会再触发 JSON 或 `--compact` 识别。
 
 Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`1` 未分类内部错误，`2` 用法错误，`3` 需要处理（例如 `warn`，或 reconciliation 的 `attention`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -49,6 +49,12 @@ python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json -
 
 JSON 模式下 stdout 只包含结果文档，原有 banner、进度、prepare 子进程输出和诊断文本实时进入 stderr。`result` 提供业务摘要，`artifacts` 提供 manifest / results / 报告路径，`status` 表示 job state 或 `safe / warn / block` 等业务状态。文本模式和默认退出码保持兼容；仍须根据 `status` 判断是否可以继续写回。
 
+### Parser-level 错误
+
+如果原始参数中包含精确的 `--output json` 或 `--output=json`，但 argparse 在生成参数 Namespace 前失败（例如未知参数、缺少参数值或非法 choice），CLI 会在 stdout 输出一个 schema v1 的错误 envelope：`error.code=ARGUMENT_PARSE_ERROR`，退出码为 `2`，并把原生 argparse usage / error 诊断保留在 stderr。若已识别出合法子命令，envelope 的 `command` 使用该名称；最早期无法识别子命令时使用 `command=cli`。
+
+这种失败发生在 workflow、`--output-file` 安全探测和字段投影之前，因此错误 envelope 始终回退到 stdout，不会尝试写入不完整参数中的输出路径。机器模式的识别边界是有意收窄的：未出现精确 JSON 输出标记（包括 `--strict-exit-codes` 单独出现）、`--output` 缺少值，或 `--output` 使用非 `json` 值时，继续使用普通 argparse 文本错误和退出码 `2`。
+
 Agent 可追加 `--strict-exit-codes`（必须与 `--output json` 同时使用），启用稳定的语义退出码：`0` 成功/继续轮询，`1` 未分类内部错误，`2` 用法错误，`3` 需要处理（例如 `warn`，或 reconciliation 的 `attention`），`4` 被安全门禁阻止或任务终止失败，`5` 输入/配置/状态失效，`6` 远端临时错误、可稍后重试。例如：
 
 ```powershell

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -61,7 +61,7 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning、
 - 默认退出码仍保持兼容。Agent 可同时传入 `--output json --strict-exit-codes`，让业务状态映射为稳定退出码；严格模式只与 JSON 输出组合使用。
 - 无论是否启用严格退出码，都必须读取 `status`；只有 `check` 的 `status=safe` 才能继续 `apply`。
 
-当 argparse 在生成参数对象前就失败时，只要原始参数包含精确的 `--output json` 或 `--output=json`，stdout 仍会返回一个 schema v1 错误 envelope（`error.code=ARGUMENT_PARSE_ERROR`，退出码 `2`），原生 usage 和诊断保留在 stderr。此阶段尚未解析出完整参数，因此不会使用 `--output-file` 或 `--fields`；未能可靠识别 JSON 意图的最早期语法错误继续使用普通 argparse 文本。
+当 argparse 在生成参数对象前就失败时，只要原始参数包含精确的 `--output json` 或 `--output=json`，stdout 仍会返回一个 schema v1 错误 envelope（`error.code=ARGUMENT_PARSE_ERROR`，退出码 `2`），原生 usage 和诊断保留在 stderr。此阶段尚未解析出完整参数，因此不会使用 `--output-file` 或 `--fields`；未能可靠识别 JSON 意图的最早期语法错误继续使用普通 argparse 文本。原始参数扫描遇到 `--` 后停止，其后的内容只作为 positional 数据处理。
 
 严格退出码约定：
 

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -61,6 +61,8 @@ JSON 模式的 stdout 只包含一个 JSON 文档；banner、进度、warning、
 - 默认退出码仍保持兼容。Agent 可同时传入 `--output json --strict-exit-codes`，让业务状态映射为稳定退出码；严格模式只与 JSON 输出组合使用。
 - 无论是否启用严格退出码，都必须读取 `status`；只有 `check` 的 `status=safe` 才能继续 `apply`。
 
+当 argparse 在生成参数对象前就失败时，只要原始参数包含精确的 `--output json` 或 `--output=json`，stdout 仍会返回一个 schema v1 错误 envelope（`error.code=ARGUMENT_PARSE_ERROR`，退出码 `2`），原生 usage 和诊断保留在 stderr。此阶段尚未解析出完整参数，因此不会使用 `--output-file` 或 `--fields`；未能可靠识别 JSON 意图的最早期语法错误继续使用普通 argparse 文本。
+
 严格退出码约定：
 
 | 退出码 | 含义 | 常见场景 |

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -15220,9 +15220,135 @@ def run_machine_command(parser, args):
     return 0
 
 
+def _machine_output_requested(argv):
+    """Return whether raw CLI arguments explicitly request JSON output."""
+
+    tokens = [str(value) for value in argv]
+    for index, token in enumerate(tokens):
+        if token == '--output=json':
+            return True
+        if (
+            token == '--output'
+            and index + 1 < len(tokens)
+            and tokens[index + 1] == 'json'
+        ):
+            return True
+    return False
+
+
+def _parser_command_choices(parser):
+    """Return current root parser subcommand names without duplicating them."""
+
+    for action in getattr(parser, '_actions', []):
+        if getattr(action, 'dest', '') != 'command':
+            continue
+        choices = getattr(action, 'choices', None)
+        if isinstance(choices, dict):
+            return set(choices)
+    return set()
+
+
+def _infer_machine_parse_command(parser, argv):
+    """Identify the requested command when argparse failed before a Namespace exists."""
+
+    choices = _parser_command_choices(parser)
+    for raw_value in argv:
+        value = str(raw_value)
+        if value == '--':
+            break
+        if value in choices:
+            return value
+    return 'cli'
+
+
+def _argparse_error_message(diagnostics):
+    """Extract argparse's concise error line for the machine envelope."""
+
+    for line in reversed(str(diagnostics or '').splitlines()):
+        marker = 'error:'
+        marker_index = line.lower().find(marker)
+        if marker_index >= 0:
+            message = line[marker_index + len(marker):].strip()
+            if message:
+                return message
+    return 'Invalid command-line arguments.'
+
+
+def _machine_parse_error_args(parser, argv):
+    """Build the minimal output options available before argparse succeeds."""
+
+    tokens = {str(value) for value in argv}
+    return argparse.Namespace(
+        command=_infer_machine_parse_command(parser, argv),
+        output='json',
+        strict_exit_codes='--strict-exit-codes' in tokens,
+        compact='--compact' in tokens,
+        fields=[],
+        # Parser failure happens before output-file safety checks. Always use
+        # stdout so an untrusted or incomplete argument list cannot overwrite
+        # a path while reporting its own syntax error.
+        output_file='',
+    )
+
+
+def _write_machine_parse_error(parser, argv, exc, diagnostics):
+    """Emit a schema-v1 usage envelope after a machine-mode parse failure."""
+
+    if diagnostics:
+        sys.stderr.write(diagnostics)
+        sys.stderr.flush()
+
+    args = _machine_parse_error_args(parser, argv)
+    exit_code = exc.code if isinstance(exc.code, int) else cli_contract.EXIT_USAGE
+    envelope = cli_contract.error_envelope(
+        args.command,
+        code='ARGUMENT_PARSE_ERROR',
+        message=_argparse_error_message(diagnostics),
+        suggested_action='fix_command_arguments',
+        details={
+            'parser': parser.prog,
+            'exit_code': exit_code,
+            'semantic_exit_code': cli_contract.EXIT_USAGE,
+            'workflow_started': False,
+            'command_completed': False,
+        },
+    )
+    _write_machine_document(
+        envelope,
+        args,
+        record_output_artifact=False,
+        command_completed=False,
+        workflow_started=False,
+    )
+    return cli_contract.EXIT_USAGE
+
+
 def main(argv=None):
     parser = build_arg_parser()
-    args = parser.parse_args(argv)
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    machine_output_requested = _machine_output_requested(raw_argv)
+    parser_diagnostics = io.StringIO()
+    try:
+        if machine_output_requested:
+            with contextlib.redirect_stderr(parser_diagnostics):
+                args = parser.parse_args(raw_argv)
+        else:
+            args = parser.parse_args(raw_argv)
+    except SystemExit as exc:
+        if not machine_output_requested:
+            raise
+        if exc.code in (None, 0):
+            diagnostics = parser_diagnostics.getvalue()
+            if diagnostics:
+                sys.stderr.write(diagnostics)
+                sys.stderr.flush()
+            raise
+        return _write_machine_parse_error(
+            parser,
+            raw_argv,
+            exc,
+            parser_diagnostics.getvalue(),
+        )
     output = getattr(args, 'output', 'text')
     json_only_options = []
     if getattr(args, 'strict_exit_codes', False):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -15220,10 +15220,22 @@ def run_machine_command(parser, args):
     return 0
 
 
+def _machine_option_tokens(argv):
+    """Return raw CLI tokens before the ``--`` positional-argument sentinel."""
+
+    tokens = []
+    for value in argv:
+        token = str(value)
+        if token == '--':
+            break
+        tokens.append(token)
+    return tokens
+
+
 def _machine_output_requested(argv):
     """Return whether raw CLI arguments explicitly request JSON output."""
 
-    tokens = [str(value) for value in argv]
+    tokens = _machine_option_tokens(argv)
     for index, token in enumerate(tokens):
         if token == '--output=json':
             return True
@@ -15252,10 +15264,7 @@ def _infer_machine_parse_command(parser, argv):
     """Identify the requested command when argparse failed before a Namespace exists."""
 
     choices = _parser_command_choices(parser)
-    for raw_value in argv:
-        value = str(raw_value)
-        if value == '--':
-            break
+    for value in _machine_option_tokens(argv):
         if value in choices:
             return value
     return 'cli'
@@ -15277,7 +15286,7 @@ def _argparse_error_message(diagnostics):
 def _machine_parse_error_args(parser, argv):
     """Build the minimal output options available before argparse succeeds."""
 
-    tokens = {str(value) for value in argv}
+    tokens = set(_machine_option_tokens(argv))
     return argparse.Namespace(
         command=_infer_machine_parse_command(parser, argv),
         output='json',

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -170,6 +170,60 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertNotIn("\n  ", stdout.getvalue())
         self.assertTrue(stdout.getvalue().endswith("\n"))
 
+    def test_parser_error_with_json_output_reports_missing_option_value(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(["status", "--output", "json", "--fields"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["command"], "status")
+        self.assertEqual(payload["error"]["code"], "ARGUMENT_PARSE_ERROR")
+        self.assertIn("argument --fields", payload["error"]["message"])
+        self.assertIn("argument --fields", stderr.getvalue())
+
+    def test_machine_option_detection_stops_at_double_dash(self):
+        text_stdout = io.StringIO()
+        text_stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(text_stdout),
+            contextlib.redirect_stderr(text_stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            batch.main(["status", "--", "--output", "json"])
+
+        self.assertEqual(raised.exception.code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(text_stdout.getvalue(), "")
+        self.assertIn("usage:", text_stderr.getvalue())
+
+        machine_stdout = io.StringIO()
+        machine_stderr = io.StringIO()
+        with (
+            contextlib.redirect_stdout(machine_stdout),
+            contextlib.redirect_stderr(machine_stderr),
+        ):
+            exit_code = batch.main(
+                [
+                    "status",
+                    "--output",
+                    "json",
+                    "--",
+                    "--compact",
+                    "--unknown-flag",
+                ]
+            )
+
+        payload = json.loads(machine_stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "ARGUMENT_PARSE_ERROR")
+        self.assertIn("\n  ", machine_stdout.getvalue())
+
     def test_earliest_machine_parse_error_uses_generic_cli_command(self):
         stdout = io.StringIO()
         stderr = io.StringIO()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -125,6 +125,94 @@ class BatchCliContractTests(unittest.TestCase):
             batch.cli_contract.EXIT_USAGE,
         )
 
+    def test_parser_error_with_json_output_returns_structured_usage_error(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                ["status", "--output", "json", "--unknown-flag"]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["schema_version"], batch.cli_contract.CLI_SCHEMA_VERSION)
+        self.assertEqual(payload["command"], "status")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["code"], "ARGUMENT_PARSE_ERROR")
+        self.assertIn("unrecognized arguments: --unknown-flag", payload["error"]["message"])
+        self.assertEqual(
+            payload["error"]["details"]["semantic_exit_code"],
+            batch.cli_contract.EXIT_USAGE,
+        )
+        self.assertFalse(payload["error"]["details"]["workflow_started"])
+        self.assertIn("usage:", stderr.getvalue())
+        self.assertIn("unrecognized arguments: --unknown-flag", stderr.getvalue())
+
+    def test_parser_error_supports_equals_json_form_and_compact_output(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(
+                ["status", "--output=json", "--compact", "--unknown-flag"]
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["error"]["code"], "ARGUMENT_PARSE_ERROR")
+        self.assertNotIn("\n  ", stdout.getvalue())
+        self.assertTrue(stdout.getvalue().endswith("\n"))
+
+    def test_earliest_machine_parse_error_uses_generic_cli_command(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            exit_code = batch.main(["--output", "json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(payload["command"], "cli")
+        self.assertEqual(payload["error"]["code"], "ARGUMENT_PARSE_ERROR")
+
+    def test_non_json_output_value_stays_on_text_argparse_boundary(self):
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            batch.main(["status", "--output", "xml"])
+
+        self.assertEqual(raised.exception.code, batch.cli_contract.EXIT_USAGE)
+        self.assertIn("invalid choice", stderr.getvalue())
+
+    def test_text_parser_error_preserves_argparse_system_exit(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            batch.main(["status", "--unknown-flag"])
+
+        self.assertEqual(raised.exception.code, batch.cli_contract.EXIT_USAGE)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("usage:", stderr.getvalue())
+        self.assertIn("unrecognized arguments: --unknown-flag", stderr.getvalue())
+
     def test_field_projection_does_not_change_strict_exit_code(self):
         manifest = {
             "_manifest_path": "C:/jobs/demo/manifest.json",


### PR DESCRIPTION
## Summary

- Capture parser-level argparse failures when the raw invocation explicitly contains `--output json` or `--output=json`.
- Emit a schema v1 `ARGUMENT_PARSE_ERROR` envelope on stdout while preserving argparse usage and diagnostics on stderr.
- Preserve the existing human-readable argparse behavior for text mode and document the early machine-intent boundary.
- Add contract coverage for unknown arguments, missing values, compact output, earliest parse failures, and text-mode compatibility.

## Root cause

`main()` called `parser.parse_args()` before entering the existing machine-output wrapper, so parser-level failures exited before a JSON envelope could be produced.

## Validation

- `python -m unittest tests.test_gemini_translate_batch_cli_contract tests.test_cli_contract tests.test_cli_discovery -q` — 60 passed
- `python -B tests/run_cli_tests.py -q` — 1124 passed, 1 skipped
- `python -m unittest tests.test_gui_cli_runner tests.test_gui_diagnostics_context tests.test_gui_check_report -q` — 66 passed
- `python scripts/run_quality_gates.py all` — all blocking gates passed
- `git diff --check` — passed
- Full GUI suite: 1068 tests, with 7 existing failures in unmodified page-gate/settings-layout tests; these are recorded separately and are unrelated to the parser changes.

P0 only; revision/keyword/final-review machine output remains for the later P1 scope.

Refs #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured JSON error responses for command-line parsing failures when JSON output is explicitly requested.
  * JSON errors include schema version, details, exit status, and the detected command when available.
  * Supports both `--output json` and `--output=json`, including compact formatting.

* **Bug Fixes**
  * Preserved standard text-based parsing errors for malformed or incomplete output options and unknown arguments.
  * Parser diagnostics and usage information remain available on stderr.

* **Documentation**
  * Updated batch workflow and quickstart documentation with JSON parsing error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->