### PR TITLE
feat(revision): import structured polish proposals safely

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -222,6 +222,14 @@ def strict_exit_code(envelope: Mapping[str, Any]) -> int:
         if status == "attention":
             return EXIT_NEEDS_ACTION
         return EXIT_INVALID_STATE
+    if command == "import-revision-proposals":
+        if status in {"previewed", "no_op", "imported"}:
+            return EXIT_OK
+        if status == "partial":
+            return EXIT_NEEDS_ACTION
+        if status in {"blocked", "stale"}:
+            return EXIT_BLOCKED
+        return EXIT_INVALID_STATE
     if command in {"submit", "status"} and status in {
         "failed",
         "cancelled",

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -303,14 +303,17 @@ python gemini_translate_batch.py import-revision-proposals C:/review/proposals.j
   "selected": true,
   "disposition": "accepted",
   "producer": {"type": "human", "tool": "optional", "model": "optional"},
+  "project_identity": {"tl_dir": "C:/game/tl/schinese"},
   "snapshot_digest": "该条 source/current_translation 的导出摘要",
   "corpus_snapshot_digest": "revision_corpus_manifest.json 的 source.snapshot_digest"
 }
 ```
 
 `producer.type` 只接受 `human` / `agent`。若 proposal 同目录存在
-`revision_corpus_manifest.json`，可省略逐行 `corpus_snapshot_digest`；也可用
-`--corpus-manifest` 显式指定。未知/重复/冲突 identity、项目或语料快照 stale、
+`revision_corpus_manifest.json`，可省略逐行 `project_identity` 和
+`corpus_snapshot_digest`；也可用 `--corpus-manifest` 显式指定。没有配套 manifest
+时，每条选中提案必须携带与当前项目匹配的 `project_identity.tl_dir`。未知/重复/冲突
+identity、项目或语料快照 stale、
 source/current translation 变化、空建议、Ren'Py 标签/变量破坏、adapter 校验失败或
 不安全写回计划都不会获得写回资格。
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -275,6 +275,51 @@ python gemini_translate_batch.py export-revision-corpus --output json
 - 只读：不修改 `.rpy`、manifest、glossary 或 RAG；机器输出可用
   `--output json`（envelope 含三个产物路径与 item/file 计数）。
 
+### 导入人工 / Agent 润色提案
+
+权威输入必须是结构化 JSONL；自由格式 Markdown 只能作为伴生审阅报告。导入会把
+通过校验的提案转换成标准 `mode=revision` 本地候选包，并立即运行
+`preview-revisions`，自身绝不修改 `.rpy`：
+
+```powershell
+python gemini_translate_batch.py import-revision-proposals C:/review/proposals.jsonl
+python gemini_translate_batch.py import-revision-proposals C:/review/proposals.jsonl `
+  --corpus-manifest C:/review/revision_corpus_manifest.json `
+  --output json --strict-exit-codes --non-interactive
+```
+
+每行 proposal schema v1 至少包含：
+
+```json
+{
+  "schema_version": 1,
+  "occurrence_id": "identity-v2-value",
+  "identity_v2": "identity-v2-value",
+  "file_rel_path": "chapter01/revisions.rpy",
+  "source": "原文",
+  "current_translation": "当前译文",
+  "proposed_translation": "建议译文",
+  "reason": "修改理由",
+  "selected": true,
+  "disposition": "accepted",
+  "producer": {"type": "human", "tool": "optional", "model": "optional"},
+  "snapshot_digest": "该条 source/current_translation 的导出摘要",
+  "corpus_snapshot_digest": "revision_corpus_manifest.json 的 source.snapshot_digest"
+}
+```
+
+`producer.type` 只接受 `human` / `agent`。若 proposal 同目录存在
+`revision_corpus_manifest.json`，可省略逐行 `corpus_snapshot_digest`；也可用
+`--corpus-manifest` 显式指定。未知/重复/冲突 identity、项目或语料快照 stale、
+source/current translation 变化、空建议、Ren'Py 标签/变量破坏、adapter 校验失败或
+不安全写回计划都不会获得写回资格。
+
+状态固定区分 `imported`（内部导入阶段）、`previewed`、`no_op`、`partial`、
+`blocked`、`stale`。机器 envelope 同时返回稳定 `status`、diagnostics、artifacts 和
+`suggested_action`；严格退出码下 `partial` 为“需处理”，`blocked/stale` 为“阻断”。
+只有 `previewed/no_op` manifest 能进入 `apply-revisions`，`--force` 不能绕过此闸门，
+也不能绕过 preview/result hash、项目身份、源快照或 adapter writeback 校验。
+
 ## 项目版本快照与只读 reconciliation
 
 本节对应 `#265` P3 / `#330`，增加两个不调用模型、不要求 API Key 的高级命令：

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -309,9 +309,12 @@ python gemini_translate_batch.py import-revision-proposals C:/review/proposals.j
 }
 ```
 
+`source`、`current_translation`、`proposed_translation` 和 `reason` 必须是字符串；
+`snapshot_digest` 与 `item_snapshot_digest` 只填一个，或同时填写且必须一致。
 `producer.type` 只接受 `human` / `agent`。若 proposal 同目录存在
 `revision_corpus_manifest.json`，可省略逐行 `project_identity` 和
-`corpus_snapshot_digest`；也可用 `--corpus-manifest` 显式指定。没有配套 manifest
+`corpus_snapshot_digest`；也可用 `--corpus-manifest` 显式指定，此时 manifest 的
+`source.snapshot_digest` 必须是非空字符串。没有配套 manifest
 时，每条选中提案必须携带与当前项目匹配的 `project_identity.tl_dir`。未知/重复/冲突
 identity、项目或语料快照 stale、
 source/current translation 变化、空建议、Ren'Py 标签/变量破坏、adapter 校验失败或

--- a/docs/quickstart_gui.md
+++ b/docs/quickstart_gui.md
@@ -91,6 +91,12 @@ doctor -> build -> submit -> status -> download -> check -> apply
 
 只有最近一次 `check` 与当前任务结果匹配且结论为 `safe` 时，GUI 才允许执行 `apply`。这里的 `safe` 只表示源快照、身份、占位符和标签等结构条件满足写回合同，**不代表译文内容已经达到交付质量**。
 
+如需导入人工或 Agent 润色建议，打开左侧「订正」，点击「导入润色提案」并选择
+schema v1 JSONL。GUI 会在本地校验 occurrence identity、语料/项目快照、当前译文、
+Ren'Py 标签变量和 adapter 写回计划，然后生成订正预览；导入步骤不会修改 `.rpy`。
+只有状态为 `previewed` 的提案包才会开放「写回订正」。完整字段合同见
+[Batch 工作流与安全检查](batch_workflows.md#导入人工--agent-润色提案)。
+
 ## 6. 写回后
 
 - 检查目标语言目录中的改动，并在 Ren'Py 中运行 lint 或实际启动游戏验证。

--- a/docs/quickstart_gui.md
+++ b/docs/quickstart_gui.md
@@ -94,6 +94,8 @@ doctor -> build -> submit -> status -> download -> check -> apply
 如需导入人工或 Agent 润色建议，打开左侧「订正」，点击「导入润色提案」并选择
 schema v1 JSONL。GUI 会在本地校验 occurrence identity、语料/项目快照、当前译文、
 Ren'Py 标签变量和 adapter 写回计划，然后生成订正预览；导入步骤不会修改 `.rpy`。
+若配套 `revision_corpus_manifest.json` 不在 proposal 同目录，可在随后出现的可选文件
+对话框中指定；若没有 manifest，可取消并由逐行项目身份与快照字段完成校验。
 只有状态为 `previewed` 的提案包才会开放「写回订正」。完整字段合同见
 [Batch 工作流与安全检查](batch_workflows.md#导入人工--agent-润色提案)。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -58,6 +58,7 @@ import keyword_glossary_merge
 import model_usage_ledger
 import prompt_context
 import revision_corpus
+import revision_proposals
 import translation_ab_experiment
 import story_memory
 import translation_core
@@ -113,6 +114,7 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'apply',
         'apply-revisions',
         'export-revision-corpus',
+        'import-revision-proposals',
         'export-project-snapshot',
         'reconcile-project-snapshots',
     }
@@ -127,6 +129,7 @@ OFFLINE_BATCH_COMMANDS = frozenset(
         'preview-revisions',
         'apply-revisions',
         'export-revision-corpus',
+        'import-revision-proposals',
         'export-project-snapshot',
         'reconcile-project-snapshots',
         'split',
@@ -3962,6 +3965,285 @@ def create_revision_package(display_name_override='', skip_prepare=False, chunk_
         for warning_text in build_warnings:
             print(f'- {warning_text}')
     return manifest_path
+
+
+def _proposal_import_report_markdown(report):
+    lines = [
+        '# Revision Proposal Import',
+        '',
+        f"- Status: {report.get('status') or 'unknown'}",
+        f"- Input rows: {report.get('input_count', 0)}",
+        f"- Selected rows: {report.get('selected_count', 0)}",
+        f"- Candidate rows: {report.get('candidate_count', 0)}",
+        '',
+    ]
+    diagnostics = list(report.get('diagnostics') or [])
+    if diagnostics:
+        lines.extend(['## Diagnostics', ''])
+        for item in diagnostics:
+            lines.append(
+                f"- `{item.get('code') or 'UNKNOWN'}` row {item.get('row') or '-'}: "
+                f"{item.get('message') or ''}"
+            )
+    return '\n'.join(lines) + '\n'
+
+
+def _write_proposal_import_report(package_dir, report):
+    json_path = os.path.join(package_dir, 'proposal_import_report.json')
+    markdown_path = os.path.join(package_dir, 'proposal_import_report.md')
+    atomic_write_json(json_path, report, ensure_ascii=False, indent=2)
+    atomic_write_text(markdown_path, _proposal_import_report_markdown(report))
+    return {'import_report': json_path, 'import_report_markdown': markdown_path}
+
+
+def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
+    """Import structured proposals into the existing revision preview gate.
+
+    The command is local-only and never writes ``.rpy``.  Invalid structural or
+    stale input produces an auditable report but no revision manifest.  Valid
+    candidates are encoded as ordinary revision results and immediately
+    previewed by ``preview_revisions``.
+    """
+    proposal_path = os.path.abspath(str(proposal_path or '').strip())
+    if not proposal_path or not os.path.isfile(proposal_path):
+        raise cli_contract.MachineContractError(
+            f'Proposal JSONL not found: {proposal_path or "(missing)"}',
+            code_name='PROPOSAL_FILE_NOT_FOUND',
+            suggested_action='pass_existing_proposal_jsonl',
+            semantic_exit_code=cli_contract.EXIT_USAGE,
+        )
+    try:
+        rows = revision_proposals.load_jsonl(proposal_path)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise cli_contract.MachineContractError(
+            f'Invalid proposal JSONL: {exc}',
+            code_name='PROPOSAL_JSONL_INVALID',
+            suggested_action='fix_proposal_jsonl',
+            semantic_exit_code=cli_contract.EXIT_INVALID_STATE,
+        ) from exc
+    resolved_corpus_manifest = revision_proposals.find_corpus_manifest(
+        proposal_path,
+        corpus_manifest_path,
+    )
+    corpus_manifest = None
+    if resolved_corpus_manifest:
+        try:
+            corpus_manifest = revision_proposals.load_corpus_manifest(
+                resolved_corpus_manifest
+            )
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise cli_contract.MachineContractError(
+                f'Invalid revision corpus manifest: {exc}',
+                code_name='CORPUS_MANIFEST_INVALID',
+                suggested_action='pass_matching_revision_corpus_manifest',
+                semantic_exit_code=cli_contract.EXIT_INVALID_STATE,
+            ) from exc
+
+    file_paths = list(collect_files_to_process())
+    file_path_map = {rel_path: file_path for rel_path, file_path in file_paths}
+    digests_before = revision_corpus.collect_file_digests(file_path_map)
+    live_jobs = collect_revision_file_jobs(file_paths=file_paths, include_empty_files=True)
+    digests_after = revision_corpus.collect_file_digests(file_path_map)
+    live_snapshot_digest = revision_corpus.aggregate_digest(digests_before)
+    live_items = {
+        str(item.get('id') or ''): item
+        for job in live_jobs
+        for item in (job.get('items') or [])
+    }
+    validation = revision_proposals.validate(
+        rows,
+        live_items,
+        live_snapshot_digest=live_snapshot_digest,
+        corpus_manifest=corpus_manifest,
+    )
+    diagnostics = [dict(item) for item in validation.diagnostics]
+    if digests_before != digests_after:
+        diagnostics.append({
+            'code': 'LIVE_SOURCE_CHANGED_DURING_IMPORT',
+            'message': 'live project files changed while proposals were being imported',
+            'row': 0,
+            'occurrence_id': '',
+        })
+    if corpus_manifest:
+        project = corpus_manifest.get('project') or {}
+        corpus_tl_dir = str(project.get('tl_dir') or '')
+        if corpus_tl_dir and _normalized_abs_path(corpus_tl_dir) != _normalized_abs_path(legacy.TL_DIR):
+            diagnostics.append({
+                'code': 'CORPUS_PROJECT_MISMATCH',
+                'message': 'corpus project identity does not match the active project',
+                'row': 0,
+                'occurrence_id': '',
+            })
+
+    stamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+    package_dir = create_batch_package_dir(
+        f'{stamp}_{guess_project_slug()}_revision_proposals'
+    )
+    status = validation.status
+    if any(item.get('code') in {
+        'CORPUS_SNAPSHOT_STALE', 'ITEM_SNAPSHOT_STALE',
+        'CURRENT_TRANSLATION_STALE', 'LIVE_SOURCE_CHANGED_DURING_IMPORT',
+    } for item in diagnostics):
+        status = 'stale'
+    elif diagnostics:
+        status = 'blocked'
+    report = {
+        'schema_version': revision_proposals.IMPORT_REPORT_SCHEMA_VERSION,
+        'kind': 'revision_proposal_import',
+        'status': status,
+        'proposal_path': proposal_path,
+        'corpus_manifest_path': resolved_corpus_manifest,
+        'live_snapshot_digest': live_snapshot_digest,
+        'input_count': validation.input_count,
+        'selected_count': validation.selected_count,
+        'candidate_count': len(validation.proposals),
+        'diagnostics': diagnostics,
+        'suggested_action': (
+            're_export_corpus_and_regenerate_proposals'
+            if status == 'stale'
+            else 'fix_proposal_diagnostics'
+            if status == 'blocked'
+            else 'inspect_revision_preview'
+        ),
+    }
+    artifacts = _write_proposal_import_report(package_dir, report)
+    if diagnostics or not validation.proposals:
+        print(f'Revision proposal import status: {status}')
+        print(f'Import report: {artifacts["import_report"]}')
+        return {**report, 'paths': {'output_dir': package_dir, **artifacts}}
+
+    selected_by_identity = {
+        str(row['identity_v2']): row for row in validation.proposals
+    }
+    filtered_jobs = []
+    for job in live_jobs:
+        items = [
+            item for item in (job.get('items') or [])
+            if str(item.get('id') or '') in selected_by_identity
+        ]
+        if items:
+            filtered_jobs.append({**job, 'items': items, 'task_count': len(items)})
+    chunks = build_revision_chunks(filtered_jobs, chunk_size=REVISION_CHUNK_SIZE)
+    requests_path = os.path.join(package_dir, 'requests.jsonl')
+    results_path = os.path.join(package_dir, 'results.jsonl')
+    atomic_write_text(requests_path, '')
+    result_rows = []
+    for chunk in chunks:
+        results = []
+        for item in chunk['items']:
+            proposal = selected_by_identity[str(item.get('id') or '')]
+            proposed = str(proposal.get('proposed_translation') or '').strip()
+            results.append({
+                'id': item['id'],
+                'should_update': compact_text(proposed) != compact_text(item.get('current_translation') or ''),
+                'revised_translation': proposed,
+                'reason': str(proposal.get('reason') or '').strip() or 'Imported revision proposal',
+            })
+        result_rows.append({
+            'key': chunk['key'],
+            'response': {'candidates': [{
+                'content': {'parts': [{'text': json.dumps(results, ensure_ascii=False)}]},
+                'finishReason': 'STOP',
+            }]},
+        })
+    atomic_write_jsonl(results_path, result_rows, ensure_ascii=False)
+    manifest = {
+        'version': 2,
+        'manifest_version': 2,
+        'core_schema_version': 2,
+        'mode': MANIFEST_MODE_REVISION,
+        'execution': 'proposal_import',
+        'created_at': datetime.now().isoformat(timespec='seconds'),
+        'display_name': f'{REVISION_DISPLAY_NAME_PREFIX}-{guess_project_slug()}-{stamp}',
+        'batch_model': '',
+        'base_dir': legacy.BASE_DIR,
+        'tl_dir': legacy.TL_DIR,
+        **_manifest_target_language_fields(),
+        **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
+        'input_jsonl_path': requests_path,
+        'result_jsonl_path': results_path,
+        'job_name': '',
+        'job_state': 'LOCAL_CANDIDATES',
+        'submit_disabled': True,
+        'settings': {'revision_chunk_size': REVISION_CHUNK_SIZE},
+        'revision_settings': {
+            'chunk_size': REVISION_CHUNK_SIZE,
+            'candidate_source': 'revision_proposals',
+        },
+        'summary': {
+            'file_count': len(filtered_jobs),
+            'chunk_count': len(chunks),
+            'item_count': sum(len(chunk['items']) for chunk in chunks),
+            'proposal_count': len(validation.proposals),
+        },
+        'files': {
+            job['file_rel_path']: {
+                'path': job['file_path'],
+                'task_count': job['task_count'],
+            }
+            for job in filtered_jobs
+        },
+        'chunks': chunks,
+        'proposal_import': {
+            'schema_version': revision_proposals.PROPOSAL_SCHEMA_VERSION,
+            'status': 'imported',
+            'history': ['imported'],
+            'writeback_eligible': False,
+            'proposal_path': proposal_path,
+            'proposal_sha256': _sha256_file(proposal_path),
+            'corpus_manifest_path': resolved_corpus_manifest,
+            'corpus_snapshot_digest': live_snapshot_digest,
+            'report_path': artifacts['import_report'],
+        },
+    }
+    manifest_path = os.path.join(package_dir, 'manifest.json')
+    atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+    remember_latest_manifest(manifest_path)
+    previewed = preview_revisions(manifest_path)
+    preview_summary = dict((previewed.get('last_revision_preview') or {}).get('summary') or {})
+    failures = int(preview_summary.get('failure_items') or 0)
+    candidates = int(preview_summary.get('valid_items') or 0)
+    unchanged = int(preview_summary.get('unchanged_items') or 0)
+    if failures and candidates:
+        final_status = 'partial'
+    elif failures:
+        final_status = 'blocked'
+    elif candidates:
+        final_status = 'previewed'
+    elif unchanged:
+        final_status = 'no_op'
+    else:
+        final_status = 'blocked'
+    proposal_state = dict(previewed.get('proposal_import') or {})
+    proposal_state['status'] = final_status
+    proposal_state['history'] = ['imported', final_status]
+    proposal_state['writeback_eligible'] = final_status in {'previewed', 'no_op'}
+    previewed['proposal_import'] = proposal_state
+    previewed['last_revision_preview']['manifest_identity'] = _revision_manifest_identity(previewed)
+    report.update({
+        'status': final_status,
+        'preview_summary': preview_summary,
+        'suggested_action': (
+            'run_apply_revisions' if final_status == 'previewed'
+            else 'no_writeback_needed' if final_status == 'no_op'
+            else 'fix_preview_diagnostics_and_reimport'
+        ),
+    })
+    _write_proposal_import_report(package_dir, report)
+    save_manifest(previewed, update_latest=True)
+    print(f'Revision proposal import status: {final_status}')
+    print(f'Manifest: {manifest_path}')
+    return {
+        **report,
+        'manifest': previewed,
+        'paths': {
+            'output_dir': package_dir,
+            'manifest': manifest_path,
+            'revision_preview_jsonl': previewed['last_revision_preview']['jsonl_path'],
+            'revision_preview_markdown': previewed['last_revision_preview']['markdown_path'],
+            **artifacts,
+        },
+    }
 
 
 def _flatten_revision_items(file_jobs):
@@ -8197,7 +8479,7 @@ def _revision_manifest_identity(manifest):
         'base_dir', 'tl_dir', 'target_language', 'language',
         'input_jsonl_path', 'result_jsonl_path',
         'settings', 'revision_settings',
-        'summary', 'files', 'chunks', 'final_review_source',
+        'summary', 'files', 'chunks', 'final_review_source', 'proposal_import',
     )
     payload = {key: manifest.get(key) for key in keys}
     return hashlib.sha256(
@@ -8243,6 +8525,16 @@ def _require_valid_revision_preview(manifest):
     ``--force`` deliberately does not bypass preview staleness, project identity
     or source snapshot checks: it only bypasses the already-applied guard.
     """
+    proposal_import = manifest.get('proposal_import')
+    if isinstance(proposal_import, dict) and (
+        not proposal_import.get('writeback_eligible')
+        or proposal_import.get('status') not in {'previewed', 'no_op'}
+    ):
+        _mark_revision_apply_blocked(
+            manifest,
+            'proposal_import_not_eligible',
+            'proposal import is blocked, partial, stale, or not previewed; re-import valid proposals.',
+        )
     preview = manifest.get('last_revision_preview')
     if (
         not isinstance(preview, dict)
@@ -13043,6 +13335,27 @@ def build_arg_parser():
     )
     add_machine_output_argument(export_revision_corpus_parser)
 
+    import_revision_proposals_parser = subparsers.add_parser(
+        'import-revision-proposals',
+        help=(
+            'Validate structured human/Agent proposal JSONL against the live project, '
+            'build a local revision package, and run preview-revisions. Never writes .rpy.'
+        ),
+    )
+    import_revision_proposals_parser.add_argument(
+        'proposal',
+        help='Proposal JSONL path (schema_version=1, identity_v2, snapshots, provenance).',
+    )
+    import_revision_proposals_parser.add_argument(
+        '--corpus-manifest',
+        default='',
+        help=(
+            'Companion revision_corpus_manifest.json. Defaults to the proposal file directory '
+            'when present.'
+        ),
+    )
+    add_machine_output_argument(import_revision_proposals_parser)
+
     export_project_snapshot_parser = subparsers.add_parser(
         'export-project-snapshot',
         help=(
@@ -14248,6 +14561,17 @@ def dispatch_command(parser, args):
             getattr(args, 'output_dir', '') or None,
         )
 
+    if command == 'import-revision-proposals':
+        # Local candidate conversion and preview only: no provider/API setup,
+        # prepare command, or game-file write is allowed here.
+        legacy.load_translator_settings(persist_corrected_game_root=False)
+        legacy.load_glossary()
+        load_batch_settings()
+        return import_revision_proposals(
+            args.proposal,
+            corpus_manifest_path=args.corpus_manifest,
+        )
+
     if command in {'usage-import', 'usage-report'}:
         as_json = bool(getattr(args, 'json', False))
 
@@ -14683,6 +15007,29 @@ def build_machine_success_envelope(command, value, args):
                 'corpus_markdown': paths.get('markdown') or '',
             },
         )
+    elif command == 'import-revision-proposals':
+        imported = dict(value or {})
+        paths = dict(imported.get('paths') or {})
+        result = {
+            'input_count': int(imported.get('input_count') or 0),
+            'selected_count': int(imported.get('selected_count') or 0),
+            'candidate_count': int(imported.get('candidate_count') or 0),
+            'diagnostics': list(imported.get('diagnostics') or []),
+            'preview_summary': dict(imported.get('preview_summary') or {}),
+            'suggested_action': imported.get('suggested_action') or '',
+        }
+        return cli_contract.success_envelope(
+            command,
+            status=str(imported.get('status') or 'blocked'),
+            result=result,
+            artifacts={
+                'manifest': paths.get('manifest') or '',
+                'import_report': paths.get('import_report') or '',
+                'import_report_markdown': paths.get('import_report_markdown') or '',
+                'revision_preview_jsonl': paths.get('revision_preview_jsonl') or '',
+                'revision_preview_markdown': paths.get('revision_preview_markdown') or '',
+            },
+        )
 
     return cli_contract.success_envelope(
         command,
@@ -14980,6 +15327,8 @@ def _collect_output_file_protected_paths(args):
         'summary_jsonl',
         'summary_markdown',
         'variants_file',
+        'proposal',
+        'corpus_manifest',
     ):
         value = getattr(args, attr, None)
         if not isinstance(value, str) or not value.strip():

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4080,10 +4080,7 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
         f'{stamp}_{guess_project_slug()}_revision_proposals'
     )
     status = validation.status
-    if any(item.get('code') in {
-        'CORPUS_SNAPSHOT_STALE', 'ITEM_SNAPSHOT_STALE',
-        'CURRENT_TRANSLATION_STALE', 'LIVE_SOURCE_CHANGED_DURING_IMPORT',
-    } for item in diagnostics):
+    if revision_proposals.diagnostics_are_stale(diagnostics):
         status = 'stale'
     elif diagnostics:
         status = 'blocked'
@@ -8479,9 +8476,14 @@ def _revision_manifest_identity(manifest):
         'base_dir', 'tl_dir', 'target_language', 'language',
         'input_jsonl_path', 'result_jsonl_path',
         'settings', 'revision_settings',
-        'summary', 'files', 'chunks', 'final_review_source', 'proposal_import',
+        'summary', 'files', 'chunks', 'final_review_source',
     )
     payload = {key: manifest.get(key) for key in keys}
+    # Preserve the v1 fingerprint for pre-proposal revision/final-review
+    # packages.  Proposal manifests bind their immutable import provenance and
+    # eligibility state without adding a null field to every legacy payload.
+    if isinstance(manifest.get('proposal_import'), dict):
+        payload['proposal_import'] = manifest['proposal_import']
     return hashlib.sha256(
         json.dumps(payload, ensure_ascii=False, sort_keys=True).encode('utf-8')
     ).hexdigest()

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4196,8 +4196,7 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
     }
     manifest_path = os.path.join(package_dir, 'manifest.json')
     atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
-    remember_latest_manifest(manifest_path)
-    previewed = preview_revisions(manifest_path)
+    previewed = preview_revisions(manifest_path, update_latest=False)
     preview_summary = dict((previewed.get('last_revision_preview') or {}).get('summary') or {})
     failures = int(preview_summary.get('failure_items') or 0)
     candidates = int(preview_summary.get('valid_items') or 0)
@@ -4228,7 +4227,10 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
         ),
     })
     _write_proposal_import_report(package_dir, report)
-    save_manifest(previewed, update_latest=True)
+    save_manifest(
+        previewed,
+        update_latest=final_status in {'previewed', 'no_op'},
+    )
     print(f'Revision proposal import status: {final_status}')
     print(f'Manifest: {manifest_path}')
     return {
@@ -8643,7 +8645,14 @@ def write_revision_markdown(path, entries, summary):
         handle.write('\n'.join(lines) + '\n')
 
 
-def preview_revisions(target=None, output_jsonl='', output_markdown=''):
+def preview_revisions(
+    target=None,
+    output_jsonl='',
+    output_markdown='',
+    *,
+    update_latest=None,
+):
+    """Build a revision preview and optionally control the latest pointer."""
     manifest = load_manifest(target)
     require_manifest_mode(manifest, MANIFEST_MODE_REVISION, 'preview-revisions')
     _replacements, _lines, _failure_entries, summary, preview_entries = collect_revision_actions(
@@ -8696,7 +8705,12 @@ def preview_revisions(target=None, output_jsonl='', output_markdown=''):
     manifest.pop('revision_applied_at', None)
     manifest.pop('revision_apply_summary', None)
     manifest.pop('last_revision_apply_summary', None)
-    save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
+    should_update_latest = (
+        manifest.get('execution') != 'sync'
+        if update_latest is None
+        else bool(update_latest)
+    )
+    save_manifest(manifest, update_latest=should_update_latest)
     if manifest.get('final_review_source'):
         import final_review as fr
         import final_review_revision

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3973,7 +3973,8 @@ def _proposal_import_report_markdown(report):
         '',
         f"- Status: {report.get('status') or 'unknown'}",
         f"- Input rows: {report.get('input_count', 0)}",
-        f"- Selected rows: {report.get('selected_count', 0)}",
+        f"- Requested selected rows: {report.get('requested_selected_count', 0)}",
+        f"- Validated selected rows: {report.get('selected_count', 0)}",
         f"- Candidate rows: {report.get('candidate_count', 0)}",
         '',
     ]
@@ -4021,6 +4022,13 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
             suggested_action='fix_proposal_jsonl',
             semantic_exit_code=cli_contract.EXIT_INVALID_STATE,
         ) from exc
+    if not rows:
+        raise cli_contract.MachineContractError(
+            'Proposal JSONL contains no proposal rows.',
+            code_name='NO_PROPOSAL_ROWS',
+            suggested_action='provide_non_empty_proposal_jsonl',
+            semantic_exit_code=cli_contract.EXIT_USAGE,
+        )
     resolved_corpus_manifest = revision_proposals.find_corpus_manifest(
         proposal_path,
         corpus_manifest_path,
@@ -4054,6 +4062,7 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
         rows,
         live_items,
         live_snapshot_digest=live_snapshot_digest,
+        live_project_identity={'tl_dir': legacy.TL_DIR},
         corpus_manifest=corpus_manifest,
     )
     diagnostics = [dict(item) for item in validation.diagnostics]
@@ -4064,17 +4073,6 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
             'row': 0,
             'occurrence_id': '',
         })
-    if corpus_manifest:
-        project = corpus_manifest.get('project') or {}
-        corpus_tl_dir = str(project.get('tl_dir') or '')
-        if corpus_tl_dir and _normalized_abs_path(corpus_tl_dir) != _normalized_abs_path(legacy.TL_DIR):
-            diagnostics.append({
-                'code': 'CORPUS_PROJECT_MISMATCH',
-                'message': 'corpus project identity does not match the active project',
-                'row': 0,
-                'occurrence_id': '',
-            })
-
     stamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
     package_dir = create_batch_package_dir(
         f'{stamp}_{guess_project_slug()}_revision_proposals'
@@ -4092,6 +4090,7 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
         'corpus_manifest_path': resolved_corpus_manifest,
         'live_snapshot_digest': live_snapshot_digest,
         'input_count': validation.input_count,
+        'requested_selected_count': validation.requested_selected_count,
         'selected_count': validation.selected_count,
         'candidate_count': len(validation.proposals),
         'diagnostics': diagnostics,
@@ -13346,7 +13345,10 @@ def build_arg_parser():
     )
     import_revision_proposals_parser.add_argument(
         'proposal',
-        help='Proposal JSONL path (schema_version=1, identity_v2, snapshots, provenance).',
+        help=(
+            'Proposal JSONL path (schema_version=1, identity_v2, project identity, '
+            'snapshots, provenance).'
+        ),
     )
     import_revision_proposals_parser.add_argument(
         '--corpus-manifest',
@@ -15014,6 +15016,9 @@ def build_machine_success_envelope(command, value, args):
         paths = dict(imported.get('paths') or {})
         result = {
             'input_count': int(imported.get('input_count') or 0),
+            'requested_selected_count': int(
+                imported.get('requested_selected_count') or 0
+            ),
             'selected_count': int(imported.get('selected_count') or 0),
             'candidate_count': int(imported.get('candidate_count') or 0),
             'diagnostics': list(imported.get('diagnostics') or []),

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4099,6 +4099,8 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
             if status == 'stale'
             else 'fix_proposal_diagnostics'
             if status == 'blocked'
+            else 'no_writeback_needed'
+            if status == 'no_op'
             else 'inspect_revision_preview'
         ),
     }

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -3997,6 +3997,22 @@ def _write_proposal_import_report(package_dir, report):
     return {'import_report': json_path, 'import_report_markdown': markdown_path}
 
 
+def _proposal_status_from_preview_summary(summary):
+    """Map the latest revision preview summary to proposal eligibility state."""
+    failures = int((summary or {}).get('failure_items') or 0)
+    candidates = int((summary or {}).get('valid_items') or 0)
+    unchanged = int((summary or {}).get('unchanged_items') or 0)
+    if failures and candidates:
+        return 'partial'
+    if failures:
+        return 'blocked'
+    if candidates:
+        return 'previewed'
+    if unchanged:
+        return 'no_op'
+    return 'blocked'
+
+
 def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
     """Import structured proposals into the existing revision preview gate.
 
@@ -4198,25 +4214,7 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
     atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
     previewed = preview_revisions(manifest_path, update_latest=False)
     preview_summary = dict((previewed.get('last_revision_preview') or {}).get('summary') or {})
-    failures = int(preview_summary.get('failure_items') or 0)
-    candidates = int(preview_summary.get('valid_items') or 0)
-    unchanged = int(preview_summary.get('unchanged_items') or 0)
-    if failures and candidates:
-        final_status = 'partial'
-    elif failures:
-        final_status = 'blocked'
-    elif candidates:
-        final_status = 'previewed'
-    elif unchanged:
-        final_status = 'no_op'
-    else:
-        final_status = 'blocked'
-    proposal_state = dict(previewed.get('proposal_import') or {})
-    proposal_state['status'] = final_status
-    proposal_state['history'] = ['imported', final_status]
-    proposal_state['writeback_eligible'] = final_status in {'previewed', 'no_op'}
-    previewed['proposal_import'] = proposal_state
-    previewed['last_revision_preview']['manifest_identity'] = _revision_manifest_identity(previewed)
+    final_status = _proposal_status_from_preview_summary(preview_summary)
     report.update({
         'status': final_status,
         'preview_summary': preview_summary,
@@ -8683,6 +8681,23 @@ def preview_revisions(
         'source_snapshots': _revision_source_snapshots(manifest),
         'summary': summary,
     }
+    proposal_state = manifest.get('proposal_import')
+    if isinstance(proposal_state, dict):
+        proposal_state = dict(proposal_state)
+        proposal_status = _proposal_status_from_preview_summary(summary)
+        history = list(proposal_state.get('history') or [])
+        if not history or history[-1] != proposal_status:
+            history.append(proposal_status)
+        proposal_state['status'] = proposal_status
+        proposal_state['history'] = history
+        proposal_state['writeback_eligible'] = proposal_status in {
+            'previewed',
+            'no_op',
+        }
+        manifest['proposal_import'] = proposal_state
+        manifest['last_revision_preview']['manifest_identity'] = (
+            _revision_manifest_identity(manifest)
+        )
     # A fresh preview invalidates any prior blocked/no_op/partial terminal state:
     # the user may have fixed the blocker and expects the writeback gate to reopen.
     # A prior real writeback is preserved in revision_apply_history.

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -9591,13 +9591,24 @@ class MainWindow(QMainWindow):
             )
             if not selected:
                 return
+            corpus_manifest_path = ""
+            companion_manifest = Path(selected).with_name(
+                "revision_corpus_manifest.json"
+            )
+            if not companion_manifest.is_file():
+                corpus_manifest_path, _filter = QFileDialog.getOpenFileName(
+                    self,
+                    REVISION_PROPOSAL_COPY["corpus_dialog_title"],
+                    str(Path(selected).parent),
+                    "JSON (*.json);;All files (*)",
+                )
             self._set_writeback_summary(
                 idle_writeback_summary_for_work_mode(WorkMode.REVISION)
             )
             self._clear_log_view()
             self._show_workbench_log_drawer()
             self._begin_translation_workflow(
-                RevisionProposalImportWorkflow(selected),
+                RevisionProposalImportWorkflow(selected, corpus_manifest_path),
                 log_heading=REVISION_PROPOSAL_COPY["running"],
                 status_tab=1,
             )

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -9575,6 +9575,33 @@ class MainWindow(QMainWindow):
         if action == "open_doctor":
             self._activate_shell_route(_SHELL_ROUTE_PROJECT_PREPARE)
             return
+        if action == "import_revision_proposals":
+            if bool(getattr(self, "_task_running", False)):
+                return
+            if not self._confirm_unsaved_config_before_workflow():
+                return
+            from .revision_workflow import RevisionProposalImportWorkflow
+            from .user_copy import REVISION_PROPOSAL_COPY
+
+            selected, _filter = QFileDialog.getOpenFileName(
+                self,
+                REVISION_PROPOSAL_COPY["dialog_title"],
+                "",
+                "JSON Lines (*.jsonl);;All files (*)",
+            )
+            if not selected:
+                return
+            self._set_writeback_summary(
+                idle_writeback_summary_for_work_mode(WorkMode.REVISION)
+            )
+            self._clear_log_view()
+            self._show_workbench_log_drawer()
+            self._begin_translation_workflow(
+                RevisionProposalImportWorkflow(selected),
+                log_heading=REVISION_PROPOSAL_COPY["running"],
+                status_tab=1,
+            )
+            return
         if action != "select_final_review_findings":
             return
         if bool(getattr(self, "_task_running", False)):

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -421,13 +421,26 @@ def build_cli_commands(
             or ""
         ).strip()
         if proposal_path:
+            proposal_args = ["import-revision-proposals", proposal_path]
+            corpus_manifest_path = str(
+                (
+                    proposal_import.get("corpus_manifest_path")
+                    if isinstance(proposal_import, dict)
+                    else ""
+                )
+                or ""
+            ).strip()
+            if corpus_manifest_path:
+                proposal_args.extend(
+                    ["--corpus-manifest", corpus_manifest_path]
+                )
             commands.append(
                 DiagnosticsCommand(
                     label="导入结构化润色提案",
                     command=format_cli_command(
                         python_exe,
                         batch_script_path,
-                        ["import-revision-proposals", proposal_path],
+                        proposal_args,
                     ),
                 )
             )

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -418,18 +418,19 @@ def build_cli_commands(
                 if isinstance(proposal_import, dict)
                 else ""
             )
-            or "proposal.jsonl"
-        )
-        commands.append(
-            DiagnosticsCommand(
-                label="导入结构化润色提案",
-                command=format_cli_command(
-                    python_exe,
-                    batch_script_path,
-                    ["import-revision-proposals", proposal_path],
-                ),
+            or ""
+        ).strip()
+        if proposal_path:
+            commands.append(
+                DiagnosticsCommand(
+                    label="导入结构化润色提案",
+                    command=format_cli_command(
+                        python_exe,
+                        batch_script_path,
+                        ["import-revision-proposals", proposal_path],
+                    ),
+                )
             )
-        )
         if not manifest.get("submit_disabled"):
             commands.extend(
                 build_cloud_job_commands(

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -411,6 +411,25 @@ def build_cli_commands(
             )
         )
     if mode_text == "revision":
+        proposal_import = manifest.get("proposal_import")
+        proposal_path = str(
+            (
+                proposal_import.get("proposal_path")
+                if isinstance(proposal_import, dict)
+                else ""
+            )
+            or "proposal.jsonl"
+        )
+        commands.append(
+            DiagnosticsCommand(
+                label="导入结构化润色提案",
+                command=format_cli_command(
+                    python_exe,
+                    batch_script_path,
+                    ["import-revision-proposals", proposal_path],
+                ),
+            )
+        )
         if not manifest.get("submit_disabled"):
             commands.extend(
                 build_cloud_job_commands(

--- a/gui_qt/revision_workflow.py
+++ b/gui_qt/revision_workflow.py
@@ -259,17 +259,21 @@ class RevisionBatchWorkflow:
 class RevisionProposalImportWorkflow:
     """One-step local proposal import that stops at the revision preview gate."""
 
-    def __init__(self, proposal_path: str):
+    def __init__(self, proposal_path: str, corpus_manifest_path: str = ""):
         self.proposal_path = proposal_path
+        self.corpus_manifest_path = corpus_manifest_path
         self.manifest_path = ""
         self._pending = True
 
     def current_step(self) -> WorkflowStep | None:
         if not self._pending:
             return None
+        args = ["import-revision-proposals", self.proposal_path]
+        if self.corpus_manifest_path:
+            args.extend(["--corpus-manifest", self.corpus_manifest_path])
         return WorkflowStep(
             key="import-revision-proposals",
-            args=["import-revision-proposals", self.proposal_path],
+            args=args,
             heading="正在导入润色提案",
             message="正在校验身份、快照和格式，并生成安全订正预览。",
         )

--- a/gui_qt/revision_workflow.py
+++ b/gui_qt/revision_workflow.py
@@ -254,3 +254,53 @@ class RevisionBatchWorkflow:
         if extra_facts:
             facts.extend(extra_facts)
         return facts
+
+
+class RevisionProposalImportWorkflow:
+    """One-step local proposal import that stops at the revision preview gate."""
+
+    def __init__(self, proposal_path: str):
+        self.proposal_path = proposal_path
+        self.manifest_path = ""
+        self._pending = True
+
+    def current_step(self) -> WorkflowStep | None:
+        if not self._pending:
+            return None
+        return WorkflowStep(
+            key="import-revision-proposals",
+            args=["import-revision-proposals", self.proposal_path],
+            heading="正在导入润色提案",
+            message="正在校验身份、快照和格式，并生成安全订正预览。",
+        )
+
+    def complete_current_step(self, exit_code: int, output: str) -> WorkflowUpdate:
+        self._pending = False
+        self.manifest_path = _extract_line_value(output, "Manifest:")
+        status = _extract_line_value(output, "Revision proposal import status:")
+        facts = self._facts()
+        if exit_code != 0 or status in {"blocked", "stale", "partial"}:
+            return WorkflowUpdate(
+                status="failed",
+                heading="润色提案未通过安全校验",
+                message="没有修改任何 .rpy；请根据导入报告修正提案后重试。",
+                facts=facts,
+            )
+        if status == "no_op":
+            return WorkflowUpdate(
+                status="done",
+                heading="润色提案无需写回",
+                message="所选提案没有产生译文变化。",
+                facts=facts,
+            )
+        return WorkflowUpdate(
+            status="done",
+            heading="润色提案预览已生成",
+            message="请检查订正预览；确认后可使用“写回订正”。",
+            facts=facts,
+        )
+
+    def _facts(self) -> list[str]:
+        if self.manifest_path:
+            return [format_manifest_path_fact(self.manifest_path)]
+        return []

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -114,6 +114,26 @@ def summarize_revision_writeback_from_manifest(
     if not isinstance(manifest_path, str) or not manifest_path.strip():
         manifest_path = ""
 
+    proposal_import = manifest.get("proposal_import")
+    if isinstance(proposal_import, dict) and (
+        proposal_import.get("status") not in {"previewed", "no_op"}
+        or not proposal_import.get("writeback_eligible")
+    ):
+        proposal_status = str(proposal_import.get("status") or "blocked")
+        facts = [format_manifest_path_fact(manifest_path)] if manifest_path else []
+        report_path = proposal_import.get("report_path")
+        if isinstance(report_path, str) and report_path.strip():
+            facts.append(f"导入报告：{report_path.strip()}")
+        return WritebackSummary(
+            status="failed",
+            heading="润色提案禁止写回",
+            message=f"提案导入状态为 {proposal_status}；请修正并重新导入后再写回。",
+            facts=facts,
+            findings=[],
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
     apply_state = manifest.get("revision_apply_state")
     if apply_state in ("blocked", "no_op", "partial"):
         facts: list[str] = []

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -85,6 +85,13 @@ TASK_PROJECT_GATE_COPY = {
     ),
 }
 
+REVISION_PROPOSAL_COPY = {
+    "action": "导入润色提案",
+    "tooltip": "导入结构化 JSONL 提案并生成安全预览；此步骤不会修改 .rpy。",
+    "dialog_title": "选择润色提案 JSONL",
+    "running": "正在校验提案并生成订正预览。",
+}
+
 USAGE_LEDGER_COPY = {
     "empty": "模型用量：当前项目暂无实际响应记录",
     "load_error": "模型用量账本读取失败，统计暂不可用",

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -89,6 +89,7 @@ REVISION_PROPOSAL_COPY = {
     "action": "导入润色提案",
     "tooltip": "导入结构化 JSONL 提案并生成安全预览；此步骤不会修改 .rpy。",
     "dialog_title": "选择润色提案 JSONL",
+    "corpus_dialog_title": "选择配套语料 manifest（没有则取消）",
     "running": "正在校验提案并生成订正预览。",
 }
 

--- a/gui_qt/workbench/revision_page.py
+++ b/gui_qt/workbench/revision_page.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
 )
 
 from ..empty_state import EmptyStateWidget
-from ..user_copy import TASK_PROJECT_GATE_COPY
+from ..user_copy import REVISION_PROPOSAL_COPY, TASK_PROJECT_GATE_COPY
 from ..work_modes import WorkMode, work_mode_submode_label
 from ..workbench_session import WorkbenchModeSession
 from .page_contract import WorkbenchPageActions
@@ -75,6 +75,13 @@ class RevisionPage(QFrame):
         self.start_btn.setEnabled(False)
         self.start_btn.clicked.connect(self._trigger_start)
         self.actions.add_action(self.start_btn, min_width=120)
+
+        self.import_proposals_btn = QPushButton(REVISION_PROPOSAL_COPY["action"])
+        self.import_proposals_btn.setObjectName("revision_import_proposals_btn")
+        self.import_proposals_btn.setEnabled(False)
+        self.import_proposals_btn.setToolTip(REVISION_PROPOSAL_COPY["tooltip"])
+        self.import_proposals_btn.clicked.connect(self._trigger_import_proposals)
+        self.actions.add_action(self.import_proposals_btn, min_width=128)
 
         self.resume_btn = QPushButton("继续订正")
         self.resume_btn.setObjectName("revision_resume_btn")
@@ -198,6 +205,7 @@ class RevisionPage(QFrame):
         self.start_btn.setText("开始最终审校" if final_review else "生成订正预览")
         self.writeback_btn.setText("写回所选订正" if final_review else "写回订正")
         self.review_findings_btn.setVisible(final_review)
+        self.import_proposals_btn.setVisible(mode == WorkMode.REVISION)
         self.result_hint.setText(
             "审查完成后，选择需要处理的问题并生成订正预览。"
             if final_review
@@ -214,6 +222,7 @@ class RevisionPage(QFrame):
             self.resume_btn.setEnabled(False)
             self.writeback_btn.setEnabled(False)
             self.review_findings_btn.setEnabled(False)
+            self.import_proposals_btn.setEnabled(False)
 
     def set_controls(
         self,
@@ -232,6 +241,7 @@ class RevisionPage(QFrame):
         self.resume_btn.setEnabled(resume_enabled and not self._running)
         self.writeback_btn.setEnabled(writeback_enabled and not self._running)
         self.review_findings_btn.setEnabled(findings_enabled and not self._running)
+        self.import_proposals_btn.setEnabled(start_enabled and not self._running)
         self.result_hint.setText(result_message)
         self.task_layout.reflow()
         self.updateGeometry()
@@ -278,6 +288,14 @@ class RevisionPage(QFrame):
             and self._actions.action is not None
         ):
             self._actions.action("select_final_review_findings")
+
+    def _trigger_import_proposals(self) -> None:
+        if (
+            not self._running
+            and self.import_proposals_btn.isEnabled()
+            and self._actions.action is not None
+        ):
+            self._actions.action("import_revision_proposals")
 
     def _trigger_writeback(self) -> None:
         if (

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -1,0 +1,197 @@
+"""Structured revision-proposal contract and live-project validation.
+
+The importer deliberately stops at validated candidates.  It never edits Ren'Py
+files; callers must hand candidates to the existing revision preview/apply gates.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import revision_corpus
+
+PROPOSAL_SCHEMA_VERSION = 1
+IMPORT_REPORT_SCHEMA_VERSION = 1
+SUPPORTED_PRODUCERS = frozenset({"human", "agent"})
+SELECTED_DISPOSITIONS = frozenset({"accepted", "approve", "approved", "proposed", "selected"})
+
+
+@dataclass(frozen=True)
+class ProposalValidation:
+    """Normalized selected proposals and deterministic diagnostics."""
+
+    proposals: tuple[dict[str, Any], ...]
+    diagnostics: tuple[dict[str, Any], ...]
+    input_count: int
+    selected_count: int
+    status: str
+
+
+def load_jsonl(path: str) -> list[dict[str, Any]]:
+    """Load proposal JSONL and retain row numbers for actionable diagnostics."""
+    rows: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            if not raw_line.strip():
+                continue
+            try:
+                value = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"proposal JSONL row {line_number} is invalid: {exc}") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"proposal JSONL row {line_number} must be an object")
+            row = dict(value)
+            row["_row_number"] = line_number
+            rows.append(row)
+    return rows
+
+
+def find_corpus_manifest(proposal_path: str, explicit_path: str = "") -> str:
+    """Resolve an explicit or same-directory revision corpus manifest."""
+    if str(explicit_path or "").strip():
+        return os.path.abspath(str(explicit_path).strip())
+    candidate = os.path.join(
+        os.path.dirname(os.path.abspath(proposal_path)),
+        revision_corpus.CORPUS_MANIFEST_NAME,
+    )
+    return candidate if os.path.isfile(candidate) else ""
+
+
+def load_corpus_manifest(path: str) -> dict[str, Any]:
+    """Load and minimally validate a revision-corpus manifest."""
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict) or value.get("kind") != "revision_corpus":
+        raise ValueError("corpus manifest must be a revision_corpus object")
+    if value.get("schema_version") != revision_corpus.REVISION_CORPUS_SCHEMA_VERSION:
+        raise ValueError("corpus manifest schema/version is unsupported")
+    return value
+
+
+def _diag(code: str, row: Mapping[str, Any] | None, message: str, **details: Any) -> dict[str, Any]:
+    result = {
+        "code": code,
+        "message": message,
+        "row": int((row or {}).get("_row_number") or 0),
+        "occurrence_id": str(
+            (row or {}).get("occurrence_id") or (row or {}).get("identity_v2") or ""
+        ),
+    }
+    result.update(details)
+    return result
+
+
+def validate(
+    rows: Sequence[Mapping[str, Any]],
+    live_items: Mapping[str, Mapping[str, Any]],
+    *,
+    live_snapshot_digest: str,
+    corpus_manifest: Mapping[str, Any] | None = None,
+) -> ProposalValidation:
+    """Validate selected proposal rows against exact live identity-v2 items.
+
+    Structural, identity, source/current-text, item-snapshot and corpus-snapshot
+    failures are all hard blockers.  Unselected rows remain auditable input but
+    are not candidates.
+    """
+    diagnostics: list[dict[str, Any]] = []
+    selected: list[dict[str, Any]] = []
+    seen: dict[str, Mapping[str, Any]] = {}
+    expected_corpus_digest = str(
+        ((corpus_manifest or {}).get("source") or {}).get("snapshot_digest") or ""
+    )
+    source_changed = bool(
+        ((corpus_manifest or {}).get("source") or {}).get("source_changed_during_scan")
+    )
+    if source_changed:
+        diagnostics.append(_diag("CORPUS_SNAPSHOT_INCONSISTENT", None, "corpus source changed during export"))
+    if expected_corpus_digest and expected_corpus_digest != live_snapshot_digest:
+        diagnostics.append(_diag("CORPUS_SNAPSHOT_STALE", None, "corpus snapshot does not match the live project"))
+
+    for raw in rows:
+        row = dict(raw)
+        identity = str(row.get("occurrence_id") or row.get("identity_v2") or "").strip()
+        occurrence_id = str(row.get("occurrence_id") or "").strip()
+        identity_v2 = str(row.get("identity_v2") or "").strip()
+        selected_value = row.get("selected")
+        disposition = str(row.get("disposition") or "").strip().lower()
+        if row.get("schema_version") != PROPOSAL_SCHEMA_VERSION:
+            diagnostics.append(_diag("UNSUPPORTED_SCHEMA_VERSION", row, "proposal schema_version is unsupported"))
+            continue
+        if not isinstance(selected_value, bool):
+            diagnostics.append(_diag("INVALID_SELECTED", row, "selected must be a boolean"))
+            continue
+        if not disposition:
+            diagnostics.append(_diag("MISSING_DISPOSITION", row, "disposition is required"))
+            continue
+        if not selected_value:
+            continue
+        if disposition not in SELECTED_DISPOSITIONS:
+            diagnostics.append(_diag("INVALID_SELECTED_DISPOSITION", row, "selected proposal has a non-accepting disposition"))
+            continue
+        producer = row.get("producer")
+        producer_type = str((producer or {}).get("type") or "").strip().lower() if isinstance(producer, Mapping) else ""
+        if producer_type not in SUPPORTED_PRODUCERS:
+            diagnostics.append(_diag("INVALID_PRODUCER", row, "producer.type must be human or agent"))
+        if not identity:
+            diagnostics.append(_diag("MISSING_OCCURRENCE_ID", row, "occurrence_id/identity_v2 is required"))
+            continue
+        if occurrence_id and identity_v2 and occurrence_id != identity_v2:
+            diagnostics.append(_diag("IDENTITY_MISMATCH", row, "occurrence_id and identity_v2 must identify the same occurrence"))
+            continue
+        if identity in seen:
+            previous = seen[identity]
+            previous_text = str(previous.get("proposed_translation") or "").strip()
+            current_text = str(row.get("proposed_translation") or "").strip()
+            code = "CONFLICTING_PROPOSAL" if previous_text != current_text else "DUPLICATE_OCCURRENCE_ID"
+            diagnostics.append(_diag(code, row, "occurrence appears more than once", first_row=int(previous.get("_row_number") or 0)))
+            continue
+        seen[identity] = row
+        live = live_items.get(identity)
+        if live is None:
+            diagnostics.append(_diag("UNKNOWN_OCCURRENCE_ID", row, "occurrence is not present in the live project"))
+            continue
+        expected_pairs = (
+            ("file_rel_path", str(live.get("file_rel_path") or ""), "FILE_PATH_MISMATCH"),
+            ("source", str(live.get("source") or ""), "SOURCE_MISMATCH"),
+            ("current_translation", str(live.get("current_translation") or ""), "CURRENT_TRANSLATION_STALE"),
+        )
+        mismatch = False
+        for field, expected, code in expected_pairs:
+            if str(row.get(field) or "") != expected:
+                diagnostics.append(_diag(code, row, f"{field} does not match the live occurrence"))
+                mismatch = True
+        proposed = str(row.get("proposed_translation") or "").strip()
+        if not proposed:
+            diagnostics.append(_diag("EMPTY_PROPOSED_TRANSLATION", row, "proposed_translation must not be empty"))
+            mismatch = True
+        item_digest = str(row.get("snapshot_digest") or row.get("item_snapshot_digest") or "")
+        expected_item_digest = revision_corpus.item_snapshot_digest(
+            str(live.get("source") or ""), str(live.get("current_translation") or "")
+        )
+        if not item_digest:
+            diagnostics.append(_diag("MISSING_ITEM_SNAPSHOT", row, "snapshot_digest/item_snapshot_digest is required"))
+            mismatch = True
+        elif item_digest != expected_item_digest:
+            diagnostics.append(_diag("ITEM_SNAPSHOT_STALE", row, "proposal item snapshot is stale"))
+            mismatch = True
+        row_corpus_digest = str(row.get("corpus_snapshot_digest") or "")
+        effective_digest = row_corpus_digest or expected_corpus_digest
+        if not effective_digest:
+            diagnostics.append(_diag("MISSING_CORPUS_SNAPSHOT", row, "corpus_snapshot_digest or companion corpus manifest is required"))
+            mismatch = True
+        elif effective_digest != live_snapshot_digest:
+            diagnostics.append(_diag("CORPUS_SNAPSHOT_STALE", row, "proposal corpus snapshot is stale"))
+            mismatch = True
+        if not mismatch:
+            row["occurrence_id"] = identity
+            row["identity_v2"] = identity
+            row["proposed_translation"] = proposed
+            selected.append(row)
+
+    status = "no_op" if not selected and not diagnostics else "stale" if any(
+        str(item.get("code") or "").endswith("STALE") for item in diagnostics
+    ) else "blocked" if diagnostics else "imported"
+    return ProposalValidation(tuple(selected), tuple(diagnostics), len(rows), len(seen), status)

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -105,6 +105,11 @@ def _normalized_project_path(value: Any) -> str:
     return os.path.normcase(os.path.abspath(text)) if text else ""
 
 
+def _normalized_relative_path(value: Any) -> str:
+    """Normalize proposal file separators without weakening identity checks."""
+    return os.path.normpath(str(value or "").replace("\\", "/")).replace("\\", "/")
+
+
 def validate(
     rows: Sequence[Mapping[str, Any]],
     live_items: Mapping[str, Mapping[str, Any]],
@@ -203,19 +208,26 @@ def validate(
         if live is None:
             diagnostics.append(_diag("UNKNOWN_OCCURRENCE_ID", row, "occurrence is not present in the live project"))
             continue
-        expected_pairs = (
-            ("file_rel_path", str(live.get("file_rel_path") or ""), "FILE_PATH_MISMATCH"),
+        mismatch = row_invalid
+        if _normalized_relative_path(row.get("file_rel_path")) != _normalized_relative_path(
+            live.get("file_rel_path")
+        ):
+            diagnostics.append(_diag("FILE_PATH_MISMATCH", row, "file_rel_path does not match the live occurrence"))
+            mismatch = True
+        for field, expected, code in (
             ("source", str(live.get("source") or ""), "SOURCE_MISMATCH"),
             ("current_translation", str(live.get("current_translation") or ""), "CURRENT_TRANSLATION_STALE"),
-        )
-        mismatch = row_invalid
-        for field, expected, code in expected_pairs:
+        ):
             if str(row.get(field) or "") != expected:
                 diagnostics.append(_diag(code, row, f"{field} does not match the live occurrence"))
                 mismatch = True
         proposed = str(row.get("proposed_translation") or "").strip()
         if not proposed:
             diagnostics.append(_diag("EMPTY_PROPOSED_TRANSLATION", row, "proposed_translation must not be empty"))
+            mismatch = True
+        reason = str(row.get("reason") or "").strip()
+        if not reason:
+            diagnostics.append(_diag("MISSING_REASON", row, "reason is required for every selected proposal"))
             mismatch = True
         item_digest = str(row.get("snapshot_digest") or row.get("item_snapshot_digest") or "")
         expected_item_digest = revision_corpus.item_snapshot_digest(
@@ -239,6 +251,7 @@ def validate(
             row["occurrence_id"] = identity
             row["identity_v2"] = identity
             row["proposed_translation"] = proposed
+            row["reason"] = reason
             selected.append(row)
 
     status = (

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -16,6 +16,12 @@ PROPOSAL_SCHEMA_VERSION = 1
 IMPORT_REPORT_SCHEMA_VERSION = 1
 SUPPORTED_PRODUCERS = frozenset({"human", "agent"})
 SELECTED_DISPOSITIONS = frozenset({"accepted", "approve", "approved", "proposed", "selected"})
+STALE_DIAGNOSTIC_CODES = frozenset(
+    {
+        "CORPUS_SNAPSHOT_INCONSISTENT",
+        "LIVE_SOURCE_CHANGED_DURING_IMPORT",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -81,6 +87,15 @@ def _diag(code: str, row: Mapping[str, Any] | None, message: str, **details: Any
     }
     result.update(details)
     return result
+
+
+def diagnostics_are_stale(diagnostics: Sequence[Mapping[str, Any]]) -> bool:
+    """Return whether diagnostics require re-exporting/reloading source state."""
+    return any(
+        str(item.get("code") or "").endswith("STALE")
+        or str(item.get("code") or "") in STALE_DIAGNOSTIC_CODES
+        for item in diagnostics
+    )
 
 
 def validate(
@@ -191,7 +206,13 @@ def validate(
             row["proposed_translation"] = proposed
             selected.append(row)
 
-    status = "no_op" if not selected and not diagnostics else "stale" if any(
-        str(item.get("code") or "").endswith("STALE") for item in diagnostics
-    ) else "blocked" if diagnostics else "imported"
+    status = (
+        "no_op"
+        if not selected and not diagnostics
+        else "stale"
+        if diagnostics_are_stale(diagnostics)
+        else "blocked"
+        if diagnostics
+        else "imported"
+    )
     return ProposalValidation(tuple(selected), tuple(diagnostics), len(rows), len(seen), status)

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -74,6 +74,10 @@ def load_corpus_manifest(path: str) -> dict[str, Any]:
         raise ValueError("corpus manifest must be a revision_corpus object")
     if value.get("schema_version") != revision_corpus.REVISION_CORPUS_SCHEMA_VERSION:
         raise ValueError("corpus manifest schema/version is unsupported")
+    if not isinstance(value.get("source"), Mapping):
+        raise ValueError("corpus manifest source must be an object")
+    if not isinstance(value.get("project"), Mapping):
+        raise ValueError("corpus manifest project must be an object")
     return value
 
 
@@ -135,12 +139,11 @@ def validate(
     manifest_tl_dir = _normalized_project_path(
         manifest_project.get("tl_dir") if isinstance(manifest_project, Mapping) else ""
     )
-    expected_corpus_digest = str(
-        ((corpus_manifest or {}).get("source") or {}).get("snapshot_digest") or ""
-    )
-    source_changed = bool(
-        ((corpus_manifest or {}).get("source") or {}).get("source_changed_during_scan")
-    )
+    manifest_source = (corpus_manifest or {}).get("source") or {}
+    if not isinstance(manifest_source, Mapping):
+        manifest_source = {}
+    expected_corpus_digest = str(manifest_source.get("snapshot_digest") or "")
+    source_changed = bool(manifest_source.get("source_changed_during_scan"))
     if source_changed:
         diagnostics.append(_diag("CORPUS_SNAPSHOT_INCONSISTENT", None, "corpus source changed during export"))
     if expected_corpus_digest and expected_corpus_digest != live_snapshot_digest:

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -224,12 +224,20 @@ def validate(
             if str(row.get(field) or "") != expected:
                 diagnostics.append(_diag(code, row, f"{field} does not match the live occurrence"))
                 mismatch = True
-        proposed = str(row.get("proposed_translation") or "").strip()
-        if not proposed:
+        proposed_value = row.get("proposed_translation")
+        proposed = proposed_value.strip() if isinstance(proposed_value, str) else ""
+        if not isinstance(proposed_value, str):
+            diagnostics.append(_diag("INVALID_PROPOSED_TRANSLATION_TYPE", row, "proposed_translation must be a string"))
+            mismatch = True
+        elif not proposed:
             diagnostics.append(_diag("EMPTY_PROPOSED_TRANSLATION", row, "proposed_translation must not be empty"))
             mismatch = True
-        reason = str(row.get("reason") or "").strip()
-        if not reason:
+        reason_value = row.get("reason")
+        reason = reason_value.strip() if isinstance(reason_value, str) else ""
+        if not isinstance(reason_value, str):
+            diagnostics.append(_diag("INVALID_REASON_TYPE", row, "reason must be a string"))
+            mismatch = True
+        elif not reason:
             diagnostics.append(_diag("MISSING_REASON", row, "reason is required for every selected proposal"))
             mismatch = True
         item_digest = str(row.get("snapshot_digest") or row.get("item_snapshot_digest") or "")

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -74,8 +74,11 @@ def load_corpus_manifest(path: str) -> dict[str, Any]:
         raise ValueError("corpus manifest must be a revision_corpus object")
     if value.get("schema_version") != revision_corpus.REVISION_CORPUS_SCHEMA_VERSION:
         raise ValueError("corpus manifest schema/version is unsupported")
-    if not isinstance(value.get("source"), Mapping):
+    source = value.get("source")
+    if not isinstance(source, Mapping):
         raise ValueError("corpus manifest source must be an object")
+    if not isinstance(source.get("snapshot_digest"), str) or not source.get("snapshot_digest").strip():
+        raise ValueError("corpus manifest source.snapshot_digest must be a non-empty string")
     if not isinstance(value.get("project"), Mapping):
         raise ValueError("corpus manifest project must be an object")
     return value
@@ -217,12 +220,27 @@ def validate(
         ):
             diagnostics.append(_diag("FILE_PATH_MISMATCH", row, "file_rel_path does not match the live occurrence"))
             mismatch = True
-        for field, expected, code in (
-            ("source", str(live.get("source") or ""), "SOURCE_MISMATCH"),
-            ("current_translation", str(live.get("current_translation") or ""), "CURRENT_TRANSLATION_STALE"),
+        for field, value, expected, type_code, mismatch_code in (
+            (
+                "source",
+                row.get("source"),
+                str(live.get("source") or ""),
+                "INVALID_SOURCE_TYPE",
+                "SOURCE_MISMATCH",
+            ),
+            (
+                "current_translation",
+                row.get("current_translation"),
+                str(live.get("current_translation") or ""),
+                "INVALID_CURRENT_TRANSLATION_TYPE",
+                "CURRENT_TRANSLATION_STALE",
+            ),
         ):
-            if str(row.get(field) or "") != expected:
-                diagnostics.append(_diag(code, row, f"{field} does not match the live occurrence"))
+            if not isinstance(value, str):
+                diagnostics.append(_diag(type_code, row, f"{field} must be a string"))
+                mismatch = True
+            elif value != expected:
+                diagnostics.append(_diag(mismatch_code, row, f"{field} does not match the live occurrence"))
                 mismatch = True
         proposed_value = row.get("proposed_translation")
         proposed = proposed_value.strip() if isinstance(proposed_value, str) else ""
@@ -240,7 +258,22 @@ def validate(
         elif not reason:
             diagnostics.append(_diag("MISSING_REASON", row, "reason is required for every selected proposal"))
             mismatch = True
-        item_digest = str(row.get("snapshot_digest") or row.get("item_snapshot_digest") or "")
+        snapshot_digest = row.get("snapshot_digest")
+        item_snapshot_digest = row.get("item_snapshot_digest")
+        if (
+            snapshot_digest is not None
+            and item_snapshot_digest is not None
+            and str(snapshot_digest or "") != str(item_snapshot_digest or "")
+        ):
+            diagnostics.append(
+                _diag(
+                    "ITEM_SNAPSHOT_CONFLICT",
+                    row,
+                    "snapshot_digest and item_snapshot_digest must identify the same item snapshot",
+                )
+            )
+            mismatch = True
+        item_digest = str(snapshot_digest or item_snapshot_digest or "")
         expected_item_digest = revision_corpus.item_snapshot_digest(
             str(live.get("source") or ""), str(live.get("current_translation") or "")
         )

--- a/revision_proposals.py
+++ b/revision_proposals.py
@@ -31,6 +31,7 @@ class ProposalValidation:
     proposals: tuple[dict[str, Any], ...]
     diagnostics: tuple[dict[str, Any], ...]
     input_count: int
+    requested_selected_count: int
     selected_count: int
     status: str
 
@@ -98,11 +99,18 @@ def diagnostics_are_stale(diagnostics: Sequence[Mapping[str, Any]]) -> bool:
     )
 
 
+def _normalized_project_path(value: Any) -> str:
+    """Normalize a project path for local identity comparisons."""
+    text = str(value or "").strip()
+    return os.path.normcase(os.path.abspath(text)) if text else ""
+
+
 def validate(
     rows: Sequence[Mapping[str, Any]],
     live_items: Mapping[str, Mapping[str, Any]],
     *,
     live_snapshot_digest: str,
+    live_project_identity: Mapping[str, Any] | None = None,
     corpus_manifest: Mapping[str, Any] | None = None,
 ) -> ProposalValidation:
     """Validate selected proposal rows against exact live identity-v2 items.
@@ -114,6 +122,14 @@ def validate(
     diagnostics: list[dict[str, Any]] = []
     selected: list[dict[str, Any]] = []
     seen: dict[str, Mapping[str, Any]] = {}
+    requested_selected_count = sum(row.get("selected") is True for row in rows)
+    live_tl_dir = _normalized_project_path(
+        (live_project_identity or {}).get("tl_dir")
+    )
+    manifest_project = (corpus_manifest or {}).get("project") or {}
+    manifest_tl_dir = _normalized_project_path(
+        manifest_project.get("tl_dir") if isinstance(manifest_project, Mapping) else ""
+    )
     expected_corpus_digest = str(
         ((corpus_manifest or {}).get("source") or {}).get("snapshot_digest") or ""
     )
@@ -124,6 +140,10 @@ def validate(
         diagnostics.append(_diag("CORPUS_SNAPSHOT_INCONSISTENT", None, "corpus source changed during export"))
     if expected_corpus_digest and expected_corpus_digest != live_snapshot_digest:
         diagnostics.append(_diag("CORPUS_SNAPSHOT_STALE", None, "corpus snapshot does not match the live project"))
+    if corpus_manifest and not manifest_tl_dir:
+        diagnostics.append(_diag("MISSING_PROJECT_IDENTITY", None, "corpus manifest project.tl_dir is required"))
+    elif manifest_tl_dir and live_tl_dir and manifest_tl_dir != live_tl_dir:
+        diagnostics.append(_diag("PROJECT_IDENTITY_STALE", None, "corpus project identity does not match the live project"))
 
     for raw in rows:
         row = dict(raw)
@@ -146,10 +166,25 @@ def validate(
         if disposition not in SELECTED_DISPOSITIONS:
             diagnostics.append(_diag("INVALID_SELECTED_DISPOSITION", row, "selected proposal has a non-accepting disposition"))
             continue
+        row_project = row.get("project_identity")
+        row_tl_dir = _normalized_project_path(
+            row_project.get("tl_dir") if isinstance(row_project, Mapping) else ""
+        )
+        if not corpus_manifest and not row_tl_dir:
+            diagnostics.append(_diag("MISSING_PROJECT_IDENTITY", row, "project_identity.tl_dir or a companion corpus manifest is required"))
+            continue
+        if manifest_tl_dir and row_tl_dir and row_tl_dir != manifest_tl_dir:
+            diagnostics.append(_diag("PROJECT_IDENTITY_CONFLICT", row, "proposal project identity conflicts with the corpus manifest"))
+            continue
+        if not corpus_manifest and live_tl_dir and row_tl_dir != live_tl_dir:
+            diagnostics.append(_diag("PROJECT_IDENTITY_STALE", row, "proposal project identity does not match the live project"))
+            continue
         producer = row.get("producer")
         producer_type = str((producer or {}).get("type") or "").strip().lower() if isinstance(producer, Mapping) else ""
+        row_invalid = False
         if producer_type not in SUPPORTED_PRODUCERS:
             diagnostics.append(_diag("INVALID_PRODUCER", row, "producer.type must be human or agent"))
+            row_invalid = True
         if not identity:
             diagnostics.append(_diag("MISSING_OCCURRENCE_ID", row, "occurrence_id/identity_v2 is required"))
             continue
@@ -173,7 +208,7 @@ def validate(
             ("source", str(live.get("source") or ""), "SOURCE_MISMATCH"),
             ("current_translation", str(live.get("current_translation") or ""), "CURRENT_TRANSLATION_STALE"),
         )
-        mismatch = False
+        mismatch = row_invalid
         for field, expected, code in expected_pairs:
             if str(row.get(field) or "") != expected:
                 diagnostics.append(_diag(code, row, f"{field} does not match the live occurrence"))
@@ -215,4 +250,11 @@ def validate(
         if diagnostics
         else "imported"
     )
-    return ProposalValidation(tuple(selected), tuple(diagnostics), len(rows), len(seen), status)
+    return ProposalValidation(
+        tuple(selected),
+        tuple(diagnostics),
+        len(rows),
+        requested_selected_count,
+        len(selected),
+        status,
+    )

--- a/tests/gui_test_support.py
+++ b/tests/gui_test_support.py
@@ -120,7 +120,13 @@ def _modal_guard_enabled() -> bool:
 
 
 def shutdown_gui_test_runtime(app: Any = None, *, wait_ms: int = 30000) -> bool:
-    """Drain test-owned Qt work and destroy the application deterministically."""
+    """Drain test-owned Qt work before the GUI runner's hard process exit.
+
+    Do not call ``QApplication.shutdown()`` here.  PySide6 can segfault while
+    destroying the offscreen platform plugin on Linux even after every test
+    passed.  ``run_gui_tests.py`` deliberately finishes with ``os._exit`` after
+    this bounded cleanup, so explicit application destruction is unnecessary.
+    """
     try:
         from PySide6.QtCore import QCoreApplication, QEvent, QThreadPool
         from PySide6.QtWidgets import QApplication
@@ -150,7 +156,6 @@ def shutdown_gui_test_runtime(app: Any = None, *, wait_ms: int = 30000) -> bool:
             QEvent.Type.DeferredDelete,
         )
         app.processEvents()
-        app.shutdown()
     except RuntimeError:
         pass
     return pool_finished

--- a/tests/gui_test_support.py
+++ b/tests/gui_test_support.py
@@ -119,13 +119,19 @@ def _modal_guard_enabled() -> bool:
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
-def shutdown_gui_test_runtime(app: Any = None, *, wait_ms: int = 30000) -> bool:
-    """Drain test-owned Qt work before the GUI runner's hard process exit.
+def shutdown_gui_test_runtime(
+    app: Any = None,
+    *,
+    wait_ms: int = 30000,
+    cleanup_widgets: bool = True,
+) -> bool:
+    """Stop test-owned Qt work and optionally drain deferred widget deletion.
 
     Do not call ``QApplication.shutdown()`` here.  PySide6 can segfault while
     destroying the offscreen platform plugin on Linux even after every test
-    passed.  ``run_gui_tests.py`` deliberately finishes with ``os._exit`` after
-    this bounded cleanup, so explicit application destruction is unnecessary.
+    passed.  The script runner uses the pool-only mode before ``os._exit``;
+    embedded callers may request the bounded widget cleanup without explicitly
+    destroying the application.
     """
     try:
         from PySide6.QtCore import QCoreApplication, QEvent, QThreadPool
@@ -143,6 +149,9 @@ def shutdown_gui_test_runtime(app: Any = None, *, wait_ms: int = 30000) -> bool:
         pool_finished = bool(pool.waitForDone(max(0, int(wait_ms))))
     except RuntimeError:
         pool_finished = True
+
+    if not cleanup_widgets:
+        return pool_finished
 
     try:
         for widget in tuple(app.topLevelWidgets()):

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -39,7 +39,11 @@ def main(
             resultclass=guarded_test_result_class(guard),
         )
     unexpected_dialogs = bool(guard and guard.rejected_dialogs)
-    runtime_stopped = shutdown_gui_test_runtime() if shutdown_runtime else True
+    runtime_stopped = (
+        shutdown_gui_test_runtime()
+        if shutdown_runtime
+        else shutdown_gui_test_runtime(cleanup_widgets=False)
+    )
     return 1 if unexpected_dialogs or not runtime_stopped else exit_code
 
 
@@ -51,6 +55,6 @@ def _terminate_process(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    # The process is about to hard-exit, so calling back into Qt after the test
-    # report only adds an offscreen-platform teardown crash window on Linux.
+    # Verify that the global pool stopped, but skip widget finalization before
+    # the hard exit to avoid the offscreen-platform teardown crash on Linux.
     _terminate_process(main(shutdown_runtime=False))

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -17,7 +17,11 @@ def build_suite() -> unittest.TestSuite:
     return suite
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    shutdown_runtime: bool = True,
+) -> int:
     args = parse_runner_args(__doc__ or "", argv)
     ensure_tests_on_path()
     from gui_test_support import (
@@ -35,7 +39,7 @@ def main(argv: list[str] | None = None) -> int:
             resultclass=guarded_test_result_class(guard),
         )
     unexpected_dialogs = bool(guard and guard.rejected_dialogs)
-    runtime_stopped = shutdown_gui_test_runtime()
+    runtime_stopped = shutdown_gui_test_runtime() if shutdown_runtime else True
     return 1 if unexpected_dialogs or not runtime_stopped else exit_code
 
 
@@ -47,4 +51,6 @@ def _terminate_process(exit_code: int) -> None:
 
 
 if __name__ == "__main__":
-    _terminate_process(main())
+    # The process is about to hard-exit, so calling back into Qt after the test
+    # report only adds an offscreen-platform teardown crash window on Linux.
+    _terminate_process(main(shutdown_runtime=False))

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -148,6 +148,12 @@ class CliContractTests(unittest.TestCase):
             "reconcile-project-snapshots",
             status="attention",
         )
+        proposal_partial = cli_contract.success_envelope(
+            "import-revision-proposals", status="partial"
+        )
+        proposal_stale = cli_contract.success_envelope(
+            "import-revision-proposals", status="stale"
+        )
 
         self.assertEqual(
             cli_contract.strict_exit_code(warn),
@@ -165,6 +171,14 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(
             cli_contract.strict_exit_code(reconciliation_attention),
             cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(proposal_partial),
+            cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(proposal_stale),
+            cli_contract.EXIT_BLOCKED,
         )
         unknown = cli_contract.success_envelope("check", status="unknown")
         unclassified_error = cli_contract.error_envelope(

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -19,6 +19,8 @@ class BatchCliContractTests(unittest.TestCase):
             return [command, "--version-id", "test-version"]
         if command == "reconcile-project-snapshots":
             return [command, "base-snapshot.json", "target-snapshot.json"]
+        if command == "import-revision-proposals":
+            return [command, "proposals.jsonl"]
         return [command]
 
     def test_core_commands_accept_json_output_after_subcommand(self):
@@ -703,6 +705,32 @@ class BatchCliContractTests(unittest.TestCase):
         )
         self.assertEqual(args.output, "json")
 
+    def test_proposal_import_machine_envelope_exposes_status_actions_and_artifacts(self):
+        args = SimpleNamespace(command="import-revision-proposals")
+        envelope = batch.build_machine_success_envelope(
+            "import-revision-proposals",
+            {
+                "status": "stale",
+                "input_count": 2,
+                "selected_count": 1,
+                "candidate_count": 0,
+                "diagnostics": [{"code": "CURRENT_TRANSLATION_STALE"}],
+                "suggested_action": "re_export_corpus_and_regenerate_proposals",
+                "paths": {"import_report": "C:/jobs/import/report.json"},
+            },
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "stale")
+        self.assertEqual(
+            envelope["result"]["suggested_action"],
+            "re_export_corpus_and_regenerate_proposals",
+        )
+        self.assertEqual(
+            envelope["artifacts"]["import_report"],
+            "C:/jobs/import/report.json",
+        )
+
     def test_build_without_pending_work_does_not_load_latest_manifest(self):
         args = SimpleNamespace(target="")
 
@@ -1178,6 +1206,14 @@ class BatchCliContractTests(unittest.TestCase):
                                 return_value={"paths": {}, "scope": {}},
                             )
                         )
+                    elif command == "import-revision-proposals":
+                        handler_patches.append(
+                            mock.patch.object(
+                                batch,
+                                "import_revision_proposals",
+                                return_value={"status": "previewed", "paths": {}},
+                            )
+                        )
                     elif command == "export-project-snapshot":
                         handler_patches.append(
                             mock.patch.object(
@@ -1224,6 +1260,8 @@ class BatchCliContractTests(unittest.TestCase):
                             argv = ["merge-keywords-to-glossary", "candidates.jsonl", "--yes"]
                         elif command == "export-revision-corpus":
                             argv = ["export-revision-corpus"]
+                        elif command == "import-revision-proposals":
+                            argv = ["import-revision-proposals", "proposals.jsonl"]
                         elif command == "export-project-snapshot":
                             argv = ["export-project-snapshot", "--version-id", "test-version"]
                         elif command == "reconcile-project-snapshots":
@@ -1239,6 +1277,7 @@ class BatchCliContractTests(unittest.TestCase):
                 self.assertEqual(exit_code, 0)
                 if command in {
                     "export-revision-corpus",
+                    "import-revision-proposals",
                     "export-project-snapshot",
                     "reconcile-project-snapshots",
                 }:

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -712,7 +712,8 @@ class BatchCliContractTests(unittest.TestCase):
             {
                 "status": "stale",
                 "input_count": 2,
-                "selected_count": 1,
+                "requested_selected_count": 1,
+                "selected_count": 0,
                 "candidate_count": 0,
                 "diagnostics": [{"code": "CURRENT_TRANSLATION_STALE"}],
                 "suggested_action": "re_export_corpus_and_regenerate_proposals",
@@ -722,6 +723,8 @@ class BatchCliContractTests(unittest.TestCase):
         )
         self.assertTrue(envelope["ok"])
         self.assertEqual(envelope["status"], "stale")
+        self.assertEqual(envelope["result"]["requested_selected_count"], 1)
+        self.assertEqual(envelope["result"]["selected_count"], 0)
         self.assertEqual(
             envelope["result"]["suggested_action"],
             "re_export_corpus_and_regenerate_proposals",

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -246,17 +246,31 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
 
         by_label = {command.label: command.command for command in commands}
         self.assertIn("预览订正结果", by_label)
-        self.assertIn("导入结构化润色提案", by_label)
+        self.assertNotIn("导入结构化润色提案", by_label)
         self.assertIn("写回订正（预览确认后）", by_label)
         self.assertNotIn("检查翻译结果", by_label)
         self.assertNotIn("写回翻译（仅可写回）", by_label)
         self.assertIn("preview-revisions", by_label["预览订正结果"])
-        self.assertIn(
-            "import-revision-proposals", by_label["导入结构化润色提案"]
-        )
         self.assertIn("apply-revisions", by_label["写回订正（预览确认后）"])
         self.assertIn("usage-import", by_label["导入当前结果用量"])
         self.assertIn("usage-report", by_label["查看项目模型用量"])
+
+    def test_proposal_import_manifest_includes_reimport_command(self):
+        proposal_path = r"C:\review\selected proposals.jsonl"
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\logs\batch_jobs\rev1\manifest.json",
+            manifest={
+                "mode": "revision",
+                "proposal_import": {"proposal_path": proposal_path},
+            },
+        )
+
+        by_label = {command.label: command.command for command in commands}
+        self.assertIn("导入结构化润色提案", by_label)
+        self.assertIn("import-revision-proposals", by_label["导入结构化润色提案"])
+        self.assertIn(proposal_path, by_label["导入结构化润色提案"])
 
     def test_local_final_review_candidates_omit_cloud_submit(self):
         commands = build_cli_commands(

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -257,13 +257,17 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
 
     def test_proposal_import_manifest_includes_reimport_command(self):
         proposal_path = r"C:\review\selected proposals.jsonl"
+        corpus_manifest_path = r"D:\exports\revision_corpus_manifest.json"
         commands = build_cli_commands(
             python_exe="python",
             batch_script_path="gemini_translate_batch.py",
             manifest_path=r"C:\logs\batch_jobs\rev1\manifest.json",
             manifest={
                 "mode": "revision",
-                "proposal_import": {"proposal_path": proposal_path},
+                "proposal_import": {
+                    "proposal_path": proposal_path,
+                    "corpus_manifest_path": corpus_manifest_path,
+                },
             },
         )
 
@@ -271,6 +275,8 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn("导入结构化润色提案", by_label)
         self.assertIn("import-revision-proposals", by_label["导入结构化润色提案"])
         self.assertIn(proposal_path, by_label["导入结构化润色提案"])
+        self.assertIn("--corpus-manifest", by_label["导入结构化润色提案"])
+        self.assertIn(corpus_manifest_path, by_label["导入结构化润色提案"])
 
     def test_local_final_review_candidates_omit_cloud_submit(self):
         commands = build_cli_commands(

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -246,10 +246,14 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
 
         by_label = {command.label: command.command for command in commands}
         self.assertIn("预览订正结果", by_label)
+        self.assertIn("导入结构化润色提案", by_label)
         self.assertIn("写回订正（预览确认后）", by_label)
         self.assertNotIn("检查翻译结果", by_label)
         self.assertNotIn("写回翻译（仅可写回）", by_label)
         self.assertIn("preview-revisions", by_label["预览订正结果"])
+        self.assertIn(
+            "import-revision-proposals", by_label["导入结构化润色提案"]
+        )
         self.assertIn("apply-revisions", by_label["写回订正（预览确认后）"])
         self.assertIn("usage-import", by_label["导入当前结果用量"])
         self.assertIn("usage-report", by_label["查看项目模型用量"])

--- a/tests/test_gui_lifecycle.py
+++ b/tests/test_gui_lifecycle.py
@@ -248,7 +248,7 @@ class GuiTestRuntimeShutdownTests(unittest.TestCase):
         widget.deleteLater.assert_called_once_with()
         send_posted_events.assert_called_once()
         app.processEvents.assert_called_once_with()
-        app.shutdown.assert_called_once_with()
+        app.shutdown.assert_not_called()
 
     @mock.patch("PySide6.QtCore.QCoreApplication.sendPostedEvents")
     @mock.patch("PySide6.QtCore.QThreadPool.globalInstance")

--- a/tests/test_gui_revision_workflow.py
+++ b/tests/test_gui_revision_workflow.py
@@ -2,6 +2,7 @@ import unittest
 
 from gui_qt.revision_workflow import (
     RevisionBatchWorkflow,
+    RevisionProposalImportWorkflow,
     extract_created_revision_package_path,
 )
 
@@ -145,6 +146,29 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
         self.assertEqual(update.status, "failed")
         self.assertFalse(update.should_continue)
         self.assertIsNone(workflow.current_step())
+
+    def test_proposal_import_runs_one_local_preview_step(self):
+        workflow = RevisionProposalImportWorkflow(r"C:\review\proposals.jsonl")
+        self.assertEqual(
+            workflow.current_step().args,
+            ["import-revision-proposals", r"C:\review\proposals.jsonl"],
+        )
+        update = workflow.complete_current_step(
+            0,
+            "Revision proposal import status: previewed\n"
+            "Manifest: C:\\package\\manifest.json\n",
+        )
+        self.assertEqual(update.status, "done")
+        self.assertIn("预览已生成", update.heading)
+        self.assertIsNone(workflow.current_step())
+
+    def test_stale_proposal_import_is_not_presented_as_writable(self):
+        workflow = RevisionProposalImportWorkflow("proposal.jsonl")
+        update = workflow.complete_current_step(
+            0, "Revision proposal import status: stale\n"
+        )
+        self.assertEqual(update.status, "failed")
+        self.assertIn("未通过安全校验", update.heading)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_revision_workflow.py
+++ b/tests/test_gui_revision_workflow.py
@@ -162,6 +162,21 @@ class GuiRevisionWorkflowTests(unittest.TestCase):
         self.assertIn("预览已生成", update.heading)
         self.assertIsNone(workflow.current_step())
 
+    def test_proposal_import_passes_explicit_corpus_manifest(self):
+        workflow = RevisionProposalImportWorkflow(
+            r"C:\review\proposals.jsonl",
+            r"D:\exports\revision_corpus_manifest.json",
+        )
+        self.assertEqual(
+            workflow.current_step().args,
+            [
+                "import-revision-proposals",
+                r"C:\review\proposals.jsonl",
+                "--corpus-manifest",
+                r"D:\exports\revision_corpus_manifest.json",
+            ],
+        )
+
     def test_stale_proposal_import_is_not_presented_as_writable(self):
         workflow = RevisionProposalImportWorkflow("proposal.jsonl")
         update = workflow.complete_current_step(

--- a/tests/test_gui_revision_writeback_report.py
+++ b/tests/test_gui_revision_writeback_report.py
@@ -80,6 +80,25 @@ class GuiRevisionWritebackReportTests(unittest.TestCase):
         self.assertEqual(summary.status, "safe")
         self.assertTrue(summary.can_apply)
 
+    def test_partial_proposal_import_never_enables_apply(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": r"C:\package\manifest.json",
+                "proposal_import": {
+                    "status": "partial",
+                    "writeback_eligible": False,
+                    "report_path": r"C:\package\proposal_import_report.json",
+                },
+                "last_revision_preview": {
+                    "summary": {"valid_items": 1, "failure_items": 1}
+                },
+            }
+        )
+        self.assertIsNotNone(summary)
+        self.assertFalse(summary.can_apply)
+        self.assertEqual(summary.status, "failed")
+        self.assertIn("partial", summary.message)
+
     def test_manifest_after_apply_blocks_apply(self):
         summary = summarize_revision_writeback_from_manifest(
             {

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -783,6 +783,7 @@ class GuiTaskPageTests(unittest.TestCase):
 
     def test_revision_proposal_action_starts_import_workflow(self) -> None:
         proposal_path = "C:/review/proposals.jsonl"
+        corpus_manifest_path = "D:/exports/revision_corpus_manifest.json"
         with (
             mock.patch.object(
                 self.window,
@@ -791,7 +792,10 @@ class GuiTaskPageTests(unittest.TestCase):
             ),
             mock.patch(
                 "gui_qt.app.QFileDialog.getOpenFileName",
-                return_value=(proposal_path, "JSON Lines (*.jsonl)"),
+                side_effect=[
+                    (proposal_path, "JSON Lines (*.jsonl)"),
+                    (corpus_manifest_path, "JSON (*.json)"),
+                ],
             ),
             mock.patch.object(self.window, "_set_writeback_summary") as set_summary,
             mock.patch.object(self.window, "_clear_log_view") as clear_log,
@@ -804,6 +808,7 @@ class GuiTaskPageTests(unittest.TestCase):
 
         workflow = begin_workflow.call_args.args[0]
         self.assertEqual(workflow.proposal_path, proposal_path)
+        self.assertEqual(workflow.corpus_manifest_path, corpus_manifest_path)
         self.assertEqual(
             begin_workflow.call_args.kwargs["log_heading"],
             REVISION_PROPOSAL_COPY["running"],

--- a/tests/test_gui_task_pages.py
+++ b/tests/test_gui_task_pages.py
@@ -30,7 +30,7 @@ from gui_qt.work_modes import (
     work_mode_submode_label,
     workbench_nav_spec,
 )
-from gui_qt.user_copy import PROJECT_ANALYSIS_COPY
+from gui_qt.user_copy import PROJECT_ANALYSIS_COPY, REVISION_PROPOSAL_COPY
 from gui_qt.workbench import WorkbenchPageActions
 from gui_qt.workbench_session import WorkbenchModeSession
 from tests import gui_test_support
@@ -737,6 +737,7 @@ class GuiTaskPageTests(unittest.TestCase):
         resumes: list[bool] = []
         stops: list[bool] = []
         writebacks: list[bool] = []
+        actions: list[str] = []
         selected: list[WorkMode] = []
         page.set_action_callbacks(
             WorkbenchPageActions(
@@ -745,6 +746,7 @@ class GuiTaskPageTests(unittest.TestCase):
                 stop=lambda: stops.append(True),
                 writeback=lambda: writebacks.append(True),
                 select_mode=selected.append,
+                action=actions.append,
             )
         )
         page.activate(WorkMode.REVISION, WorkbenchModeSession())
@@ -757,6 +759,12 @@ class GuiTaskPageTests(unittest.TestCase):
             result_message="订正预览已通过。",
         )
         page.start_btn.click()
+        self.assertFalse(page.import_proposals_btn.isHidden())
+        self.assertEqual(page.import_proposals_btn.text(), REVISION_PROPOSAL_COPY["action"])
+        self.assertEqual(
+            page.import_proposals_btn.toolTip(), REVISION_PROPOSAL_COPY["tooltip"]
+        )
+        page.import_proposals_btn.click()
         page.resume_btn.click()
         page.writeback_btn.click()
         page.set_task_running(True)
@@ -769,8 +777,41 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertEqual(starts, [True])
         self.assertEqual(resumes, [True])
         self.assertEqual(writebacks, [True])
+        self.assertEqual(actions, ["import_revision_proposals"])
         self.assertEqual(stops, [True])
         self.assertEqual(selected, [WorkMode.SYNC_REVISION])
+
+    def test_revision_proposal_action_starts_import_workflow(self) -> None:
+        proposal_path = "C:/review/proposals.jsonl"
+        with (
+            mock.patch.object(
+                self.window,
+                "_confirm_unsaved_config_before_workflow",
+                return_value=True,
+            ),
+            mock.patch(
+                "gui_qt.app.QFileDialog.getOpenFileName",
+                return_value=(proposal_path, "JSON Lines (*.jsonl)"),
+            ),
+            mock.patch.object(self.window, "_set_writeback_summary") as set_summary,
+            mock.patch.object(self.window, "_clear_log_view") as clear_log,
+            mock.patch.object(self.window, "_show_workbench_log_drawer") as show_log,
+            mock.patch.object(
+                self.window, "_begin_translation_workflow"
+            ) as begin_workflow,
+        ):
+            self.window._on_final_review_page_action("import_revision_proposals")
+
+        workflow = begin_workflow.call_args.args[0]
+        self.assertEqual(workflow.proposal_path, proposal_path)
+        self.assertEqual(
+            begin_workflow.call_args.kwargs["log_heading"],
+            REVISION_PROPOSAL_COPY["running"],
+        )
+        self.assertEqual(begin_workflow.call_args.kwargs["status_tab"], 1)
+        set_summary.assert_called_once()
+        clear_log.assert_called_once_with()
+        show_log.assert_called_once_with()
 
     def test_revision_page_mode_selector_and_running_lock(self) -> None:
         self.window._set_work_mode(WorkMode.REVISION, refresh_manifest_writeback=False)
@@ -792,6 +833,7 @@ class GuiTaskPageTests(unittest.TestCase):
         self.assertEqual(page.mode_combo.currentData(), WorkMode.FINAL_REVIEW.value)
         self.assertEqual(page.start_btn.text(), "开始最终审校")
         self.assertFalse(page.review_findings_btn.isHidden())
+        self.assertTrue(page.import_proposals_btn.isHidden())
         self.assertEqual(page.writeback_btn.text(), "写回所选订正")
         self.assertIn("人工选择", self.window.work_mode_hint_label.text())
 

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -88,6 +88,25 @@ class RevisionProposalContractTests(unittest.TestCase):
         )
         self.assertIn("IDENTITY_MISMATCH", {x["code"] for x in result.diagnostics})
 
+    def test_reason_is_required_for_selected_proposals(self):
+        result = proposals.validate(
+            [self.row(reason="  ")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn("MISSING_REASON", {x["code"] for x in result.diagnostics})
+
+    def test_file_path_separator_style_is_normalized(self):
+        self.live["occ-1"]["file_rel_path"] = "chapter/scene.rpy"
+        result = proposals.validate(
+            [self.row(file_rel_path=r"chapter\scene.rpy")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "imported")
+
     def test_corpus_snapshot_mismatch_is_stale(self):
         result = proposals.validate(
             [self.row(corpus_snapshot_digest="b" * 64)],
@@ -300,6 +319,10 @@ class RevisionProposalImportTests(unittest.TestCase):
         manifest = result["manifest"]
         self.assertEqual(manifest["mode"], batch.MANIFEST_MODE_REVISION)
         self.assertTrue(manifest["proposal_import"]["writeback_eligible"])
+        self.assertEqual(
+            Path(batch.LATEST_MANIFEST_FILE).read_text(encoding="utf-8"),
+            result["paths"]["manifest"],
+        )
 
     def test_empty_proposal_file_is_rejected_before_artifacts_are_created(self):
         proposal_path = self.root / "empty.jsonl"
@@ -321,11 +344,16 @@ class RevisionProposalImportTests(unittest.TestCase):
 
     def test_broken_interpolation_token_is_blocked_and_never_writes(self):
         before = self.rpy.read_bytes()
+        latest_path = Path(batch.LATEST_MANIFEST_FILE)
+        latest_path.parent.mkdir(parents=True, exist_ok=True)
+        previous_manifest = self.root / "previous" / "manifest.json"
+        latest_path.write_text(str(previous_manifest), encoding="utf-8")
         result = batch.import_revision_proposals(
             str(self._write_proposal(self._proposal(proposed="您好")))
         )
         self.assertEqual(result["status"], "blocked")
         self.assertEqual(self.rpy.read_bytes(), before)
+        self.assertEqual(latest_path.read_text(encoding="utf-8"), str(previous_manifest))
         self.assertFalse(result["manifest"]["proposal_import"]["writeback_eligible"])
         with self.assertRaisesRegex(SystemExit, "proposal import"):
             batch.apply_revisions(result["paths"]["manifest"], force=True)

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -334,6 +334,27 @@ class RevisionProposalImportTests(unittest.TestCase):
         self.assertEqual(self.rpy.read_bytes(), before)
         self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
 
+    def test_malformed_corpus_manifest_has_stable_machine_error(self):
+        corpus_path = self.root / "bad-corpus.json"
+        corpus_path.write_text(
+            json.dumps(
+                {
+                    "kind": "revision_corpus",
+                    "schema_version": revision_corpus.REVISION_CORPUS_SCHEMA_VERSION,
+                    "project": {"tl_dir": str(self.tl_dir)},
+                    "source": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(batch.cli_contract.MachineContractError) as caught:
+            batch.import_revision_proposals(
+                str(self._write_proposal(self._proposal())),
+                corpus_manifest_path=str(corpus_path),
+            )
+        self.assertEqual(caught.exception.code_name, "CORPUS_MANIFEST_INVALID")
+        self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
+
     def test_unselected_proposals_report_no_writeback_needed(self):
         row = self._proposal()
         row.update(selected=False, disposition="rejected")

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import os
 import tempfile
 import unittest
@@ -94,6 +95,73 @@ class RevisionProposalContractTests(unittest.TestCase):
         )
         self.assertEqual(result.status, "stale")
         self.assertIn("CORPUS_SNAPSHOT_STALE", {x["code"] for x in result.diagnostics})
+
+    def test_inconsistent_corpus_export_is_stale(self):
+        result = proposals.validate(
+            [self.row()],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+            corpus_manifest={
+                "source": {
+                    "snapshot_digest": self.corpus_digest,
+                    "source_changed_during_scan": True,
+                }
+            },
+        )
+        self.assertEqual(result.status, "stale")
+        self.assertIn(
+            "CORPUS_SNAPSHOT_INCONSISTENT",
+            {x["code"] for x in result.diagnostics},
+        )
+
+    def test_legacy_revision_identity_keeps_pre_proposal_fingerprint(self):
+        manifest = {
+            "mode": "revision",
+            "manifest_version": 2,
+            "version": 2,
+            "core_schema_version": 2,
+            "display_name": "legacy",
+            "summary": {"item_count": 1},
+            "files": {"chapter.rpy": {"task_count": 1}},
+            "chunks": [{"key": "rv-1"}],
+        }
+        legacy_keys = (
+            "mode", "manifest_version", "version", "core_schema_version",
+            "display_name", "job_name", "created_at", "execution",
+            "batch_model", "model", "base_dir", "tl_dir",
+            "target_language", "language", "input_jsonl_path",
+            "result_jsonl_path", "settings", "revision_settings", "summary",
+            "files", "chunks", "final_review_source",
+        )
+        payload = {key: manifest.get(key) for key in legacy_keys}
+        expected = hashlib.sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(batch._revision_manifest_identity(manifest), expected)
+        self.assertEqual(
+            batch._revision_manifest_identity({**manifest, "proposal_import": None}),
+            expected,
+        )
+
+    def test_proposal_import_state_is_bound_by_manifest_identity(self):
+        manifest = {
+            "mode": "revision",
+            "proposal_import": {
+                "status": "previewed",
+                "writeback_eligible": True,
+            },
+        }
+        previewed = batch._revision_manifest_identity(manifest)
+        blocked = batch._revision_manifest_identity(
+            {
+                **manifest,
+                "proposal_import": {
+                    "status": "blocked",
+                    "writeback_eligible": False,
+                },
+            }
+        )
+        self.assertNotEqual(previewed, blocked)
 
     def test_unselected_rows_produce_no_op(self):
         result = proposals.validate(

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -380,6 +380,29 @@ class RevisionProposalImportTests(unittest.TestCase):
             batch.apply_revisions(result["paths"]["manifest"], force=True)
         self.assertEqual(self.rpy.read_bytes(), before)
 
+    def test_repreview_recomputes_proposal_writeback_eligibility(self):
+        result = batch.import_revision_proposals(
+            str(self._write_proposal(self._proposal()))
+        )
+        manifest_path = result["paths"]["manifest"]
+        self.rpy.write_text(
+            'translate schinese demo:\n'
+            '    old "Hello {name}"\n'
+            '    new "源文件已变化 {name}"\n',
+            encoding="utf-8",
+        )
+
+        repreviewed = batch.preview_revisions(manifest_path)
+
+        self.assertEqual(repreviewed["proposal_import"]["status"], "blocked")
+        self.assertFalse(repreviewed["proposal_import"]["writeback_eligible"])
+        self.assertEqual(
+            repreviewed["proposal_import"]["history"],
+            ["imported", "previewed", "blocked"],
+        )
+        with self.assertRaisesRegex(SystemExit, "proposal import"):
+            batch.apply_revisions(manifest_path, force=True)
+
     def test_duplicate_source_applies_only_selected_occurrence(self):
         self.rpy.write_text(
             'translate schinese demo:\n'

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -1,0 +1,249 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch
+import revision_corpus
+import revision_proposals as proposals
+
+
+class RevisionProposalContractTests(unittest.TestCase):
+    def setUp(self):
+        self.live = {
+            "occ-1": {
+                "id": "occ-1",
+                "file_rel_path": "chapter.rpy",
+                "source": "Hello {name}",
+                "current_translation": "你好 {name}",
+            }
+        }
+        self.corpus_digest = "a" * 64
+
+    def row(self, **updates):
+        row = {
+            "schema_version": 1,
+            "occurrence_id": "occ-1",
+            "identity_v2": "occ-1",
+            "file_rel_path": "chapter.rpy",
+            "source": "Hello {name}",
+            "current_translation": "你好 {name}",
+            "proposed_translation": "您好，{name}",
+            "reason": "语气更自然",
+            "selected": True,
+            "disposition": "accepted",
+            "producer": {"type": "human"},
+            "snapshot_digest": revision_corpus.item_snapshot_digest(
+                "Hello {name}", "你好 {name}"
+            ),
+            "corpus_snapshot_digest": self.corpus_digest,
+        }
+        row.update(updates)
+        return row
+
+    def test_valid_human_proposal_is_imported(self):
+        result = proposals.validate(
+            [self.row()], self.live, live_snapshot_digest=self.corpus_digest
+        )
+        self.assertEqual(result.status, "imported")
+        self.assertEqual(len(result.proposals), 1)
+        self.assertEqual(result.diagnostics, ())
+
+    def test_duplicate_and_conflicting_occurrences_are_blocked(self):
+        duplicate = proposals.validate(
+            [self.row(), self.row()], self.live, live_snapshot_digest=self.corpus_digest
+        )
+        self.assertIn("DUPLICATE_OCCURRENCE_ID", {x["code"] for x in duplicate.diagnostics})
+        conflict = proposals.validate(
+            [self.row(), self.row(proposed_translation="另一版")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertIn("CONFLICTING_PROPOSAL", {x["code"] for x in conflict.diagnostics})
+
+    def test_unknown_and_stale_current_translation_are_rejected(self):
+        unknown = proposals.validate(
+            [self.row(occurrence_id="missing", identity_v2="missing")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertIn("UNKNOWN_OCCURRENCE_ID", {x["code"] for x in unknown.diagnostics})
+        stale = proposals.validate(
+            [self.row(current_translation="旧译文")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(stale.status, "stale")
+        self.assertIn("CURRENT_TRANSLATION_STALE", {x["code"] for x in stale.diagnostics})
+
+    def test_occurrence_and_identity_v2_must_agree(self):
+        result = proposals.validate(
+            [self.row(identity_v2="different")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertIn("IDENTITY_MISMATCH", {x["code"] for x in result.diagnostics})
+
+    def test_corpus_snapshot_mismatch_is_stale(self):
+        result = proposals.validate(
+            [self.row(corpus_snapshot_digest="b" * 64)],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "stale")
+        self.assertIn("CORPUS_SNAPSHOT_STALE", {x["code"] for x in result.diagnostics})
+
+    def test_unselected_rows_produce_no_op(self):
+        result = proposals.validate(
+            [self.row(selected=False, disposition="rejected")],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "no_op")
+        self.assertFalse(result.proposals)
+
+    def test_jsonl_loader_reports_bad_row(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "proposal.jsonl")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(self.row(), ensure_ascii=False) + "\n{bad\n")
+            with self.assertRaisesRegex(ValueError, "row 2"):
+                proposals.load_jsonl(path)
+
+
+class RevisionProposalImportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.tl_dir = self.root / "game" / "tl" / "schinese"
+        self.tl_dir.mkdir(parents=True)
+        self.rpy = self.tl_dir / "chapter.rpy"
+        self.rpy.write_text(
+            'translate schinese demo:\n    old "Hello {name}"\n    new "你好 {name}"\n',
+            encoding="utf-8",
+        )
+        self.old = {
+            "base": batch.legacy.BASE_DIR,
+            "tl": batch.legacy.TL_DIR,
+            "files": set(batch.legacy.INCLUDE_FILES),
+            "prefixes": set(batch.legacy.INCLUDE_PREFIXES),
+            "jobs": batch.BATCH_JOBS_DIR,
+            "latest": batch.LATEST_MANIFEST_FILE,
+            "rag": batch.RAG_ENABLED,
+            "story": batch.STORY_MEMORY_ENABLED,
+        }
+        batch.legacy.BASE_DIR = str(self.root)
+        batch.legacy.TL_DIR = str(self.tl_dir)
+        batch.legacy.INCLUDE_FILES = set()
+        batch.legacy.INCLUDE_PREFIXES = set()
+        batch.BATCH_JOBS_DIR = str(self.root / "logs" / "batch_jobs")
+        batch.LATEST_MANIFEST_FILE = str(Path(batch.BATCH_JOBS_DIR) / "latest_manifest.txt")
+        batch.RAG_ENABLED = False
+        batch.STORY_MEMORY_ENABLED = False
+
+    def tearDown(self):
+        batch.legacy.BASE_DIR = self.old["base"]
+        batch.legacy.TL_DIR = self.old["tl"]
+        batch.legacy.INCLUDE_FILES = self.old["files"]
+        batch.legacy.INCLUDE_PREFIXES = self.old["prefixes"]
+        batch.BATCH_JOBS_DIR = self.old["jobs"]
+        batch.LATEST_MANIFEST_FILE = self.old["latest"]
+        batch.RAG_ENABLED = self.old["rag"]
+        batch.STORY_MEMORY_ENABLED = self.old["story"]
+        self.temp.cleanup()
+
+    def _proposal(self, proposed="您好，{name}"):
+        item = batch.collect_revision_file_jobs()[0]["items"][0]
+        paths = dict(batch.collect_files_to_process())
+        corpus_digest = revision_corpus.aggregate_digest(
+            revision_corpus.collect_file_digests(paths)
+        )
+        return {
+            "schema_version": 1,
+            "occurrence_id": item["id"],
+            "identity_v2": item["id"],
+            "file_rel_path": item["file_rel_path"],
+            "source": item["source"],
+            "current_translation": item["current_translation"],
+            "proposed_translation": proposed,
+            "reason": "test",
+            "selected": True,
+            "disposition": "accepted",
+            "producer": {"type": "agent", "tool": "unit-test"},
+            "snapshot_digest": revision_corpus.item_snapshot_digest(
+                item["source"], item["current_translation"]
+            ),
+            "corpus_snapshot_digest": corpus_digest,
+        }
+
+    def _write_proposal(self, row):
+        path = self.root / "proposal.jsonl"
+        path.write_text(json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
+        return path
+
+    def test_valid_proposal_builds_standard_preview_without_writing_rpy(self):
+        before = self.rpy.read_bytes()
+        result = batch.import_revision_proposals(str(self._write_proposal(self._proposal())))
+        self.assertEqual(result["status"], "previewed")
+        self.assertEqual(self.rpy.read_bytes(), before)
+        self.assertTrue(Path(result["paths"]["manifest"]).is_file())
+        self.assertTrue(Path(result["paths"]["revision_preview_jsonl"]).is_file())
+        manifest = result["manifest"]
+        self.assertEqual(manifest["mode"], batch.MANIFEST_MODE_REVISION)
+        self.assertTrue(manifest["proposal_import"]["writeback_eligible"])
+
+    def test_broken_interpolation_token_is_blocked_and_never_writes(self):
+        before = self.rpy.read_bytes()
+        result = batch.import_revision_proposals(
+            str(self._write_proposal(self._proposal(proposed="您好")))
+        )
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(self.rpy.read_bytes(), before)
+        self.assertFalse(result["manifest"]["proposal_import"]["writeback_eligible"])
+        with self.assertRaisesRegex(SystemExit, "proposal import"):
+            batch.apply_revisions(result["paths"]["manifest"], force=True)
+        self.assertEqual(self.rpy.read_bytes(), before)
+
+    def test_duplicate_source_applies_only_selected_occurrence(self):
+        self.rpy.write_text(
+            'translate schinese demo:\n'
+            '    old "Repeat"\n'
+            '    new "第一处"\n\n'
+            '    old "Repeat"\n'
+            '    new "第二处"\n',
+            encoding="utf-8",
+        )
+        jobs = batch.collect_revision_file_jobs()
+        target = jobs[0]["items"][1]
+        paths = dict(batch.collect_files_to_process())
+        corpus_digest = revision_corpus.aggregate_digest(
+            revision_corpus.collect_file_digests(paths)
+        )
+        row = {
+            "schema_version": 1,
+            "occurrence_id": target["id"],
+            "identity_v2": target["id"],
+            "file_rel_path": target["file_rel_path"],
+            "source": target["source"],
+            "current_translation": target["current_translation"],
+            "proposed_translation": "只改第二处",
+            "reason": "target occurrence",
+            "selected": True,
+            "disposition": "accepted",
+            "producer": {"type": "human"},
+            "snapshot_digest": revision_corpus.item_snapshot_digest(
+                target["source"], target["current_translation"]
+            ),
+            "corpus_snapshot_digest": corpus_digest,
+        }
+        result = batch.import_revision_proposals(str(self._write_proposal(row)))
+        batch.apply_revisions(result["paths"]["manifest"])
+        written = self.rpy.read_text(encoding="utf-8")
+        self.assertIn('new "第一处"', written)
+        self.assertIn('new "只改第二处"', written)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -36,6 +36,7 @@ class RevisionProposalContractTests(unittest.TestCase):
             "selected": True,
             "disposition": "accepted",
             "producer": {"type": "human"},
+            "project_identity": {"tl_dir": "C:/demo/game/tl/schinese"},
             "snapshot_digest": revision_corpus.item_snapshot_digest(
                 "Hello {name}", "你好 {name}"
             ),
@@ -102,6 +103,7 @@ class RevisionProposalContractTests(unittest.TestCase):
             self.live,
             live_snapshot_digest=self.corpus_digest,
             corpus_manifest={
+                "project": {"tl_dir": "C:/demo/game/tl/schinese"},
                 "source": {
                     "snapshot_digest": self.corpus_digest,
                     "source_changed_during_scan": True,
@@ -172,6 +174,42 @@ class RevisionProposalContractTests(unittest.TestCase):
         self.assertEqual(result.status, "no_op")
         self.assertFalse(result.proposals)
 
+    def test_project_identity_is_required_without_corpus_manifest(self):
+        result = proposals.validate(
+            [self.row(project_identity=None)],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+            live_project_identity={"tl_dir": "C:/demo/game/tl/schinese"},
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertIn("MISSING_PROJECT_IDENTITY", {x["code"] for x in result.diagnostics})
+
+    def test_cross_project_proposal_is_stale_without_corpus_manifest(self):
+        result = proposals.validate(
+            [self.row(project_identity={"tl_dir": "C:/other/game/tl/schinese"})],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+            live_project_identity={"tl_dir": "C:/demo/game/tl/schinese"},
+        )
+        self.assertEqual(result.status, "stale")
+        self.assertEqual(result.requested_selected_count, 1)
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn("PROJECT_IDENTITY_STALE", {x["code"] for x in result.diagnostics})
+
+    def test_matching_corpus_manifest_supplies_project_identity(self):
+        result = proposals.validate(
+            [self.row(project_identity=None)],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+            live_project_identity={"tl_dir": "C:/demo/game/tl/schinese"},
+            corpus_manifest={
+                "project": {"tl_dir": "C:/demo/game/tl/schinese"},
+                "source": {"snapshot_digest": self.corpus_digest},
+            },
+        )
+        self.assertEqual(result.status, "imported")
+        self.assertEqual(result.selected_count, 1)
+
     def test_jsonl_loader_reports_bad_row(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, "proposal.jsonl")
@@ -240,6 +278,7 @@ class RevisionProposalImportTests(unittest.TestCase):
             "selected": True,
             "disposition": "accepted",
             "producer": {"type": "agent", "tool": "unit-test"},
+            "project_identity": {"tl_dir": str(self.tl_dir)},
             "snapshot_digest": revision_corpus.item_snapshot_digest(
                 item["source"], item["current_translation"]
             ),
@@ -261,6 +300,16 @@ class RevisionProposalImportTests(unittest.TestCase):
         manifest = result["manifest"]
         self.assertEqual(manifest["mode"], batch.MANIFEST_MODE_REVISION)
         self.assertTrue(manifest["proposal_import"]["writeback_eligible"])
+
+    def test_empty_proposal_file_is_rejected_before_artifacts_are_created(self):
+        proposal_path = self.root / "empty.jsonl"
+        proposal_path.write_text("\n", encoding="utf-8")
+        before = self.rpy.read_bytes()
+        with self.assertRaises(batch.cli_contract.MachineContractError) as caught:
+            batch.import_revision_proposals(str(proposal_path))
+        self.assertEqual(caught.exception.code_name, "NO_PROPOSAL_ROWS")
+        self.assertEqual(self.rpy.read_bytes(), before)
+        self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
 
     def test_broken_interpolation_token_is_blocked_and_never_writes(self):
         before = self.rpy.read_bytes()
@@ -301,6 +350,7 @@ class RevisionProposalImportTests(unittest.TestCase):
             "selected": True,
             "disposition": "accepted",
             "producer": {"type": "human"},
+            "project_identity": {"tl_dir": str(self.tl_dir)},
             "snapshot_digest": revision_corpus.item_snapshot_digest(
                 target["source"], target["current_translation"]
             ),

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -112,6 +112,58 @@ class RevisionProposalContractTests(unittest.TestCase):
         )
         self.assertIn("INVALID_REASON_TYPE", {x["code"] for x in result.diagnostics})
 
+    def test_source_and_current_translation_must_be_strings(self):
+        result = proposals.validate(
+            [self.row(source=123, current_translation=["你好 {name}"])],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn("INVALID_SOURCE_TYPE", {x["code"] for x in result.diagnostics})
+        self.assertIn(
+            "INVALID_CURRENT_TRANSLATION_TYPE",
+            {x["code"] for x in result.diagnostics},
+        )
+
+    def test_stringified_source_and_current_translation_are_not_accepted(self):
+        live = {
+            "occ-1": {
+                "id": "occ-1",
+                "file_rel_path": "chapter.rpy",
+                "source": "123",
+                "current_translation": "456",
+            }
+        }
+        row = self.row(
+            source=123,
+            current_translation=456,
+            snapshot_digest=revision_corpus.item_snapshot_digest("123", "456"),
+        )
+        result = proposals.validate(
+            [row], live, live_snapshot_digest=self.corpus_digest
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn("INVALID_SOURCE_TYPE", {x["code"] for x in result.diagnostics})
+        self.assertIn(
+            "INVALID_CURRENT_TRANSLATION_TYPE",
+            {x["code"] for x in result.diagnostics},
+        )
+
+    def test_conflicting_item_snapshot_fields_are_blocked(self):
+        result = proposals.validate(
+            [self.row(item_snapshot_digest="b" * 64)],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn(
+            "ITEM_SNAPSHOT_CONFLICT",
+            {x["code"] for x in result.diagnostics},
+        )
+
     def test_file_path_separator_style_is_normalized(self):
         self.live["occ-1"]["file_rel_path"] = "chapter/scene.rpy"
         result = proposals.validate(
@@ -346,6 +398,27 @@ class RevisionProposalImportTests(unittest.TestCase):
             batch.import_revision_proposals(str(proposal_path))
         self.assertEqual(caught.exception.code_name, "NO_PROPOSAL_ROWS")
         self.assertEqual(self.rpy.read_bytes(), before)
+        self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
+
+    def test_corpus_manifest_without_snapshot_digest_is_rejected(self):
+        corpus_path = self.root / "missing-snapshot-corpus.json"
+        corpus_path.write_text(
+            json.dumps(
+                {
+                    "kind": "revision_corpus",
+                    "schema_version": revision_corpus.REVISION_CORPUS_SCHEMA_VERSION,
+                    "project": {"tl_dir": str(self.tl_dir)},
+                    "source": {"source_changed_during_scan": False},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(batch.cli_contract.MachineContractError) as caught:
+            batch.import_revision_proposals(
+                str(self._write_proposal(self._proposal())),
+                corpus_manifest_path=str(corpus_path),
+            )
+        self.assertEqual(caught.exception.code_name, "CORPUS_MANIFEST_INVALID")
         self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
 
     def test_malformed_corpus_manifest_has_stable_machine_error(self):

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -98,6 +98,20 @@ class RevisionProposalContractTests(unittest.TestCase):
         self.assertEqual(result.selected_count, 0)
         self.assertIn("MISSING_REASON", {x["code"] for x in result.diagnostics})
 
+    def test_proposed_translation_and_reason_must_be_strings(self):
+        result = proposals.validate(
+            [self.row(proposed_translation=123, reason=["not", "text"])],
+            self.live,
+            live_snapshot_digest=self.corpus_digest,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.selected_count, 0)
+        self.assertIn(
+            "INVALID_PROPOSED_TRANSLATION_TYPE",
+            {x["code"] for x in result.diagnostics},
+        )
+        self.assertIn("INVALID_REASON_TYPE", {x["code"] for x in result.diagnostics})
+
     def test_file_path_separator_style_is_normalized(self):
         self.live["occ-1"]["file_rel_path"] = "chapter/scene.rpy"
         result = proposals.validate(

--- a/tests/test_revision_proposals.py
+++ b/tests/test_revision_proposals.py
@@ -311,6 +311,14 @@ class RevisionProposalImportTests(unittest.TestCase):
         self.assertEqual(self.rpy.read_bytes(), before)
         self.assertFalse(Path(batch.BATCH_JOBS_DIR).exists())
 
+    def test_unselected_proposals_report_no_writeback_needed(self):
+        row = self._proposal()
+        row.update(selected=False, disposition="rejected")
+        result = batch.import_revision_proposals(str(self._write_proposal(row)))
+        self.assertEqual(result["status"], "no_op")
+        self.assertEqual(result["suggested_action"], "no_writeback_needed")
+        self.assertNotIn("manifest", result["paths"])
+
     def test_broken_interpolation_token_is_blocked_and_never_writes(self):
         before = self.rpy.read_bytes()
         result = batch.import_revision_proposals(

--- a/tests/test_test_runners.py
+++ b/tests/test_test_runners.py
@@ -115,7 +115,7 @@ class TestDiscoveryRunners(unittest.TestCase):
 
         shutdown.assert_called_once_with()
 
-    def test_gui_script_path_skips_qt_cleanup_before_hard_exit(self):
+    def test_gui_script_path_checks_pool_without_widget_cleanup(self):
         guard = mock.Mock(rejected_dialogs=())
         manager = mock.MagicMock()
         manager.__enter__.return_value = guard
@@ -145,7 +145,7 @@ class TestDiscoveryRunners(unittest.TestCase):
                 0,
             )
 
-        shutdown.assert_not_called()
+        shutdown.assert_called_once_with(cleanup_widgets=False)
 
     def test_gui_runner_fails_when_qt_pool_does_not_stop(self):
         guard = mock.Mock(rejected_dialogs=())

--- a/tests/test_test_runners.py
+++ b/tests/test_test_runners.py
@@ -115,6 +115,38 @@ class TestDiscoveryRunners(unittest.TestCase):
 
         shutdown.assert_called_once_with()
 
+    def test_gui_script_path_skips_qt_cleanup_before_hard_exit(self):
+        guard = mock.Mock(rejected_dialogs=())
+        manager = mock.MagicMock()
+        manager.__enter__.return_value = guard
+        manager.__exit__.return_value = False
+        with (
+            mock.patch(
+                "gui_test_support.guarded_gui_test_environment",
+                return_value=manager,
+            ),
+            mock.patch(
+                "gui_test_support.shutdown_gui_test_runtime",
+                return_value=True,
+            ) as shutdown,
+            mock.patch.object(
+                run_gui_tests,
+                "build_suite",
+                return_value=unittest.TestSuite(),
+            ),
+            mock.patch.object(
+                run_gui_tests,
+                "run_discovered_suite",
+                return_value=0,
+            ),
+        ):
+            self.assertEqual(
+                run_gui_tests.main([], shutdown_runtime=False),
+                0,
+            )
+
+        shutdown.assert_not_called()
+
     def test_gui_runner_fails_when_qt_pool_does_not_stop(self):
         guard = mock.Mock(rejected_dialogs=())
         manager = mock.MagicMock()


### PR DESCRIPTION
Closes #321

## What changed

- add `import-revision-proposals` for structured human/Agent JSONL proposals
- validate schema, identity v2, duplicate/conflicting occurrences, project/corpus snapshots, live source/current translation, provenance, and empty proposals
- convert valid proposals into the existing `mode=revision` manifest/results contract and immediately run `preview-revisions`
- add stable `imported`, `previewed`, `no_op`, `partial`, `blocked`, and `stale` machine statuses with diagnostics, artifacts, suggested actions, and strict exit codes
- prevent `apply-revisions --force` from bypassing proposal eligibility, preview hashes, project identity, source snapshots, or adapter validation
- add a GUI file-import entry, diagnostics command reference, and proposal-aware writeback gating
- document proposal schema and the CLI/GUI workflow

## Why

The prototype searched Current/Proposed strings and performed broad replacements. That cannot safely distinguish duplicate dialogue occurrences or detect stale translations and project snapshots. This change anchors proposals to identity v2 and reuses the existing revision preview/apply transaction instead of adding a second writeback state machine.

## Out of scope

- Importing #313 quality findings as revision candidates is not delivered in this PR; that path is tracked by #363 and must reuse the proposal/candidate contract introduced here.

## Validation

- targeted suites: 110 tests passed
- CLI suite: 1135 passed, 1 skipped
- `python scripts/run_quality_gates.py all`: passed
- `git diff --check`: passed
- GUI suite: 1070/1071 passed; the remaining failure is the independently reproducible existing settings-layout copy assertion `test_workspace_action_bar_uses_immediate_save_context`, outside this diff

