### PR TITLE
feat(quality): 统一 sync / revision / final review 质量 finding schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - 增加 Ren'Py Engine Adapter 的稳定扫描/occurrence/coverage 产物和写回计划校验。
 - 增加提交恢复、成本估算、翻译 A/B 对比、同步预览写回与订正预览写回等完整工作流。
 - `check` 新增确定性机械质量检查与 `quality_findings.jsonl`：标签插字、未闭合括号、中英文粘连、可疑英文残留、CJK/拉丁间距、半角标点、glossary 未满足、说话人标签与短感叹词漏译、配置错乱词黑名单等。
+- sync 预览、revision 预览/写回与 final review 统一消费同一套 quality finding schema：共享 normalize / validate / load / filter / digest 工具，各路径生成同一 `quality_findings.jsonl` + `quality_gate` 摘要；final review 仅做 LLM 语义字段到公共模型的适配，不冒充机械规则。
 - 同步初译增加局部前后文（`sync.context_before` / `sync.context_after`，默认 30/10，限定同文件与 translate block 边界）、`sync.macro_setting_file` 风格设定注入，以及不依赖 RAG 开关、不受 `top_k_terms` 截断的术语命中（`normalize_map` / 保留词 / 不可翻译词，全部实际命中进入提示词）；上下文构造事实与 macro 指纹写入 manifest 并纳入预览指纹。
 
 ### 变更
@@ -29,6 +30,7 @@
 
 - Batch `apply` 改为要求与当前 manifest/results 匹配的最近一次 `writeback_gate.decision=allow`，并在写回前重读源快照；`--force` 不绕过 stale check、源快照或结构阻断。
 - `check` 结果拆分为 `writeback_gate`（结构写回安全）与 `quality_gate`（质量报警）；质量报警默认不阻止写回，但不会因 `apply` 成功自动清除，项目配置可把规则提升为 blocker，且配置变化会使旧 check stale。
+- revision 预览/写回同样生成质量 findings；warning 不阻止订正写回，配置为 blocker 的机械规则进入 revision 自己的写回门禁。规则或质量策略版本变化会使 sync / revision 旧预览 stale。
 - 订正与最终审校候选必须经过 `preview-revisions -> apply-revisions` 的独立 provenance、项目身份和源快照校验。
 - `writeback_gate.decision=allow` 仅代表结构性可写回；`quality_gate` 负责机械质量报警，正式交付前仍需人工/LLM 语义审校。
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - 构造带 glossary、macro setting、RAG 与可选 Story Memory 的请求。
 - 完整 Batch 异步流程，以及 `check` / `apply` / `repair` 写回闸门（`apply` 默认只接受最近一次 `safe` check）。
 - 订正、关键词候选提取，以及独立关系 / 语义分析工作流。
+- Batch、同步翻译、订正与最终审校共享统一质量 finding schema（`quality_findings.jsonl` + `quality_gate`），机械规则集中维护在 `translation_quality.py`。
 
 ## 快速开始
 

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -115,7 +115,9 @@ def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:
         "quality rules changed since",
         "quality policy changed since",
         "quality glossary changed since",
+        "quality glossary content changed",
         "quality findings changed since",
+        "quality findings changed after",
     )
     retryable_markers = (
         "429",

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -112,6 +112,10 @@ def classify_error(message: str, *, exception_type: str = "") -> dict[str, Any]:
         "manifest or results changed",
         "has no valid check summary",
         "older check contract",
+        "quality rules changed since",
+        "quality policy changed since",
+        "quality glossary changed since",
+        "quality findings changed since",
     )
     retryable_markers = (
         "429",

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -150,7 +150,7 @@ python gemini_translate_batch.py sync-revisions --limit 3
 python gemini_translate_batch.py sync-revisions --apply
 ```
 
-`build-revisions` 会复用 include 过滤、glossary、macro setting、可选 RAG / Story Memory，把已有原文和当前译文送入 Batch。`preview-revisions` 导出 `revision_preview.jsonl` 和 `revision_preview.md`，并把合同绑定写回 manifest：结果文件 SHA-256、manifest / 项目身份指纹、涉及源文件的快照指纹、preview schema 版本与生成时间。`apply-revisions` 必须找到有效且匹配的 preview 才允许写回；`--force` 只能绕过「已写回」守卫，不能绕过 preview 缺失、结果被替换、项目变化或源文件快照变化。
+`build-revisions` 会复用 include 过滤、glossary、macro setting、可选 RAG / Story Memory，把已有原文和当前译文送入 Batch。`preview-revisions` 导出 `revision_preview.jsonl` 和 `revision_preview.md`，并对将被写回的修订结果运行共享机械质量规则，生成包目录下的 `quality_findings.jsonl`；合同绑定写回 manifest：结果文件 SHA-256、manifest / 项目身份指纹、涉及源文件的快照指纹、质量 finding 路径与哈希、质量策略/规则版本、preview schema 版本与生成时间。`apply-revisions` 必须找到有效且匹配的 preview 才允许写回，写回前还会在最终候选上重新运行质量规则；质量 warning 不阻止订正写回，配置为 blocker 的规则按 revision 自己的写回门禁拒绝写回。`--force` 只能绕过「已写回」守卫，不能绕过 preview 缺失、结果被替换、项目变化、源文件快照变化、质量规则/策略变化或 blocker。
 
 `apply-revisions` 的终态写在 manifest 的 `revision_apply_state`，固定区分：
 
@@ -165,7 +165,7 @@ python gemini_translate_batch.py sync-revisions --apply
 
 阻断的退出语义：preview 校验类阻断（preview 缺失、结果/项目/源快照变化）与 `adapter_writeback_block` 以非零退出码结束；有效 preview 下全部条目被跳过/源不匹配/校验失败时的 `blocked` 以零退出码结束，但 machine envelope 的 `status=blocked` 且 manifest 写有 `revision_apply_blocked_reason`。依赖退出码的自动化应解析 `revision_apply_state` / `status`，不要仅凭零退出码判定写回成功。
 
-当前 `writeback_gate` 强制闸门只覆盖普通 translation manifest 的 `check/apply`；质量 `quality_gate` 默认不阻断写回。订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
+普通 translation manifest 的 `check/apply` 使用 `writeback_gate` 强制闸门；revision 预览/写回使用同一 `quality_findings.jsonl` 与 `quality_gate` 数据模型，warning 默认不阻断写回，`disposition=blocker` 才进入 revision 写回门禁。订正写回仍走 `preview-revisions -> apply-revisions` 的独立快照校验。
 
 `sync-revisions` 复用订正 prompt、schema、RAG / Story Memory 注入、预览报告和写回前源快照校验；默认只预览，传 `--apply` 才调用 `apply-revisions` 写回。
 
@@ -232,8 +232,11 @@ logs/batch_jobs/<ts>_<project>_final_review/
   requests.jsonl         # Batch 请求（build / resume 写入）
   results.jsonl          # download 后的模型结果（resume 会作废上一份）
   findings.jsonl         # 审校发现（执行后填充；build 时为空）
+  quality_findings.jsonl # 映射到公共 quality finding schema 的派生视图（GUI 复用同一数据模型）
   report.md              # 人类可读报告
 ```
+
+`findings.jsonl` 是最终审校的语义事实源，保留 `finding_type` / LLM 证据 / 建议译文等字段；`quality_findings.jsonl` 只是把语义 finding 适配到公共 quality finding schema（`quality.llm.*` reason code、severity / disposition / 定位字段），不把文学性结论伪装成确定性机械规则。
 
 ### 选择、状态与 GUI
 

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -101,6 +101,8 @@ manifest 同时记录本次运行的局部上下文、macro 与术语命中诊�
 
 默认命令不会修改 `.rpy`，终端会打印本次 manifest 和 diff 的绝对路径。若模型结果合同仍有未解决项，或部分文件未通过 adapter 写回计划校验，运行结果会标为 `partial`；无效项不会进入可写回预览，已经通过合同与 adapter 校验的项仍会保留。
 
+同步预览只对通过结构校验的候选运行机械质量规则，并在包目录生成与 Batch 一致的 `quality_findings.jsonl`。manifest 的 `summary.quality_gate` 记录质量门禁摘要，顶层持久化 finding 路径、规则版本与策略 digest；这些字段进入预览指纹，质量规则/策略或 glossary 变化会使旧预览在 `--apply` 时拒绝写回。质量报警默认不阻止同步写回，正式交付前仍须按报告逐条复核。
+
 只有明确需要运行配置中的 prepare 步骤时才使用：
 
 ```powershell
@@ -126,7 +128,7 @@ python gemini_translate.py --prepare
 python gemini_translate.py --apply logs/sync_runs/<run>/manifest.json
 ```
 
-`--apply` 不会重新调用模型。写回前会重新核对当前项目、TL 目录、每个源文件快照、预览制品哈希和 adapter 计划；项目切换、源文件变化或预览制品被修改都会阻止写回。遇到阻断时不要强行复用旧 manifest，应基于当前文件重新生成并审查预览。
+`--apply` 不会重新调用模型。写回前会重新核对当前项目、TL 目录、每个源文件快照、预览制品哈希、质量 finding 报告哈希和 adapter 计划；项目切换、源文件变化、预览制品被修改或质量规则/策略版本变化都会阻止写回。遇到阻断时不要强行复用旧 manifest，应基于当前文件重新生成并审查预览。
 
 `--prepare` 与 `--apply` 不能同时使用。同步 CLI 当前输出面向人类阅读，不提供 Batch 核心命令的 JSON envelope；自动化需要稳定机器合同、远程状态轮询或断点恢复时应改用 Batch。
 

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -101,7 +101,7 @@ manifest 同时记录本次运行的局部上下文、macro 与术语命中诊�
 
 默认命令不会修改 `.rpy`，终端会打印本次 manifest 和 diff 的绝对路径。若模型结果合同仍有未解决项，或部分文件未通过 adapter 写回计划校验，运行结果会标为 `partial`；无效项不会进入可写回预览，已经通过合同与 adapter 校验的项仍会保留。
 
-同步预览只对通过结构校验的候选运行机械质量规则，并在包目录生成与 Batch 一致的 `quality_findings.jsonl`。manifest 的 `summary.quality_gate` 记录质量门禁摘要，顶层持久化 finding 路径、规则版本与策略 digest；这些字段进入预览指纹，质量规则/策略或 glossary 变化会使旧预览在 `--apply` 时拒绝写回。质量报警默认不阻止同步写回，正式交付前仍须按报告逐条复核。
+同步预览只对通过结构校验的候选运行机械质量规则，并在包目录生成与 Batch 一致的 `quality_findings.jsonl`。manifest 的 `summary.quality_gate` 记录质量门禁摘要，顶层持久化 finding 路径、规则版本、策略 digest 与 glossary 内容 digest；这些字段进入预览指纹，质量规则/策略或 glossary 变化会使旧预览在 `--apply` 时拒绝写回。普通 `warning` 不阻止同步写回，但项目配置为 `blocker` 的规则会像 Batch 一样阻止 `--apply`；正式交付前仍须按报告逐条复核。
 
 只有明确需要运行配置中的 prepare 步骤时才使用：
 

--- a/final_review.py
+++ b/final_review.py
@@ -25,6 +25,8 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text, file_sha256
 
+import translation_quality
+
 SCHEMA_VERSION = 1
 MANIFEST_MODE_FINAL_REVIEW = "final_review"
 PROMPT_SCHEMA_VERSION = "final-review-v1"
@@ -34,6 +36,8 @@ MANIFEST_FILENAME = "manifest.json"
 SNAPSHOT_FILENAME = "snapshot.json"
 REVIEW_UNITS_FILENAME = "review_units.jsonl"
 FINDINGS_FILENAME = "findings.jsonl"
+QUALITY_FINDINGS_FILENAME = "quality_findings.jsonl"
+FINAL_REVIEW_QUALITY_MAPPING_VERSION = 1
 REPORT_MD_FILENAME = "report.md"
 REQUESTS_JSONL_FILENAME = "requests.jsonl"
 
@@ -926,6 +930,29 @@ def mark_unit_done(
 # ---------------------------------------------------------------------------
 
 
+def adapt_findings_to_quality_schema(
+    findings: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Map normalized final-review findings into the shared quality model.
+
+    The semantic ``findings.jsonl`` remains authoritative for review;
+    ``quality_findings.jsonl`` is a derived shared-consumer artifact so GUI
+    lists, filters, and digest tools do not need a second parser.
+    """
+
+    return translation_quality.adapt_final_review_findings(
+        [normalize_finding(finding) for finding in findings]
+    )
+
+
+def summarize_final_review_quality_gate(
+    findings: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return translation_quality.summarize_quality_gate(
+        adapt_findings_to_quality_schema(findings)
+    )
+
+
 def normalize_finding(
     record: Mapping[str, Any],
     *,
@@ -1199,6 +1226,8 @@ def write_campaign_package(
         unit_rows.append(row)
 
     finding_rows = [normalize_finding(f) for f in (findings or [])]
+    quality_finding_rows = adapt_findings_to_quality_schema(finding_rows)
+    quality_gate = summarize_final_review_quality_gate(finding_rows)
 
     manifest_out = dict(manifest)
     manifest_out["package_dir"] = root
@@ -1211,17 +1240,23 @@ def write_campaign_package(
         "unit_count": len(unit_rows),
         "item_count": sum(int(u.get("item_count") or 0) for u in unit_rows),
         "finding_count": len(finding_rows),
+        "quality_findings_count": len(quality_finding_rows),
+        "quality_gate": quality_gate,
+        "quality_mapping_version": FINAL_REVIEW_QUALITY_MAPPING_VERSION,
         "status_counts": status_counts,
     }
     manifest_out["status"] = derive_campaign_status(status_counts)
+    manifest_out["quality_findings_path"] = QUALITY_FINDINGS_FILENAME
 
     snapshot_path = os.path.join(root, SNAPSHOT_FILENAME)
     units_path = os.path.join(root, REVIEW_UNITS_FILENAME)
     findings_path = os.path.join(root, FINDINGS_FILENAME)
+    quality_findings_path = os.path.join(root, QUALITY_FINDINGS_FILENAME)
 
     atomic_write_json(snapshot_path, dict(snapshot), ensure_ascii=False, indent=2)
     atomic_write_jsonl(units_path, unit_rows, ensure_ascii=False)
     atomic_write_jsonl(findings_path, finding_rows, ensure_ascii=False)
+    translation_quality.write_findings(quality_findings_path, quality_finding_rows)
     atomic_write_json(manifest_path, manifest_out, ensure_ascii=False, indent=2)
 
     paths = {
@@ -1230,6 +1265,7 @@ def write_campaign_package(
         "snapshot": snapshot_path,
         "review_units": units_path,
         "findings": findings_path,
+        "quality_findings": quality_findings_path,
     }
 
     if write_report:
@@ -1293,6 +1329,7 @@ def resolve_campaign_paths(
         "snapshot": os.path.join(package_dir, SNAPSHOT_FILENAME),
         "review_units": os.path.join(package_dir, REVIEW_UNITS_FILENAME),
         "findings": os.path.join(package_dir, FINDINGS_FILENAME),
+        "quality_findings": os.path.join(package_dir, QUALITY_FINDINGS_FILENAME),
         "report": os.path.join(package_dir, REPORT_MD_FILENAME),
     }
 
@@ -1314,6 +1351,11 @@ def load_campaign_package(target: str | os.PathLike[str]) -> dict[str, Any]:
             snapshot = loaded
     units = load_jsonl_file(paths["review_units"])
     findings = load_jsonl_file(paths["findings"])
+    quality_findings = []
+    if os.path.isfile(paths.get("quality_findings", "")):
+        quality_findings = translation_quality.load_findings(
+            paths["quality_findings"]
+        )
     for unit in units:
         assert_failure_not_done(unit)
 
@@ -1326,6 +1368,7 @@ def load_campaign_package(target: str | os.PathLike[str]) -> dict[str, Any]:
         "snapshot": snapshot,
         "units": units,
         "findings": findings,
+        "quality_findings": quality_findings,
     }
 
 

--- a/final_review.py
+++ b/final_review.py
@@ -1344,6 +1344,19 @@ def load_campaign_package(target: str | os.PathLike[str]) -> dict[str, Any]:
         raise FinalReviewSchemaError(
             f"expected mode={MANIFEST_MODE_FINAL_REVIEW!r}, got {mode!r}"
         )
+    summary = manifest.get("summary")
+    mapping_version = (
+        summary.get("quality_mapping_version")
+        if isinstance(summary, Mapping)
+        else None
+    )
+    if mapping_version is not None and mapping_version != (
+        FINAL_REVIEW_QUALITY_MAPPING_VERSION
+    ):
+        raise FinalReviewSchemaError(
+            "final-review quality mapping version is stale; "
+            "re-run the campaign ingest to regenerate quality_findings.jsonl"
+        )
     snapshot = {}
     if os.path.isfile(paths["snapshot"]):
         loaded = load_json_file(paths["snapshot"])

--- a/final_review_llm.py
+++ b/final_review_llm.py
@@ -14,14 +14,20 @@ import re
 from typing import Any, Callable, Mapping, Sequence
 
 from atomic_io import atomic_write_json, atomic_write_jsonl, atomic_write_text
+
+import translation_quality
 from gemini_model_catalog import filter_gemini_generation_config, is_gemini_3_model
 from final_review import (
+    FINAL_REVIEW_QUALITY_MAPPING_VERSION,
     FINDINGS_FILENAME,
     MANIFEST_FILENAME,
     PROMPT_SCHEMA_VERSION,
+    QUALITY_FINDINGS_FILENAME,
     REPORT_MD_FILENAME,
     REQUESTS_JSONL_FILENAME,
     REVIEW_UNITS_FILENAME,
+    adapt_findings_to_quality_schema,
+    summarize_final_review_quality_gate,
     STATUS_DONE,
     STATUS_FAILED,
     STATUS_PENDING,
@@ -705,6 +711,8 @@ def persist_campaign_state(
     status_counts = summarize_unit_statuses(units)
     campaign_status = derive_campaign_status(status_counts)
     finding_rows = [normalize_finding(f) for f in findings]
+    quality_finding_rows = adapt_findings_to_quality_schema(finding_rows)
+    quality_gate = summarize_final_review_quality_gate(finding_rows)
 
     manifest_out = dict(manifest)
     manifest_out["status"] = campaign_status
@@ -726,17 +734,23 @@ def persist_campaign_state(
         "unit_count": len(unit_list),
         "item_count": sum(int(u.get("item_count") or 0) for u in unit_list),
         "finding_count": len(finding_rows),
+        "quality_findings_count": len(quality_finding_rows),
+        "quality_gate": quality_gate,
+        "quality_mapping_version": FINAL_REVIEW_QUALITY_MAPPING_VERSION,
         "status_counts": status_counts,
         "chunk_count": chunk_count,
     }
     manifest_out["last_ingest_at"] = utc_now_iso()
+    manifest_out["quality_findings_path"] = QUALITY_FINDINGS_FILENAME
 
     units_path = os.path.join(root, REVIEW_UNITS_FILENAME)
     findings_path = os.path.join(root, FINDINGS_FILENAME)
+    quality_findings_path = os.path.join(root, QUALITY_FINDINGS_FILENAME)
     report_path = os.path.join(root, REPORT_MD_FILENAME)
 
     atomic_write_jsonl(units_path, list(units), ensure_ascii=False)
     atomic_write_jsonl(findings_path, finding_rows, ensure_ascii=False)
+    translation_quality.write_findings(quality_findings_path, quality_finding_rows)
     atomic_write_text(
         report_path,
         format_campaign_report_markdown(manifest_out, units, finding_rows),
@@ -757,6 +771,7 @@ def persist_campaign_state(
         "manifest": manifest_path,
         "review_units": units_path,
         "findings": findings_path,
+        "quality_findings": quality_findings_path,
         "report": report_path,
     }
 

--- a/final_review_revision.py
+++ b/final_review_revision.py
@@ -27,8 +27,19 @@ def _write_findings(package: Mapping[str, Any], findings: Sequence[Mapping[str, 
     manifest = dict(package["manifest"])
     manifest.pop("_manifest_path", None)
     manifest.pop("_package_dir", None)
-    manifest["summary"] = {**dict(manifest.get("summary") or {}), "finding_count": len(findings)}
+    summary = {
+        **dict(manifest.get("summary") or {}),
+        "finding_count": len(findings),
+    }
+    quality_rows = fr.adapt_findings_to_quality_schema(findings)
+    summary["quality_findings_count"] = len(quality_rows)
+    summary["quality_gate"] = fr.summarize_final_review_quality_gate(findings)
+    summary["quality_mapping_version"] = fr.FINAL_REVIEW_QUALITY_MAPPING_VERSION
+    manifest["summary"] = summary
+    manifest.setdefault("quality_findings_path", fr.QUALITY_FINDINGS_FILENAME)
     atomic_write_jsonl(paths["findings"], findings, ensure_ascii=False)
+    if paths.get("quality_findings"):
+        fr.translation_quality.write_findings(paths["quality_findings"], quality_rows)
     atomic_write_json(paths["manifest"], manifest, ensure_ascii=False, indent=2)
     atomic_write_text(paths["report"], fr.format_campaign_report_markdown(
         manifest, package.get("units") or [], findings,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -9423,12 +9423,21 @@ def _require_valid_revision_preview(manifest):
             'source files changed since preview; run preview-revisions again.',
         )
 
+    quality_staleness = _revision_quality_staleness(manifest, preview)
+    if quality_staleness is not None:
+        reason, message = quality_staleness
+        _mark_revision_apply_blocked(manifest, reason, message)
+    return preview
+
+
+def _revision_quality_staleness(manifest, preview):
+    """Return ``(reason, message)`` when revision quality evidence is stale."""
+
     expected_rule_version = preview.get('quality_rule_schema_version')
     if expected_rule_version is not None and expected_rule_version != (
         translation_quality.QUALITY_RULE_SCHEMA_VERSION
     ):
-        _mark_revision_apply_blocked(
-            manifest,
+        return (
             'quality_rules_changed',
             'quality rules changed since revision preview; run preview-revisions again.',
         )
@@ -9436,8 +9445,7 @@ def _require_valid_revision_preview(manifest):
     if expected_runtime_policy_digest and expected_runtime_policy_digest != (
         translation_quality.policy_digest(BATCH_QUALITY_POLICY)
     ):
-        _mark_revision_apply_blocked(
-            manifest,
+        return (
             'quality_policy_changed',
             'quality policy changed since revision preview; run preview-revisions again.',
         )
@@ -9447,24 +9455,21 @@ def _require_valid_revision_preview(manifest):
             translation_quality.effective_policy(manifest)
         )
     ):
-        _mark_revision_apply_blocked(
-            manifest,
+        return (
             'quality_policy_changed',
             'manifest quality policy changed since revision preview; run preview-revisions again.',
         )
     quality_findings_path = preview.get('quality_findings_path')
     if quality_findings_path:
         if not os.path.isfile(quality_findings_path):
-            _mark_revision_apply_blocked(
-                manifest,
+            return (
                 'quality_findings_missing',
                 'quality findings report no longer exists; run preview-revisions again.',
             )
         if _sha256_file(quality_findings_path) != preview.get(
             'quality_findings_sha256'
         ):
-            _mark_revision_apply_blocked(
-                manifest,
+            return (
                 'quality_findings_changed',
                 'quality findings changed since revision preview; run preview-revisions again.',
             )
@@ -9472,12 +9477,11 @@ def _require_valid_revision_preview(manifest):
     if isinstance(writeback_gate, dict) and writeback_gate.get(
         'decision'
     ) != translation_quality.GATE_ALLOW:
-        _mark_revision_apply_blocked(
-            manifest,
+        return (
             'revision_writeback_gate_denied',
             'revision preview is not allowed to write back; resolve quality blockers or structural blocks and run preview-revisions again.',
         )
-    return preview
+    return None
 
 
 def write_revision_markdown(path, entries, summary):

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -4796,6 +4796,9 @@ def import_revision_proposals(proposal_path, *, corpus_manifest_path=''):
         'tl_dir': legacy.TL_DIR,
         **_manifest_target_language_fields(),
         **batch_non_chinese_rules.manifest_non_chinese_rules_fields(),
+        **translation_quality.manifest_quality_policy_fields(
+            runtime_policy=BATCH_QUALITY_POLICY
+        ),
         'input_jsonl_path': requests_path,
         'result_jsonl_path': results_path,
         'job_name': '',
@@ -9291,10 +9294,7 @@ def _revision_manifest_identity(manifest):
         'summary', 'files', 'chunks', 'final_review_source',
     )
     payload = {key: manifest.get(key) for key in keys}
-    # ``quality_policy`` deliberately stays outside this fingerprint for
-    # backward compatibility: pre-existing previews already persisted their
-    # identity with the original key set.  Fresh policy mismatches are detected
-    # by ``_revision_quality_staleness`` through the preview policy digest.
+    # Policy drift is enforced by ``_revision_quality_staleness``, not here.
     # Preserve the v1 fingerprint for pre-proposal revision/final-review
     # packages.  Proposal manifests bind their immutable import provenance and
     # eligibility state without adding a null field to every legacy payload.
@@ -10206,12 +10206,19 @@ def collect_revision_quality_subjects(manifest, replacements_by_file, stats=None
     return subjects
 
 
-def run_revision_quality_check(manifest, summary, replacements_by_file):
+def run_revision_quality_check(
+    manifest,
+    summary,
+    replacements_by_file,
+    *,
+    apply_stage=False,
+):
     """Run shared mechanical rules on revision writeback candidates.
 
-    The manifest quality-policy snapshot is authoritative for the findings,
-    while the current runtime policy digest is persisted separately so a
-    configuration change between preview and apply makes the preview stale.
+    Like Batch ``check``, revision consumes the current runtime policy
+    (``BATCH_QUALITY_POLICY``) and then refreshes the manifest snapshot so the
+    persisted policy matches the findings just produced.  A policy change after
+    preview is detected through the separately persisted runtime digest.
     """
 
     collection_stats = {}
@@ -10245,13 +10252,37 @@ def run_revision_quality_check(manifest, summary, replacements_by_file):
     if not quality_glossary_map and glossary_path:
         quality_glossary_map = translation_quality.load_glossary_map(glossary_path)
 
-    policy = translation_quality.effective_policy(manifest)
+    policy = translation_quality.normalize_policy(BATCH_QUALITY_POLICY)
+    manifest['quality_policy'] = policy
     quality_findings = translation_quality.check_quality(
         quality_subjects,
         policy=policy,
         glossary_map=quality_glossary_map,
     )
-    quality_report_path = write_quality_findings(manifest, quality_findings)
+    if int(collection_stats.get('quality_unmatched_items') or 0) > 0:
+        quality_findings.append(
+            translation_quality.make_unmatched_quality_subject_finding(
+                collection_stats
+            )
+        )
+    if apply_stage:
+        quality_report_path = os.path.join(
+            manifest.get('_package_dir', ''),
+            'quality_findings.apply.jsonl',
+        )
+        atomic_write_jsonl(
+            quality_report_path,
+            [
+                translation_quality.normalize_finding(finding)
+                for finding in quality_findings
+            ],
+            ensure_ascii=False,
+        )
+    else:
+        quality_report_path = write_quality_findings(
+            manifest,
+            quality_findings,
+        )
     quality_gate = translation_quality.summarize_quality_gate(
         quality_findings,
         acknowledged_ids=manifest.get('quality_acknowledged_finding_ids') or [],
@@ -10273,6 +10304,7 @@ def run_revision_quality_check(manifest, summary, replacements_by_file):
     summary['quality_findings_count'] = len(quality_findings)
     summary['quality_reason_counts'] = quality_reason_counts
     summary['quality_findings_path'] = quality_report_path
+    summary['quality_findings_sha256'] = _sha256_file(quality_report_path)
     summary['quality_findings_digest'] = translation_quality.findings_digest(
         quality_findings
     )
@@ -10615,31 +10647,10 @@ def check_results(target=None):
     )
     summary['quality_coverage_complete'] = quality_coverage_complete
     if not quality_coverage_complete:
-        evidence = json.dumps(
-            dict(quality_collection_stats),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
-        finding_id = hashlib.sha256(
-            f'{translation_quality.QUALITY_FINDING_SCHEMA_VERSION}:{evidence}'.encode('utf-8')
-        ).hexdigest()[:20]
         quality_findings.append(
-            {
-                'finding_id': finding_id,
-                'schema_version': translation_quality.QUALITY_FINDING_SCHEMA_VERSION,
-                'reason_code': translation_quality.REASON_UNMATCHED_QUALITY_SUBJECT,
-                'rule_id': 'unmatched_subject',
-                'severity': 'medium',
-                'disposition': translation_quality.DISPOSITION_WARNING,
-                'item_id': '',
-                'file': '',
-                'line': 0,
-                'source': '',
-                'translation': '',
-                'evidence': evidence,
-                'suggestion': 'Inspect quality_action_items / quality_unmatched_items and rerun check.',
-                'rule_version': translation_quality.QUALITY_RULE_SCHEMA_VERSION,
-            }
+            translation_quality.make_unmatched_quality_subject_finding(
+                quality_collection_stats
+            )
         )
     quality_report_path = write_quality_findings(manifest, quality_findings)
     quality_reason_counts = {}
@@ -10909,11 +10920,12 @@ def apply_revisions(target=None, force=False):
         manifest,
         summary,
         revalidated_replacements_by_file,
+        apply_stage=True,
     )
-    manifest['last_revision_quality_findings_path'] = quality_report_path
-    manifest['last_revision_quality_findings_sha256'] = _sha256_file(
-        quality_report_path
-    )
+    # The preview-bound quality_findings.jsonl stays immutable; apply-time
+    # findings live in quality_findings.apply.jsonl and are attached only to
+    # the apply summary so a later apply re-check cannot see the preview
+    # artifact as tampered.
     manifest['last_revision_apply_summary'] = summary
 
     # Validate the structural writeback plan before terminating on quality
@@ -11050,7 +11062,8 @@ def apply_revisions(target=None, force=False):
         'quality_gate': summary.get('quality_gate'),
         'writeback_gate': summary.get('writeback_gate'),
         'quality_findings_count': summary.get('quality_findings_count', 0),
-        'quality_findings_path': 'quality_findings.jsonl',
+        'quality_findings_path': 'quality_findings.apply.jsonl',
+        'quality_findings_sha256': summary.get('quality_findings_sha256'),
         'rag': rag_apply_summary,
     }
     manifest['last_revision_apply_summary'] = summary

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -10913,15 +10913,10 @@ def apply_revisions(target=None, force=False):
         quality_report_path
     )
     manifest['last_revision_apply_summary'] = summary
-    quality_gate = summary.get('quality_gate') or {}
-    if int(quality_gate.get('blocker_count') or 0) > 0:
-        append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
-        _mark_revision_apply_blocked(
-            manifest,
-            'quality_blockers_present',
-            'configured quality blocker rules matched revision candidates. No files were written.',
-        )
 
+    # Validate the structural writeback plan before terminating on quality
+    # blockers so both structural and quality diagnostics are persisted in the
+    # blocked apply summary.
     adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
         manifest,
         revalidated_replacements_by_file,
@@ -10933,20 +10928,36 @@ def apply_revisions(target=None, force=False):
             if file_key in revalidated_source_documents
         ),
     )
-    if summary.get('adapter_writeback_status') == 'block':
+    structural_block = summary.get('adapter_writeback_status') == 'block'
+    if structural_block:
         summary['pending_files'] = 0
         summary['pending_lines'] = 0
+
+    quality_gate = summary.get('quality_gate') or {}
+    quality_blocker_count = int(quality_gate.get('blocker_count') or 0)
+    if quality_blocker_count > 0 or structural_block:
         summarize_revision_writeback_gate(summary)
         summary['check_status'] = translation_quality.overall_check_status(
             summary['writeback_gate'],
-            summary.get('quality_gate') or {},
+            quality_gate,
         )
         append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
-        _mark_revision_apply_blocked(
-            manifest,
-            'adapter_writeback_block',
-            'the adapter writeback plan is not safe. No files were written.',
-        )
+        if quality_blocker_count > 0 and structural_block:
+            reason = 'quality_and_structural_blockers_present'
+            message = (
+                'configured quality blocker rules matched revision candidates and '
+                'the adapter writeback plan is not safe. No files were written.'
+            )
+        elif quality_blocker_count > 0:
+            reason = 'quality_blockers_present'
+            message = (
+                'configured quality blocker rules matched revision candidates. '
+                'No files were written.'
+            )
+        else:
+            reason = 'adapter_writeback_block'
+            message = 'the adapter writeback plan is not safe. No files were written.'
+        _mark_revision_apply_blocked(manifest, reason, message)
 
     writeback_files = []
     applied_file_keys = set()

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7591,6 +7591,7 @@ def validate_keyword_export_paths(manifest, *output_paths):
         os.path.join(manifest.get('_package_dir', ''), 'requests.jsonl'),
         os.path.join(manifest.get('_package_dir', ''), 'results.jsonl'),
         os.path.join(manifest.get('_package_dir', ''), 'failures.jsonl'),
+        os.path.join(manifest.get('_package_dir', ''), 'quality_findings.jsonl'),
     }
     for manifest_key in ('_manifest_path', 'input_jsonl_path', 'result_jsonl_path'):
         value = manifest.get(manifest_key)
@@ -9226,6 +9227,19 @@ def print_revision_summary(summary):
         print('Failure categories:')
         for name in sorted(summary['reason_counts']):
             print(f"- {name}: {summary['reason_counts'][name]}")
+    if 'quality_gate' in summary:
+        quality_gate = summary.get('quality_gate') or {}
+        print(
+            f"Quality gate: {quality_gate.get('decision', 'unknown')} "
+            f"(warnings={quality_gate.get('warning_count', 0)}, "
+            f"blockers={quality_gate.get('blocker_count', 0)})"
+        )
+        writeback_gate = summary.get('writeback_gate') or {}
+        print(
+            f"Revision writeback gate: {writeback_gate.get('decision', 'unknown')}"
+        )
+    if summary.get('quality_findings_path'):
+        print(f"Quality findings: {summary['quality_findings_path']}")
 
 
 def resolve_revision_output_path(manifest, value, default_name, field_name):
@@ -9246,6 +9260,7 @@ def validate_revision_output_paths(manifest, jsonl_path, markdown_path):
         os.path.join(manifest.get('_package_dir', ''), 'requests.jsonl'),
         os.path.join(manifest.get('_package_dir', ''), 'results.jsonl'),
         os.path.join(manifest.get('_package_dir', ''), 'failures.jsonl'),
+        os.path.join(manifest.get('_package_dir', ''), 'quality_findings.jsonl'),
     }
     for manifest_key in ('_manifest_path', 'input_jsonl_path', 'result_jsonl_path'):
         value = manifest.get(manifest_key)
@@ -9276,6 +9291,8 @@ def _revision_manifest_identity(manifest):
         'summary', 'files', 'chunks', 'final_review_source',
     )
     payload = {key: manifest.get(key) for key in keys}
+    if isinstance(manifest.get('quality_policy'), dict):
+        payload['quality_policy'] = manifest['quality_policy']
     # Preserve the v1 fingerprint for pre-proposal revision/final-review
     # packages.  Proposal manifests bind their immutable import provenance and
     # eligibility state without adding a null field to every legacy payload.
@@ -9405,6 +9422,61 @@ def _require_valid_revision_preview(manifest):
             'source_changed',
             'source files changed since preview; run preview-revisions again.',
         )
+
+    expected_rule_version = preview.get('quality_rule_schema_version')
+    if expected_rule_version is not None and expected_rule_version != (
+        translation_quality.QUALITY_RULE_SCHEMA_VERSION
+    ):
+        _mark_revision_apply_blocked(
+            manifest,
+            'quality_rules_changed',
+            'quality rules changed since revision preview; run preview-revisions again.',
+        )
+    expected_runtime_policy_digest = preview.get('quality_policy_runtime_digest')
+    if expected_runtime_policy_digest and expected_runtime_policy_digest != (
+        translation_quality.policy_digest(BATCH_QUALITY_POLICY)
+    ):
+        _mark_revision_apply_blocked(
+            manifest,
+            'quality_policy_changed',
+            'quality policy changed since revision preview; run preview-revisions again.',
+        )
+    expected_manifest_policy_digest = preview.get('quality_policy_digest')
+    if expected_manifest_policy_digest and expected_manifest_policy_digest != (
+        translation_quality.policy_digest(
+            translation_quality.effective_policy(manifest)
+        )
+    ):
+        _mark_revision_apply_blocked(
+            manifest,
+            'quality_policy_changed',
+            'manifest quality policy changed since revision preview; run preview-revisions again.',
+        )
+    quality_findings_path = preview.get('quality_findings_path')
+    if quality_findings_path:
+        if not os.path.isfile(quality_findings_path):
+            _mark_revision_apply_blocked(
+                manifest,
+                'quality_findings_missing',
+                'quality findings report no longer exists; run preview-revisions again.',
+            )
+        if _sha256_file(quality_findings_path) != preview.get(
+            'quality_findings_sha256'
+        ):
+            _mark_revision_apply_blocked(
+                manifest,
+                'quality_findings_changed',
+                'quality findings changed since revision preview; run preview-revisions again.',
+            )
+    writeback_gate = preview.get('writeback_gate')
+    if isinstance(writeback_gate, dict) and writeback_gate.get(
+        'decision'
+    ) != translation_quality.GATE_ALLOW:
+        _mark_revision_apply_blocked(
+            manifest,
+            'revision_writeback_gate_denied',
+            'revision preview is not allowed to write back; resolve quality blockers or structural blocks and run preview-revisions again.',
+        )
     return preview
 
 
@@ -9449,9 +9521,14 @@ def preview_revisions(
     """Build a revision preview and optionally control the latest pointer."""
     manifest = load_manifest(target)
     require_manifest_mode(manifest, MANIFEST_MODE_REVISION, 'preview-revisions')
-    _replacements, _lines, _failure_entries, summary, preview_entries = collect_revision_actions(
+    replacements_by_file, _lines, _failure_entries, summary, preview_entries = collect_revision_actions(
         manifest,
         validate_sources=True,
+    )
+    _quality_findings, quality_report_path = run_revision_quality_check(
+        manifest,
+        summary,
+        replacements_by_file,
     )
     jsonl_path = resolve_revision_output_path(manifest, output_jsonl, 'revision_preview.jsonl', 'revision JSONL output')
     markdown_path = resolve_revision_output_path(manifest, output_markdown, 'revision_preview.md', 'revision Markdown output')
@@ -9465,6 +9542,10 @@ def preview_revisions(
 
     now = datetime.now().isoformat(timespec='seconds')
     manifest['last_revision_preview_at'] = now
+    manifest['last_revision_quality_findings_path'] = quality_report_path
+    manifest['last_revision_quality_findings_sha256'] = _sha256_file(
+        quality_report_path
+    )
     manifest['last_revision_preview'] = {
         'schema_version': REVISION_PREVIEW_CONTRACT_VERSION,
         'generated_at': now,
@@ -9475,6 +9556,21 @@ def preview_revisions(
         'manifest_identity': _revision_manifest_identity(manifest),
         'project_identity': manifest_project_identity(manifest),
         'source_snapshots': _revision_source_snapshots(manifest),
+        'quality_findings_path': quality_report_path,
+        'quality_findings_sha256': _sha256_file(quality_report_path),
+        'quality_findings_count': summary.get('quality_findings_count', 0),
+        'quality_findings_digest': summary.get('quality_findings_digest'),
+        'quality_gate': summary.get('quality_gate'),
+        'writeback_gate': summary.get('writeback_gate'),
+        'check_status': summary.get('check_status'),
+        'quality_finding_schema_version': summary.get(
+            'quality_finding_schema_version'
+        ),
+        'quality_rule_schema_version': summary.get('quality_rule_schema_version'),
+        'quality_policy_digest': summary.get('quality_policy_digest'),
+        'quality_policy_runtime_digest': summary.get(
+            'quality_policy_runtime_digest'
+        ),
         'summary': summary,
     }
     proposal_state = manifest.get('proposal_import')
@@ -10028,6 +10124,192 @@ def write_quality_findings(manifest, findings):
         ensure_ascii=False,
     )
     return path
+
+
+def collect_revision_quality_subjects(manifest, replacements_by_file, stats=None):
+    """Build quality subjects from structurally validated revision actions.
+
+    Revision quality inspection uses the same stable identity fields as Batch
+    check: item ID, file, line, source, and the text that is about to be
+    written back.  Quality findings never replace the structural writeback
+    contract; they are attached only to actions that already passed it.
+    """
+
+    item_index = {}
+    counters = {
+        'quality_action_items': 0,
+        'quality_subject_items': 0,
+        'quality_unmatched_items': 0,
+    }
+    for chunk in manifest.get('chunks') or []:
+        if not isinstance(chunk, dict):
+            continue
+        file_rel_path = str(chunk.get('file_rel_path') or '')
+        for item in chunk.get('items') or []:
+            if not isinstance(item, dict):
+                continue
+            item_id = str(item.get('id') or '')
+            item_index[(file_rel_path, item_id)] = (chunk, item)
+            item_index[(str(chunk.get('key') or ''), item_id)] = (chunk, item)
+
+    subjects = []
+    for file_key, replacements_by_line in replacements_by_file.items():
+        for line_index, actions in replacements_by_line.items():
+            for action in actions or []:
+                counters['quality_action_items'] += 1
+                if not isinstance(action, (tuple, list)) or len(action) < 6:
+                    counters['quality_unmatched_items'] += 1
+                    continue
+                replacement = str(action[2] or '')
+                item_id = str(action[6] or '') if len(action) > 6 else ''
+                chunk_key = str(action[7] or '') if len(action) > 7 else ''
+                chunk, item = item_index.get(
+                    (str(file_key), item_id),
+                    item_index.get((chunk_key, item_id), (None, None)),
+                )
+                if chunk is None or item is None:
+                    counters['quality_unmatched_items'] += 1
+                    continue
+                try:
+                    unit = translation_core.unit_from_manifest_item(
+                        item,
+                        mode=translation_core.MODE_REVISION,
+                        chunk=chunk,
+                    )
+                    if unit is None:
+                        raise ValueError('unit_from_manifest_item returned None')
+                    subject = {
+                        'item_id': item_id,
+                        'file_rel_path': str(file_key),
+                        'line': unit.line,
+                        'line_number': unit.display_line_number,
+                        'start': unit.start,
+                        'end': unit.end,
+                        'source': unit.source_text,
+                        'translation': replacement,
+                        'speaker_id': unit.speaker_id,
+                        'speaker_name': unit.speaker_name,
+                    }
+                except (AttributeError, TypeError, ValueError):
+                    counters['quality_unmatched_items'] += 1
+                    continue
+                subjects.append(subject)
+    counters['quality_subject_items'] = len(subjects)
+    if isinstance(stats, dict):
+        stats.update(counters)
+    return subjects
+
+
+def run_revision_quality_check(manifest, summary, replacements_by_file):
+    """Run shared mechanical rules on revision writeback candidates.
+
+    The manifest quality-policy snapshot is authoritative for the findings,
+    while the current runtime policy digest is persisted separately so a
+    configuration change between preview and apply makes the preview stale.
+    """
+
+    collection_stats = {}
+    quality_subjects = collect_revision_quality_subjects(
+        manifest,
+        replacements_by_file,
+        stats=collection_stats,
+    )
+    glossary_path = str(
+        manifest.get('glossary_file')
+        or os.environ.get('GLOSSARY_FILE')
+        or getattr(legacy, 'GLOSSARY_FILE', '')
+        or ''
+    )
+    quality_glossary_map = {}
+    quality_glossary_base = ''
+    for base_dir in (
+        str(manifest.get('_package_dir') or ''),
+        str(manifest.get('base_dir') or ''),
+    ):
+        if not base_dir:
+            continue
+        candidate = translation_quality.load_glossary_map(
+            glossary_path,
+            base_dir=base_dir,
+        )
+        if candidate:
+            quality_glossary_map = candidate
+            quality_glossary_base = base_dir
+            break
+    if not quality_glossary_map and glossary_path:
+        quality_glossary_map = translation_quality.load_glossary_map(glossary_path)
+
+    policy = translation_quality.effective_policy(manifest)
+    quality_findings = translation_quality.check_quality(
+        quality_subjects,
+        policy=policy,
+        glossary_map=quality_glossary_map,
+    )
+    quality_report_path = write_quality_findings(manifest, quality_findings)
+    quality_gate = translation_quality.summarize_quality_gate(
+        quality_findings,
+        acknowledged_ids=manifest.get('quality_acknowledged_finding_ids') or [],
+    )
+    quality_reason_counts = {}
+    for finding in quality_findings:
+        bump_counter(
+            quality_reason_counts,
+            finding.get('reason_code') or 'quality.unknown',
+        )
+
+    summary.update(collection_stats)
+    summary['quality_glossary_path'] = glossary_path
+    summary['quality_glossary_base'] = quality_glossary_base
+    summary['quality_glossary_entries'] = len(quality_glossary_map)
+    summary['quality_glossary_loaded'] = bool(
+        not glossary_path or quality_glossary_map
+    )
+    summary['quality_findings_count'] = len(quality_findings)
+    summary['quality_reason_counts'] = quality_reason_counts
+    summary['quality_findings_path'] = quality_report_path
+    summary['quality_findings_digest'] = translation_quality.findings_digest(
+        quality_findings
+    )
+    summary['quality_gate'] = quality_gate
+    summary['quality_finding_schema_version'] = (
+        translation_quality.QUALITY_FINDING_SCHEMA_VERSION
+    )
+    summary['quality_rule_schema_version'] = (
+        translation_quality.QUALITY_RULE_SCHEMA_VERSION
+    )
+    summary['quality_policy_digest'] = translation_quality.policy_digest(policy)
+    summary['quality_policy_runtime_digest'] = translation_quality.policy_digest(
+        BATCH_QUALITY_POLICY
+    )
+
+    summarize_revision_writeback_gate(summary)
+    summary['has_warnings'] = bool(quality_gate.get('has_warnings'))
+    summary['check_status'] = translation_quality.overall_check_status(
+        summary['writeback_gate'],
+        quality_gate,
+    )
+    return quality_findings, quality_report_path
+
+
+def summarize_revision_writeback_gate(summary):
+    """Compute revision writeback gate from structural and quality blockers."""
+
+    quality_gate = summary.get('quality_gate') or {}
+    structural_block = summary.get('adapter_writeback_status') == 'block'
+    quality_blocker_count = int(quality_gate.get('blocker_count') or 0)
+    can_apply = (not structural_block) and quality_blocker_count == 0
+    summary['writeback_gate'] = {
+        'decision': (
+            translation_quality.GATE_ALLOW
+            if can_apply
+            else translation_quality.GATE_DENY
+        ),
+        'can_apply': can_apply,
+        'blocker_count': quality_blocker_count + (1 if structural_block else 0),
+        'structural_blocker_count': 1 if structural_block else 0,
+        'quality_blocker_count': quality_blocker_count,
+    }
+    return summary['writeback_gate']
 
 
 def print_check_summary(summary):
@@ -10617,6 +10899,25 @@ def apply_revisions(target=None, force=False):
             revalidated_file_paths[file_key] = file_path
             revalidated_source_documents[file_key] = source_document
 
+    _quality_findings, quality_report_path = run_revision_quality_check(
+        manifest,
+        summary,
+        revalidated_replacements_by_file,
+    )
+    manifest['last_revision_quality_findings_path'] = quality_report_path
+    manifest['last_revision_quality_findings_sha256'] = _sha256_file(
+        quality_report_path
+    )
+    manifest['last_revision_apply_summary'] = summary
+    quality_gate = summary.get('quality_gate') or {}
+    if int(quality_gate.get('blocker_count') or 0) > 0:
+        append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
+        _mark_revision_apply_blocked(
+            manifest,
+            'quality_blockers_present',
+            'configured quality blocker rules matched revision candidates. No files were written.',
+        )
+
     adapter_plan, adapter_snapshot = _validate_adapter_writeback_plan(
         manifest,
         revalidated_replacements_by_file,
@@ -10631,6 +10932,11 @@ def apply_revisions(target=None, force=False):
     if summary.get('adapter_writeback_status') == 'block':
         summary['pending_files'] = 0
         summary['pending_lines'] = 0
+        summarize_revision_writeback_gate(summary)
+        summary['check_status'] = translation_quality.overall_check_status(
+            summary['writeback_gate'],
+            summary.get('quality_gate') or {},
+        )
         append_failure_entries(failure_entries, package_dir=manifest['_package_dir'])
         _mark_revision_apply_blocked(
             manifest,
@@ -10724,6 +11030,10 @@ def apply_revisions(target=None, force=False):
         'skipped_items': summary.get('skipped_items', 0),
         'source_mismatch_items': summary.get('source_mismatch_items', 0),
         'failure_count': len(failure_entries),
+        'quality_gate': summary.get('quality_gate'),
+        'writeback_gate': summary.get('writeback_gate'),
+        'quality_findings_count': summary.get('quality_findings_count', 0),
+        'quality_findings_path': 'quality_findings.jsonl',
         'rag': rag_apply_summary,
     }
     manifest['last_revision_apply_summary'] = summary

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -9291,8 +9291,10 @@ def _revision_manifest_identity(manifest):
         'summary', 'files', 'chunks', 'final_review_source',
     )
     payload = {key: manifest.get(key) for key in keys}
-    if isinstance(manifest.get('quality_policy'), dict):
-        payload['quality_policy'] = manifest['quality_policy']
+    # ``quality_policy`` deliberately stays outside this fingerprint for
+    # backward compatibility: pre-existing previews already persisted their
+    # identity with the original key set.  Fresh policy mismatches are detected
+    # by ``_revision_quality_staleness`` through the preview policy digest.
     # Preserve the v1 fingerprint for pre-proposal revision/final-review
     # packages.  Proposal manifests bind their immutable import provenance and
     # eligibility state without adding a null field to every legacy payload.

--- a/gui_qt/quality_findings_dialog.py
+++ b/gui_qt/quality_findings_dialog.py
@@ -81,7 +81,7 @@ class QualityFindingsDialog(QDialog):
         filters.addWidget(QLabel("最低严重程度："))
         self.severity_filter = QComboBox()
         self.severity_filter.addItem("全部", "")
-        for severity in ("low", "medium", "high"):
+        for severity in ("info", "low", "medium", "high"):
             self.severity_filter.addItem(severity_label(severity), severity)
         filters.addWidget(self.severity_filter)
         layout.addLayout(filters)

--- a/gui_qt/quality_findings_report.py
+++ b/gui_qt/quality_findings_report.py
@@ -142,11 +142,20 @@ def resolve_quality_findings_path(
             selected = report_path.strip()
             break
     if not selected:
-        revision_preview = manifest.get("last_revision_preview")
-        if isinstance(revision_preview, dict):
-            report_path = revision_preview.get("quality_findings_path")
+        for summary_key in ("revision_apply_summary", "last_revision_apply_summary"):
+            apply_summary = manifest.get(summary_key)
+            if not isinstance(apply_summary, dict):
+                continue
+            report_path = apply_summary.get("quality_findings_path")
             if isinstance(report_path, str) and report_path.strip():
                 selected = report_path.strip()
+                break
+        if not selected:
+            revision_preview = manifest.get("last_revision_preview")
+            if isinstance(revision_preview, dict):
+                report_path = revision_preview.get("quality_findings_path")
+                if isinstance(report_path, str) and report_path.strip():
+                    selected = report_path.strip()
     if selected:
         if Path(selected).is_absolute():
             return selected

--- a/gui_qt/quality_findings_report.py
+++ b/gui_qt/quality_findings_report.py
@@ -167,14 +167,10 @@ def quality_gate_from_manifest(manifest: dict[str, object]) -> dict[str, object]
         quality_gate = last_summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
-    summary = manifest.get("summary")
-    if isinstance(summary, dict):
-        quality_gate = summary.get("quality_gate")
-        if isinstance(quality_gate, dict):
-            return dict(quality_gate)
-    # Apply-time gates are newer than ``last_revision_preview`` and must win
-    # when both exist.  Blocked apply paths only persist the full revalidated
-    # summary under ``last_revision_apply_summary``.
+    # Apply-time gates are newer than both ``last_revision_preview`` and any
+    # top-level build summary carried over from an earlier Batch stage.
+    # Blocked apply paths only persist the full revalidated summary under
+    # ``last_revision_apply_summary``.
     revision_apply_summary = manifest.get("revision_apply_summary")
     if isinstance(revision_apply_summary, dict):
         quality_gate = revision_apply_summary.get("quality_gate")
@@ -188,6 +184,11 @@ def quality_gate_from_manifest(manifest: dict[str, object]) -> dict[str, object]
     revision_preview = manifest.get("last_revision_preview")
     if isinstance(revision_preview, dict):
         quality_gate = revision_preview.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
+    summary = manifest.get("summary")
+    if isinstance(summary, dict):
+        quality_gate = summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
     return {}

--- a/gui_qt/quality_findings_report.py
+++ b/gui_qt/quality_findings_report.py
@@ -182,6 +182,14 @@ def quality_gate_from_manifest(manifest: dict[str, object]) -> dict[str, object]
         quality_gate = revision_apply_summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
+    # Blocked/no-op apply paths persist the full revalidated summary under
+    # ``last_revision_apply_summary``; prefer it over the older preview gate so
+    # GUI shows the quality gate that was actually enforced at apply time.
+    last_revision_apply_summary = manifest.get("last_revision_apply_summary")
+    if isinstance(last_revision_apply_summary, dict):
+        quality_gate = last_revision_apply_summary.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
     return {}
 
 
@@ -213,7 +221,10 @@ def filter_quality_items(
     for item in items:
         if selected_reason and item.reason_code != selected_reason:
             continue
-        if selected_file and selected_file not in item.file_rel_path.casefold():
+        if selected_file and not translation_quality.file_matches_filter(
+            item.file_rel_path,
+            selected_file,
+        ):
             continue
         if SEVERITY_ORDER.get(item.severity.lower(), 2) < minimum:
             continue

--- a/gui_qt/quality_findings_report.py
+++ b/gui_qt/quality_findings_report.py
@@ -12,8 +12,8 @@ import translation_quality
 from .diagnostics_context import join_directory_file, resolve_package_dir
 from .user_copy import QUALITY_DELIVERY_NOTICE
 
-SEVERITY_ORDER = {"low": 0, "medium": 1, "high": 2}
-SEVERITY_LABELS = {"low": "低", "medium": "中", "high": "高"}
+SEVERITY_ORDER = {"info": 0, "low": 1, "medium": 2, "high": 3}
+SEVERITY_LABELS = {"info": "提示", "low": "低", "medium": "中", "high": "高"}
 
 REASON_LABELS = {
     translation_quality.REASON_WAIT_TAG_INSIDE_CJK: "等待标签插入中文词内",
@@ -27,6 +27,15 @@ REASON_LABELS = {
     translation_quality.REASON_SPEAKER_LABEL_UNTRANSLATED: "说话人标签未翻译",
     translation_quality.REASON_INTERJECTION_UNTRANSLATED: "短感叹词/拟声词未翻译",
     translation_quality.REASON_KNOWN_GARBLED_PHRASE: "已知错乱词",
+    translation_quality.REASON_UNMATCHED_QUALITY_SUBJECT: "质量采集无法匹配",
+    translation_quality.FINAL_REVIEW_REASON_OMISSION: "最终审校：漏译",
+    translation_quality.FINAL_REVIEW_REASON_MISTRANSLATION: "最终审校：误译",
+    translation_quality.FINAL_REVIEW_REASON_ADDITION: "最终审校：多余内容",
+    translation_quality.FINAL_REVIEW_REASON_FORMAT: "最终审校：格式问题",
+    translation_quality.FINAL_REVIEW_REASON_TERMINOLOGY: "最终审校：术语问题",
+    translation_quality.FINAL_REVIEW_REASON_ADDRESS: "最终审校：称呼问题",
+    translation_quality.FINAL_REVIEW_REASON_STYLE_DRIFT: "最终审校：文风漂移",
+    translation_quality.FINAL_REVIEW_REASON_NEEDS_CONFIRMATION: "最终审校：待确认",
 }
 
 
@@ -92,7 +101,8 @@ def parse_quality_findings_jsonl(text: str) -> list[dict[str, object]]:
 
 
 def normalize_quality_finding(entry: dict[str, object]) -> QualityFindingItem:
-    line_value = entry.get("line")
+    normalized = translation_quality.normalize_finding(entry)
+    line_value = normalized.get("line")
     line_number: int | None
     if isinstance(line_value, int):
         line_number = line_value
@@ -102,17 +112,17 @@ def normalize_quality_finding(entry: dict[str, object]) -> QualityFindingItem:
         line_number = None
 
     return QualityFindingItem(
-        reason_code=str(entry.get("reason_code") or "").strip(),
-        disposition=str(entry.get("disposition") or "warning").strip(),
-        severity=str(entry.get("severity") or "medium").strip(),
-        file_rel_path=str(entry.get("file") or "").strip(),
+        reason_code=str(normalized.get("reason_code") or "").strip(),
+        disposition=str(normalized.get("disposition") or "warning").strip(),
+        severity=str(normalized.get("severity") or "medium").strip(),
+        file_rel_path=str(normalized.get("file") or "").strip(),
         line=line_number,
-        item_id=str(entry.get("item_id") or "").strip(),
-        source=str(entry.get("source") or ""),
-        translation=str(entry.get("translation") or ""),
-        evidence=str(entry.get("evidence") or ""),
-        suggestion=str(entry.get("suggestion") or ""),
-        finding_id=str(entry.get("finding_id") or ""),
+        item_id=str(normalized.get("item_id") or "").strip(),
+        source=str(normalized.get("source") or ""),
+        translation=str(normalized.get("translation") or ""),
+        evidence=str(normalized.get("evidence") or ""),
+        suggestion=str(normalized.get("suggestion") or ""),
+        finding_id=str(normalized.get("finding_id") or ""),
     )
 
 
@@ -121,9 +131,29 @@ def resolve_quality_findings_path(
     *,
     manifest_path: str = "",
 ) -> str:
-    report_path = manifest.get("last_quality_findings_path")
-    if isinstance(report_path, str) and report_path.strip():
-        return report_path.strip()
+    selected = ""
+    for key in (
+        "last_quality_findings_path",
+        "last_revision_quality_findings_path",
+        "quality_findings_path",
+    ):
+        report_path = manifest.get(key)
+        if isinstance(report_path, str) and report_path.strip():
+            selected = report_path.strip()
+            break
+    if not selected:
+        revision_preview = manifest.get("last_revision_preview")
+        if isinstance(revision_preview, dict):
+            report_path = revision_preview.get("quality_findings_path")
+            if isinstance(report_path, str) and report_path.strip():
+                selected = report_path.strip()
+    if selected:
+        if Path(selected).is_absolute():
+            return selected
+        package_dir = resolve_package_dir(manifest_path, manifest)
+        if package_dir:
+            return join_directory_file(package_dir, selected)
+        return selected
 
     package_dir = resolve_package_dir(manifest_path, manifest)
     if package_dir:
@@ -135,6 +165,21 @@ def quality_gate_from_manifest(manifest: dict[str, object]) -> dict[str, object]
     last_summary = manifest.get("last_check_summary")
     if isinstance(last_summary, dict):
         quality_gate = last_summary.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
+    summary = manifest.get("summary")
+    if isinstance(summary, dict):
+        quality_gate = summary.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
+    revision_preview = manifest.get("last_revision_preview")
+    if isinstance(revision_preview, dict):
+        quality_gate = revision_preview.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
+    revision_apply_summary = manifest.get("revision_apply_summary")
+    if isinstance(revision_apply_summary, dict):
+        quality_gate = revision_apply_summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
     return {}

--- a/gui_qt/quality_findings_report.py
+++ b/gui_qt/quality_findings_report.py
@@ -172,22 +172,22 @@ def quality_gate_from_manifest(manifest: dict[str, object]) -> dict[str, object]
         quality_gate = summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
-    revision_preview = manifest.get("last_revision_preview")
-    if isinstance(revision_preview, dict):
-        quality_gate = revision_preview.get("quality_gate")
-        if isinstance(quality_gate, dict):
-            return dict(quality_gate)
+    # Apply-time gates are newer than ``last_revision_preview`` and must win
+    # when both exist.  Blocked apply paths only persist the full revalidated
+    # summary under ``last_revision_apply_summary``.
     revision_apply_summary = manifest.get("revision_apply_summary")
     if isinstance(revision_apply_summary, dict):
         quality_gate = revision_apply_summary.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
-    # Blocked/no-op apply paths persist the full revalidated summary under
-    # ``last_revision_apply_summary``; prefer it over the older preview gate so
-    # GUI shows the quality gate that was actually enforced at apply time.
     last_revision_apply_summary = manifest.get("last_revision_apply_summary")
     if isinstance(last_revision_apply_summary, dict):
         quality_gate = last_revision_apply_summary.get("quality_gate")
+        if isinstance(quality_gate, dict):
+            return dict(quality_gate)
+    revision_preview = manifest.get("last_revision_preview")
+    if isinstance(revision_preview, dict):
+        quality_gate = revision_preview.get("quality_gate")
         if isinstance(quality_gate, dict):
             return dict(quality_gate)
     return {}

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -135,6 +135,22 @@ def _quality_gate_fact(quality_gate_text: str) -> str:
     return f"质量报警 {warnings} 条，质量阻断 {blockers} 条"
 
 
+def revision_writeback_gate_denial(parsed: dict[str, object]) -> tuple[str, int] | None:
+    """Return ``(kind, quality_blockers)`` when preview output denies writeback.
+
+    ``kind`` is ``"quality"`` when at least one configured quality blocker was
+    reported, otherwise ``"structural"`` for an adapter/writeback-plan block.
+    A missing or ``allow`` gate returns ``None``.
+    """
+    gate = str(parsed.get("revision_writeback_gate") or "").strip().lower()
+    if not gate or gate == "allow":
+        return None
+    quality_gate_text = str(parsed.get("quality_gate") or "")
+    blockers_match = re.search(r"blockers=(\d+)", quality_gate_text)
+    quality_blockers = int(blockers_match.group(1)) if blockers_match else 0
+    return ("quality" if quality_blockers else "structural", quality_blockers)
+
+
 def summarize_revision_preview_output(output: str, exit_code: int) -> WorkflowUpdate:
     if exit_code != 0:
         return WorkflowUpdate(
@@ -162,6 +178,28 @@ def summarize_revision_preview_output(output: str, exit_code: int) -> WorkflowUp
     ]
     if findings:
         facts = extend_facts_with_notices(facts, findings)
+
+    denial = revision_writeback_gate_denial(parsed)
+    if denial is not None:
+        kind, quality_blockers = denial
+        if kind == "quality":
+            heading = "订正预览被质量门禁阻止"
+            message = (
+                f"预览完成，但最近一次预览有 {quality_blockers} 个质量 blocker；"
+                "请处理后重新预览。"
+            )
+        else:
+            heading = "订正预览被结构校验阻止"
+            message = (
+                "预览完成，但未通过结构校验，不能写回；"
+                "请查看失败项后重新预览。"
+            )
+        return WorkflowUpdate(
+            status="warning",
+            heading=heading,
+            message=message,
+            facts=facts,
+        )
 
     if valid_items == 0:
         return WorkflowUpdate(
@@ -214,6 +252,28 @@ def summarize_sync_revision_output(output: str, exit_code: int) -> WorkflowUpdat
     ]
     if findings:
         facts = extend_facts_with_notices(facts, findings)
+
+    denial = revision_writeback_gate_denial(parsed)
+    if denial is not None:
+        kind, quality_blockers = denial
+        if kind == "quality":
+            heading = "同步订正预览被质量门禁阻止"
+            message = (
+                f"预览完成，但最近一次预览有 {quality_blockers} 个质量 blocker；"
+                "请处理后重新预览。"
+            )
+        else:
+            heading = "同步订正预览被结构校验阻止"
+            message = (
+                "预览完成，但未通过结构校验，不能写回；"
+                "请查看失败项后重新预览。"
+            )
+        return WorkflowUpdate(
+            status="warning",
+            heading=heading,
+            message=message,
+            facts=facts,
+        )
 
     if valid_items == 0:
         unresolved = _contract_unresolved_count(output)

--- a/gui_qt/revision_report.py
+++ b/gui_qt/revision_report.py
@@ -73,6 +73,15 @@ def parse_revision_summary(output: str) -> dict[str, object]:
     apply_reason = _parse_line_value(output, "Revision apply reason:")
     if apply_reason:
         parsed["apply_reason"] = apply_reason
+    quality_gate = _parse_line_value(output, "Quality gate:")
+    if quality_gate:
+        parsed["quality_gate"] = quality_gate
+    quality_findings = _parse_line_value(output, "Quality findings:")
+    if quality_findings:
+        parsed["quality_findings"] = quality_findings
+    writeback_gate = _parse_line_value(output, "Revision writeback gate:")
+    if writeback_gate:
+        parsed["revision_writeback_gate"] = writeback_gate
 
     current_section = ""
     for raw_line in output.splitlines():
@@ -107,7 +116,23 @@ def _collect_revision_preview_facts(output: str, parsed: dict[str, object]) -> l
     preview_markdown = parsed.get("preview_markdown")
     if isinstance(preview_markdown, str) and preview_markdown.strip():
         facts.append(f"预览 Markdown：{preview_markdown.strip()}")
+    quality_fact = _quality_gate_fact(str(parsed.get("quality_gate") or ""))
+    if quality_fact:
+        facts.append(quality_fact)
+    quality_findings = parsed.get("quality_findings")
+    if isinstance(quality_findings, str) and quality_findings.strip():
+        facts.append(f"质量检查报告：{quality_findings.strip()}")
     return facts
+
+
+def _quality_gate_fact(quality_gate_text: str) -> str:
+    warnings_match = re.search(r"warnings=(\d+)", quality_gate_text)
+    blockers_match = re.search(r"blockers=(\d+)", quality_gate_text)
+    if warnings_match is None and blockers_match is None:
+        return ""
+    warnings = int(warnings_match.group(1)) if warnings_match else 0
+    blockers = int(blockers_match.group(1)) if blockers_match else 0
+    return f"质量报警 {warnings} 条，质量阻断 {blockers} 条"
 
 
 def summarize_revision_preview_output(output: str, exit_code: int) -> WorkflowUpdate:

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from .check_report import WritebackSummary
-from .revision_report import parse_revision_summary
+from .revision_report import (
+    _collect_revision_preview_facts,
+    parse_revision_summary,
+    revision_writeback_gate_denial,
+)
 from .summary_helpers import extend_facts_with_notices
 from .user_copy import format_manifest_path_fact, format_quality_gate_fact
 
@@ -29,26 +33,9 @@ def summarize_revision_writeback_from_preview_output(
     facts: list[str] = []
     if manifest_path:
         facts.append(format_manifest_path_fact(manifest_path))
+    facts.extend(_collect_revision_preview_facts(output, parsed))
 
     valid_items = parsed.get("valid_items")
-    pending_files = parsed.get("pending_files")
-    pending_lines = parsed.get("pending_lines")
-    if isinstance(valid_items, int):
-        facts.append(f"可写回订正项：{valid_items}")
-    if isinstance(pending_files, int) and isinstance(pending_lines, int):
-        facts.append(f"将影响 {pending_files} 个文件，约 {pending_lines} 处译文行")
-
-    failure_items = parsed.get("failure_items")
-    if isinstance(failure_items, int):
-        facts.append(f"失败项：{failure_items}")
-
-    preview_jsonl = parsed.get("preview_jsonl")
-    if isinstance(preview_jsonl, str) and preview_jsonl.strip():
-        facts.append(f"预览 JSONL：{preview_jsonl.strip()}")
-    preview_markdown = parsed.get("preview_markdown")
-    if isinstance(preview_markdown, str) and preview_markdown.strip():
-        facts.append(f"预览 Markdown：{preview_markdown.strip()}")
-
     findings = [
         finding
         for finding in parsed.get("findings", [])
@@ -72,6 +59,31 @@ def summarize_revision_writeback_from_preview_output(
             heading="订正已写回",
             message="该订正任务已经写回过。",
             facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
+
+    denial = revision_writeback_gate_denial(parsed)
+    if denial is not None:
+        kind, quality_blockers = denial
+        if kind == "quality":
+            heading = "订正写回被质量门禁阻止"
+            message = (
+                f"最近一次订正预览有 {quality_blockers} 个质量 blocker；"
+                "请处理后重新预览。"
+            )
+        else:
+            heading = "订正写回被结构校验阻止"
+            message = (
+                "最近一次订正预览未通过结构校验，不能写回；"
+                "请查看失败项后重新预览。"
+            )
+        return WritebackSummary(
+            status="failed",
+            heading=heading,
+            message=message,
+            facts=extend_facts_with_notices(facts, findings),
             findings=findings,
             can_apply=False,
             manifest_path=manifest_path,

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -257,14 +257,34 @@ def summarize_revision_writeback_from_manifest(
     if isinstance(writeback_gate, dict) and writeback_gate.get(
         "decision"
     ) != "allow":
-        blocker_count = int(writeback_gate.get("blocker_count") or 0)
+        quality_blockers = int(
+            writeback_gate.get("quality_blocker_count") or 0
+        )
+        structural_blockers = int(
+            writeback_gate.get("structural_blocker_count") or 0
+        )
+        if quality_blockers and structural_blockers:
+            heading = "订正写回被质量与结构门禁阻止"
+            message = (
+                f"最近一次订正预览有 {quality_blockers} 个质量 blocker、"
+                f"{structural_blockers} 个结构阻断；处理后重新预览。"
+            )
+        elif structural_blockers:
+            heading = "订正写回被结构校验阻止"
+            message = (
+                "最近一次订正预览未通过结构校验，不能写回；"
+                "请查看失败项后重新预览。"
+            )
+        else:
+            heading = "订正写回被质量门禁阻止"
+            message = (
+                f"最近一次订正预览有 {quality_blockers} 个质量 blocker；"
+                "请处理后重新预览。"
+            )
         return WritebackSummary(
             status="failed",
-            heading="订正写回被质量门禁阻止",
-            message=(
-                f"最近一次订正预览有 {blocker_count} 个阻断项；"
-                "请处理质量 blocker 或结构阻断后重新预览。"
-            ),
+            heading=heading,
+            message=message,
             facts=facts,
             findings=findings,
             can_apply=False,

--- a/gui_qt/revision_writeback_report.py
+++ b/gui_qt/revision_writeback_report.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .check_report import WritebackSummary
 from .revision_report import parse_revision_summary
 from .summary_helpers import extend_facts_with_notices
-from .user_copy import format_manifest_path_fact
+from .user_copy import format_manifest_path_fact, format_quality_gate_fact
 
 
 def summarize_revision_writeback_from_preview_output(
@@ -234,6 +234,15 @@ def summarize_revision_writeback_from_manifest(
     if isinstance(markdown_path, str) and markdown_path.strip():
         facts.append(f"预览 Markdown：{markdown_path.strip()}")
 
+    quality_gate = last_preview.get("quality_gate")
+    if not isinstance(quality_gate, dict):
+        quality_gate = summary.get("quality_gate")
+    if isinstance(quality_gate, dict):
+        facts.append(format_quality_gate_fact(quality_gate))
+        quality_findings_path = last_preview.get("quality_findings_path")
+        if isinstance(quality_findings_path, str) and quality_findings_path.strip():
+            facts.append(f"质量检查报告：{quality_findings_path.strip()}")
+
     findings: list[str] = []
     reason_counts = summary.get("reason_counts")
     if isinstance(reason_counts, dict):
@@ -241,6 +250,26 @@ def summarize_revision_writeback_from_manifest(
             count = reason_counts[name]
             if isinstance(count, int):
                 findings.append(f"{name}: {count}")
+
+    writeback_gate = last_preview.get("writeback_gate")
+    if not isinstance(writeback_gate, dict):
+        writeback_gate = summary.get("writeback_gate")
+    if isinstance(writeback_gate, dict) and writeback_gate.get(
+        "decision"
+    ) != "allow":
+        blocker_count = int(writeback_gate.get("blocker_count") or 0)
+        return WritebackSummary(
+            status="failed",
+            heading="订正写回被质量门禁阻止",
+            message=(
+                f"最近一次订正预览有 {blocker_count} 个阻断项；"
+                "请处理质量 blocker 或结构阻断后重新预览。"
+            ),
+            facts=facts,
+            findings=findings,
+            can_apply=False,
+            manifest_path=manifest_path,
+        )
 
     if isinstance(valid_items, int) and valid_items > 0:
         return WritebackSummary(

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -155,9 +155,13 @@ def extract_quality_gate(output: str) -> dict[str, object]:
                 return dict(gate)
 
     gate: dict[str, object] = {}
-    decision = _extract_line_value(output, "Quality gate:")
+    decision = ""
+    for prefix in ("Quality gate:", "Sync quality gate:", "Sync apply quality gate:"):
+        decision = _extract_line_value(output, prefix)
+        if decision:
+            break
     if decision:
-        gate["decision"] = decision
+        gate["decision"] = decision.split(",", 1)[0].strip()
     for prefix, key in (
         ("Quality warnings:", "warning_count"),
         ("Quality blockers:", "blocker_count"),
@@ -168,6 +172,14 @@ def extract_quality_gate(output: str) -> dict[str, object]:
             gate[key] = int(value)
         except (TypeError, ValueError):
             pass
+    warnings_match = re.search(r"warnings=(\d+)", output)
+    if warnings_match:
+        gate["warning_count"] = int(warnings_match.group(1))
+    blockers_match = re.search(r"blockers=(\d+)", output)
+    if blockers_match:
+        gate["blocker_count"] = int(blockers_match.group(1))
+    if not gate.get("decision") and gate.get("warning_count") is not None:
+        gate["decision"] = "needs_review"
     return gate
 
 

--- a/gui_qt/translation_workflow.py
+++ b/gui_qt/translation_workflow.py
@@ -161,7 +161,12 @@ def extract_quality_gate(output: str) -> dict[str, object]:
         if decision:
             break
     if decision:
-        gate["decision"] = decision.split(",", 1)[0].strip()
+        decision_match = re.match(r"^[A-Za-z_]{2,}", decision)
+        gate["decision"] = (
+            decision_match.group(0).strip()
+            if decision_match
+            else decision.split(",", 1)[0].strip()
+        )
     for prefix, key in (
         ("Quality warnings:", "warning_count"),
         ("Quality blockers:", "blocker_count"),

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -19,6 +19,8 @@ from atomic_io import (
     sha256_text,
 )
 
+import translation_quality
+
 
 SCHEMA = "sync_translation_preview"
 VERSION = 1
@@ -69,6 +71,18 @@ def _fingerprint_payload(manifest: dict[str, Any]) -> dict[str, Any]:
         "summary": manifest.get("summary"),
         "files": manifest.get("files"),
     }
+    for key in (
+        "quality_policy",
+        "quality_policy_digest",
+        "quality_glossary_file",
+        "last_quality_findings_path",
+        "quality_findings_sha256",
+        "quality_findings_digest",
+        "quality_finding_schema_version",
+        "quality_rule_schema_version",
+    ):
+        if key in manifest:
+            payload[key] = manifest.get(key)
     if "prompt_context" in manifest:
         payload["prompt_context"] = manifest.get("prompt_context")
     if "failures" in manifest:
@@ -153,6 +167,8 @@ def create_sync_preview(
     failures: Iterable[dict[str, Any]] = (),
     contract_diagnostics: dict[str, Any] | None = None,
     prompt_context: dict[str, Any] | None = None,
+    quality_policy: dict[str, Any] | None = None,
+    glossary_file: str | os.PathLike[str] = "",
 ) -> tuple[str, dict[str, Any]]:
     """Persist source/proposed snapshots, a unified diff, and a bound manifest.
 
@@ -162,6 +178,12 @@ def create_sync_preview(
     per-batch context construction facts used for the run; when present it is
     also covered by the fingerprint so a changed macro/settings file invalidates
     an old preview at apply time.
+
+    Structurally validated sync candidates passed through each file's
+    ``quality_subjects`` list are run through the shared mechanical quality
+    rules.  Findings are persisted next to the preview diff as
+    ``quality_findings.jsonl`` and summarized by the same ``quality_gate``
+    contract as Batch check.
     """
     created = datetime.now(timezone.utc)
     run_name = created.strftime("%Y%m%dT%H%M%S.%fZ")
@@ -180,6 +202,7 @@ def create_sync_preview(
     package_dir.mkdir(parents=True, exist_ok=False)
 
     entries: list[dict[str, Any]] = []
+    quality_subjects: list[dict[str, Any]] = []
     report_lines = [
         "# Synchronous translation preview\n\n",
         f"Created: {created.isoformat()}\n\n",
@@ -219,6 +242,12 @@ def create_sync_preview(
             entries[-1]["writeback_plan"] = raw.get("writeback_plan")
         if raw.get("prompt_context") is not None:
             entries[-1]["prompt_context"] = raw.get("prompt_context")
+        for subject in raw.get("quality_subjects") or []:
+            if not isinstance(subject, dict):
+                continue
+            normalized_subject = dict(subject)
+            normalized_subject.setdefault("file_rel_path", relative_path)
+            quality_subjects.append(normalized_subject)
         report_lines.extend(
             difflib.unified_diff(
                 source_text.splitlines(keepends=True),
@@ -233,6 +262,24 @@ def create_sync_preview(
 
     report_path = package_dir / "preview.diff"
     atomic_write_text(report_path, "".join(report_lines), encoding="utf-8")
+
+    effective_quality_policy = translation_quality.normalize_policy(quality_policy)
+    glossary_text = str(glossary_file or "").strip()
+    quality_glossary_map = translation_quality.load_glossary_map(
+        glossary_text,
+        base_dir=os.path.realpath(os.path.abspath(os.fspath(project_root))),
+    )
+    if not quality_glossary_map and glossary_text:
+        quality_glossary_map = translation_quality.load_glossary_map(glossary_text)
+    quality_findings = translation_quality.check_quality(
+        quality_subjects,
+        policy=effective_quality_policy,
+        glossary_map=quality_glossary_map,
+    )
+    quality_findings_path = package_dir / "quality_findings.jsonl"
+    translation_quality.write_findings(quality_findings_path, quality_findings)
+    quality_gate = translation_quality.summarize_quality_gate(quality_findings)
+
     manifest: dict[str, Any] = {
         "schema": SCHEMA,
         "version": VERSION,
@@ -264,10 +311,45 @@ def create_sync_preview(
                 contract.get("targeted_retry_requests") or 0
             ),
             "model_contract_unresolved": len(contract.get("unresolved_ids") or []),
+            "quality_gate": quality_gate,
+            "quality_findings_count": len(quality_findings),
+            "quality_finding_schema_version": (
+                translation_quality.QUALITY_FINDING_SCHEMA_VERSION
+            ),
+            "quality_rule_schema_version": (
+                translation_quality.QUALITY_RULE_SCHEMA_VERSION
+            ),
+            "quality_policy_digest": translation_quality.policy_digest(
+                effective_quality_policy
+            ),
+            "quality_findings_digest": translation_quality.findings_digest(
+                quality_findings
+            ),
+            "quality_glossary_path": glossary_text,
+            "quality_glossary_entries": len(quality_glossary_map),
+            "quality_glossary_loaded": bool(
+                not glossary_text or quality_glossary_map
+            ),
         },
         "files": entries,
         "failures": failure_entries,
         "model_contract": contract,
+        "quality_policy": effective_quality_policy,
+        "quality_policy_digest": translation_quality.policy_digest(
+            effective_quality_policy
+        ),
+        "quality_glossary_file": glossary_text,
+        "last_quality_findings_path": "quality_findings.jsonl",
+        "quality_findings_sha256": file_sha256(quality_findings_path),
+        "quality_findings_digest": translation_quality.findings_digest(
+            quality_findings
+        ),
+        "quality_finding_schema_version": (
+            translation_quality.QUALITY_FINDING_SCHEMA_VERSION
+        ),
+        "quality_rule_schema_version": (
+            translation_quality.QUALITY_RULE_SCHEMA_VERSION
+        ),
     }
     if prompt_context is not None:
         manifest["prompt_context"] = dict(prompt_context)
@@ -300,6 +382,8 @@ def prepare_sync_preview_apply(
     *,
     active_project_root: str | os.PathLike[str],
     active_tl_dir: str | os.PathLike[str],
+    active_quality_policy: dict[str, Any] | None = None,
+    active_glossary_file: str | os.PathLike[str] = "",
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Validate every source and artifact before the first project write."""
     manifest = load_sync_preview(manifest_path)
@@ -309,8 +393,43 @@ def prepare_sync_preview_apply(
         raise ValueError("Sync preview belongs to a different project.")
     if _canonical(manifest.get("tl_dir", "")) != _canonical(active_tl_dir):
         raise ValueError("Sync preview belongs to a different translation directory.")
+    if manifest.get("quality_rule_schema_version") not in {
+        None,
+        translation_quality.QUALITY_RULE_SCHEMA_VERSION,
+    }:
+        raise ValueError(
+            "Quality rules changed since sync preview; regenerate the preview."
+        )
+    summary = manifest.get("summary") or {}
+    if isinstance(active_quality_policy, dict):
+        expected_digest = summary.get("quality_policy_digest")
+        current_digest = translation_quality.policy_digest(
+            translation_quality.normalize_policy(active_quality_policy)
+        )
+        if expected_digest and current_digest != expected_digest:
+            raise ValueError(
+                "Quality policy changed since sync preview; regenerate the preview."
+            )
+    active_glossary_text = str(active_glossary_file or "").strip()
+    if (
+        active_glossary_text
+        and "quality_glossary_file" in manifest
+        and active_glossary_text != str(manifest.get("quality_glossary_file") or "")
+    ):
+        raise ValueError(
+            "Quality glossary changed since sync preview; regenerate the preview."
+        )
 
     package_dir = Path(manifest["_manifest_path"]).parent
+    if manifest.get("last_quality_findings_path"):
+        quality_report_path = _artifact_path(
+            package_dir,
+            manifest.get("last_quality_findings_path"),
+        )
+        if not quality_report_path.is_file():
+            raise ValueError("Sync preview quality findings are missing.")
+        if file_sha256(quality_report_path) != manifest.get("quality_findings_sha256"):
+            raise ValueError("Sync preview quality findings changed after preview generation.")
     report_path = _artifact_path(package_dir, manifest.get("report_path"))
     if not report_path.is_file() or file_sha256(report_path) != manifest.get("report_sha256"):
         raise ValueError("Sync preview diff report changed after preview generation.")
@@ -380,6 +499,8 @@ def apply_sync_preview(
     active_project_root: str | os.PathLike[str],
     active_tl_dir: str | os.PathLike[str],
     on_file_applied: Callable[[dict[str, Any]], None] | None = None,
+    active_quality_policy: dict[str, Any] | None = None,
+    active_glossary_file: str | os.PathLike[str] = "",
 ) -> dict[str, Any]:
     manifest_file = Path(manifest_path).resolve()
     transaction_path = manifest_file.parent / ".sync_writeback_transaction.json"
@@ -388,6 +509,8 @@ def apply_sync_preview(
         manifest_path,
         active_project_root=active_project_root,
         active_tl_dir=active_tl_dir,
+        active_quality_policy=active_quality_policy,
+        active_glossary_file=active_glossary_file,
     )
     applied_paths: list[str] = []
     try:

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -407,6 +407,14 @@ def prepare_sync_preview_apply(
             "Quality rules changed since sync preview; regenerate the preview."
         )
     summary = manifest.get("summary") or {}
+    quality_gate = summary.get("quality_gate")
+    if isinstance(quality_gate, dict) and int(
+        quality_gate.get("blocker_count") or 0
+    ) > 0:
+        raise ValueError(
+            "Sync preview has quality blockers; resolve them and regenerate "
+            "the preview before applying."
+        )
     if isinstance(active_quality_policy, dict):
         expected_digest = summary.get("quality_policy_digest")
         current_digest = translation_quality.policy_digest(

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -75,6 +75,7 @@ def _fingerprint_payload(manifest: dict[str, Any]) -> dict[str, Any]:
         "quality_policy",
         "quality_policy_digest",
         "quality_glossary_file",
+        "quality_glossary_digest",
         "last_quality_findings_path",
         "quality_findings_sha256",
         "quality_findings_digest",
@@ -271,6 +272,9 @@ def create_sync_preview(
     )
     if not quality_glossary_map and glossary_text:
         quality_glossary_map = translation_quality.load_glossary_map(glossary_text)
+    quality_glossary_digest = translation_quality.glossary_digest(
+        quality_glossary_map
+    )
     quality_findings = translation_quality.check_quality(
         quality_subjects,
         policy=effective_quality_policy,
@@ -326,6 +330,7 @@ def create_sync_preview(
                 quality_findings
             ),
             "quality_glossary_path": glossary_text,
+            "quality_glossary_digest": quality_glossary_digest,
             "quality_glossary_entries": len(quality_glossary_map),
             "quality_glossary_loaded": bool(
                 not glossary_text or quality_glossary_map
@@ -339,6 +344,7 @@ def create_sync_preview(
             effective_quality_policy
         ),
         "quality_glossary_file": glossary_text,
+        "quality_glossary_digest": quality_glossary_digest,
         "last_quality_findings_path": "quality_findings.jsonl",
         "quality_findings_sha256": file_sha256(quality_findings_path),
         "quality_findings_digest": translation_quality.findings_digest(
@@ -419,6 +425,29 @@ def prepare_sync_preview_apply(
         raise ValueError(
             "Quality glossary changed since sync preview; regenerate the preview."
         )
+    if active_glossary_file is not None and "quality_glossary_digest" in manifest:
+        current_glossary_map = translation_quality.load_glossary_map(
+            active_glossary_text,
+            base_dir=os.path.realpath(
+                os.path.abspath(os.fspath(active_project_root))
+            ),
+        )
+        if not current_glossary_map and active_glossary_text:
+            current_glossary_map = translation_quality.load_glossary_map(
+                active_glossary_text
+            )
+        current_glossary_digest = translation_quality.glossary_digest(
+            current_glossary_map
+        )
+        expected_glossary_digest = (
+            manifest.get("quality_glossary_digest")
+            or summary.get("quality_glossary_digest")
+        )
+        if current_glossary_digest != expected_glossary_digest:
+            raise ValueError(
+                "Quality glossary content changed since sync preview; "
+                "regenerate the preview."
+            )
 
     package_dir = Path(manifest["_manifest_path"]).parent
     if manifest.get("last_quality_findings_path"):

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -383,7 +383,7 @@ def prepare_sync_preview_apply(
     active_project_root: str | os.PathLike[str],
     active_tl_dir: str | os.PathLike[str],
     active_quality_policy: dict[str, Any] | None = None,
-    active_glossary_file: str | os.PathLike[str] = "",
+    active_glossary_file: str | os.PathLike[str] | None = None,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Validate every source and artifact before the first project write."""
     manifest = load_sync_preview(manifest_path)
@@ -412,7 +412,7 @@ def prepare_sync_preview_apply(
             )
     active_glossary_text = str(active_glossary_file or "").strip()
     if (
-        active_glossary_text
+        active_glossary_file is not None
         and "quality_glossary_file" in manifest
         and active_glossary_text != str(manifest.get("quality_glossary_file") or "")
     ):
@@ -500,7 +500,7 @@ def apply_sync_preview(
     active_tl_dir: str | os.PathLike[str],
     on_file_applied: Callable[[dict[str, Any]], None] | None = None,
     active_quality_policy: dict[str, Any] | None = None,
-    active_glossary_file: str | os.PathLike[str] = "",
+    active_glossary_file: str | os.PathLike[str] | None = None,
 ) -> dict[str, Any]:
     manifest_file = Path(manifest_path).resolve()
     transaction_path = manifest_file.parent / ".sync_writeback_transaction.json"

--- a/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
@@ -84,7 +84,8 @@
       "quality_blocker_count": 0
     },
     "quality_findings_count": 0,
-    "quality_findings_path": "quality_findings.jsonl",
+    "quality_findings_path": "quality_findings.apply.jsonl",
+    "quality_findings_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "rag": {}
   },
   "last_revision_apply_summary": {

--- a/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
+++ b/tests/fixtures/golden_revision_minimal/expected/preview_apply_snapshot.json
@@ -69,6 +69,22 @@
     "skipped_items": 0,
     "source_mismatch_items": 0,
     "failure_count": 0,
+    "quality_gate": {
+      "decision": "pass",
+      "warning_count": 0,
+      "blocker_count": 0,
+      "acknowledged_count": 0,
+      "has_warnings": false
+    },
+    "writeback_gate": {
+      "decision": "allow",
+      "can_apply": true,
+      "blocker_count": 0,
+      "structural_blocker_count": 0,
+      "quality_blocker_count": 0
+    },
+    "quality_findings_count": 0,
+    "quality_findings_path": "quality_findings.jsonl",
     "rag": {}
   },
   "last_revision_apply_summary": {

--- a/tests/gui_test_support.py
+++ b/tests/gui_test_support.py
@@ -183,8 +183,13 @@ def guarded_test_result_class(guard: GuiTestModalGuard | None):
 
 
 @contextmanager
-def guarded_gui_test_environment():
-    """Reject accidental dialogs without changing the caller's Qt platform."""
+def guarded_gui_test_environment(*, process_events: bool = True):
+    """Reject accidental dialogs without changing the caller's Qt platform.
+
+    ``process_events=False`` is used by the script entrypoint before its hard
+    exit: draining Qt events after the suite can crash the offscreen Linux
+    platform plugin even when every test passed.
+    """
     try:
         from PySide6.QtCore import QCoreApplication, Qt
         from PySide6.QtWidgets import QApplication
@@ -210,10 +215,11 @@ def guarded_gui_test_environment():
             guard.reject_active_modal()
             guard.stop()
             guard.cleanup_top_levels()
-        try:
-            app.processEvents()
-        except RuntimeError:
-            pass
+        if process_events:
+            try:
+                app.processEvents()
+            except RuntimeError:
+                pass
         if guard is not None:
             if guard.rejected_dialogs:
                 summary = "\n".join(

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -36,7 +36,7 @@ def main(
     )
 
     guard = None
-    with guarded_gui_test_environment() as guard:
+    with guarded_gui_test_environment(process_events=shutdown_runtime) as guard:
         exit_code = run_discovered_suite(
             build_suite(),
             quiet=args.quiet,

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -22,6 +22,11 @@ def main(
     *,
     shutdown_runtime: bool = True,
 ) -> int:
+    """Run the GUI suite; ``shutdown_runtime=False`` is hard-exit mode.
+
+    In hard-exit mode the caller is expected to call :func:`_terminate_process`
+    immediately, so no Qt pool teardown is performed at all.
+    """
     args = parse_runner_args(__doc__ or "", argv)
     ensure_tests_on_path()
     from gui_test_support import (
@@ -39,11 +44,13 @@ def main(
             resultclass=guarded_test_result_class(guard),
         )
     unexpected_dialogs = bool(guard and guard.rejected_dialogs)
-    runtime_stopped = (
-        shutdown_gui_test_runtime()
-        if shutdown_runtime
-        else shutdown_gui_test_runtime(cleanup_widgets=False)
-    )
+    if shutdown_runtime:
+        runtime_stopped = shutdown_gui_test_runtime()
+    else:
+        # Script entrypoint mode hard-exits immediately after ``main`` returns.
+        # Skip even the pool-only Qt teardown here: offscreen Linux runners can
+        # segfault after all tests passed while QThreadPool shuts down.
+        runtime_stopped = True
     return 1 if unexpected_dialogs or not runtime_stopped else exit_code
 
 

--- a/tests/test_gui_quality_findings_report.py
+++ b/tests/test_gui_quality_findings_report.py
@@ -7,6 +7,7 @@ from gui_qt.quality_findings_report import (
     normalize_quality_finding,
     parse_quality_findings_jsonl,
     quality_issues_report_ready,
+    resolve_quality_findings_path,
 )
 
 
@@ -83,6 +84,33 @@ class QualityFindingsReportTests(unittest.TestCase):
             quality_issues_report_ready(
                 {"last_check_summary": {"quality_gate": {"warning_count": 0}}}
             )
+        )
+
+    def test_resolve_quality_paths_prefers_revision_apply_summary(self):
+        manifest = {
+            "last_revision_preview": {
+                "quality_findings_path": "preview/quality_findings.jsonl",
+            },
+            "revision_apply_summary": {
+                "quality_findings_path": "apply/quality_findings.apply.jsonl",
+            },
+        }
+        self.assertEqual(
+            resolve_quality_findings_path(manifest),
+            "apply/quality_findings.apply.jsonl",
+        )
+
+        blocked_manifest = {
+            "last_revision_preview": {
+                "quality_findings_path": "preview/quality_findings.jsonl",
+            },
+            "last_revision_apply_summary": {
+                "quality_findings_path": "blocked/quality_findings.apply.jsonl",
+            },
+        }
+        self.assertEqual(
+            resolve_quality_findings_path(blocked_manifest),
+            "blocked/quality_findings.apply.jsonl",
         )
 
     def test_filter_by_rule_file_and_severity(self):

--- a/tests/test_gui_revision_report.py
+++ b/tests/test_gui_revision_report.py
@@ -59,6 +59,17 @@ Preview JSONL: C:\\package\\revision_preview.jsonl
 Preview Markdown: C:\\package\\revision_preview.md
 """
 
+BLOCKED_PREVIEW_OUTPUT = """
+Recoverable revision items: 2
+Pending files: 1
+Pending lines: 2
+Failure items: 0
+Quality gate: blocked (warnings=1, blockers=1)
+Revision writeback gate: deny
+Preview JSONL: C:\\package\\revision_preview.jsonl
+Preview Markdown: C:\\package\\revision_preview.md
+"""
+
 
 class GuiRevisionReportTests(unittest.TestCase):
     def test_parse_revision_summary_extracts_preview_paths_and_counts(self):
@@ -97,6 +108,13 @@ class GuiRevisionReportTests(unittest.TestCase):
 
         self.assertEqual(update.status, "failed")
         self.assertIn("预览中断", update.heading)
+
+    def test_summarize_preview_gate_deny_warns(self):
+        update = summarize_revision_preview_output(BLOCKED_PREVIEW_OUTPUT, 0)
+
+        self.assertEqual(update.status, "warning")
+        self.assertIn("质量门禁", update.heading)
+        self.assertIn("质量阻断 1 条", "\n".join(update.facts))
 
     def test_summarize_sync_success_marks_done(self):
         update = summarize_sync_revision_output(SYNC_OUTPUT, 0)

--- a/tests/test_gui_revision_writeback_report.py
+++ b/tests/test_gui_revision_writeback_report.py
@@ -122,6 +122,58 @@ class GuiRevisionWritebackReportTests(unittest.TestCase):
 
         self.assertIsNone(summary)
 
+    def test_manifest_structural_preview_deny_is_not_quality_label(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": "C:\\package\\manifest.json",
+                "last_revision_preview": {
+                    "jsonl_path": "C:\\package\\revision_preview.jsonl",
+                    "markdown_path": "C:\\package\\revision_preview.md",
+                    "writeback_gate": {
+                        "decision": "deny",
+                        "quality_blocker_count": 0,
+                        "structural_blocker_count": 1,
+                    },
+                    "summary": {
+                        "valid_items": 0,
+                        "pending_files": 0,
+                        "pending_lines": 0,
+                        "failure_items": 1,
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertEqual(summary.heading, "订正写回被结构校验阻止")
+        self.assertFalse(summary.can_apply)
+
+    def test_manifest_quality_preview_deny_keeps_quality_label(self):
+        summary = summarize_revision_writeback_from_manifest(
+            {
+                "_manifest_path": "C:\\package\\manifest.json",
+                "last_revision_preview": {
+                    "jsonl_path": "C:\\package\\revision_preview.jsonl",
+                    "markdown_path": "C:\\package\\revision_preview.md",
+                    "writeback_gate": {
+                        "decision": "deny",
+                        "quality_blocker_count": 2,
+                        "structural_blocker_count": 0,
+                    },
+                    "summary": {
+                        "valid_items": 0,
+                        "pending_files": 0,
+                        "pending_lines": 0,
+                        "failure_items": 0,
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertEqual(summary.heading, "订正写回被质量门禁阻止")
+        self.assertFalse(summary.can_apply)
+
     def test_manifest_blocked_apply_reports_blocked(self):
         summary = summarize_revision_writeback_from_manifest(
             {

--- a/tests/test_gui_revision_writeback_report.py
+++ b/tests/test_gui_revision_writeback_report.py
@@ -15,6 +15,28 @@ Preview JSONL: C:\\package\\revision_preview.jsonl
 Preview Markdown: C:\\package\\revision_preview.md
 """
 
+QUALITY_BLOCKED_PREVIEW_OUTPUT = """
+Recoverable revision items: 2
+Pending files: 1
+Pending lines: 2
+Failure items: 0
+Quality gate: blocked (warnings=1, blockers=1)
+Revision writeback gate: deny
+Preview JSONL: C:\\package\\revision_preview.jsonl
+Preview Markdown: C:\\package\\revision_preview.md
+"""
+
+STRUCTURAL_BLOCKED_PREVIEW_OUTPUT = """
+Recoverable revision items: 2
+Pending files: 1
+Pending lines: 2
+Failure items: 0
+Quality gate: ready (warnings=0, blockers=0)
+Revision writeback gate: deny
+Preview JSONL: C:\\package\\revision_preview.jsonl
+Preview Markdown: C:\\package\\revision_preview.md
+"""
+
 
 class GuiRevisionWritebackReportTests(unittest.TestCase):
     def test_preview_with_recoverable_items_enables_apply(self):
@@ -58,6 +80,30 @@ class GuiRevisionWritebackReportTests(unittest.TestCase):
 
         self.assertEqual(summary.status, "failed")
         self.assertFalse(summary.can_apply)
+
+    def test_preview_quality_gate_deny_blocks_apply(self):
+        summary = summarize_revision_writeback_from_preview_output(
+            QUALITY_BLOCKED_PREVIEW_OUTPUT,
+            0,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("质量门禁", summary.heading)
+        self.assertIn("1 个质量 blocker", summary.message)
+        self.assertIn("质量报警 1 条，质量阻断 1 条", "\n".join(summary.facts))
+
+    def test_preview_structural_gate_deny_blocks_apply(self):
+        summary = summarize_revision_writeback_from_preview_output(
+            STRUCTURAL_BLOCKED_PREVIEW_OUTPUT,
+            0,
+            manifest_path="C:\\package\\manifest.json",
+        )
+
+        self.assertEqual(summary.status, "failed")
+        self.assertFalse(summary.can_apply)
+        self.assertIn("结构校验", summary.heading)
 
     def test_manifest_after_preview_enables_apply(self):
         summary = summarize_revision_writeback_from_manifest(

--- a/tests/test_test_runners.py
+++ b/tests/test_test_runners.py
@@ -99,7 +99,7 @@ class TestDiscoveryRunners(unittest.TestCase):
             mock.patch(
                 "gui_test_support.guarded_gui_test_environment",
                 return_value=manager,
-            ),
+            ) as guarded,
             mock.patch(
                 "gui_test_support.shutdown_gui_test_runtime",
                 return_value=True,
@@ -124,7 +124,7 @@ class TestDiscoveryRunners(unittest.TestCase):
             mock.patch(
                 "gui_test_support.guarded_gui_test_environment",
                 return_value=manager,
-            ),
+            ) as guarded,
             mock.patch(
                 "gui_test_support.shutdown_gui_test_runtime",
                 return_value=True,
@@ -146,6 +146,7 @@ class TestDiscoveryRunners(unittest.TestCase):
             )
 
         shutdown.assert_not_called()
+        guarded.assert_called_once_with(process_events=False)
 
     def test_gui_runner_fails_when_qt_pool_does_not_stop(self):
         guard = mock.Mock(rejected_dialogs=())

--- a/tests/test_test_runners.py
+++ b/tests/test_test_runners.py
@@ -99,7 +99,7 @@ class TestDiscoveryRunners(unittest.TestCase):
             mock.patch(
                 "gui_test_support.guarded_gui_test_environment",
                 return_value=manager,
-            ) as guarded,
+            ),
             mock.patch(
                 "gui_test_support.shutdown_gui_test_runtime",
                 return_value=True,

--- a/tests/test_test_runners.py
+++ b/tests/test_test_runners.py
@@ -115,7 +115,7 @@ class TestDiscoveryRunners(unittest.TestCase):
 
         shutdown.assert_called_once_with()
 
-    def test_gui_script_path_checks_pool_without_widget_cleanup(self):
+    def test_gui_script_path_skips_qt_teardown_before_hard_exit(self):
         guard = mock.Mock(rejected_dialogs=())
         manager = mock.MagicMock()
         manager.__enter__.return_value = guard
@@ -145,7 +145,7 @@ class TestDiscoveryRunners(unittest.TestCase):
                 0,
             )
 
-        shutdown.assert_called_once_with(cleanup_widgets=False)
+        shutdown.assert_not_called()
 
     def test_gui_runner_fails_when_qt_pool_does_not_stop(self):
         guard = mock.Mock(rejected_dialogs=())

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -198,6 +198,24 @@ class SharedSchemaContractTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'row 2'):
                 quality.load_findings(path, strict=True)
 
+    def test_strict_load_rejects_invalid_enum_values_before_normalizing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'findings.jsonl'
+            invalid = quality.normalize_finding(
+                quality.check_subject(mechanical_subject())[0]
+            )
+            invalid['severity'] = 'catastrophic'
+            invalid['disposition'] = 'sometimes'
+            invalid['line'] = -1
+            invalid['rule_version'] = 'not-an-int'
+            path.write_text(
+                json.dumps(invalid, ensure_ascii=False) + '\n',
+                encoding='utf-8',
+            )
+
+            with self.assertRaisesRegex(ValueError, 'severity'):
+                quality.load_findings(path, strict=True)
+
     def test_final_review_adapter_preserves_semantic_fields(self):
         semantic = fr.normalize_finding(
             {
@@ -268,6 +286,9 @@ class SharedSchemaContractTests(unittest.TestCase):
 
     def test_gui_prefers_apply_time_revision_quality_gate(self):
         manifest = {
+            'last_revision_preview': {
+                'quality_gate': {'decision': 'pass', 'warning_count': 0},
+            },
             'revision_apply_summary': {
                 'quality_gate': {'decision': 'needs_review', 'warning_count': 1},
             },
@@ -278,6 +299,9 @@ class SharedSchemaContractTests(unittest.TestCase):
         )
 
         blocked = {
+            'last_revision_preview': {
+                'quality_gate': {'decision': 'pass', 'warning_count': 0},
+            },
             'last_revision_apply_summary': {
                 'quality_gate': {'decision': 'needs_review', 'warning_count': 2},
             },
@@ -581,6 +605,27 @@ class RevisionQualityStalenessTests(unittest.TestCase):
             self._preview(writeback_gate={'decision': quality.GATE_DENY}),
         )
         self.assertEqual(reason, 'revision_writeback_gate_denied')
+
+    def test_revision_blocked_marker_raises_after_persisting_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = {
+                '_manifest_path': str(Path(tmp) / 'manifest.json'),
+                'execution': 'sync',
+            }
+            with mock.patch.object(batch, 'save_manifest') as save:
+                with self.assertRaises(SystemExit):
+                    batch._mark_revision_apply_blocked(
+                        manifest,
+                        'quality_blockers_present',
+                        'configured quality blocker rules matched revision candidates.',
+                    )
+
+            save.assert_called_once()
+            self.assertEqual(manifest['revision_apply_state'], 'blocked')
+            self.assertEqual(
+                manifest['revision_apply_blocked_reason'],
+                'quality_blockers_present',
+            )
 
 
 class RevisionQualityFindingsTests(unittest.TestCase):

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -14,6 +14,7 @@ import translator_runtime as runtime
 from gui_qt.quality_findings_report import (
     filter_quality_items,
     normalize_quality_finding,
+    quality_gate_from_manifest,
     reason_label,
     resolve_quality_findings_path,
 )
@@ -130,6 +131,39 @@ class SharedSchemaContractTests(unittest.TestCase):
             ['b'],
         )
 
+    def test_file_filter_does_not_match_across_name_boundaries(self):
+        findings = [
+            {
+                'finding_id': 'f1',
+                'schema_version': 1,
+                'reason_code': quality.REASON_CJK_LATIN_SPACING,
+                'rule_id': 'cjk_latin_spacing',
+                'severity': 'medium',
+                'disposition': 'warning',
+                'item_id': 'i1',
+                'file': 'xscript.rpy',
+                'line': 1,
+                'source': '',
+                'translation': '',
+                'evidence': '',
+                'suggestion': '',
+                'rule_version': 1,
+            },
+        ]
+
+        self.assertEqual(
+            quality.filter_findings(findings, files=['script.rpy']),
+            [],
+        )
+        self.assertEqual(
+            len(quality.filter_findings(findings, files=['script'])),
+            1,
+        )
+        self.assertEqual(
+            len(quality.filter_findings(findings, files=['xscript'])),
+            1,
+        )
+
     def test_load_write_and_digest_round_trip(self):
         findings = quality.check_subject(mechanical_subject())
         with tempfile.TemporaryDirectory() as tmp:
@@ -223,6 +257,27 @@ class SharedSchemaContractTests(unittest.TestCase):
         self.assertEqual(gate["decision"], "needs_review")
         self.assertEqual(gate["warning_count"], 3)
         self.assertEqual(gate["blocker_count"], 1)
+
+    def test_gui_prefers_apply_time_revision_quality_gate(self):
+        manifest = {
+            'revision_apply_summary': {
+                'quality_gate': {'decision': 'needs_review', 'warning_count': 1},
+            },
+        }
+        self.assertEqual(
+            quality_gate_from_manifest(manifest)['warning_count'],
+            1,
+        )
+
+        blocked = {
+            'last_revision_apply_summary': {
+                'quality_gate': {'decision': 'needs_review', 'warning_count': 2},
+            },
+        }
+        self.assertEqual(
+            quality_gate_from_manifest(blocked)['warning_count'],
+            2,
+        )
 
     def test_gui_resolves_quality_paths_across_producers(self):
         sync_manifest = {

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -258,6 +258,14 @@ class SharedSchemaContractTests(unittest.TestCase):
         self.assertEqual(gate["warning_count"], 3)
         self.assertEqual(gate["blocker_count"], 1)
 
+    def test_gui_extracts_revision_quality_gate_with_parenthesized_counts(self):
+        gate = extract_quality_gate(
+            "Quality gate: needs_review (warnings=3, blockers=1)"
+        )
+        self.assertEqual(gate["decision"], "needs_review")
+        self.assertEqual(gate["warning_count"], 3)
+        self.assertEqual(gate["blocker_count"], 1)
+
     def test_gui_prefers_apply_time_revision_quality_gate(self):
         manifest = {
             'revision_apply_summary': {
@@ -344,7 +352,7 @@ class SharedSchemaContractTests(unittest.TestCase):
 
 
 class SyncQualityFindingsTests(unittest.TestCase):
-    def _make_preview(self, root: Path, subject=None):
+    def _make_preview(self, root: Path, subject=None, *, glossary_file=""):
         tl_dir = root / 'game' / 'tl' / 'schinese'
         tl_dir.mkdir(parents=True)
         target = tl_dir / 'a.rpy'
@@ -368,6 +376,7 @@ class SyncQualityFindingsTests(unittest.TestCase):
             project_root=root,
             tl_dir=tl_dir,
             files=rows,
+            glossary_file=glossary_file,
         )
 
     def test_sync_preview_persists_findings_and_quality_gate(self):
@@ -406,6 +415,23 @@ class SyncQualityFindingsTests(unittest.TestCase):
                     active_quality_policy=quality.normalize_policy(
                         {'rules': {'renpy_wait_inside_cjk': 'off'}}
                     ),
+                )
+
+    def test_sync_apply_stales_when_glossary_is_cleared_explicitly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, _manifest = self._make_preview(
+                root,
+                glossary_file='glossary.json',
+            )
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+
+            with self.assertRaisesRegex(ValueError, 'Quality glossary changed'):
+                preview.apply_sync_preview(
+                    manifest_path,
+                    active_project_root=root,
+                    active_tl_dir=tl_dir,
+                    active_glossary_file='',
                 )
 
     def test_sync_apply_stales_when_quality_rule_version_changes(self):
@@ -484,6 +510,77 @@ class SyncRuntimeQualityFindingsTests(unittest.TestCase):
                     quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
                 }
             )
+
+
+class RevisionQualityStalenessTests(unittest.TestCase):
+    def _preview(self, **overrides):
+        preview = {
+            'quality_rule_schema_version': quality.QUALITY_RULE_SCHEMA_VERSION,
+            'quality_policy_runtime_digest': quality.policy_digest(
+                batch.BATCH_QUALITY_POLICY
+            ),
+            'quality_policy_digest': quality.policy_digest(
+                quality.normalize_policy(None)
+            ),
+            'quality_findings_path': '',
+            'writeback_gate': {'decision': quality.GATE_ALLOW},
+        }
+        preview.update(overrides)
+        return preview
+
+    def test_fresh_revision_quality_preview_returns_none(self):
+        manifest = {'quality_policy': quality.normalize_policy(None)}
+        self.assertIsNone(
+            batch._revision_quality_staleness(manifest, self._preview())
+        )
+
+    def test_rule_version_change_makes_revision_preview_stale(self):
+        manifest = {'quality_policy': quality.normalize_policy(None)}
+        reason, _message = batch._revision_quality_staleness(
+            manifest,
+            self._preview(
+                quality_rule_schema_version=(
+                    quality.QUALITY_RULE_SCHEMA_VERSION + 1
+                )
+            ),
+        )
+        self.assertEqual(reason, 'quality_rules_changed')
+
+    def test_runtime_policy_change_makes_revision_preview_stale(self):
+        manifest = {'quality_policy': quality.normalize_policy(None)}
+        changed_policy = quality.normalize_policy(
+            {'rules': {'renpy_wait_inside_cjk': 'off'}}
+        )
+        reason, _message = batch._revision_quality_staleness(
+            manifest,
+            self._preview(
+                quality_policy_runtime_digest=quality.policy_digest(
+                    changed_policy
+                )
+            ),
+        )
+        self.assertEqual(reason, 'quality_policy_changed')
+
+    def test_manifest_policy_change_makes_revision_preview_stale(self):
+        manifest = {'quality_policy': quality.normalize_policy(None)}
+        changed_policy = quality.normalize_policy(
+            {'rules': {'renpy_wait_inside_cjk': 'off'}}
+        )
+        reason, _message = batch._revision_quality_staleness(
+            manifest,
+            self._preview(
+                quality_policy_digest=quality.policy_digest(changed_policy)
+            ),
+        )
+        self.assertEqual(reason, 'quality_policy_changed')
+
+    def test_denied_revision_writeback_gate_is_stale(self):
+        manifest = {'quality_policy': quality.normalize_policy(None)}
+        reason, _message = batch._revision_quality_staleness(
+            manifest,
+            self._preview(writeback_gate={'decision': quality.GATE_DENY}),
+        )
+        self.assertEqual(reason, 'revision_writeback_gate_denied')
 
 
 class RevisionQualityFindingsTests(unittest.TestCase):

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -694,6 +694,19 @@ class RevisionQualityStalenessTests(unittest.TestCase):
         )
         self.assertEqual(reason, 'revision_writeback_gate_denied')
 
+    def test_manifest_identity_ignores_quality_policy_for_legacy_compat(self):
+        with_policy = {
+            'mode': 'revision',
+            'quality_policy': quality.normalize_policy(None),
+        }
+        without_policy = dict(with_policy)
+        without_policy.pop('quality_policy', None)
+
+        self.assertEqual(
+            batch._revision_manifest_identity(with_policy),
+            batch._revision_manifest_identity(without_policy),
+        )
+
     def test_revision_blocked_marker_raises_after_persisting_state(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest = {

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -1,0 +1,515 @@
+"""Acceptance tests for issue #363: one quality-finding schema across paths."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+import final_review as fr
+import gemini_translate_batch as batch
+import sync_translation_preview as preview
+import translation_quality as quality
+import translator_runtime as runtime
+from gui_qt.quality_findings_report import (
+    filter_quality_items,
+    normalize_quality_finding,
+    reason_label,
+    resolve_quality_findings_path,
+)
+from gui_qt.translation_workflow import extract_quality_gate
+
+
+def mechanical_subject(**overrides):
+    subject = {
+        'item_id': 'item-1',
+        'file_rel_path': 'script.rpy',
+        'line': 0,
+        'line_number': 1,
+        'source': 'Hello',
+        'translation': '你{w=0.5}好',
+    }
+    subject.update(overrides)
+    return subject
+
+
+class SharedSchemaContractTests(unittest.TestCase):
+    def test_normalize_filling_and_coercion(self):
+        normalized = quality.normalize_finding(
+            {
+                'reason_code': quality.REASON_CJK_LATIN_SPACING,
+                'severity': 'high',
+                'disposition': 'warning',
+                'line': '7',
+                'rule_version': '1',
+            }
+        )
+
+        self.assertEqual(normalized['line'], 7)
+        self.assertEqual(normalized['rule_version'], 1)
+        self.assertEqual(normalized['rule_id'], 'cjk_latin_spacing')
+        self.assertIn('finding_id', normalized)
+
+    def test_validate_finding_reports_contract_errors(self):
+        finding = quality.normalize_finding(
+            quality.check_subject(mechanical_subject())[0]
+        )
+        self.assertEqual(quality.validate_finding(finding), [])
+
+        invalid = dict(finding)
+        invalid.pop('reason_code')
+        invalid['severity'] = 'catastrophic'
+        invalid['line'] = -1
+        errors = quality.validate_finding(invalid)
+        self.assertIn('missing required field: reason_code', errors)
+        self.assertTrue(any('severity' in error for error in errors))
+        self.assertTrue(any('line' in error for error in errors))
+
+    def test_filter_findings_supports_shared_dimensions(self):
+        findings = [
+            {
+                'finding_id': 'a',
+                'schema_version': 1,
+                'reason_code': quality.REASON_CJK_LATIN_SPACING,
+                'rule_id': 'cjk_latin_spacing',
+                'severity': 'medium',
+                'disposition': 'warning',
+                'item_id': 'i1',
+                'file': 'a.rpy',
+                'line': 1,
+                'source': 'Hello',
+                'translation': '你好iPhone',
+                'evidence': '{}',
+                'suggestion': '',
+                'rule_version': 1,
+            },
+            {
+                'finding_id': 'b',
+                'schema_version': 1,
+                'reason_code': quality.REASON_HALFWIDTH_PUNCTUATION,
+                'rule_id': 'halfwidth_punctuation',
+                'severity': 'high',
+                'disposition': 'blocker',
+                'item_id': 'i2',
+                'file': 'b.rpy',
+                'line': 2,
+                'source': 'Hello',
+                'translation': '你好,',
+                'evidence': '{}',
+                'suggestion': '',
+                'rule_version': 1,
+            },
+        ]
+
+        self.assertEqual(
+            [row['finding_id'] for row in quality.filter_findings(
+                findings,
+                reason_codes=[quality.REASON_CJK_LATIN_SPACING],
+            )],
+            ['a'],
+        )
+        self.assertEqual(
+            [row['finding_id'] for row in quality.filter_findings(
+                findings,
+                files=['a.rpy'],
+            )],
+            ['a'],
+        )
+        self.assertEqual(
+            [row['finding_id'] for row in quality.filter_findings(
+                findings,
+                min_severity='high',
+            )],
+            ['b'],
+        )
+        self.assertEqual(
+            [row['finding_id'] for row in quality.filter_findings(
+                findings,
+                dispositions=['blocker'],
+            )],
+            ['b'],
+        )
+
+    def test_load_write_and_digest_round_trip(self):
+        findings = quality.check_subject(mechanical_subject())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = quality.write_findings(Path(tmp) / 'findings.jsonl', findings)
+            loaded = quality.load_findings(path)
+
+        self.assertEqual(len(loaded), len(findings))
+        self.assertEqual(loaded[0]['finding_id'], findings[0]['finding_id'])
+        self.assertEqual(
+            quality.findings_digest(findings),
+            quality.findings_digest(loaded),
+        )
+        changed = [dict(findings[0])]
+        changed[0]['evidence'] = '{}'
+        self.assertNotEqual(
+            quality.findings_digest(findings),
+            quality.findings_digest(changed),
+        )
+
+    def test_load_findings_is_lenient_by_default_and_strict_on_request(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'findings.jsonl'
+            valid = quality.normalize_finding(
+                quality.check_subject(mechanical_subject())[0]
+            )
+            path.write_text(
+                json.dumps(valid, ensure_ascii=False) + '\n{bad\n',
+                encoding='utf-8',
+            )
+
+            self.assertEqual(len(quality.load_findings(path)), 1)
+            with self.assertRaisesRegex(ValueError, 'row 2'):
+                quality.load_findings(path, strict=True)
+
+    def test_final_review_adapter_preserves_semantic_fields(self):
+        semantic = fr.normalize_finding(
+            {
+                'identity_v2': 'script.rpy:item-1',
+                'file_rel_path': 'script.rpy',
+                'source': 'Hello Sir',
+                'current_translation': '你好Sir',
+                'finding_type': 'mistranslation',
+                'severity': 'high',
+                'evidence': 'Sir kept in English',
+                'reason': '称呼未本地化',
+                'suggested_revision': '你好，先生',
+            }
+        )
+        adapted = quality.adapt_final_review_finding(semantic)
+
+        self.assertEqual(adapted['reason_code'], quality.FINAL_REVIEW_REASON_MISTRANSLATION)
+        self.assertEqual(adapted['rule_id'], 'final_review')
+        self.assertEqual(adapted['disposition'], quality.DISPOSITION_WARNING)
+        self.assertEqual(adapted['severity'], 'high')
+        self.assertEqual(adapted['item_id'], 'script.rpy:item-1')
+        self.assertEqual(adapted['translation'], '你好Sir')
+        self.assertEqual(adapted['finding_type'], 'mistranslation')
+        self.assertEqual(adapted['reason'], '称呼未本地化')
+        self.assertEqual(adapted['suggestion'], '你好，先生')
+        self.assertEqual(quality.validate_finding(adapted), [])
+
+    def test_final_review_finding_feeds_shared_gui_filters(self):
+        semantic = fr.normalize_finding(
+            {
+                'identity_v2': 'script.rpy:item-1',
+                'file_rel_path': 'script.rpy',
+                'source': 'Hello',
+                'current_translation': 'Hello',
+                'finding_type': 'omission',
+                'severity': 'high',
+                'reason': '未翻译',
+            }
+        )
+        adapted = quality.adapt_final_review_finding(semantic)
+        item = normalize_quality_finding(adapted)
+
+        self.assertEqual(item.reason_code, quality.FINAL_REVIEW_REASON_OMISSION)
+        self.assertIn('最终审校', reason_label(item.reason_code))
+        self.assertEqual(
+            filter_quality_items(
+                [item],
+                min_severity='high',
+            )[0].finding_id,
+            adapted['finding_id'],
+        )
+
+    def test_gui_extracts_sync_quality_gate_text(self):
+        gate = extract_quality_gate(
+            "Sync quality gate: needs_review, warnings=3, blockers=1"
+        )
+        self.assertEqual(gate["decision"], "needs_review")
+        self.assertEqual(gate["warning_count"], 3)
+        self.assertEqual(gate["blocker_count"], 1)
+
+    def test_gui_resolves_quality_paths_across_producers(self):
+        sync_manifest = {
+            'last_quality_findings_path': 'sync/quality_findings.jsonl',
+            'last_revision_quality_findings_path': 'revision/quality_findings.jsonl',
+        }
+        self.assertEqual(
+            resolve_quality_findings_path(sync_manifest),
+            'sync/quality_findings.jsonl',
+        )
+        revision_manifest = {
+            'last_revision_quality_findings_path': 'revision/quality_findings.jsonl',
+        }
+        self.assertEqual(
+            resolve_quality_findings_path(revision_manifest),
+            'revision/quality_findings.jsonl',
+        )
+        final_review_manifest = {
+            'quality_findings_path': 'final/quality_findings.jsonl',
+        }
+        self.assertEqual(
+            resolve_quality_findings_path(final_review_manifest),
+            'final/quality_findings.jsonl',
+        )
+
+    def test_final_review_package_persists_shared_quality_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fr.write_campaign_package(
+                tmp,
+                manifest=fr.build_campaign_manifest(
+                    package_dir=tmp,
+                    display_name='quality-mapping-test',
+                    base_dir='/tmp/project',
+                    tl_dir='/tmp/project/game/tl/schinese',
+                    snapshot={
+                        'context_digest': 'c',
+                        'snapshot_digest': 's',
+                        'scope': {},
+                    },
+                    units=[],
+                    readiness={'enabled': True, 'require_zero_pending': True},
+                ),
+                snapshot={'context_digest': 'c', 'snapshot_digest': 's', 'scope': {}},
+                units=[],
+                findings=[
+                    {
+                        'identity_v2': 'script.rpy:item-1',
+                        'file_rel_path': 'script.rpy',
+                        'source': 'Hello',
+                        'current_translation': 'Hello',
+                        'finding_type': 'omission',
+                        'severity': 'medium',
+                        'reason': '未翻译',
+                    }
+                ],
+                write_report=False,
+            )
+
+            package = fr.load_campaign_package(paths['manifest'])
+            self.assertTrue(Path(paths['quality_findings']).is_file())
+            self.assertEqual(package['quality_findings'][0]['reason_code'],
+                             quality.FINAL_REVIEW_REASON_OMISSION)
+            self.assertIn('quality_gate', package['manifest']['summary'])
+
+
+class SyncQualityFindingsTests(unittest.TestCase):
+    def _make_preview(self, root: Path, subject=None):
+        tl_dir = root / 'game' / 'tl' / 'schinese'
+        tl_dir.mkdir(parents=True)
+        target = tl_dir / 'a.rpy'
+        source_text = '    "Hello"\n'
+        preview_text = '    "你{w=0.5}好"\n'
+        target.write_text(source_text, encoding='utf-8')
+        rows = [{
+            'relative_path': 'a.rpy',
+            'source_text': source_text,
+            'source_sha256': '',
+            'preview_text': preview_text,
+            'progress_entries': ['id:1'],
+            'quality_subjects': [
+                mechanical_subject(translation='你{w=0.5}好', item_id='id:1')
+            ],
+        }]
+        from atomic_io import file_sha256
+        rows[0]['source_sha256'] = file_sha256(target)
+        return preview.create_sync_preview(
+            log_dir=root / 'logs',
+            project_root=root,
+            tl_dir=tl_dir,
+            files=rows,
+        )
+
+    def test_sync_preview_persists_findings_and_quality_gate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, manifest = self._make_preview(root)
+
+            report_path = Path(manifest_path).parent / 'quality_findings.jsonl'
+            self.assertTrue(report_path.is_file())
+            self.assertEqual(manifest['last_quality_findings_path'],
+                             'quality_findings.jsonl')
+            self.assertEqual(manifest['summary']['quality_gate']['decision'],
+                             quality.GATE_NEEDS_REVIEW)
+            self.assertGreater(
+                manifest['summary']['quality_gate']['warning_count'], 0
+            )
+            loaded = quality.load_findings(str(report_path))
+            self.assertTrue(any(
+                row['reason_code'] == quality.REASON_WAIT_TAG_INSIDE_CJK
+                for row in loaded
+            ))
+            self.assertIn('quality_policy_digest', manifest['summary'])
+            self.assertIn('quality_rule_schema_version', manifest)
+
+    def test_sync_apply_stales_when_quality_policy_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, _manifest = self._make_preview(root)
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+
+            with self.assertRaisesRegex(ValueError, 'Quality policy changed'):
+                preview.apply_sync_preview(
+                    manifest_path,
+                    active_project_root=root,
+                    active_tl_dir=tl_dir,
+                    active_quality_policy=quality.normalize_policy(
+                        {'rules': {'renpy_wait_inside_cjk': 'off'}}
+                    ),
+                )
+
+    def test_sync_apply_stales_when_quality_rule_version_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, manifest = self._make_preview(root)
+            manifest['quality_rule_schema_version'] += 1
+            manifest['preview_fingerprint'] = preview._fingerprint(manifest)
+            Path(manifest_path).write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2),
+                encoding='utf-8',
+            )
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+
+            with self.assertRaisesRegex(ValueError, 'Quality rules changed'):
+                preview.apply_sync_preview(
+                    manifest_path,
+                    active_project_root=root,
+                    active_tl_dir=tl_dir,
+                )
+
+
+class SyncRuntimeQualityFindingsTests(unittest.TestCase):
+    def test_runtime_sync_preview_runs_quality_rules_on_accepted_candidates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+            tl_dir.mkdir(parents=True)
+            target = tl_dir / 'script.rpy'
+            target.write_text('    "Hello"\n', encoding='utf-8')
+
+            def translate_batch(batch, replacements, usage_run_id="", **_kwargs):
+                task = batch[0]
+                replacements.setdefault(task["line"], []).append(
+                    (
+                        task["start"],
+                        task["end"],
+                        '你好iPhone',
+                        task.get("prefix") or "",
+                        task["quote"],
+                    )
+                )
+                return [task.get("progress_entry") or f"id:{task['line']}"]
+
+            with (
+                mock.patch.object(runtime, "BASE_DIR", str(root)),
+                mock.patch.object(runtime, "TL_DIR", str(tl_dir)),
+                mock.patch.object(runtime, "LOG_DIR", str(root / "logs")),
+                mock.patch.object(runtime, "SYNC_BACKEND", "litellm"),
+                mock.patch.object(runtime, "PREP_ENABLED", False),
+                mock.patch.object(runtime, "INCLUDE_FILES", []),
+                mock.patch.object(runtime, "INCLUDE_PREFIXES", []),
+                mock.patch.object(runtime, "load_config"),
+                mock.patch.object(runtime, "load_translator_settings"),
+                mock.patch.object(runtime, "load_glossary"),
+                mock.patch.object(runtime, "load_progress", return_value={}),
+                mock.patch.object(
+                    runtime,
+                    "process_batch_with_retry",
+                    side_effect=translate_batch,
+                ),
+            ):
+                manifest_path = runtime.run_translation()
+
+            manifest = preview.load_sync_preview(manifest_path)
+            gate = manifest["summary"]["quality_gate"]
+            self.assertEqual(gate["decision"], quality.GATE_NEEDS_REVIEW)
+            self.assertGreater(gate["warning_count"], 0)
+            loaded = quality.load_findings(
+                str(Path(manifest_path).parent / "quality_findings.jsonl")
+            )
+            self.assertTrue(
+                {finding["reason_code"] for finding in loaded}
+                & {
+                    quality.REASON_CJK_LATIN_SPACING,
+                    quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
+                }
+            )
+
+
+class RevisionQualityFindingsTests(unittest.TestCase):
+    def _manifest(self, package_dir: Path, policy=None):
+        item = {
+            'id': 'a.rpy:block:1:hash',
+            'text': 'Hello',
+            'source': 'Hello',
+            'current_translation': '你好',
+            'line': 0,
+            'line_number': 1,
+            'start': 4,
+            'end': 9,
+            'prefix': '',
+            'quote': '"',
+        }
+        manifest = {
+            '_manifest_path': str(package_dir / 'manifest.json'),
+            '_package_dir': str(package_dir),
+            'base_dir': str(package_dir),
+            'chunks': [{
+                'key': 'chunk-1',
+                'file_rel_path': 'a.rpy',
+                'items': [item],
+            }],
+            'quality_policy': quality.normalize_policy(policy),
+            'quality_acknowledged_finding_ids': [],
+        }
+        return manifest
+
+    def _replacements(self):
+        action = (4, 9, '你{w=0.5}好', '', '"', '你好', 'a.rpy:block:1:hash', 'chunk-1')
+        return {'a.rpy': {0: [action]}}
+
+    def test_revision_quality_subjects_use_revision_identity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest = self._manifest(package_dir)
+            subjects = batch.collect_revision_quality_subjects(
+                manifest,
+                self._replacements(),
+            )
+
+            self.assertEqual(len(subjects), 1)
+            self.assertEqual(subjects[0]['item_id'], 'a.rpy:block:1:hash')
+            self.assertEqual(subjects[0]['file_rel_path'], 'a.rpy')
+            self.assertEqual(subjects[0]['line_number'], 1)
+            self.assertEqual(subjects[0]['source'], 'Hello')
+            self.assertEqual(subjects[0]['translation'], '你{w=0.5}好')
+
+    def test_revision_quality_warning_does_not_block_but_blocker_does(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest = self._manifest(package_dir)
+            summary = {'adapter_writeback_status': 'pass'}
+            _findings, path = batch.run_revision_quality_check(
+                manifest,
+                summary,
+                self._replacements(),
+            )
+
+            self.assertTrue(Path(path).is_file())
+            self.assertEqual(summary['quality_gate']['decision'],
+                             quality.GATE_NEEDS_REVIEW)
+            self.assertTrue(summary['writeback_gate']['can_apply'])
+
+            manifest = self._manifest(
+                package_dir,
+                policy={'rules': {'renpy_wait_inside_cjk': 'blocker'}},
+            )
+            summary = {'adapter_writeback_status': 'pass'}
+            _findings, path = batch.run_revision_quality_check(
+                manifest,
+                summary,
+                self._replacements(),
+            )
+            self.assertEqual(summary['quality_gate']['blocker_count'], 1)
+            self.assertFalse(summary['writeback_gate']['can_apply'])
+            self.assertEqual(summary['writeback_gate']['decision'],
+                             quality.GATE_DENY)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -62,10 +62,12 @@ class SharedSchemaContractTests(unittest.TestCase):
         invalid.pop('reason_code')
         invalid['severity'] = 'catastrophic'
         invalid['line'] = -1
+        invalid['schema_version'] = True
         errors = quality.validate_finding(invalid)
         self.assertIn('missing required field: reason_code', errors)
         self.assertTrue(any('severity' in error for error in errors))
         self.assertTrue(any('line' in error for error in errors))
+        self.assertTrue(any('schema_version' in error for error in errors))
 
     def test_filter_findings_supports_shared_dimensions(self):
         findings = [

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -572,6 +572,8 @@ class SyncRuntimeQualityFindingsTests(unittest.TestCase):
                     quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
                 }
             )
+            self.assertTrue(loaded)
+            self.assertTrue(all(finding["line"] == 1 for finding in loaded))
 
 
 class RevisionQualityStalenessTests(unittest.TestCase):

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -284,6 +284,20 @@ class SharedSchemaContractTests(unittest.TestCase):
         self.assertEqual(gate["warning_count"], 3)
         self.assertEqual(gate["blocker_count"], 1)
 
+    def test_gui_revision_apply_gate_beats_carried_over_summary(self):
+        manifest = {
+            'summary': {
+                'quality_gate': {'decision': 'pass', 'warning_count': 0},
+            },
+            'revision_apply_summary': {
+                'quality_gate': {'decision': 'needs_review', 'warning_count': 4},
+            },
+        }
+        self.assertEqual(
+            quality_gate_from_manifest(manifest)['warning_count'],
+            4,
+        )
+
     def test_gui_prefers_apply_time_revision_quality_gate(self):
         manifest = {
             'last_revision_preview': {
@@ -388,7 +402,14 @@ class SharedSchemaContractTests(unittest.TestCase):
 
 
 class SyncQualityFindingsTests(unittest.TestCase):
-    def _make_preview(self, root: Path, subject=None, *, glossary_file=""):
+    def _make_preview(
+        self,
+        root: Path,
+        subject=None,
+        *,
+        glossary_file="",
+        quality_policy=None,
+    ):
         tl_dir = root / 'game' / 'tl' / 'schinese'
         tl_dir.mkdir(parents=True)
         target = tl_dir / 'a.rpy'
@@ -413,6 +434,7 @@ class SyncQualityFindingsTests(unittest.TestCase):
             tl_dir=tl_dir,
             files=rows,
             glossary_file=glossary_file,
+            quality_policy=quality_policy,
         )
 
     def test_sync_preview_persists_findings_and_quality_gate(self):
@@ -436,6 +458,32 @@ class SyncQualityFindingsTests(unittest.TestCase):
             ))
             self.assertIn('quality_policy_digest', manifest['summary'])
             self.assertIn('quality_rule_schema_version', manifest)
+
+    def test_sync_apply_blocks_quality_blockers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path, manifest = self._make_preview(
+                root,
+                quality_policy={
+                    'rules': {'renpy_wait_inside_cjk': 'blocker'}
+                },
+            )
+            self.assertEqual(
+                manifest['summary']['quality_gate']['blocker_count'],
+                1,
+            )
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+
+            with self.assertRaisesRegex(ValueError, 'quality blockers'):
+                preview.apply_sync_preview(
+                    manifest_path,
+                    active_project_root=root,
+                    active_tl_dir=tl_dir,
+                )
+            self.assertEqual(
+                (tl_dir / 'a.rpy').read_text(encoding='utf-8'),
+                '    "Hello"\n',
+            )
 
     def test_sync_apply_stales_when_quality_policy_changes(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
+import cli_contract
 import final_review as fr
 import gemini_translate_batch as batch
 import sync_translation_preview as preview
@@ -275,6 +276,18 @@ class SharedSchemaContractTests(unittest.TestCase):
         self.assertEqual(gate["decision"], "needs_review")
         self.assertEqual(gate["warning_count"], 3)
         self.assertEqual(gate["blocker_count"], 1)
+
+    def test_cli_classifies_new_quality_stale_reasons(self):
+        for message in (
+            'Quality glossary content changed since sync preview',
+            'Sync preview quality findings changed after preview generation',
+        ):
+            classification = cli_contract.classify_error(message)
+            self.assertEqual(classification['code'], 'STALE_STATE')
+            self.assertEqual(
+                classification['suggested_action'],
+                'run_check_again',
+            )
 
     def test_gui_extracts_revision_quality_gate_with_parenthesized_counts(self):
         gate = extract_quality_gate(
@@ -761,6 +774,48 @@ class RevisionQualityFindingsTests(unittest.TestCase):
         action = (4, 9, '你{w=0.5}好', '', '"', '你好', 'a.rpy:block:1:hash', 'chunk-1')
         return {'a.rpy': {0: [action]}}
 
+    def test_revision_unmatched_actions_emit_collection_diagnostic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            manifest = self._manifest(package_dir)
+            summary = {'adapter_writeback_status': 'pass'}
+            replacements = {
+                'a.rpy': {0: [(4, 9, '译文', '', '"', '旧', 'missing', 'chunk-1')]},
+            }
+            findings, _path = batch.run_revision_quality_check(
+                manifest,
+                summary,
+                replacements,
+            )
+
+            self.assertEqual(summary['quality_unmatched_items'], 1)
+            self.assertIn(
+                quality.REASON_UNMATCHED_QUALITY_SUBJECT,
+                {finding['reason_code'] for finding in findings},
+            )
+
+    def test_revision_apply_stage_writes_separate_findings_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp)
+            preview_path = package_dir / 'quality_findings.jsonl'
+            preview_path.write_text('immutable\n', encoding='utf-8')
+            manifest = self._manifest(package_dir)
+            summary = {'adapter_writeback_status': 'pass'}
+            _findings, apply_path = batch.run_revision_quality_check(
+                manifest,
+                summary,
+                self._replacements(),
+                apply_stage=True,
+            )
+
+            self.assertEqual(Path(apply_path).name, 'quality_findings.apply.jsonl')
+            self.assertTrue(Path(apply_path).is_file())
+            self.assertEqual(preview_path.read_text(encoding='utf-8'), 'immutable\n')
+            self.assertEqual(
+                summary['quality_findings_sha256'],
+                batch._sha256_file(apply_path),
+            )
+
     def test_revision_quality_subjects_use_revision_identity(self):
         with tempfile.TemporaryDirectory() as tmp:
             package_dir = Path(tmp)
@@ -793,20 +848,29 @@ class RevisionQualityFindingsTests(unittest.TestCase):
                              quality.GATE_NEEDS_REVIEW)
             self.assertTrue(summary['writeback_gate']['can_apply'])
 
-            manifest = self._manifest(
-                package_dir,
-                policy={'rules': {'renpy_wait_inside_cjk': 'blocker'}},
-            )
+            manifest = self._manifest(package_dir)
+            manifest.pop('quality_policy', None)
             summary = {'adapter_writeback_status': 'pass'}
-            _findings, path = batch.run_revision_quality_check(
-                manifest,
-                summary,
-                self._replacements(),
-            )
+            with mock.patch.object(
+                batch,
+                'BATCH_QUALITY_POLICY',
+                quality.normalize_policy(
+                    {'rules': {'renpy_wait_inside_cjk': 'blocker'}}
+                ),
+            ):
+                _findings, path = batch.run_revision_quality_check(
+                    manifest,
+                    summary,
+                    self._replacements(),
+                )
             self.assertEqual(summary['quality_gate']['blocker_count'], 1)
             self.assertFalse(summary['writeback_gate']['can_apply'])
             self.assertEqual(summary['writeback_gate']['decision'],
                              quality.GATE_DENY)
+            self.assertEqual(
+                manifest['quality_policy']['rules']['renpy_wait_inside_cjk'],
+                quality.DISPOSITION_BLOCKER,
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_unified_quality_findings.py
+++ b/tests/test_unified_quality_findings.py
@@ -374,6 +374,18 @@ class SharedSchemaContractTests(unittest.TestCase):
                              quality.FINAL_REVIEW_REASON_OMISSION)
             self.assertIn('quality_gate', package['manifest']['summary'])
 
+            stale_manifest = dict(package['manifest'])
+            stale_manifest['summary'] = {
+                **stale_manifest['summary'],
+                'quality_mapping_version': 999,
+            }
+            Path(paths['manifest']).write_text(
+                json.dumps(stale_manifest, ensure_ascii=False),
+                encoding='utf-8',
+            )
+            with self.assertRaisesRegex(fr.FinalReviewSchemaError, 'stale'):
+                fr.load_campaign_package(paths['manifest'])
+
 
 class SyncQualityFindingsTests(unittest.TestCase):
     def _make_preview(self, root: Path, subject=None, *, glossary_file=""):
@@ -456,6 +468,32 @@ class SyncQualityFindingsTests(unittest.TestCase):
                     active_project_root=root,
                     active_tl_dir=tl_dir,
                     active_glossary_file='',
+                )
+
+    def test_sync_apply_stales_when_glossary_content_changes_on_same_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            glossary = root / 'glossary.json'
+            glossary.write_text(
+                json.dumps({'normalize_map': {'Church Knight': '教会骑士'}}),
+                encoding='utf-8',
+            )
+            manifest_path, _manifest = self._make_preview(
+                root,
+                glossary_file='glossary.json',
+            )
+            glossary.write_text(
+                json.dumps({'normalize_map': {'Church Knight': '圣殿骑士'}}),
+                encoding='utf-8',
+            )
+            tl_dir = root / 'game' / 'tl' / 'schinese'
+
+            with self.assertRaisesRegex(ValueError, 'glossary content changed'):
+                preview.apply_sync_preview(
+                    manifest_path,
+                    active_project_root=root,
+                    active_tl_dir=tl_dir,
+                    active_glossary_file='glossary.json',
                 )
 
     def test_sync_apply_stales_when_quality_rule_version_changes(self):

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -937,6 +937,39 @@ def check_quality(
     return findings
 
 
+def make_unmatched_quality_subject_finding(
+    collection_stats: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the collection-diagnostic finding for unmappable actions."""
+
+    evidence = json.dumps(
+        dict(collection_stats),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    finding_id = hashlib.sha256(
+        f'{QUALITY_FINDING_SCHEMA_VERSION}:{evidence}'.encode('utf-8')
+    ).hexdigest()[:20]
+    return {
+        'finding_id': finding_id,
+        'schema_version': QUALITY_FINDING_SCHEMA_VERSION,
+        'reason_code': REASON_UNMATCHED_QUALITY_SUBJECT,
+        'rule_id': 'unmatched_subject',
+        'severity': SEVERITY_MEDIUM,
+        'disposition': DISPOSITION_WARNING,
+        'item_id': '',
+        'file': '',
+        'line': 0,
+        'source': '',
+        'translation': '',
+        'evidence': evidence,
+        'suggestion': (
+            'Inspect quality_action_items / quality_unmatched_items and rerun check.'
+        ),
+        'rule_version': QUALITY_RULE_SCHEMA_VERSION,
+    }
+
+
 def _count_disposition(findings: Iterable[Mapping[str, Any]], disposition: str) -> int:
     return sum(
         1

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -343,6 +343,24 @@ def policy_digest(policy: Mapping[str, Any] | None) -> str:
     return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
 
 
+def glossary_digest(glossary_map: Mapping[str, str] | None) -> str:
+    """Stable digest of the glossary pairs actually consumed by quality rules."""
+
+    entries = [
+        [str(source), str(target)]
+        for source, target in (glossary_map or {}).items()
+        if str(source).strip() or str(target).strip()
+    ]
+    entries.sort(key=lambda pair: (pair[0], pair[1]))
+    serialized = json.dumps(
+        entries,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
+
+
 def load_policy_from_config(translator_config: Any) -> dict[str, Any]:
     if not isinstance(translator_config, Mapping):
         return normalize_policy(None)

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -1132,7 +1132,11 @@ def validate_finding(
     if not str(item.get('finding_id') or '').strip():
         errors.append('finding_id must be a non-empty string')
     schema_version = item.get('schema_version')
-    if not isinstance(schema_version, int) or schema_version < 1:
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version < 1
+    ):
         errors.append('schema_version must be a positive integer')
     reason_code = item.get('reason_code')
     if not isinstance(reason_code, str) or not reason_code.strip():

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -31,6 +31,33 @@ DISPOSITION_BLOCKER = 'blocker'
 DISPOSITION_OFF = 'off'
 VALID_DISPOSITIONS = (DISPOSITION_WARNING, DISPOSITION_BLOCKER, DISPOSITION_OFF)
 
+SEVERITY_INFO = 'info'
+SEVERITY_LOW = 'low'
+SEVERITY_MEDIUM = 'medium'
+SEVERITY_HIGH = 'high'
+VALID_SEVERITIES = (SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH)
+SEVERITY_ORDER = {SEVERITY_INFO: 0, SEVERITY_LOW: 1, SEVERITY_MEDIUM: 2, SEVERITY_HIGH: 3}
+
+# Fields every persisted quality finding must carry.  Final-review semantic
+# findings are adapted into this same shape instead of inventing a second
+# persistence contract for GUI lists, filters, and digest/staleness checks.
+QUALITY_FINDING_FIELDS: tuple[str, ...] = (
+    'finding_id',
+    'schema_version',
+    'reason_code',
+    'rule_id',
+    'severity',
+    'disposition',
+    'item_id',
+    'file',
+    'line',
+    'source',
+    'translation',
+    'evidence',
+    'suggestion',
+    'rule_version',
+)
+
 GATE_READY = 'ready'
 GATE_READY_WITH_WARNINGS = 'ready_with_warnings'
 GATE_BLOCKED = 'blocked'
@@ -55,6 +82,35 @@ REASON_KNOWN_GARBLED_PHRASE = 'quality.garbled.known_bad_phrase'
 # Collection diagnostic emitted by check when a validated writeback action
 # cannot be mapped back to a manifest item for mechanical inspection.
 REASON_UNMATCHED_QUALITY_SUBJECT = 'quality.collection.unmatched_subject'
+
+# Final-review findings keep their LLM semantic fields, but are adapted into the
+# common quality-finding data model with stable ``quality.llm.*`` reason codes.
+# These codes deliberately sit in their own namespace so a literary conclusion
+# can never be mistaken for a deterministic mechanical rule.
+FINAL_REVIEW_REASON_PREFIX = 'quality.llm'
+FINAL_REVIEW_REASON_OMISSION = 'quality.llm.omission'
+FINAL_REVIEW_REASON_MISTRANSLATION = 'quality.llm.mistranslation'
+FINAL_REVIEW_REASON_ADDITION = 'quality.llm.addition'
+FINAL_REVIEW_REASON_FORMAT = 'quality.llm.format'
+FINAL_REVIEW_REASON_TERMINOLOGY = 'quality.llm.terminology'
+FINAL_REVIEW_REASON_ADDRESS = 'quality.llm.address'
+FINAL_REVIEW_REASON_STYLE_DRIFT = 'quality.llm.style_drift'
+FINAL_REVIEW_REASON_NEEDS_CONFIRMATION = 'quality.llm.needs_confirmation'
+
+FINAL_REVIEW_FINDING_TYPE_TO_REASON: dict[str, str] = {
+    'omission': FINAL_REVIEW_REASON_OMISSION,
+    'mistranslation': FINAL_REVIEW_REASON_MISTRANSLATION,
+    'addition': FINAL_REVIEW_REASON_ADDITION,
+    'format': FINAL_REVIEW_REASON_FORMAT,
+    'terminology': FINAL_REVIEW_REASON_TERMINOLOGY,
+    'address': FINAL_REVIEW_REASON_ADDRESS,
+    'style_drift': FINAL_REVIEW_REASON_STYLE_DRIFT,
+    'needs_confirmation': FINAL_REVIEW_REASON_NEEDS_CONFIRMATION,
+}
+FINAL_REVIEW_REASON_TO_FINDING_TYPE = {
+    reason: finding_type
+    for finding_type, reason in FINAL_REVIEW_FINDING_TYPE_TO_REASON.items()
+}
 
 ALL_REASON_CODES: tuple[str, ...] = (
     REASON_WAIT_TAG_INSIDE_CJK,
@@ -918,20 +974,64 @@ def overall_check_status(writeback_gate: Mapping[str, Any], quality_gate: Mappin
     return GATE_READY
 
 
-def normalize_finding(finding: Mapping[str, Any]) -> dict[str, Any]:
-    """Ensure a persisted finding carries the required contract fields."""
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
+
+def _coerce_line(value: Any) -> int:
+    return max(0, _coerce_int(value, 0))
+
+
+def _coerce_rule_version(value: Any, *, default: int) -> int:
+    """Normalize rule versions without dropping intentionally unknown values."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return default
+
+
+def normalize_finding(finding: Mapping[str, Any]) -> dict[str, Any]:
+    """Ensure a persisted finding carries the required contract fields.
+
+    Extra fields (for example final-review provenance) are preserved so shared
+    GUI consumers can display the same record regardless of producer.
+    """
+
+    if not isinstance(finding, Mapping):
+        raise ValueError('quality finding must be a mapping')
     item = dict(finding)
-    item.setdefault('schema_version', QUALITY_FINDING_SCHEMA_VERSION)
+    schema_version = _coerce_int(
+        item.get('schema_version'),
+        QUALITY_FINDING_SCHEMA_VERSION,
+    )
+    reason_code = str(item.get('reason_code') or '').strip()
+    rule_id = str(item.get('rule_id') or '').strip() or REASON_TO_RULE_KEY.get(
+        reason_code,
+        reason_code,
+    )
+    severity = str(item.get('severity') or SEVERITY_MEDIUM).strip().lower()
+    if severity not in VALID_SEVERITIES:
+        severity = SEVERITY_MEDIUM
+    disposition = str(item.get('disposition') or DISPOSITION_WARNING).strip().lower()
+    if disposition not in VALID_DISPOSITIONS:
+        disposition = DISPOSITION_WARNING
+
+    item['schema_version'] = schema_version
     if not item.get('finding_id'):
         item['finding_id'] = hashlib.sha256(
             json.dumps(
                 [
-                    item.get('schema_version'),
+                    schema_version,
                     str(item.get('item_id') or ''),
                     str(item.get('file') or ''),
-                    int(item.get('line') or 0),
-                    str(item.get('reason_code') or ''),
+                    _coerce_line(item.get('line')),
+                    reason_code,
                     str(item.get('evidence') or ''),
                 ],
                 ensure_ascii=False,
@@ -939,36 +1039,362 @@ def normalize_finding(finding: Mapping[str, Any]) -> dict[str, Any]:
                 separators=(',', ':'),
             ).encode('utf-8')
         ).hexdigest()[:20]
+    item['finding_id'] = str(item.get('finding_id') or '').strip()
     item.setdefault('reason_code', '')
-    item.setdefault('severity', 'medium')
-    item.setdefault('disposition', DISPOSITION_WARNING)
-    item.setdefault('item_id', '')
-    item.setdefault('file', '')
-    item.setdefault('line', 0)
-    item.setdefault('source', '')
-    item.setdefault('translation', '')
-    item.setdefault('evidence', '')
-    item.setdefault('suggestion', '')
-    item.setdefault('rule_version', QUALITY_RULE_SCHEMA_VERSION)
+    item['reason_code'] = reason_code
+    item['rule_id'] = rule_id
+    item['severity'] = severity
+    item['disposition'] = disposition
+    item['item_id'] = str(item.get('item_id') or '')
+    item['file'] = str(item.get('file') or '')
+    item['line'] = _coerce_line(item.get('line'))
+    item['source'] = str(item.get('source') or '')
+    item['translation'] = str(item.get('translation') or '')
+    item['evidence'] = str(item.get('evidence') or '')
+    item['suggestion'] = str(item.get('suggestion') or '')
+    item['rule_version'] = _coerce_rule_version(
+        item.get('rule_version'),
+        default=QUALITY_RULE_SCHEMA_VERSION,
+    )
     return item
 
 
-def load_findings(path: str) -> list[dict[str, Any]]:
-    if not path or not os.path.isfile(path):
+def validate_finding(
+    finding: Mapping[str, Any],
+    *,
+    require_known_reason_code: bool = False,
+) -> list[str]:
+    """Return structural contract violations for one finding (empty means valid).
+
+    Validation is intentionally shape-only.  It does not judge whether a
+    finding is correct; final-review semantic findings and mechanical findings
+    must both satisfy the same persisted shape.
+    """
+
+    if not isinstance(finding, Mapping):
+        return ['quality finding must be a mapping']
+    item = dict(finding)
+    errors: list[str] = []
+    for field in QUALITY_FINDING_FIELDS:
+        if item.get(field) is None:
+            errors.append(f"missing required field: {field}")
+    if not str(item.get('finding_id') or '').strip():
+        errors.append('finding_id must be a non-empty string')
+    schema_version = item.get('schema_version')
+    if not isinstance(schema_version, int) or schema_version < 1:
+        errors.append('schema_version must be a positive integer')
+    reason_code = item.get('reason_code')
+    if not isinstance(reason_code, str) or not reason_code.strip():
+        errors.append('reason_code must be a non-empty string')
+    elif require_known_reason_code and reason_code not in {
+        *ALL_REASON_CODES,
+        REASON_UNMATCHED_QUALITY_SUBJECT,
+        *FINAL_REVIEW_REASON_TO_FINDING_TYPE,
+    }:
+        errors.append(f'unknown reason_code: {reason_code}')
+    if item.get('severity') not in VALID_SEVERITIES:
+        errors.append(
+            'severity must be one of: ' + ', '.join(VALID_SEVERITIES)
+        )
+    if item.get('disposition') not in VALID_DISPOSITIONS:
+        errors.append(
+            'disposition must be one of: ' + ', '.join(VALID_DISPOSITIONS)
+        )
+    line = item.get('line')
+    if not isinstance(line, int) or isinstance(line, bool) or line < 0:
+        errors.append('line must be a non-negative integer')
+    rule_version = item.get('rule_version')
+    if (
+        not isinstance(rule_version, int)
+        or isinstance(rule_version, bool)
+        or rule_version < 0
+    ):
+        errors.append('rule_version must be a non-negative integer')
+    return errors
+
+
+def validate_findings(
+    findings: Iterable[Mapping[str, Any]],
+    *,
+    require_known_reason_code: bool = False,
+) -> dict[int, list[str]]:
+    """Return row-indexed validation errors for an iterable of findings."""
+
+    errors: dict[int, list[str]] = {}
+    for index, finding in enumerate(findings):
+        row_errors = validate_finding(
+            finding,
+            require_known_reason_code=require_known_reason_code,
+        )
+        if row_errors:
+            errors[index] = row_errors
+    return errors
+
+
+def filter_findings(
+    findings: Iterable[Mapping[str, Any]],
+    *,
+    reason_codes: Iterable[str] | None = None,
+    files: Iterable[str] | None = None,
+    min_severity: str = '',
+    dispositions: Iterable[str] | None = None,
+    item_ids: Iterable[str] | None = None,
+    text: str = '',
+) -> list[dict[str, Any]]:
+    """Filter normalized findings by the shared GUI/persistence dimensions."""
+
+    selected_reasons = {
+        str(value).strip()
+        for value in (reason_codes or ())
+        if str(value).strip()
+    }
+    selected_files = {
+        str(value).strip().casefold()
+        for value in (files or ())
+        if str(value).strip()
+    }
+    selected_dispositions = {
+        str(value).strip().lower()
+        for value in (dispositions or ())
+        if str(value).strip()
+    }
+    selected_item_ids = {
+        str(value).strip()
+        for value in (item_ids or ())
+        if str(value).strip()
+    }
+    minimum = SEVERITY_ORDER.get(
+        str(min_severity or '').strip().lower(),
+        0,
+    )
+    needle = str(text or '').strip().casefold()
+    result: list[dict[str, Any]] = []
+    for raw in findings:
+        if not isinstance(raw, Mapping):
+            continue
+        item = normalize_finding(raw)
+        if selected_reasons and item.get('reason_code') not in selected_reasons:
+            continue
+        if selected_files and not any(
+            candidate in str(item.get('file') or '').casefold()
+            for candidate in selected_files
+        ):
+            continue
+        if (
+            SEVERITY_ORDER.get(str(item.get('severity') or ''), 2)
+            < minimum
+        ):
+            continue
+        if selected_dispositions and item.get('disposition') not in selected_dispositions:
+            continue
+        if selected_item_ids and item.get('item_id') not in selected_item_ids:
+            continue
+        if needle and needle not in ' '.join(
+            (
+                str(item.get('source') or ''),
+                str(item.get('translation') or ''),
+                str(item.get('evidence') or ''),
+            )
+        ).casefold():
+            continue
+        result.append(item)
+    return result
+
+
+def findings_digest(findings: Iterable[Mapping[str, Any]]) -> str:
+    """Stable SHA-256 over the shared persisted finding fields."""
+
+    rows = [
+        {
+            field: normalize_finding(finding).get(field)
+            for field in QUALITY_FINDING_FIELDS
+        }
+        for finding in findings
+        if isinstance(finding, Mapping)
+    ]
+    rows.sort(
+        key=lambda row: (
+            str(row.get('finding_id') or ''),
+            str(row.get('file') or ''),
+            int(row.get('line') or 0),
+            str(row.get('reason_code') or ''),
+        )
+    )
+    serialized = json.dumps(
+        rows,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
+
+
+def write_findings(
+    path: str | os.PathLike[str],
+    findings: Iterable[Mapping[str, Any]],
+) -> str:
+    """Atomically write normalized findings as JSONL and return the path."""
+
+    from atomic_io import atomic_write_jsonl
+
+    target = os.fspath(path)
+    atomic_write_jsonl(
+        target,
+        [normalize_finding(finding) for finding in findings if isinstance(finding, Mapping)],
+        ensure_ascii=False,
+    )
+    return target
+
+
+def final_review_reason_code(finding_type: Any) -> str:
+    """Map a final-review finding type to its stable common-schema code."""
+
+    key = str(finding_type or '').strip().lower()
+    return FINAL_REVIEW_FINDING_TYPE_TO_REASON.get(
+        key,
+        FINAL_REVIEW_REASON_NEEDS_CONFIRMATION,
+    )
+
+
+def adapt_final_review_finding(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Adapt a final-review finding to the common quality finding shape.
+
+    Final-review records keep their LLM semantic fields and are never claimed
+    to be deterministic mechanical findings.  The adapter only adds the shared
+    location, severity, disposition, and provenance envelope used by GUI lists,
+    filters, persistence, and digest checks.
+    """
+
+    if not isinstance(record, Mapping):
+        raise ValueError('final-review finding must be a mapping')
+    item = dict(record)
+    finding_type = str(item.get('finding_type') or item.get('type') or '').strip().lower()
+    if not finding_type:
+        finding_type = 'needs_confirmation'
+    reason_code = final_review_reason_code(finding_type)
+    severity = str(item.get('severity') or SEVERITY_MEDIUM).strip().lower()
+    if severity not in VALID_SEVERITIES:
+        severity = SEVERITY_MEDIUM
+    identity = str(
+        item.get('identity_v2')
+        or item.get('item_id')
+        or item.get('id')
+        or ''
+    ).strip()
+    file_rel_path = str(item.get('file_rel_path') or item.get('file') or '')
+    source = str(item.get('source') or '')
+    translation = str(
+        item.get('current_translation')
+        or item.get('translation')
+        or ''
+    )
+    evidence = str(item.get('evidence') or '')
+    reason = str(item.get('reason') or item.get('detail') or '')
+    # ``evidence`` is the shared filter/detail field; the full semantic reason
+    # is preserved verbatim in the ``reason`` provenance field below.
+    evidence = evidence or reason
+    suggestion = str(
+        item.get('suggested_revision')
+        or item.get('suggestion')
+        or ''
+    )
+    finding_id = str(item.get('finding_id') or '').strip()
+    if not finding_id:
+        finding_id = hashlib.sha256(
+            json.dumps(
+                [identity, finding_type, source, translation, reason],
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(',', ':'),
+            ).encode('utf-8')
+        ).hexdigest()[:20]
+    adapted = {
+        'finding_id': finding_id,
+        'schema_version': QUALITY_FINDING_SCHEMA_VERSION,
+        'reason_code': reason_code,
+        'rule_id': 'final_review',
+        'severity': severity,
+        'disposition': DISPOSITION_WARNING,
+        'item_id': identity,
+        'file': file_rel_path,
+        'line': _coerce_line(item.get('line')),
+        'source': source,
+        'translation': translation,
+        'evidence': evidence,
+        'suggestion': suggestion,
+        'rule_version': 0,
+        # Semantic provenance stays intact and explicit.
+        'provenance': 'final_review',
+        'finding_type': finding_type,
+        'reason': reason,
+        'review_unit_id': str(item.get('review_unit_id') or ''),
+        'review_unit_digest': str(item.get('review_unit_digest') or ''),
+        'prompt_schema_version': str(item.get('prompt_schema_version') or ''),
+        'selection_state': str(item.get('selection_state') or ''),
+        'revision_state': str(item.get('revision_state') or ''),
+    }
+    return normalize_finding(adapted)
+
+
+def adapt_final_review_findings(
+    records: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Adapt a collection of final-review findings for shared consumers."""
+
+    return [
+        adapt_final_review_finding(record)
+        for record in records
+        if isinstance(record, Mapping)
+    ]
+
+
+def load_findings(
+    path: str | os.PathLike[str],
+    *,
+    strict: bool = False,
+) -> list[dict[str, Any]]:
+    """Load a JSONL findings report.
+
+    Default mode is lenient for backward compatibility: unreadable rows are
+    skipped.  ``strict=True`` raises ``ValueError`` on malformed JSON or rows
+    that do not satisfy :func:`validate_finding`.
+    """
+
+    target = os.fspath(path)
+    if not target or not os.path.isfile(target):
         return []
     findings: list[dict[str, Any]] = []
     try:
-        with open(path, 'r', encoding='utf-8-sig') as handle:
-            for raw_line in handle:
+        with open(target, 'r', encoding='utf-8-sig') as handle:
+            for row_number, raw_line in enumerate(handle, start=1):
                 line = raw_line.strip()
                 if not line:
                     continue
                 try:
                     value = json.loads(line)
-                except json.JSONDecodeError:
+                except json.JSONDecodeError as exc:
+                    if strict:
+                        raise ValueError(
+                            f'quality findings row {row_number} is invalid JSON: {exc}'
+                        ) from exc
                     continue
-                if isinstance(value, Mapping):
-                    findings.append(normalize_finding(value))
+                if not isinstance(value, Mapping):
+                    if strict:
+                        raise ValueError(
+                            f'quality findings row {row_number} must be an object'
+                        )
+                    continue
+                normalized = normalize_finding(value)
+                if strict:
+                    errors = validate_finding(normalized)
+                    if errors:
+                        raise ValueError(
+                            f'quality findings row {row_number} is invalid: '
+                            + '; '.join(errors)
+                        )
+                findings.append(normalized)
     except OSError:
+        if strict:
+            raise
         return []
     return findings

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -1131,6 +1131,30 @@ def validate_findings(
     return errors
 
 
+def file_matches_filter(file_value: Any, candidate: Any) -> bool:
+    """Path-aware file filter for findings and GUI file fragments.
+
+    Exact file names and path prefixes match at component boundaries so
+    ``script.rpy`` does not match ``xscript.rpy``.  Bare extension-less
+    fragments such as ``script`` keep the legacy substring behaviour expected
+    by the GUI file filter.
+    """
+
+    file_text = str(file_value or '').replace('\\', '/').casefold()
+    candidate_text = str(candidate or '').replace('\\', '/').strip().casefold()
+    if not file_text or not candidate_text:
+        return False
+    if file_text == candidate_text:
+        return True
+    if file_text.startswith(candidate_text.rstrip('/') + '/'):
+        return True
+    parts = file_text.split('/')
+    if candidate_text in parts:
+        return True
+    # Bare, extension-less fragments are the GUI file-filter contract.
+    return '/' not in candidate_text and '.' not in candidate_text and candidate_text in file_text
+
+
 def filter_findings(
     findings: Iterable[Mapping[str, Any]],
     *,
@@ -1176,7 +1200,7 @@ def filter_findings(
         if selected_reasons and item.get('reason_code') not in selected_reasons:
             continue
         if selected_files and not any(
-            candidate in str(item.get('file') or '').casefold()
+            file_matches_filter(item.get('file'), candidate)
             for candidate in selected_files
         ):
             continue

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -1408,15 +1408,17 @@ def load_findings(
                             f'quality findings row {row_number} must be an object'
                         )
                     continue
-                normalized = normalize_finding(value)
                 if strict:
-                    errors = validate_finding(normalized)
+                    # Validate the raw persisted row before normalization so
+                    # invalid enums/numbers cannot be silently coerced into
+                    # defaults and then treated as contract-valid findings.
+                    errors = validate_finding(value)
                     if errors:
                         raise ValueError(
                             f'quality findings row {row_number} is invalid: '
                             + '; '.join(errors)
                         )
-                findings.append(normalized)
+                findings.append(normalize_finding(value))
     except OSError:
         if strict:
             raise

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -5960,6 +5960,7 @@ def run_translation(*, prepare=False):
                             "item_id": str(task.get("id") or ""),
                             "file_rel_path": progress_key,
                             "line": int(task.get("line") or 0),
+                            "line_number": int(task.get("line") or 0) + 1,
                             "start": int(task.get("start") or 0),
                             "end": int(task.get("end") or 0),
                             "source": str(

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -64,6 +64,7 @@ import prompt_context
 import story_memory
 import sync_translation_preview
 import translation_core
+import translation_quality
 from sync_model_backend import (
     DEFAULT_SYNC_TIMEOUT_SECONDS,
     MAX_SYNC_TIMEOUT_SECONDS,
@@ -5735,20 +5736,33 @@ def apply_sync_translation_preview(manifest_path):
             "Sync apply blocked: the macro setting file changed since this "
             "preview was generated. Regenerate and review a new preview."
         )
+    runtime_config = _read_json_object(TRANSLATOR_CONFIG, label="translator config")
+    active_quality_policy = translation_quality.load_policy_from_config(
+        runtime_config
+    )
     try:
         manifest = sync_translation_preview.apply_sync_preview(
             manifest_path,
             active_project_root=BASE_DIR,
             active_tl_dir=TL_DIR,
             on_file_applied=record_progress,
+            active_quality_policy=active_quality_policy,
+            active_glossary_file=GLOSSARY_FILE,
         )
     except ValueError as exc:
         raise SystemExit(f"Sync apply blocked: {exc}") from exc
 
     summary = manifest.get("summary") or {}
+    quality_gate = summary.get("quality_gate") or {}
     print(f"Sync apply manifest: {os.path.abspath(manifest_path)}")
     print(f"Applied files: {len(manifest.get('applied_files') or [])}")
     print(f"Applied translations: {int(summary.get('translated_items') or 0)}")
+    print(
+        "Sync apply quality gate: "
+        f"{quality_gate.get('decision') or 'pass'}, "
+        f"warnings={int(quality_gate.get('warning_count') or 0)}, "
+        f"blockers={int(quality_gate.get('blocker_count') or 0)}"
+    )
     print("Sync translation apply complete.")
     return manifest
 
@@ -5921,6 +5935,43 @@ def run_translation(*, prepare=False):
 
             if any(replacements.values()):
                 normalized_entries = _normalize_progress_entries(successful_entries)
+                accepted_entries = set(normalized_entries)
+                quality_subjects = []
+                for task in tasks:
+                    task_progress = _normalize_progress_entry(
+                        task.get("progress_entry")
+                    )
+                    if not task_progress or task_progress not in accepted_entries:
+                        continue
+                    translated_text = str(task.get("translated_text") or "")
+                    if not translated_text:
+                        task_line = int(task.get("line") or 0)
+                        task_start = int(task.get("start") or 0)
+                        for replacement in replacements.get(task_line, []) or []:
+                            if (
+                                isinstance(replacement, (tuple, list))
+                                and len(replacement) >= 3
+                                and int(replacement[0]) == task_start
+                            ):
+                                translated_text = str(replacement[2] or "")
+                                break
+                    quality_subjects.append(
+                        {
+                            "item_id": str(task.get("id") or ""),
+                            "file_rel_path": progress_key,
+                            "line": int(task.get("line") or 0),
+                            "start": int(task.get("start") or 0),
+                            "end": int(task.get("end") or 0),
+                            "source": str(
+                                task.get("source_for_id")
+                                or task.get("text")
+                                or ""
+                            ),
+                            "translation": translated_text,
+                            "speaker_id": str(task.get("speaker_id") or ""),
+                            "speaker_name": str(task.get("speaker_name") or ""),
+                        }
+                    )
                 adapter_plan, rendered_by_file, preview_failure = build_sync_adapter_preview(
                     adapter,
                     adapter_snapshot,
@@ -5951,6 +6002,7 @@ def run_translation(*, prepare=False):
                         "progress_entries": normalized_entries,
                         "translated_items": len(normalized_entries),
                         "writeback_plan": adapter_plan.to_dict(),
+                        "quality_subjects": quality_subjects,
                         "prompt_context": {
                             "batches": file_context_batches,
                         },
@@ -5982,6 +6034,13 @@ def run_translation(*, prepare=False):
             "truncated_batches": context_truncated_batches,
             "files": attempted_file_contexts,
         }
+        runtime_config = _read_json_object(
+            TRANSLATOR_CONFIG,
+            label="translator config",
+        )
+        quality_policy = translation_quality.load_policy_from_config(
+            runtime_config
+        )
         manifest_path, manifest = sync_translation_preview.create_sync_preview(
             log_dir=LOG_DIR,
             project_root=BASE_DIR,
@@ -5990,6 +6049,8 @@ def run_translation(*, prepare=False):
             failures=preview_failures,
             contract_diagnostics=finalized_contract,
             prompt_context=prompt_context,
+            quality_policy=quality_policy,
+            glossary_file=GLOSSARY_FILE,
         )
         try:
             export_coverage_package(
@@ -6008,6 +6069,21 @@ def run_translation(*, prepare=False):
         print(f"Sync preview report: {report_path}")
         print(f"Preview files: {int(summary.get('files_changed') or 0)}")
         print(f"Preview translations: {int(summary.get('translated_items') or 0)}")
+        quality_gate = summary.get("quality_gate") or {}
+        quality_findings_path = manifest.get("last_quality_findings_path")
+        if quality_findings_path:
+            quality_findings_path = os.path.join(
+                os.path.dirname(manifest_path),
+                quality_findings_path,
+            )
+        print(
+            "Sync quality gate: "
+            f"{quality_gate.get('decision') or 'pass'}, "
+            f"warnings={int(quality_gate.get('warning_count') or 0)}, "
+            f"blockers={int(quality_gate.get('blocker_count') or 0)}"
+        )
+        if quality_findings_path:
+            print(f"Sync quality findings: {quality_findings_path}")
         print(
             "Model contract completeness: "
             f"{finalized_contract.get('final_valid', 0)}/"


### PR DESCRIPTION
Closes #363

## 实现
- `translation_quality.py` 抽公共契约：finding 字段、severity/disposition、reason code、rule/schema version；新增共享 normalize / validate_findings / filter_findings / load_findings(strict) / findings_digest / write_findings。
- sync 预览对通过结构校验的候选运行机械规则，生成 `quality_findings.jsonl` 和 `quality_gate` 摘要；manifest 持久化 finding 路径、规则版本和策略 digest。apply 校验 finding 报告哈希，规则/策略/glossary 变化使旧预览 stale。
- revision preview/apply 复用 Batch 的机械规则与 finding 数据模型；warning 不阻止写回，blocker 进入 revision 写回门禁；apply 前在最终候选上重跑质量检查。
- final review 保留语义 findings，另写派生 `quality_findings.jsonl`（`quality.llm.*` reason code），GUI 列表/筛选/持久化复用同一数据模型。
- GUI：质量报告可解析 sync / revision / final review manifest；订正预览/写回摘要显示质量报警；同步质量 gate 文本可解析。
- 文档、CHANGELOG、golden fixture 和测试同步。

## 验证
- 新增 `tests/test_unified_quality_findings.py`（16 个验收测试）。
- 相关 CLI 测试与 golden revision 端到端测试通过。
- 本机 `run_cli_tests` 仍有两个与本次改动无关的环境性失败（`tests.test_translation_reuse_workflow` 命名空间冲突、GUI suite 在无 PySide6 环境下包含 `unittest.loader._FailedTest`），main 基线同样存在。