### PR TITLE
docs: add WSL2 read-only home sandbox notes

### DIFF
--- a/docs/gui_tests_sandbox_notes.md
+++ b/docs/gui_tests_sandbox_notes.md
@@ -73,7 +73,7 @@ tempfile._mkstemp_inner
 
 ## WSL2 只读 home 环境（实测补充）
 
-- 与 Codex 沙箱的差异：当前 WSL2 环境根文件系统 `/dev/sdd` 为 `ro`，
+- 与 Codex 沙箱的差异：当前 WSL2 环境根文件系统为只读（`ro`），
   仅仓库目录是单独的 `rw` 挂载，`/tmp` 可写；默认缓存路径
   `~/.local/state/renpy-translation-lab/litellm_catalog_cache.json` 同样不可写。
 - 但 `atomic_write_text` 会**立即**失败并返回 `OSError 30 (Read-only file system)`，
@@ -85,8 +85,9 @@ tempfile._mkstemp_inner
   无进程残留。
 - 注意：当前环境未安装 `litellm` 时，该测试不会触发缓存 `_save`（埋点调用次数为 0），
   所以“测试通过”不能证明缓存路径可写；需要直接写入探针验证。
-- 规避：需要真实持久化 GUI 缓存时，将 `XDG_STATE_HOME` 指到可写目录，例如
+- 规避：仅需当前 WSL 会话缓存时，将 `XDG_STATE_HOME` 指到可写目录，例如
   `XDG_STATE_HOME=/tmp/renpy-translation-lab-state`；实测同一写入路径约 0.79 毫秒成功。
+  需要跨 WSL 重启持久化时，将 `XDG_STATE_HOME` 指到可写且持久的挂载点。
 
 ## 规避与修复
 

--- a/docs/gui_tests_sandbox_notes.md
+++ b/docs/gui_tests_sandbox_notes.md
@@ -71,6 +71,23 @@ tempfile._mkstemp_inner
 - CI 的 GUI 测试 job 在 Linux offscreen 环境运行，不受此问题影响。
 - 与 #338 的代码改动无关：在写 cache 之前的位置并无本次改动介入。
 
+## WSL2 只读 home 环境（实测补充）
+
+- 与 Codex 沙箱的差异：当前 WSL2 环境根文件系统 `/dev/sdd` 为 `ro`，
+  仅仓库目录是单独的 `rw` 挂载，`/tmp` 可写；默认缓存路径
+  `~/.local/state/renpy-translation-lab/litellm_catalog_cache.json` 同样不可写。
+- 但 `atomic_write_text` 会**立即**失败并返回 `OSError 30 (Read-only file system)`，
+  不会像 Codex 沙箱那样挂起；`gui_qt/app.py` 的 `_save_litellm_cache()` 会捕获
+  该 `OSError` 并仅记录日志，因此 GUI 测试可以继续跑完。
+- 实测（PySide6 6.11.1 + `QT_QPA_PLATFORM=offscreen`）：
+  `test_settings_sections_controls_no_clip_or_overlap` 约 0.5 秒通过；
+  整个 `tests/test_gui_control_layout_audit.py` 3 个用例 1.136 秒全部通过，
+  无进程残留。
+- 注意：当前环境未安装 `litellm` 时，该测试不会触发缓存 `_save`（埋点调用次数为 0），
+  所以“测试通过”不能证明缓存路径可写；需要直接写入探针验证。
+- 规避：需要真实持久化 GUI 缓存时，将 `XDG_STATE_HOME` 指到可写目录，例如
+  `XDG_STATE_HOME=/tmp/renpy-translation-lab-state`；实测同一写入路径约 0.79 毫秒成功。
+
 ## 规避与修复
 
 ### 在 Codex 会话内


### PR DESCRIPTION
## Summary

补充 `docs/gui_tests_sandbox_notes.md`：记录当前 WSL2 只读 home 环境下，GUI 缓存路径的实测行为与规避方法。

## Details

- 当前环境根文件系统为 `ro`，默认缓存路径 `~/.local/state/renpy-translation-lab/litellm_catalog_cache.json` 不可写。
- 与 Codex 沙箱不同，写入会立即返回 `OSError 30`，不会挂起；`gui_qt/app.py` 会捕获该错误。
- 实测 `tests/test_gui_control_layout_audit.py` 在 offscreen 模式下 3 个用例全部通过，无进程残留。
- 需要持久化缓存时，可将 `XDG_STATE_HOME` 指向可写目录（如 `/tmp/renpy-translation-lab-state`）。

## Test

- `QT_QPA_PLATFORM=offscreen python -m unittest tests.test_gui_control_layout_audit -v`：3/3 通过
- 默认缓存路径直接写入探针：`OSError 30 (Read-only file system)`
- `XDG_STATE_HOME=/tmp/...` 写入探针：成功（约 0.79 ms）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for read-only home environments, including cache-write behavior and resulting errors.
  * Documented differences between immediate failures and sandbox hangs during testing.
  * Recorded GUI test results and limitations when required tooling is unavailable.
  * Added a workaround using `XDG_STATE_HOME` to preserve cache data in a writable location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->