### PR TITLE
fix(keyword): plural variant generation misses y->ies and mishandles s-ending singulars

### DIFF
--- a/keyword_history.py
+++ b/keyword_history.py
@@ -140,6 +140,63 @@ def _boundary_pattern(term: str) -> str:
     return left + pattern + right
 
 
+_SINGULAR_S_ENDING_EXCEPTIONS = frozenset(
+    {
+        # Common English words that end in "s" but are singular.  For these we
+        # generate the regular "-es" plural instead of blindly stripping the s.
+        "alias",
+        "atlas",
+        "bias",
+        "boss",
+        "bus",
+        "campus",
+        "canvas",
+        "chaos",
+        "class",
+        "cosmos",
+        "cross",
+        "dress",
+        "ethos",
+        "focus",
+        "gas",
+        "glass",
+        "grass",
+        "iris",
+        "kiss",
+        "lens",
+        "logos",
+        "loss",
+        "miss",
+        "news",
+        "oasis",
+        "pathos",
+        "press",
+        "status",
+        "this",
+        "virus",
+        "walrus",
+        "yes",
+    }
+)
+
+
+def _looks_like_regular_plural(word: str) -> bool:
+    """Return whether a word looks like a regular English plural form."""
+
+    lower = word.casefold()
+    if len(lower) <= 2:
+        return False
+    if lower.endswith("ies") and len(lower) > 3:
+        return True
+    if lower.endswith(("ses", "xes", "zes", "ches", "shes")):
+        return True
+    if lower.endswith("s"):
+        return lower not in _SINGULAR_S_ENDING_EXCEPTIONS and not lower.endswith(
+            ("ss", "us", "is")
+        )
+    return False
+
+
 def _plural_variants(term: str) -> list[str]:
     """Return conservative English singular/plural alternatives for a term."""
 
@@ -150,16 +207,27 @@ def _plural_variants(term: str) -> list[str]:
     if len(last) <= 2:
         return []
     prefix = term[:words[-1].start()]
+    lower = last.casefold()
     variants: list[str] = []
-    if last.casefold().endswith("ies") and len(last) > 3:
+
+    # Plural -> singular: keep the existing conservative rules.
+    if lower.endswith("ies") and len(last) > 3:
         variants.append(prefix + last[:-3] + "y")
-    elif last.casefold().endswith(("ses", "xes", "zes", "ches", "shes")):
+    elif lower.endswith(("ses", "xes", "zes", "ches", "shes")):
         variants.append(prefix + last[:-2])
-    elif last.casefold().endswith("s"):
+    elif _looks_like_regular_plural(last):
         variants.append(prefix + last[:-1])
-    else:
-        suffix = "es" if last.casefold().endswith(("s", "x", "z", "ch", "sh")) else "s"
-        variants.append(term + suffix)
+
+    # Singular -> plural: add the missing direction.  Skip when the input
+    # already looks like a plural so we do not produce forms like "storieses".
+    if not _looks_like_regular_plural(last):
+        if lower.endswith("y") and len(last) > 1 and lower[-2] not in "aeiou":
+            variants.append(prefix + last[:-1] + "ies")
+        elif lower.endswith(("s", "x", "z", "ch", "sh")):
+            variants.append(term + "es")
+        else:
+            variants.append(term + "s")
+
     return [variant for variant in variants if _match_key(variant) != _match_key(term)]
 
 

--- a/tests/test_keyword_history.py
+++ b/tests/test_keyword_history.py
@@ -385,5 +385,33 @@ class KeywordHistoryEvidenceTests(unittest.TestCase):
                     self.assertEqual(evidence["conflict_codes"], [])
 
 
+class PluralVariantGenerationTests(unittest.TestCase):
+    def test_consonant_y_becomes_ies(self):
+        self.assertIn("stories", keyword_history._plural_variants("story"))
+        self.assertIn("bossies", keyword_history._plural_variants("bossy"))
+        self.assertNotIn("storys", keyword_history._plural_variants("story"))
+        self.assertNotIn("bossys", keyword_history._plural_variants("bossy"))
+
+    def test_s_ending_singular_gets_es_plural(self):
+        self.assertEqual(keyword_history._plural_variants("boss"), ["bosses"])
+        self.assertNotIn("bos", keyword_history._plural_variants("boss"))
+        self.assertIn("classes", keyword_history._plural_variants("class"))
+        self.assertNotIn("clas", keyword_history._plural_variants("class"))
+        self.assertIn("buses", keyword_history._plural_variants("bus"))
+        self.assertNotIn("bu", keyword_history._plural_variants("bus"))
+
+    def test_existing_plural_to_singular_rules_are_preserved(self):
+        self.assertEqual(keyword_history._plural_variants("stories"), ["story"])
+        self.assertEqual(keyword_history._plural_variants("bosses"), ["boss"])
+        self.assertEqual(keyword_history._plural_variants("cats"), ["cat"])
+        self.assertEqual(keyword_history._plural_variants("boxes"), ["box"])
+
+    def test_vowel_y_and_regular_plurals_still_work(self):
+        self.assertEqual(keyword_history._plural_variants("boy"), ["boys"])
+        self.assertEqual(keyword_history._plural_variants("day"), ["days"])
+        self.assertEqual(keyword_history._plural_variants("church"), ["churches"])
+        self.assertEqual(keyword_history._plural_variants("bush"), ["bushes"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #365

## 改动
- 补齐 `辅音+y -> ies` 的单数->复数规则：`story -> stories`、`bossy -> bossies`。
- 对 `s/x/z/ch/sh` 结尾单数词生成 `-es` 复数：`boss -> bosses`、`class -> classes`、`box -> boxes`。
- 避免把 `s` 结尾单数词盲目去掉 `s`，不再生成 `bos`、`clas` 等无意义变体。
- 保留原有 `ies -> y`、`ses/xes/zes/ches/shes -> 原形` 的复数->单数规则。

## 测试
- 新增 `PluralVariantGenerationTests` 覆盖 issue 中的 `story`、`boss`、`bossy` 及回归场景。
- `python3 -m unittest discover -s tests -p 'test_keyword_history.py' -q` 通过。
- `python3 -m unittest discover -s tests -p 'test_keyword_glossary_merge.py' -q` 通过。