### PR TITLE
feat(model): ModelProfile/ExecutionStrategy/TaskRoute contract (issue #345 P1)

### DIFF
--- a/model_profile.py
+++ b/model_profile.py
@@ -18,10 +18,20 @@ Resolution semantics (approved with issue #345, option B):
 The production entry points (``run_sync_request``, ``call_gemini_sdk``, ...)
 adopt this resolver in follow-up PRs; until then nothing in the runtime
 imports this module besides tests.
+
+Profile ids are **resolver slot ids** (``primary``, ``batch``,
+``<stage>_model``, ``<stage>_override``) — an internal compatibility layer
+over the legacy config keys, not the user-visible profile namespace of the
+productized config (#344/#348). User profile ids must match
+``USER_PROFILE_ID_PATTERN`` and stay clear of the reserved slots (see
+:data:`RESERVED_PROFILE_SLOT_IDS`, :func:`is_profile_slot_id`); in the
+productized config ``primary`` becomes a role pointer
+(``ModelRoutingPlan.primary_profile_id``) rather than a profile's own id.
 """
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -65,17 +75,18 @@ KNOWN_STAGES = frozenset({
 
 # How a route was decided. "stage_config" = the stage's own config key,
 # "explicit" = a caller-supplied override (CLI flag / manifest value),
-# "primary_inherited" = the stage has no own config and inherits the run's
-# base profile, "builtin_default" = nothing configured anywhere; tool
-# default.
+# "inherited" = the stage has no own config and inherits the run's base
+# profile (the primary sync profile for sync runs, the batch profile for
+# gemini_batch runs — ``TaskRoute.profile_id`` says which), "builtin_default"
+# = nothing configured anywhere; tool default.
 ROUTE_SOURCE_STAGE_CONFIG = "stage_config"
 ROUTE_SOURCE_EXPLICIT = "explicit"
-ROUTE_SOURCE_PRIMARY_INHERITED = "primary_inherited"
+ROUTE_SOURCE_INHERITED = "inherited"
 ROUTE_SOURCE_BUILTIN_DEFAULT = "builtin_default"
 KNOWN_ROUTE_SOURCES = frozenset({
     ROUTE_SOURCE_STAGE_CONFIG,
     ROUTE_SOURCE_EXPLICIT,
-    ROUTE_SOURCE_PRIMARY_INHERITED,
+    ROUTE_SOURCE_INHERITED,
     ROUTE_SOURCE_BUILTIN_DEFAULT,
 })
 
@@ -91,6 +102,14 @@ CAPABILITY_SOURCES = frozenset({
     CAPABILITY_SOURCE_CONFIG_OVERRIDE,
 })
 
+# How an adapter's structured-output mode was chosen (``StructuredOutputSpec
+# .basis``). This is deliberately a separate vocabulary from
+# ``CAPABILITY_SOURCES``: basis answers "which adapter table picked this
+# mode", provenance answers "who vouches for this capability value".
+STRUCTURED_OUTPUT_BASIS_BUILTIN = "builtin"
+STRUCTURED_OUTPUT_BASIS_CUSTOM_OPENAI_COMPATIBLE = "custom_openai_compatible"
+STRUCTURED_OUTPUT_BASIS_CONSERVATIVE_DEFAULT = "conservative_default"
+
 # Credential reference kinds. References only; no key material ever enters
 # this module.
 CREDENTIAL_KIND_API_KEYS_JSON = "api_keys_json"
@@ -103,6 +122,53 @@ CREDENTIAL_KIND_NONE = "none"
 MODEL_PROFILE_INVALID = "MODEL_PROFILE_INVALID"
 MODEL_ROUTE_CAPABILITY_MISSING = "MODEL_ROUTE_CAPABILITY_MISSING"
 MODEL_PROFILE_CREDENTIAL_REF_MISSING = "MODEL_PROFILE_CREDENTIAL_REF_MISSING"
+
+# Per-code next actions for the machine refusal contract. Reuses the
+# existing ``inspect_configuration_and_artifacts`` token for credential
+# problems because the config file itself may be perfectly valid — the
+# missing credential lives in the environment or keyring.
+_SUGGESTED_ACTION_BY_CODE = {
+    MODEL_PROFILE_INVALID: "fix_translator_config",
+    MODEL_ROUTE_CAPABILITY_MISSING: "choose_supported_strategy_or_profile",
+    MODEL_PROFILE_CREDENTIAL_REF_MISSING: "inspect_configuration_and_artifacts",
+}
+
+# Resolver slot ids are internal compatibility slots over the legacy
+# ``sync.*`` / ``batch.*`` keys — they are NOT the user-visible profile ids
+# of the productized config (#344/#348). User profile ids must match
+# ``USER_PROFILE_ID_PATTERN`` and must not collide with a reserved slot.
+PROFILE_SLOT_PRIMARY = "primary"
+PROFILE_SLOT_BATCH = "batch"
+RESERVED_PROFILE_SLOT_IDS = frozenset({PROFILE_SLOT_PRIMARY, PROFILE_SLOT_BATCH})
+RESERVED_PROFILE_SLOT_SUFFIXES = ("_model", "_override")
+USER_PROFILE_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+
+def is_profile_slot_id(profile_id: str) -> bool:
+    """True when *profile_id* belongs to the resolver's reserved slot space."""
+    text = str(profile_id or "")
+    if text in RESERVED_PROFILE_SLOT_IDS:
+        return True
+    return any(
+        text.endswith(suffix) and text[: -len(suffix)] in KNOWN_STAGES
+        for suffix in RESERVED_PROFILE_SLOT_SUFFIXES
+    )
+
+
+def user_profile_id_error(profile_id: str) -> str:
+    """Return why *profile_id* cannot be a user profile id, or "" if valid."""
+    text = str(profile_id or "")
+    if not USER_PROFILE_ID_PATTERN.match(text):
+        return (
+            f"Profile id {text!r} must match ^[a-z0-9_-]+$ "
+            "(same rule as custom provider ids)."
+        )
+    if is_profile_slot_id(text):
+        return (
+            f"Profile id {text!r} collides with a reserved resolver slot "
+            "(primary/batch/<stage>_model/<stage>_override); pick another id."
+        )
+    return ""
 
 # Capability keys accepted in ``ModelProfile.capability_overrides``.
 CAPABILITY_OVERRIDE_KEYS = frozenset({
@@ -170,6 +236,42 @@ class CapabilityFlag:
 
 
 @dataclass(frozen=True)
+class StructuredOutputSpec:
+    """Structured-output capability with provenance separated from basis.
+
+    ``source`` uses the shared :data:`CAPABILITY_SOURCES` vocabulary (who
+    vouches for this value); ``basis`` keeps the adapter-table detail of how
+    the mode was chosen (``builtin`` / ``custom_openai_compatible`` /
+    ``conservative_default``). Keeping them apart lets a #340 probe write
+    ``source=probed`` without erasing which adapter table picked the mode.
+    """
+
+    mode: str
+    source: str = CAPABILITY_SOURCE_ADAPTER_DEFAULT
+    basis: str = ""
+
+    @classmethod
+    def from_capability(cls, cap: StructuredOutputCapability) -> "StructuredOutputSpec":
+        source = (
+            CAPABILITY_SOURCE_CONFIG_OVERRIDE
+            if cap.source == CAPABILITY_SOURCE_CONFIG_OVERRIDE
+            else CAPABILITY_SOURCE_ADAPTER_DEFAULT
+        )
+        return cls(mode=cap.mode, source=source, basis=cap.source)
+
+    def to_manifest_dict(self) -> dict[str, str]:
+        return {"mode": self.mode, "source": self.source, "basis": self.basis}
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "StructuredOutputSpec":
+        return cls(
+            mode=str(payload.get("mode") or "prompt_only_json"),
+            source=str(payload.get("source") or CAPABILITY_SOURCE_ADAPTER_DEFAULT),
+            basis=str(payload.get("basis") or ""),
+        )
+
+
+@dataclass(frozen=True)
 class ModelCapabilities:
     """What a profile's provider/model actually supports.
 
@@ -177,11 +279,18 @@ class ModelCapabilities:
     branching is not allowed here.  Conservative adapter defaults err on the
     safe side so unsupported combinations fail validation instead of
     producing degraded requests.
+
+    Context numbers v1 convention: ``context_limit_tokens`` and
+    ``context_budget_tokens`` share the single ``context_source`` (both
+    values come from the same origin); mixed provenance is not expressible
+    in v1 and #340 probe results must not be written into these two fields —
+    probes feed per-capability ``source=probed`` flags and ``params``
+    instead. Unknown values are ``None``, never sentinel strings.
     """
 
     sync_generation: CapabilityFlag = CapabilityFlag(False)
-    structured_output: StructuredOutputCapability = StructuredOutputCapability(
-        "prompt_only_json", CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+    structured_output: StructuredOutputSpec = StructuredOutputSpec(
+        "prompt_only_json",
     )
     reasoning_request: CapabilityFlag = CapabilityFlag(False)
     reasoning_response: CapabilityFlag = CapabilityFlag(False)
@@ -195,10 +304,7 @@ class ModelCapabilities:
     def to_manifest_dict(self) -> dict[str, Any]:
         return {
             "sync_generation": self.sync_generation.to_manifest_dict(),
-            "structured_output": {
-                "mode": self.structured_output.mode,
-                "source": self.structured_output.source,
-            },
+            "structured_output": self.structured_output.to_manifest_dict(),
             "reasoning_request": self.reasoning_request.to_manifest_dict(),
             "reasoning_response": self.reasoning_response.to_manifest_dict(),
             "usage_stats": self.usage_stats.to_manifest_dict(),
@@ -218,14 +324,12 @@ class ModelCapabilities:
                 source=str(raw.get("source") or CAPABILITY_SOURCE_ADAPTER_DEFAULT),
             )
 
-        structured = payload.get("structured_output") or {}
         limit = payload.get("context_limit_tokens")
         budget = payload.get("context_budget_tokens")
         return cls(
             sync_generation=flag("sync_generation"),
-            structured_output=StructuredOutputCapability(
-                str(structured.get("mode") or "prompt_only_json"),
-                str(structured.get("source") or CAPABILITY_SOURCE_ADAPTER_DEFAULT),
+            structured_output=StructuredOutputSpec.from_manifest_dict(
+                payload.get("structured_output") or {},
             ),
             reasoning_request=flag("reasoning_request"),
             reasoning_response=flag("reasoning_response"),
@@ -326,13 +430,44 @@ class TaskRoute:
 
 
 @dataclass(frozen=True)
+class ConfigOrigin:
+    """Which config file contributed to a routing plan (path + fingerprint).
+
+    Fingerprints hash non-sensitive content only. Populated by the P2 wiring
+    when a plan is first written into a manifest; plans built purely in
+    memory may carry none.
+    """
+
+    kind: str  # e.g. "translator_config" | "game_config"
+    path: str
+    fingerprint: str = ""
+
+    def to_manifest_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "fingerprint": self.fingerprint,
+        }
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "ConfigOrigin":
+        return cls(
+            kind=str(payload.get("kind") or ""),
+            path=str(payload.get("path") or ""),
+            fingerprint=str(payload.get("fingerprint") or ""),
+        )
+
+
+@dataclass(frozen=True)
 class ModelRoutingPlan:
     """Immutable per-run snapshot of profiles, routes, and capabilities.
 
     Built once at run start; later config changes must not affect a run that
     already holds a plan. The manifest snapshot carries references only, so
     answering "which provider/model/strategy/capabilities did each stage
-    actually use" never leaks credentials.
+    actually use" never leaks credentials. ``primary_profile_id`` is a role
+    pointer (which profile unconfigured stages inherit), not a user-facing
+    profile identity.
     """
 
     schema_version: int
@@ -341,6 +476,7 @@ class ModelRoutingPlan:
     routes: Mapping[str, TaskRoute]
     capabilities: Mapping[str, ModelCapabilities]
     created_at: str = ""
+    config_origins: tuple[ConfigOrigin, ...] = ()
 
     def to_manifest_dict(self) -> dict[str, Any]:
         return {
@@ -359,6 +495,9 @@ class ModelRoutingPlan:
                 profile_id: caps.to_manifest_dict()
                 for profile_id, caps in sorted(self.capabilities.items())
             },
+            "config_origins": [
+                origin.to_manifest_dict() for origin in self.config_origins
+            ],
         }
 
     @classmethod
@@ -379,6 +518,10 @@ class ModelRoutingPlan:
                 for profile_id, caps in (payload.get("capabilities") or {}).items()
             },
             created_at=str(payload.get("created_at") or ""),
+            config_origins=tuple(
+                ConfigOrigin.from_manifest_dict(origin)
+                for origin in payload.get("config_origins") or ()
+            ),
         )
 
 
@@ -410,7 +553,9 @@ def routing_validation_error(
     return MachineContractError(
         primary.message,
         code_name=primary.code,
-        suggested_action="fix_translator_config",
+        suggested_action=_SUGGESTED_ACTION_BY_CODE.get(
+            primary.code, "inspect_configuration_and_artifacts",
+        ),
         semantic_exit_code=EXIT_INVALID_STATE,
         retryable=False,
         details={
@@ -434,7 +579,11 @@ def _gemini_capabilities(overrides: Mapping[str, Any]) -> ModelCapabilities:
     """Adapter defaults for the direct google-genai client."""
     caps = ModelCapabilities(
         sync_generation=CapabilityFlag(True),
-        structured_output=StructuredOutputCapability("strict_json_schema", "builtin"),
+        structured_output=StructuredOutputSpec(
+            mode="strict_json_schema",
+            source=CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+            basis=STRUCTURED_OUTPUT_BASIS_BUILTIN,
+        ),
         reasoning_request=CapabilityFlag(True),
         reasoning_response=CapabilityFlag(True),
         usage_stats=CapabilityFlag(True),
@@ -458,7 +607,9 @@ def _litellm_capabilities(
     """
     caps = ModelCapabilities(
         sync_generation=CapabilityFlag(True),
-        structured_output=structured_output_capability(provider, custom_providers),
+        structured_output=StructuredOutputSpec.from_capability(
+            structured_output_capability(provider, custom_providers),
+        ),
         reasoning_request=CapabilityFlag(False),
         reasoning_response=CapabilityFlag(False),
         usage_stats=CapabilityFlag(True),
@@ -488,9 +639,12 @@ def _apply_capability_overrides(
     }
     for key, value in (overrides or {}).items():
         if key == "structured_output" and isinstance(value, Mapping):
-            data["structured_output"] = StructuredOutputCapability(
-                str(value.get("mode") or caps.structured_output.mode),
-                CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+            data["structured_output"] = StructuredOutputSpec(
+                mode=str(value.get("mode") or caps.structured_output.mode),
+                source=CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+                # Keep the adapter-table basis the override replaced so the
+                # manifest still explains what the default would have been.
+                basis=caps.structured_output.basis,
             )
         elif key in {"context_limit_tokens", "context_budget_tokens"}:
             data[key] = int(value) if value is not None else None
@@ -519,8 +673,10 @@ def resolve_capabilities(
         )
     return _apply_capability_overrides(
         ModelCapabilities(
-            structured_output=StructuredOutputCapability(
-                "prompt_only_json", CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+            structured_output=StructuredOutputSpec(
+                mode="prompt_only_json",
+                source=CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+                basis=STRUCTURED_OUTPUT_BASIS_CONSERVATIVE_DEFAULT,
             ),
         ),
         profile.capability_overrides,
@@ -759,7 +915,7 @@ def resolve_routing_plan(
         if sync_model:
             return ROUTE_SOURCE_STAGE_CONFIG
         if batch_model:
-            return ROUTE_SOURCE_PRIMARY_INHERITED
+            return ROUTE_SOURCE_INHERITED
         return ROUTE_SOURCE_BUILTIN_DEFAULT
 
     routes: dict[str, TaskRoute] = {}
@@ -779,12 +935,12 @@ def resolve_routing_plan(
 
     if strategy is ExecutionStrategy.GEMINI_BATCH:
         route(STAGE_TRANSLATION, "batch", strategy, translation_source())
-        route(STAGE_KEYWORD, "batch", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
-        route(STAGE_REVISION, "batch", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+        route(STAGE_KEYWORD, "batch", strategy, ROUTE_SOURCE_INHERITED)
+        route(STAGE_REVISION, "batch", strategy, ROUTE_SOURCE_INHERITED)
     else:
         route(STAGE_TRANSLATION, "primary", strategy, translation_source())
-        route(STAGE_KEYWORD, "primary", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
-        route(STAGE_REVISION, "primary", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+        route(STAGE_KEYWORD, "primary", strategy, ROUTE_SOURCE_INHERITED)
+        route(STAGE_REVISION, "primary", strategy, ROUTE_SOURCE_INHERITED)
 
     if STAGE_PROJECT_ANALYSIS in overrides:
         route(
@@ -805,7 +961,7 @@ def resolve_routing_plan(
             STAGE_PROJECT_ANALYSIS,
             "primary",
             ExecutionStrategy.SYNC,
-            ROUTE_SOURCE_PRIMARY_INHERITED,
+            ROUTE_SOURCE_INHERITED,
         )
 
     if STAGE_FINAL_REVIEW in overrides:
@@ -827,7 +983,7 @@ def resolve_routing_plan(
             STAGE_FINAL_REVIEW,
             "batch",
             ExecutionStrategy.GEMINI_BATCH,
-            ROUTE_SOURCE_PRIMARY_INHERITED,
+            ROUTE_SOURCE_INHERITED,
         )
 
     if STAGE_AB_EXPERIMENT in overrides:
@@ -842,7 +998,7 @@ def resolve_routing_plan(
             STAGE_AB_EXPERIMENT,
             "primary",
             ExecutionStrategy.SYNC,
-            ROUTE_SOURCE_PRIMARY_INHERITED,
+            ROUTE_SOURCE_INHERITED,
         )
 
     capabilities = {

--- a/model_profile.py
+++ b/model_profile.py
@@ -1,0 +1,1035 @@
+"""Provider-neutral model routing contract: profiles, capabilities, strategies.
+
+This module is the single place that answers "which model, through which
+adapter, with which execution strategy, for which stage" (issue #345).  It is
+intentionally pure: it reads the legacy ``sync.*`` / ``batch.*`` config shape
+read-only, never imports optional SDKs at module scope, and never touches
+credential *values* — profiles hold :class:`CredentialRef` references only.
+
+Resolution semantics (approved with issue #345, option B):
+
+* A stage's own config key (``batch.project_analysis.model``,
+  ``batch.final_review.model``) or an explicit caller override (A/B
+  ``--model``, manifest model) wins over the primary profile.
+* Stages without their own configuration inherit the run's base profile —
+  the primary sync profile for ``sync`` runs, the Gemini batch profile for
+  ``gemini_batch`` runs.
+
+The production entry points (``run_sync_request``, ``call_gemini_sdk``, ...)
+adopt this resolver in follow-up PRs; until then nothing in the runtime
+imports this module besides tests.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Mapping
+
+from cli_contract import EXIT_INVALID_STATE, MachineContractError
+from gemini_model_catalog import DEFAULT_GEMINI_TRANSLATION_MODEL
+from litellm_provider_config import (
+    CustomLiteLLMProvider,
+    StructuredOutputCapability,
+    provider_from_model,
+    provider_display_label,
+    structured_output_capability,
+)
+
+MODEL_PROFILE_SCHEMA_VERSION = 1
+
+ADAPTER_GEMINI = "gemini"
+ADAPTER_LITELLM = "litellm"
+KNOWN_ADAPTERS = frozenset({ADAPTER_GEMINI, ADAPTER_LITELLM})
+
+SYNC_BACKEND_GEMINI = "gemini"
+SYNC_BACKEND_LITELLM = "litellm"
+KNOWN_SYNC_BACKENDS = frozenset({SYNC_BACKEND_GEMINI, SYNC_BACKEND_LITELLM})
+
+# Task stages that may appear in a routing plan.
+STAGE_TRANSLATION = "translation"
+STAGE_KEYWORD = "keyword"
+STAGE_REVISION = "revision"
+STAGE_PROJECT_ANALYSIS = "project_analysis"
+STAGE_FINAL_REVIEW = "final_review"
+STAGE_AB_EXPERIMENT = "ab_experiment"
+KNOWN_STAGES = frozenset({
+    STAGE_TRANSLATION,
+    STAGE_KEYWORD,
+    STAGE_REVISION,
+    STAGE_PROJECT_ANALYSIS,
+    STAGE_FINAL_REVIEW,
+    STAGE_AB_EXPERIMENT,
+})
+
+# How a route was decided. "stage_config" = the stage's own config key,
+# "explicit" = a caller-supplied override (CLI flag / manifest value),
+# "primary_inherited" = the stage has no own config and inherits the run's
+# base profile, "builtin_default" = nothing configured anywhere; tool
+# default.
+ROUTE_SOURCE_STAGE_CONFIG = "stage_config"
+ROUTE_SOURCE_EXPLICIT = "explicit"
+ROUTE_SOURCE_PRIMARY_INHERITED = "primary_inherited"
+ROUTE_SOURCE_BUILTIN_DEFAULT = "builtin_default"
+KNOWN_ROUTE_SOURCES = frozenset({
+    ROUTE_SOURCE_STAGE_CONFIG,
+    ROUTE_SOURCE_EXPLICIT,
+    ROUTE_SOURCE_PRIMARY_INHERITED,
+    ROUTE_SOURCE_BUILTIN_DEFAULT,
+})
+
+# Capability provenance. Adapter defaults come from this module's builtin
+# tables, probe results are reserved for #340/#341 wiring, and config
+# overrides arrive with the productized config format (#344).
+CAPABILITY_SOURCE_ADAPTER_DEFAULT = "adapter_default"
+CAPABILITY_SOURCE_PROBED = "probed"
+CAPABILITY_SOURCE_CONFIG_OVERRIDE = "config_override"
+CAPABILITY_SOURCES = frozenset({
+    CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+    CAPABILITY_SOURCE_PROBED,
+    CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+})
+
+# Credential reference kinds. References only; no key material ever enters
+# this module.
+CREDENTIAL_KIND_API_KEYS_JSON = "api_keys_json"
+CREDENTIAL_KIND_KEYRING = "keyring"
+CREDENTIAL_KIND_ENV = "env"
+CREDENTIAL_KIND_NONE = "none"
+
+# Machine-decidable error code names (stable CLI contract; registered in
+# docs/quickstart_agent.md when the fail-fast wiring lands).
+MODEL_PROFILE_INVALID = "MODEL_PROFILE_INVALID"
+MODEL_ROUTE_CAPABILITY_MISSING = "MODEL_ROUTE_CAPABILITY_MISSING"
+MODEL_PROFILE_CREDENTIAL_REF_MISSING = "MODEL_PROFILE_CREDENTIAL_REF_MISSING"
+
+# Capability keys accepted in ``ModelProfile.capability_overrides``.
+CAPABILITY_OVERRIDE_KEYS = frozenset({
+    "sync_generation",
+    "structured_output",
+    "reasoning_request",
+    "reasoning_response",
+    "usage_stats",
+    "remote_batch",
+    "embedding",
+    "context_limit_tokens",
+    "context_budget_tokens",
+})
+
+
+class ExecutionStrategy(str, Enum):
+    """How a stage's requests are transported and scheduled.
+
+    Strategies own transport, scheduling, and task lifecycle only; prompts,
+    context assembly, and translation schemas stay with the stage callers.
+    """
+
+    SYNC = "sync"
+    GEMINI_BATCH = "gemini_batch"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class CredentialRef:
+    """Where an adapter looks up credentials — a reference, never a value.
+
+    ``name`` is the lookup key (API key slot id, keyring username, or env
+    var name); ``env_name`` is the optional secondary environment lookup used
+    by custom OpenAI-compatible providers.
+    """
+
+    kind: str
+    name: str = ""
+    env_name: str = ""
+
+    def to_manifest_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "name": self.name, "env_name": self.env_name}
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "CredentialRef":
+        return cls(
+            kind=str(payload.get("kind") or CREDENTIAL_KIND_NONE),
+            name=str(payload.get("name") or ""),
+            env_name=str(payload.get("env_name") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class CapabilityFlag:
+    """One boolean capability plus its explainable provenance."""
+
+    supported: bool
+    source: str = CAPABILITY_SOURCE_ADAPTER_DEFAULT
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {"supported": bool(self.supported), "source": str(self.source)}
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """What a profile's provider/model actually supports.
+
+    Sources must be one of :data:`CAPABILITY_SOURCES`; model-name string
+    branching is not allowed here.  Conservative adapter defaults err on the
+    safe side so unsupported combinations fail validation instead of
+    producing degraded requests.
+    """
+
+    sync_generation: CapabilityFlag = CapabilityFlag(False)
+    structured_output: StructuredOutputCapability = StructuredOutputCapability(
+        "prompt_only_json", CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+    )
+    reasoning_request: CapabilityFlag = CapabilityFlag(False)
+    reasoning_response: CapabilityFlag = CapabilityFlag(False)
+    usage_stats: CapabilityFlag = CapabilityFlag(False)
+    remote_batch: CapabilityFlag = CapabilityFlag(False)
+    embedding: CapabilityFlag = CapabilityFlag(False)
+    context_limit_tokens: int | None = None
+    context_budget_tokens: int | None = None
+    context_source: str = ""
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {
+            "sync_generation": self.sync_generation.to_manifest_dict(),
+            "structured_output": {
+                "mode": self.structured_output.mode,
+                "source": self.structured_output.source,
+            },
+            "reasoning_request": self.reasoning_request.to_manifest_dict(),
+            "reasoning_response": self.reasoning_response.to_manifest_dict(),
+            "usage_stats": self.usage_stats.to_manifest_dict(),
+            "remote_batch": self.remote_batch.to_manifest_dict(),
+            "embedding": self.embedding.to_manifest_dict(),
+            "context_limit_tokens": self.context_limit_tokens,
+            "context_budget_tokens": self.context_budget_tokens,
+            "context_source": self.context_source,
+        }
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "ModelCapabilities":
+        def flag(key: str) -> CapabilityFlag:
+            raw = payload.get(key) or {}
+            return CapabilityFlag(
+                supported=bool(raw.get("supported")),
+                source=str(raw.get("source") or CAPABILITY_SOURCE_ADAPTER_DEFAULT),
+            )
+
+        structured = payload.get("structured_output") or {}
+        limit = payload.get("context_limit_tokens")
+        budget = payload.get("context_budget_tokens")
+        return cls(
+            sync_generation=flag("sync_generation"),
+            structured_output=StructuredOutputCapability(
+                str(structured.get("mode") or "prompt_only_json"),
+                str(structured.get("source") or CAPABILITY_SOURCE_ADAPTER_DEFAULT),
+            ),
+            reasoning_request=flag("reasoning_request"),
+            reasoning_response=flag("reasoning_response"),
+            usage_stats=flag("usage_stats"),
+            remote_batch=flag("remote_batch"),
+            embedding=flag("embedding"),
+            context_limit_tokens=int(limit) if limit is not None else None,
+            context_budget_tokens=int(budget) if budget is not None else None,
+            context_source=str(payload.get("context_source") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """One addressable model configuration that tasks can route to.
+
+    ``models`` is the explicit candidate pool for model rotation inside this
+    profile (provider, credentials, and capabilities stay fixed); it holds
+    exactly ``(model,)`` when no rotation list is configured.
+    ``capability_overrides`` and ``params`` must stay non-sensitive: no API
+    keys, only flags and generation parameters.
+    """
+
+    id: str
+    label: str
+    adapter: str
+    provider: str
+    model: str
+    credential_ref: CredentialRef
+    models: tuple[str, ...] = ()
+    base_url: str = ""
+    extra_headers: Mapping[str, str] = field(default_factory=dict)
+    capability_overrides: Mapping[str, Any] = field(default_factory=dict)
+    params: Mapping[str, Any] = field(default_factory=dict)
+    embedding_profile_id: str = ""
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "adapter": self.adapter,
+            "provider": self.provider,
+            "model": self.model,
+            "models": list(self.models or (self.model,)),
+            "credential_ref": self.credential_ref.to_manifest_dict(),
+            "base_url": self.base_url,
+            "extra_headers": dict(self.extra_headers or {}),
+            "capability_overrides": dict(self.capability_overrides or {}),
+            "params": dict(self.params or {}),
+            "embedding_profile_id": self.embedding_profile_id,
+        }
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "ModelProfile":
+        return cls(
+            id=str(payload.get("id") or ""),
+            label=str(payload.get("label") or ""),
+            adapter=str(payload.get("adapter") or ""),
+            provider=str(payload.get("provider") or ""),
+            model=str(payload.get("model") or ""),
+            credential_ref=CredentialRef.from_manifest_dict(
+                payload.get("credential_ref") or {},
+            ),
+            models=tuple(str(item) for item in payload.get("models") or ()),
+            base_url=str(payload.get("base_url") or ""),
+            extra_headers=dict(payload.get("extra_headers") or {}),
+            capability_overrides=dict(payload.get("capability_overrides") or {}),
+            params=dict(payload.get("params") or {}),
+            embedding_profile_id=str(payload.get("embedding_profile_id") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class TaskRoute:
+    """Which profile and strategy one stage uses, plus why."""
+
+    stage: str
+    profile_id: str
+    strategy: ExecutionStrategy
+    source: str
+
+    def to_manifest_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "profile_id": self.profile_id,
+            "strategy": self.strategy.value,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "TaskRoute":
+        return cls(
+            stage=str(payload.get("stage") or ""),
+            profile_id=str(payload.get("profile_id") or ""),
+            strategy=ExecutionStrategy(str(payload.get("strategy") or "sync")),
+            source=str(payload.get("source") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class ModelRoutingPlan:
+    """Immutable per-run snapshot of profiles, routes, and capabilities.
+
+    Built once at run start; later config changes must not affect a run that
+    already holds a plan. The manifest snapshot carries references only, so
+    answering "which provider/model/strategy/capabilities did each stage
+    actually use" never leaks credentials.
+    """
+
+    schema_version: int
+    primary_profile_id: str
+    profiles: Mapping[str, ModelProfile]
+    routes: Mapping[str, TaskRoute]
+    capabilities: Mapping[str, ModelCapabilities]
+    created_at: str = ""
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "created_at": self.created_at,
+            "primary_profile_id": self.primary_profile_id,
+            "profiles": {
+                profile_id: profile.to_manifest_dict()
+                for profile_id, profile in sorted(self.profiles.items())
+            },
+            "routes": {
+                stage: route.to_manifest_dict()
+                for stage, route in sorted(self.routes.items())
+            },
+            "capabilities": {
+                profile_id: caps.to_manifest_dict()
+                for profile_id, caps in sorted(self.capabilities.items())
+            },
+        }
+
+    @classmethod
+    def from_manifest_dict(cls, payload: Mapping[str, Any]) -> "ModelRoutingPlan":
+        return cls(
+            schema_version=int(payload.get("schema_version") or 0),
+            primary_profile_id=str(payload.get("primary_profile_id") or ""),
+            profiles={
+                str(profile_id): ModelProfile.from_manifest_dict(profile)
+                for profile_id, profile in (payload.get("profiles") or {}).items()
+            },
+            routes={
+                str(stage): TaskRoute.from_manifest_dict(route)
+                for stage, route in (payload.get("routes") or {}).items()
+            },
+            capabilities={
+                str(profile_id): ModelCapabilities.from_manifest_dict(caps)
+                for profile_id, caps in (payload.get("capabilities") or {}).items()
+            },
+            created_at=str(payload.get("created_at") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class RoutingValidationIssue:
+    """One machine-decidable routing problem found before a run starts."""
+
+    code: str
+    message: str
+    stage: str = ""
+    profile_id: str = ""
+    missing_capabilities: tuple[str, ...] = ()
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "stage": self.stage,
+            "profile_id": self.profile_id,
+            "missing_capabilities": list(self.missing_capabilities),
+        }
+
+
+def routing_validation_error(
+    issues: tuple[RoutingValidationIssue, ...],
+) -> MachineContractError:
+    """Convert validation issues into the stable CLI refusal contract."""
+    primary = issues[0]
+    return MachineContractError(
+        primary.message,
+        code_name=primary.code,
+        suggested_action="fix_translator_config",
+        semantic_exit_code=EXIT_INVALID_STATE,
+        retryable=False,
+        details={
+            "issues": [issue.to_manifest_dict() for issue in issues],
+            "stage": primary.stage,
+            "profile_id": primary.profile_id,
+            "missing_capabilities": list(primary.missing_capabilities),
+        },
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _clean_str(value: Any) -> str:
+    return str(value).strip() if isinstance(value, str) else ""
+
+
+def _gemini_capabilities(overrides: Mapping[str, Any]) -> ModelCapabilities:
+    """Adapter defaults for the direct google-genai client."""
+    caps = ModelCapabilities(
+        sync_generation=CapabilityFlag(True),
+        structured_output=StructuredOutputCapability("strict_json_schema", "builtin"),
+        reasoning_request=CapabilityFlag(True),
+        reasoning_response=CapabilityFlag(True),
+        usage_stats=CapabilityFlag(True),
+        remote_batch=CapabilityFlag(True),
+        embedding=CapabilityFlag(True),
+    )
+    return _apply_capability_overrides(caps, overrides)
+
+
+def _litellm_capabilities(
+    provider: str,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None,
+    overrides: Mapping[str, Any],
+) -> ModelCapabilities:
+    """Adapter defaults for the LiteLLM sync backend.
+
+    ``thinking_config`` is intentionally dropped by the LiteLLM adapter (see
+    ``LiteLLMSyncBackend._build_request_context``), so reasoning stays
+    conservatively unsupported; remote batch and embeddings are non-goals of
+    the first phase (#341 will revisit embeddings).
+    """
+    caps = ModelCapabilities(
+        sync_generation=CapabilityFlag(True),
+        structured_output=structured_output_capability(provider, custom_providers),
+        reasoning_request=CapabilityFlag(False),
+        reasoning_response=CapabilityFlag(False),
+        usage_stats=CapabilityFlag(True),
+        remote_batch=CapabilityFlag(False),
+        embedding=CapabilityFlag(False),
+    )
+    return _apply_capability_overrides(caps, overrides)
+
+
+def _apply_capability_overrides(
+    caps: ModelCapabilities,
+    overrides: Mapping[str, Any],
+) -> ModelCapabilities:
+    if not overrides:
+        return caps
+    data: dict[str, Any] = {
+        "sync_generation": caps.sync_generation,
+        "structured_output": caps.structured_output,
+        "reasoning_request": caps.reasoning_request,
+        "reasoning_response": caps.reasoning_response,
+        "usage_stats": caps.usage_stats,
+        "remote_batch": caps.remote_batch,
+        "embedding": caps.embedding,
+        "context_limit_tokens": caps.context_limit_tokens,
+        "context_budget_tokens": caps.context_budget_tokens,
+        "context_source": caps.context_source,
+    }
+    for key, value in (overrides or {}).items():
+        if key == "structured_output" and isinstance(value, Mapping):
+            data["structured_output"] = StructuredOutputCapability(
+                str(value.get("mode") or caps.structured_output.mode),
+                CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+            )
+        elif key in {"context_limit_tokens", "context_budget_tokens"}:
+            data[key] = int(value) if value is not None else None
+            data["context_source"] = CAPABILITY_SOURCE_CONFIG_OVERRIDE
+        elif key in data and isinstance(data[key], CapabilityFlag):
+            data[key] = CapabilityFlag(
+                bool(value),
+                CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+            )
+    return ModelCapabilities(**data)
+
+
+def resolve_capabilities(
+    profile: ModelProfile,
+    *,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+) -> ModelCapabilities:
+    """Resolve one profile's capabilities from adapter defaults + overrides."""
+    if profile.adapter == ADAPTER_GEMINI:
+        return _gemini_capabilities(profile.capability_overrides)
+    if profile.adapter == ADAPTER_LITELLM:
+        return _litellm_capabilities(
+            profile.provider,
+            custom_providers,
+            profile.capability_overrides,
+        )
+    return _apply_capability_overrides(
+        ModelCapabilities(
+            structured_output=StructuredOutputCapability(
+                "prompt_only_json", CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+            ),
+        ),
+        profile.capability_overrides,
+    )
+
+
+def _sync_profile(
+    profile_id: str,
+    model: str,
+    sync_backend: str,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None,
+    *,
+    label: str = "",
+    models: tuple[str, ...] = (),
+) -> ModelProfile:
+    """Build a profile for the sync execution path.
+
+    The adapter mirrors the runtime branch exactly: ``sync.backend`` decides
+    gemini-direct vs LiteLLM, so a provider-prefixed model under the gemini
+    backend stays a gemini-adapter profile and is rejected by validation
+    instead of being rerouted behind the config's back.
+    """
+    if sync_backend == SYNC_BACKEND_LITELLM:
+        provider = provider_from_model(model)
+        custom = (custom_providers or {}).get(provider)
+        if custom is not None:
+            credential = CredentialRef(
+                CREDENTIAL_KIND_NONE if not custom.requires_key
+                else CREDENTIAL_KIND_KEYRING,
+                name=custom.id,
+                env_name=custom.api_key_env,
+            )
+        else:
+            credential = CredentialRef(CREDENTIAL_KIND_KEYRING, provider)
+        return ModelProfile(
+            id=profile_id,
+            label=label or provider_display_label(provider, custom_providers) or model,
+            adapter=ADAPTER_LITELLM,
+            provider=provider,
+            model=model,
+            credential_ref=credential,
+            models=models or (model,),
+            base_url=custom.base_url if custom is not None else "",
+        )
+    return ModelProfile(
+        id=profile_id,
+        label=label or "Gemini",
+        adapter=ADAPTER_GEMINI,
+        provider="gemini",
+        model=model,
+        credential_ref=CredentialRef(CREDENTIAL_KIND_API_KEYS_JSON, "api_keys"),
+        models=models or (model,),
+    )
+
+
+def _batch_profile(
+    model: str,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None,
+    *,
+    profile_id: str = "batch",
+    label: str = "Gemini Batch",
+) -> ModelProfile:
+    """Build the Gemini batch transport profile.
+
+    A provider-prefixed batch model is kept as a litellm-adapter profile on
+    purpose so validation rejects it with a machine-decidable
+    missing-``remote_batch`` error instead of shipping it to a Gemini-only
+    transport.
+    """
+    provider = provider_from_model(model)
+    if provider:
+        return ModelProfile(
+            id=profile_id,
+            label=label or provider_display_label(provider, custom_providers) or model,
+            adapter=ADAPTER_LITELLM,
+            provider=provider,
+            model=model,
+            credential_ref=CredentialRef(CREDENTIAL_KIND_KEYRING, provider),
+            models=(model,),
+        )
+    return ModelProfile(
+        id=profile_id,
+        label=label,
+        adapter=ADAPTER_GEMINI,
+        provider="gemini",
+        model=model,
+        credential_ref=CredentialRef(CREDENTIAL_KIND_API_KEYS_JSON, "api_keys"),
+        models=(model,),
+    )
+
+
+def build_profile_registry(
+    translator_config: Mapping[str, Any],
+    *,
+    game_config: Mapping[str, Any] | None = None,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+) -> dict[str, ModelProfile]:
+    """Build every profile addressable by the legacy config, read-only.
+
+    Always present: ``primary`` (sync execution) and ``batch`` (Gemini batch
+    execution). Stage-specific profiles appear only when their config key is
+    set.
+    """
+    sync_cfg = _mapping(translator_config.get("sync"))
+    batch_cfg = _mapping(translator_config.get("batch"))
+    game_cfg = _mapping(game_config)
+
+    sync_backend = _clean_str(sync_cfg.get("backend")).lower() or SYNC_BACKEND_GEMINI
+    sync_model = _clean_str(sync_cfg.get("model"))
+    batch_model = (
+        _clean_str(batch_cfg.get("model"))
+        or _clean_str(game_cfg.get("batch_model"))
+        or DEFAULT_GEMINI_TRANSLATION_MODEL
+    )
+    primary_model = sync_model or batch_model
+
+    raw_models = sync_cfg.get("models")
+    models = (
+        tuple(_clean_str(item) for item in raw_models if _clean_str(item))
+        if isinstance(raw_models, (list, tuple))
+        else ()
+    )
+
+    registry: dict[str, ModelProfile] = {
+        "primary": _sync_profile(
+            "primary",
+            primary_model,
+            sync_backend,
+            custom_providers,
+            label="Primary sync model",
+            models=models,
+        ),
+        "batch": _batch_profile(batch_model, custom_providers),
+    }
+
+    project_analysis_model = _clean_str(
+        _mapping(batch_cfg.get("project_analysis")).get("model"),
+    )
+    if project_analysis_model:
+        registry["project_analysis_model"] = _sync_profile(
+            "project_analysis_model",
+            project_analysis_model,
+            sync_backend,
+            custom_providers,
+            label="Project analysis model",
+        )
+
+    final_review_model = _clean_str(
+        _mapping(batch_cfg.get("final_review")).get("model"),
+    )
+    if final_review_model:
+        # Final review is batch-executed, so its dedicated model always runs
+        # on the Gemini batch transport.
+        registry["final_review_model"] = _batch_profile(
+            final_review_model,
+            custom_providers,
+            profile_id="final_review_model",
+            label="Final review model",
+        )
+    return registry
+
+
+def resolve_routing_plan(
+    translator_config: Mapping[str, Any],
+    *,
+    game_config: Mapping[str, Any] | None = None,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+    execution: str | ExecutionStrategy = ExecutionStrategy.SYNC,
+    stage_overrides: Mapping[str, str] | None = None,
+    created_at: str = "",
+) -> ModelRoutingPlan:
+    """Resolve the immutable routing snapshot for one run.
+
+    ``execution`` selects the strategy for stages that support both ways
+    (translation / keyword / revision); final review is always Gemini batch
+    and project analysis is always sync, matching today's CLI surface.
+    ``stage_overrides`` maps a stage to an explicit model string (A/B
+    ``--model``, manifest model); explicit overrides win over the primary
+    profile (issue #345 option B semantics).
+    """
+    sync_cfg = _mapping(translator_config.get("sync"))
+    batch_cfg = _mapping(translator_config.get("batch"))
+    game_cfg = _mapping(game_config)
+
+    sync_backend = _clean_str(sync_cfg.get("backend")).lower() or SYNC_BACKEND_GEMINI
+    if sync_backend not in KNOWN_SYNC_BACKENDS:
+        raise ValueError(
+            f"Unsupported sync backend: {sync_backend}. "
+            "Choose 'gemini' or 'litellm'."
+        )
+
+    strategy = (
+        execution
+        if isinstance(execution, ExecutionStrategy)
+        else ExecutionStrategy(str(execution))
+    )
+
+    profiles = build_profile_registry(
+        translator_config,
+        game_config=game_config,
+        custom_providers=custom_providers,
+    )
+    overrides = dict(stage_overrides or {})
+    for stage in list(overrides):
+        model = _clean_str(overrides[stage])
+        if not model:
+            overrides.pop(stage)
+            continue
+        if stage == STAGE_FINAL_REVIEW:
+            profiles[f"{stage}_override"] = _batch_profile(
+                model,
+                custom_providers,
+                profile_id=f"{stage}_override",
+                label="final review explicit model",
+            )
+        else:
+            profiles[f"{stage}_override"] = _sync_profile(
+                f"{stage}_override",
+                model,
+                sync_backend,
+                custom_providers,
+                label=f"{stage} explicit model",
+            )
+
+    sync_model = _clean_str(sync_cfg.get("model"))
+    batch_model = (
+        _clean_str(batch_cfg.get("model"))
+        or _clean_str(game_cfg.get("batch_model"))
+    )
+
+    def translation_source() -> str:
+        if strategy is ExecutionStrategy.GEMINI_BATCH:
+            if batch_model:
+                return ROUTE_SOURCE_STAGE_CONFIG
+            return ROUTE_SOURCE_BUILTIN_DEFAULT
+        if sync_model:
+            return ROUTE_SOURCE_STAGE_CONFIG
+        if batch_model:
+            return ROUTE_SOURCE_PRIMARY_INHERITED
+        return ROUTE_SOURCE_BUILTIN_DEFAULT
+
+    routes: dict[str, TaskRoute] = {}
+
+    def route(
+        stage: str,
+        profile_id: str,
+        stage_strategy: ExecutionStrategy,
+        source: str,
+    ) -> None:
+        routes[stage] = TaskRoute(
+            stage=stage,
+            profile_id=profile_id,
+            strategy=stage_strategy,
+            source=source,
+        )
+
+    if strategy is ExecutionStrategy.GEMINI_BATCH:
+        route(STAGE_TRANSLATION, "batch", strategy, translation_source())
+        route(STAGE_KEYWORD, "batch", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+        route(STAGE_REVISION, "batch", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+    else:
+        route(STAGE_TRANSLATION, "primary", strategy, translation_source())
+        route(STAGE_KEYWORD, "primary", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+        route(STAGE_REVISION, "primary", strategy, ROUTE_SOURCE_PRIMARY_INHERITED)
+
+    if STAGE_PROJECT_ANALYSIS in overrides:
+        route(
+            STAGE_PROJECT_ANALYSIS,
+            "project_analysis_override",
+            ExecutionStrategy.SYNC,
+            ROUTE_SOURCE_EXPLICIT,
+        )
+    elif "project_analysis_model" in profiles:
+        route(
+            STAGE_PROJECT_ANALYSIS,
+            "project_analysis_model",
+            ExecutionStrategy.SYNC,
+            ROUTE_SOURCE_STAGE_CONFIG,
+        )
+    else:
+        route(
+            STAGE_PROJECT_ANALYSIS,
+            "primary",
+            ExecutionStrategy.SYNC,
+            ROUTE_SOURCE_PRIMARY_INHERITED,
+        )
+
+    if STAGE_FINAL_REVIEW in overrides:
+        route(
+            STAGE_FINAL_REVIEW,
+            "final_review_override",
+            ExecutionStrategy.GEMINI_BATCH,
+            ROUTE_SOURCE_EXPLICIT,
+        )
+    elif "final_review_model" in profiles:
+        route(
+            STAGE_FINAL_REVIEW,
+            "final_review_model",
+            ExecutionStrategy.GEMINI_BATCH,
+            ROUTE_SOURCE_STAGE_CONFIG,
+        )
+    else:
+        route(
+            STAGE_FINAL_REVIEW,
+            "batch",
+            ExecutionStrategy.GEMINI_BATCH,
+            ROUTE_SOURCE_PRIMARY_INHERITED,
+        )
+
+    if STAGE_AB_EXPERIMENT in overrides:
+        route(
+            STAGE_AB_EXPERIMENT,
+            "ab_experiment_override",
+            ExecutionStrategy.SYNC,
+            ROUTE_SOURCE_EXPLICIT,
+        )
+    else:
+        route(
+            STAGE_AB_EXPERIMENT,
+            "primary",
+            ExecutionStrategy.SYNC,
+            ROUTE_SOURCE_PRIMARY_INHERITED,
+        )
+
+    capabilities = {
+        profile_id: resolve_capabilities(profile, custom_providers=custom_providers)
+        for profile_id, profile in profiles.items()
+    }
+    return ModelRoutingPlan(
+        schema_version=MODEL_PROFILE_SCHEMA_VERSION,
+        primary_profile_id="primary",
+        profiles=profiles,
+        routes=routes,
+        capabilities=capabilities,
+        created_at=created_at or utc_now_iso(),
+    )
+
+
+def validate_routing_plan(
+    plan: ModelRoutingPlan,
+    *,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+    environ: Mapping[str, str] | None = None,
+    keyring_has_credential: Callable[[str], bool] | None = None,
+) -> tuple[RoutingValidationIssue, ...]:
+    """Return every machine-decidable routing problem.
+
+    An empty tuple means the plan may start. Credential availability is
+    checked honestly: environment references are verified against
+    ``environ`` (default: the real process environment); keyring references
+    are only flagged when a ``keyring_has_credential`` probe is supplied and
+    reports the slot empty.
+    """
+    issues: list[RoutingValidationIssue] = []
+    env_lookup = os.environ if environ is None else environ
+
+    for stage, task_route in sorted(plan.routes.items()):
+        if stage not in KNOWN_STAGES:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Unknown task stage in routing plan: {stage}",
+                stage=stage,
+            ))
+        profile = plan.profiles.get(task_route.profile_id)
+        if profile is None:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Route for stage {stage} references unknown profile "
+                f"{task_route.profile_id}.",
+                stage=stage,
+                profile_id=task_route.profile_id,
+            ))
+            continue
+        caps = plan.capabilities.get(task_route.profile_id)
+        if caps is None:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Profile {task_route.profile_id} has no capability snapshot.",
+                stage=stage,
+                profile_id=task_route.profile_id,
+            ))
+            continue
+
+        if (
+            task_route.strategy is ExecutionStrategy.SYNC
+            and not caps.sync_generation.supported
+        ):
+            issues.append(RoutingValidationIssue(
+                MODEL_ROUTE_CAPABILITY_MISSING,
+                f"Profile {task_route.profile_id} cannot serve stage {stage}: "
+                "sync generation is not supported.",
+                stage=stage,
+                profile_id=task_route.profile_id,
+                missing_capabilities=("sync_generation",),
+            ))
+        if task_route.strategy is ExecutionStrategy.GEMINI_BATCH:
+            missing: list[str] = []
+            if profile.adapter != ADAPTER_GEMINI:
+                missing.append("gemini_adapter")
+            if not caps.remote_batch.supported:
+                missing.append("remote_batch")
+            if missing:
+                issues.append(RoutingValidationIssue(
+                    MODEL_ROUTE_CAPABILITY_MISSING,
+                    f"Profile {task_route.profile_id} cannot serve stage "
+                    f"{stage} with the gemini_batch strategy.",
+                    stage=stage,
+                    profile_id=task_route.profile_id,
+                    missing_capabilities=tuple(missing),
+                ))
+
+    for profile_id, profile in sorted(plan.profiles.items()):
+        if profile.adapter not in KNOWN_ADAPTERS:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Profile {profile_id} uses unknown adapter {profile.adapter}.",
+                profile_id=profile_id,
+            ))
+            continue
+        if profile.adapter == ADAPTER_LITELLM and not profile.provider:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Profile {profile_id} has a model without a provider prefix; "
+                "LiteLLM needs '<provider>/<model>'.",
+                profile_id=profile_id,
+            ))
+        if profile.adapter == ADAPTER_GEMINI and "/" in profile.model:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Profile {profile_id} uses provider-prefixed model "
+                f"{profile.model} on the direct Gemini adapter; configure "
+                "sync.backend 'litellm' or use a plain Gemini model id.",
+                profile_id=profile_id,
+            ))
+        unknown_overrides = sorted(
+            str(key) for key in profile.capability_overrides
+            if key not in CAPABILITY_OVERRIDE_KEYS
+        )
+        if unknown_overrides:
+            issues.append(RoutingValidationIssue(
+                MODEL_PROFILE_INVALID,
+                f"Profile {profile_id} has unknown capability overrides: "
+                + ", ".join(unknown_overrides),
+                profile_id=profile_id,
+            ))
+
+        ref = profile.credential_ref
+        custom = (custom_providers or {}).get(profile.provider)
+        requires_key = custom.requires_key if custom is not None else True
+        if not requires_key:
+            continue
+        if ref.kind == CREDENTIAL_KIND_ENV:
+            if ref.name and ref.name not in env_lookup:
+                issues.append(RoutingValidationIssue(
+                    MODEL_PROFILE_CREDENTIAL_REF_MISSING,
+                    f"Profile {profile_id} references environment variable "
+                    f"{ref.name}, which is not set.",
+                    profile_id=profile_id,
+                ))
+        elif ref.kind == CREDENTIAL_KIND_KEYRING:
+            env_missing = not (ref.env_name and ref.env_name in env_lookup)
+            keyring_missing = (
+                keyring_has_credential is not None
+                and ref.name
+                and not keyring_has_credential(ref.name)
+            )
+            if env_missing and keyring_missing:
+                detail = f"keyring slot {ref.name or '(unnamed)'} is empty"
+                if ref.env_name:
+                    detail += f" and {ref.env_name} is not set"
+                issues.append(RoutingValidationIssue(
+                    MODEL_PROFILE_CREDENTIAL_REF_MISSING,
+                    f"Profile {profile_id} has no usable credential: {detail}.",
+                    profile_id=profile_id,
+                ))
+
+    return tuple(issues)
+
+
+def build_sync_backend(
+    profile: ModelProfile,
+    *,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+):
+    """Construct the sync backend for one profile.
+
+    Deferred imports keep this module free of heavy SDK imports; the gemini
+    branch mirrors the production wiring in ``translator_runtime`` and the
+    litellm branch forwards the custom provider registry exactly like
+    ``run_sync_request`` does today.
+    """
+    if profile.adapter == ADAPTER_GEMINI:
+        import model_usage_ledger
+        import translator_runtime as runtime
+        from sync_model_backend import GeminiSyncBackend
+
+        runtime.configure_genai()
+        return GeminiSyncBackend(
+            runtime.create_genai_client(),
+            serialize_response=runtime.serialize_unknown,
+            extract_text=runtime.extract_text_from_response_payload,
+            extract_finish_reason=runtime.extract_finish_reason,
+            extract_usage=model_usage_ledger.extract_provider_usage,
+        )
+    if profile.adapter == ADAPTER_LITELLM:
+        from litellm_sync_backend import LiteLLMSyncBackend
+
+        return LiteLLMSyncBackend(custom_providers=dict(custom_providers or {}))
+    raise ValueError(
+        f"Profile {profile.id} uses adapter {profile.adapter}, which has no "
+        "sync backend."
+    )

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -1,0 +1,569 @@
+"""Tests for the model routing contract module (issue #345 P1)."""
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import replace
+from unittest import mock
+
+import litellm_provider_config as lpc
+import model_profile as mp
+from sync_model_backend import GeminiSyncBackend
+
+
+def _custom_providers() -> dict[str, lpc.CustomLiteLLMProvider]:
+    provider = lpc.CustomLiteLLMProvider(
+        id="opencode-go",
+        label="OpenCode Go",
+        base_url="https://api.opencode-go.example",
+        models_url="https://api.opencode-go.example/models",
+        api_key_env="OPENCODE_GO_API_KEY",
+    )
+    return {provider.id: provider}
+
+
+def _no_key_custom_provider() -> dict[str, lpc.CustomLiteLLMProvider]:
+    provider = lpc.CustomLiteLLMProvider(
+        id="local-llama",
+        label="Local llama",
+        base_url="http://127.0.0.1:11434",
+        models_url="http://127.0.0.1:11434/models",
+        requires_key=False,
+    )
+    return {provider.id: provider}
+
+
+class BuildProfileRegistryTests(unittest.TestCase):
+    def test_gemini_defaults_without_config(self) -> None:
+        registry = mp.build_profile_registry({})
+        self.assertEqual(set(registry), {"primary", "batch"})
+        for profile in registry.values():
+            self.assertEqual(profile.adapter, mp.ADAPTER_GEMINI)
+            self.assertEqual(profile.provider, "gemini")
+            self.assertEqual(profile.model, "gemini-3.1-flash-lite")
+            self.assertEqual(
+                profile.credential_ref,
+                mp.CredentialRef(mp.CREDENTIAL_KIND_API_KEYS_JSON, "api_keys"),
+            )
+
+    def test_sync_model_over_batch_model(self) -> None:
+        registry = mp.build_profile_registry({
+            "sync": {"backend": "gemini", "model": "gemini-3.5-flash"},
+            "batch": {"model": "gemini-2.5-flash"},
+        })
+        self.assertEqual(registry["primary"].model, "gemini-3.5-flash")
+        self.assertEqual(registry["batch"].model, "gemini-2.5-flash")
+
+    def test_game_config_batch_model_fallback(self) -> None:
+        registry = mp.build_profile_registry(
+            {"batch": {}},
+            game_config={"batch_model": "gemini-2.5-pro"},
+        )
+        # batch.model wins over the game-level batch_model ...
+        self.assertEqual(registry["batch"].model, "gemini-2.5-pro")
+        # ... and primary falls back to it when sync.model is unset.
+        self.assertEqual(registry["primary"].model, "gemini-2.5-pro")
+
+    def test_litellm_builtin_provider(self) -> None:
+        registry = mp.build_profile_registry({
+            "sync": {"backend": "litellm", "model": "deepseek/deepseek-chat"},
+        })
+        primary = registry["primary"]
+        self.assertEqual(primary.adapter, mp.ADAPTER_LITELLM)
+        self.assertEqual(primary.provider, "deepseek")
+        self.assertEqual(primary.base_url, "")
+        self.assertEqual(
+            primary.credential_ref,
+            mp.CredentialRef(mp.CREDENTIAL_KIND_KEYRING, "deepseek"),
+        )
+
+    def test_litellm_custom_provider(self) -> None:
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        primary = registry["primary"]
+        self.assertEqual(primary.provider, "opencode-go")
+        self.assertEqual(primary.base_url, "https://api.opencode-go.example")
+        self.assertEqual(
+            primary.credential_ref,
+            mp.CredentialRef(
+                mp.CREDENTIAL_KIND_KEYRING,
+                "opencode-go",
+                env_name="OPENCODE_GO_API_KEY",
+            ),
+        )
+
+    def test_custom_provider_without_key_requirement(self) -> None:
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "local-llama/llama-4"}},
+            custom_providers=_no_key_custom_provider(),
+        )
+        self.assertEqual(
+            registry["primary"].credential_ref.kind,
+            mp.CREDENTIAL_KIND_NONE,
+        )
+
+    def test_rotation_pool_from_sync_models(self) -> None:
+        registry = mp.build_profile_registry({
+            "sync": {
+                "backend": "gemini",
+                "model": "gemini-3.5-flash",
+                "models": ["gemini-3.5-flash", "gemini-3.1-flash-lite"],
+            },
+        })
+        self.assertEqual(
+            registry["primary"].models,
+            ("gemini-3.5-flash", "gemini-3.1-flash-lite"),
+        )
+
+    def test_stage_profiles_only_when_configured(self) -> None:
+        base = {"batch": {"model": "gemini-2.5-flash"}}
+        self.assertNotIn("project_analysis_model", mp.build_profile_registry(base))
+        self.assertNotIn("final_review_model", mp.build_profile_registry(base))
+        registry = mp.build_profile_registry({
+            "sync": {"backend": "litellm", "model": "deepseek/deepseek-chat"},
+            "batch": {
+                "model": "gemini-2.5-flash",
+                "project_analysis": {"model": "gemini-3.5-flash"},
+                "final_review": {"model": "gemini-3.1-pro-preview"},
+            },
+        })
+        # Project analysis runs through the sync path, so it follows the
+        # configured sync backend adapter; a bare Gemini model id under the
+        # litellm backend keeps an empty provider, which validation flags as
+        # an invalid profile instead of rerouting it silently.
+        pa = registry["project_analysis_model"]
+        self.assertEqual(pa.adapter, mp.ADAPTER_LITELLM)
+        self.assertEqual(pa.provider, "")
+        self.assertEqual(pa.model, "gemini-3.5-flash")
+        # Final review is batch-executed and always stays on Gemini.
+        fr = registry["final_review_model"]
+        self.assertEqual(fr.adapter, mp.ADAPTER_GEMINI)
+        self.assertEqual(fr.model, "gemini-3.1-pro-preview")
+
+
+class ResolveRoutingPlanTests(unittest.TestCase):
+    def test_default_sync_plan(self) -> None:
+        plan = mp.resolve_routing_plan({}, created_at="2026-08-16T00:00:00Z")
+        self.assertEqual(plan.schema_version, mp.MODEL_PROFILE_SCHEMA_VERSION)
+        self.assertEqual(plan.created_at, "2026-08-16T00:00:00Z")
+        self.assertEqual(plan.primary_profile_id, "primary")
+        expected = {
+            "translation": ("primary", "sync", "builtin_default"),
+            "keyword": ("primary", "sync", "primary_inherited"),
+            "revision": ("primary", "sync", "primary_inherited"),
+            "project_analysis": ("primary", "sync", "primary_inherited"),
+            "final_review": ("batch", "gemini_batch", "primary_inherited"),
+            "ab_experiment": ("primary", "sync", "primary_inherited"),
+        }
+        for stage, (profile_id, strategy, source) in expected.items():
+            route = plan.routes[stage]
+            self.assertEqual(route.profile_id, profile_id, stage)
+            self.assertEqual(route.strategy.value, strategy, stage)
+            self.assertEqual(route.source, source, stage)
+
+    def test_sync_run_source_labels(self) -> None:
+        plan = mp.resolve_routing_plan({
+            "sync": {"backend": "gemini", "model": "gemini-3.5-flash"},
+            "batch": {"model": "gemini-2.5-flash"},
+        })
+        self.assertEqual(
+            plan.routes["translation"].source, mp.ROUTE_SOURCE_STAGE_CONFIG,
+        )
+        plan_without_sync_model = mp.resolve_routing_plan({
+            "batch": {"model": "gemini-2.5-flash"},
+        })
+        self.assertEqual(
+            plan_without_sync_model.routes["translation"].source,
+            mp.ROUTE_SOURCE_PRIMARY_INHERITED,
+        )
+
+    def test_batch_execution_routes(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "litellm", "model": "deepseek/deepseek-chat"}},
+            execution=mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+        for stage in ("translation", "keyword", "revision"):
+            route = plan.routes[stage]
+            self.assertEqual(route.profile_id, "batch", stage)
+            self.assertEqual(route.strategy, mp.ExecutionStrategy.GEMINI_BATCH)
+        # Project analysis stays sync; final review stays gemini_batch.
+        self.assertEqual(
+            plan.routes["project_analysis"].profile_id, "primary",
+        )
+        self.assertEqual(
+            plan.routes["final_review"].strategy, mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+
+    def test_explicit_stage_model_wins_over_primary(self) -> None:
+        # Issue #345 option B: the stage's own config key must not be
+        # silently overridden by sync.model anymore.
+        plan = mp.resolve_routing_plan({
+            "sync": {"backend": "litellm", "model": "deepseek/deepseek-chat"},
+            "batch": {
+                "model": "gemini-2.5-flash",
+                "project_analysis": {"model": "gemini-3.5-flash"},
+            },
+        })
+        route = plan.routes["project_analysis"]
+        self.assertEqual(route.profile_id, "project_analysis_model")
+        self.assertEqual(route.source, mp.ROUTE_SOURCE_STAGE_CONFIG)
+        self.assertEqual(
+            plan.profiles["project_analysis_model"].model, "gemini-3.5-flash",
+        )
+        # The primary profile keeps serving the unconfigured stages.
+        self.assertEqual(plan.routes["keyword"].profile_id, "primary")
+
+    def test_stage_override_beats_configured_stage_model(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"batch": {"project_analysis": {"model": "gemini-3.5-flash"}}},
+            stage_overrides={"project_analysis": "deepseek/deepseek-chat"},
+        )
+        route = plan.routes["project_analysis"]
+        self.assertEqual(route.profile_id, "project_analysis_override")
+        self.assertEqual(route.source, mp.ROUTE_SOURCE_EXPLICIT)
+        self.assertEqual(
+            plan.profiles["project_analysis_override"].model,
+            "deepseek/deepseek-chat",
+        )
+
+    def test_ab_experiment_override(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {},
+            stage_overrides={"ab_experiment": "gemini-2.5-pro"},
+        )
+        route = plan.routes["ab_experiment"]
+        self.assertEqual(route.profile_id, "ab_experiment_override")
+        self.assertEqual(route.source, mp.ROUTE_SOURCE_EXPLICIT)
+        self.assertEqual(route.strategy, mp.ExecutionStrategy.SYNC)
+
+    def test_final_review_override_stays_batch_transport(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {},
+            stage_overrides={"final_review": "gemini-2.5-pro"},
+        )
+        route = plan.routes["final_review"]
+        self.assertEqual(route.profile_id, "final_review_override")
+        self.assertEqual(route.strategy, mp.ExecutionStrategy.GEMINI_BATCH)
+        self.assertEqual(
+            plan.profiles["final_review_override"].adapter, mp.ADAPTER_GEMINI,
+        )
+
+    def test_unknown_sync_backend_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            mp.resolve_routing_plan({"sync": {"backend": "openai"}})
+
+    def test_plan_frozen_against_config_mutation(self) -> None:
+        config = {"sync": {"backend": "gemini", "model": "gemini-3.5-flash"}}
+        plan = mp.resolve_routing_plan(config, created_at="fixed")
+        before = plan.to_manifest_dict()
+        config["sync"]["model"] = "gemini-2.5-flash"
+        config["batch"] = {"model": "gemini-2.5-pro"}
+        self.assertEqual(plan.to_manifest_dict(), before)
+
+
+class CapabilityTests(unittest.TestCase):
+    def test_gemini_capability_defaults(self) -> None:
+        profile = mp.build_profile_registry({})["primary"]
+        caps = mp.resolve_capabilities(profile)
+        self.assertTrue(caps.sync_generation.supported)
+        self.assertTrue(caps.remote_batch.supported)
+        self.assertTrue(caps.embedding.supported)
+        self.assertTrue(caps.reasoning_request.supported)
+        self.assertTrue(caps.usage_stats.supported)
+        self.assertEqual(caps.structured_output.mode, "strict_json_schema")
+        for flag in (
+            caps.sync_generation, caps.reasoning_request, caps.remote_batch,
+        ):
+            self.assertEqual(flag.source, mp.CAPABILITY_SOURCE_ADAPTER_DEFAULT)
+        self.assertIsNone(caps.context_limit_tokens)
+
+    def test_litellm_capability_defaults(self) -> None:
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        caps = mp.resolve_capabilities(
+            registry["primary"], custom_providers=_custom_providers(),
+        )
+        self.assertTrue(caps.sync_generation.supported)
+        self.assertFalse(caps.remote_batch.supported)
+        self.assertFalse(caps.embedding.supported)
+        self.assertFalse(caps.reasoning_request.supported)
+        self.assertEqual(caps.structured_output.mode, "json_object")
+        self.assertEqual(caps.structured_output.source, "custom_openai_compatible")
+
+    def test_capability_overrides_flip_source(self) -> None:
+        base = mp.build_profile_registry({})["primary"]
+        profile = replace(base, capability_overrides={
+            "remote_batch": False,
+            "structured_output": {"mode": "json_object"},
+            "context_limit_tokens": 1048576,
+        })
+        caps = mp.resolve_capabilities(profile)
+        self.assertFalse(caps.remote_batch.supported)
+        self.assertEqual(
+            caps.remote_batch.source, mp.CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+        )
+        self.assertEqual(
+            caps.structured_output.source, mp.CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+        )
+        self.assertEqual(caps.context_limit_tokens, 1048576)
+        self.assertEqual(
+            caps.context_source, mp.CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+        )
+
+
+class ValidateRoutingPlanTests(unittest.TestCase):
+    def test_default_plan_validates_cleanly(self) -> None:
+        plan = mp.resolve_routing_plan({})
+        self.assertEqual(
+            mp.validate_routing_plan(plan, environ={}, keyring_has_credential=None),
+            (),
+        )
+
+    def test_gemini_batch_rejects_non_gemini_profile(self) -> None:
+        # A provider-prefixed batch model keeps the litellm adapter, so the
+        # gemini_batch strategy must fail with machine-decidable missing
+        # capabilities.
+        plan = mp.resolve_routing_plan(
+            {"batch": {"model": "deepseek/deepseek-chat"}},
+            execution=mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+        issues = mp.validate_routing_plan(plan, environ={})
+        batch_issues = [
+            issue for issue in issues
+            if issue.stage in {"translation", "keyword", "revision"}
+        ]
+        self.assertTrue(batch_issues)
+        for issue in batch_issues:
+            self.assertEqual(issue.code, mp.MODEL_ROUTE_CAPABILITY_MISSING)
+            self.assertIn("remote_batch", issue.missing_capabilities)
+            self.assertIn("gemini_adapter", issue.missing_capabilities)
+
+    def test_litellm_bare_model_invalid(self) -> None:
+        plan = mp.resolve_routing_plan({
+            "sync": {"backend": "litellm", "model": "no-prefix-model"},
+        })
+        issues = mp.validate_routing_plan(plan, environ={})
+        self.assertTrue(any(
+            issue.code == mp.MODEL_PROFILE_INVALID and "provider prefix" in issue.message
+            for issue in issues
+        ))
+
+    def test_gemini_adapter_rejects_prefixed_model(self) -> None:
+        plan = mp.resolve_routing_plan({
+            "sync": {"backend": "gemini", "model": "deepseek/deepseek-chat"},
+        })
+        issues = mp.validate_routing_plan(plan, environ={})
+        self.assertTrue(any(
+            issue.code == mp.MODEL_PROFILE_INVALID
+            and issue.profile_id == "primary"
+            for issue in issues
+        ))
+
+    def test_env_credential_reference_missing(self) -> None:
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        caps = mp.resolve_capabilities(registry["primary"])
+        env_ref_profile = replace(
+            registry["primary"],
+            credential_ref=mp.CredentialRef(
+                mp.CREDENTIAL_KIND_ENV, "OPENCODE_GO_API_KEY",
+            ),
+        )
+        plan = mp.ModelRoutingPlan(
+            schema_version=mp.MODEL_PROFILE_SCHEMA_VERSION,
+            primary_profile_id="primary",
+            profiles={"primary": env_ref_profile},
+            routes={
+                "translation": mp.TaskRoute(
+                    "translation", "primary", mp.ExecutionStrategy.SYNC,
+                    mp.ROUTE_SOURCE_STAGE_CONFIG,
+                ),
+            },
+            capabilities={"primary": caps},
+        )
+        issues = mp.validate_routing_plan(plan, environ={})
+        self.assertTrue(any(
+            issue.code == mp.MODEL_PROFILE_CREDENTIAL_REF_MISSING
+            and "OPENCODE_GO_API_KEY" in issue.message
+            for issue in issues
+        ))
+        # The same plan validates when the environment provides the value.
+        self.assertEqual(
+            mp.validate_routing_plan(
+                plan, environ={"OPENCODE_GO_API_KEY": "x"},
+            ),
+            (),
+        )
+
+    def test_keyring_credential_only_flagged_with_probe(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {
+                "sync": {
+                    "backend": "litellm",
+                    "model": "opencode-go/glm-5.3",
+                },
+            },
+            custom_providers=_custom_providers(),
+        )
+        # Without a keyring probe the validator stays silent (it cannot know).
+        self.assertEqual(
+            mp.validate_routing_plan(
+                plan, environ={}, keyring_has_credential=None,
+            ),
+            (),
+        )
+        issues = mp.validate_routing_plan(
+            plan,
+            environ={},
+            keyring_has_credential=lambda name: False,
+        )
+        self.assertTrue(any(
+            issue.code == mp.MODEL_PROFILE_CREDENTIAL_REF_MISSING
+            and "opencode-go" in issue.message
+            for issue in issues
+        ))
+
+    def test_unknown_capability_override_flagged(self) -> None:
+        base = mp.build_profile_registry({})["primary"]
+        profile = replace(base, capability_overrides={"telepathy": True})
+        plan = mp.ModelRoutingPlan(
+            schema_version=mp.MODEL_PROFILE_SCHEMA_VERSION,
+            primary_profile_id="primary",
+            profiles={"primary": profile},
+            routes={
+                "translation": mp.TaskRoute(
+                    "translation", "primary", mp.ExecutionStrategy.SYNC,
+                    mp.ROUTE_SOURCE_STAGE_CONFIG,
+                ),
+            },
+            capabilities={"primary": mp.resolve_capabilities(profile)},
+        )
+        issues = mp.validate_routing_plan(plan, environ={})
+        self.assertTrue(any(
+            issue.code == mp.MODEL_PROFILE_INVALID and "telepathy" in issue.message
+            for issue in issues
+        ))
+
+    def test_routing_validation_error_contract(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"batch": {"model": "deepseek/deepseek-chat"}},
+            execution=mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+        issues = mp.validate_routing_plan(plan, environ={})
+        error = mp.routing_validation_error(issues)
+        # MachineContractError extends SystemExit so CLI guards can raise it
+        # straight through main().
+        self.assertIsInstance(error, SystemExit)
+        self.assertEqual(error.code_name, mp.MODEL_ROUTE_CAPABILITY_MISSING)
+        self.assertFalse(error.retryable)
+        self.assertEqual(error.suggested_action, "fix_translator_config")
+        self.assertEqual(error.details["missing_capabilities"], [
+            "gemini_adapter", "remote_batch",
+        ])
+
+
+class SerializationTests(unittest.TestCase):
+    def test_manifest_roundtrip(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {
+                "sync": {
+                    "backend": "litellm",
+                    "model": "opencode-go/glm-5.3",
+                    "models": ["opencode-go/glm-5.3", "opencode-go/glm-5.3-air"],
+                },
+                "batch": {
+                    "model": "gemini-2.5-flash",
+                    "project_analysis": {"model": "gemini-3.5-flash"},
+                },
+            },
+            custom_providers=_custom_providers(),
+            stage_overrides={"ab_experiment": "gemini-2.5-pro"},
+            created_at="2026-08-16T00:00:00Z",
+        )
+        restored = mp.ModelRoutingPlan.from_manifest_dict(
+            plan.to_manifest_dict(),
+        )
+        self.assertEqual(restored, plan)
+
+    def test_manifest_has_no_credential_values(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        payload = plan.to_manifest_dict()
+
+        def walk(node: object) -> None:
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    self.assertNotIn(
+                        key.lower(),
+                        {"api_key", "apikey", "value", "secret", "token"},
+                    )
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(payload)
+        text = json.dumps(payload)
+        # The env var NAME is a reference and may appear; a planted fake key
+        # value must never appear.
+        self.assertNotIn("sk-test-secret", text)
+
+    def test_manifest_credential_ref_shape(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        ref = plan.to_manifest_dict()["profiles"]["primary"]["credential_ref"]
+        self.assertEqual(set(ref), {"kind", "name", "env_name"})
+        self.assertEqual(ref["kind"], "keyring")
+        self.assertEqual(ref["name"], "opencode-go")
+        self.assertEqual(ref["env_name"], "OPENCODE_GO_API_KEY")
+
+
+class BuildSyncBackendTests(unittest.TestCase):
+    def test_litellm_backend_gets_custom_providers(self) -> None:
+        from litellm_sync_backend import LiteLLMSyncBackend
+
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        backend = mp.build_sync_backend(
+            registry["primary"],
+            custom_providers=_custom_providers(),
+        )
+        self.assertIsInstance(backend, LiteLLMSyncBackend)
+        self.assertEqual(backend._custom_providers.keys(), {"opencode-go"})
+
+    def test_gemini_backend_wiring(self) -> None:
+        import translator_runtime as runtime
+
+        registry = mp.build_profile_registry({})
+        with mock.patch.object(
+            runtime, "configure_genai", lambda: None,
+        ), mock.patch.object(
+            runtime, "create_genai_client", lambda: object(),
+        ):
+            backend = mp.build_sync_backend(registry["primary"])
+        self.assertIsInstance(backend, GeminiSyncBackend)
+        self.assertEqual(backend.provider, "gemini")
+
+    def test_unknown_adapter_refused(self) -> None:
+        profile = mp.ModelProfile(
+            id="x", label="x", adapter="carrier-pigeon", provider="x",
+            model="x", credential_ref=mp.CredentialRef("none"),
+        )
+        with self.assertRaises(ValueError):
+            mp.build_sync_backend(profile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -151,11 +151,11 @@ class ResolveRoutingPlanTests(unittest.TestCase):
         self.assertEqual(plan.primary_profile_id, "primary")
         expected = {
             "translation": ("primary", "sync", "builtin_default"),
-            "keyword": ("primary", "sync", "primary_inherited"),
-            "revision": ("primary", "sync", "primary_inherited"),
-            "project_analysis": ("primary", "sync", "primary_inherited"),
-            "final_review": ("batch", "gemini_batch", "primary_inherited"),
-            "ab_experiment": ("primary", "sync", "primary_inherited"),
+            "keyword": ("primary", "sync", "inherited"),
+            "revision": ("primary", "sync", "inherited"),
+            "project_analysis": ("primary", "sync", "inherited"),
+            "final_review": ("batch", "gemini_batch", "inherited"),
+            "ab_experiment": ("primary", "sync", "inherited"),
         }
         for stage, (profile_id, strategy, source) in expected.items():
             route = plan.routes[stage]
@@ -176,7 +176,7 @@ class ResolveRoutingPlanTests(unittest.TestCase):
         })
         self.assertEqual(
             plan_without_sync_model.routes["translation"].source,
-            mp.ROUTE_SOURCE_PRIMARY_INHERITED,
+            mp.ROUTE_SOURCE_INHERITED,
         )
 
     def test_batch_execution_routes(self) -> None:
@@ -273,6 +273,12 @@ class CapabilityTests(unittest.TestCase):
         self.assertTrue(caps.reasoning_request.supported)
         self.assertTrue(caps.usage_stats.supported)
         self.assertEqual(caps.structured_output.mode, "strict_json_schema")
+        self.assertEqual(
+            caps.structured_output.source, mp.CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+        )
+        self.assertEqual(
+            caps.structured_output.basis, mp.STRUCTURED_OUTPUT_BASIS_BUILTIN,
+        )
         for flag in (
             caps.sync_generation, caps.reasoning_request, caps.remote_batch,
         ):
@@ -292,7 +298,16 @@ class CapabilityTests(unittest.TestCase):
         self.assertFalse(caps.embedding.supported)
         self.assertFalse(caps.reasoning_request.supported)
         self.assertEqual(caps.structured_output.mode, "json_object")
-        self.assertEqual(caps.structured_output.source, "custom_openai_compatible")
+        # Provenance and mode-basis are separate vocabularies: the adapter
+        # table's "custom_openai_compatible" detail lives in basis, while
+        # source shares the capability-source vocabulary.
+        self.assertEqual(
+            caps.structured_output.source, mp.CAPABILITY_SOURCE_ADAPTER_DEFAULT,
+        )
+        self.assertEqual(
+            caps.structured_output.basis,
+            mp.STRUCTURED_OUTPUT_BASIS_CUSTOM_OPENAI_COMPATIBLE,
+        )
 
     def test_capability_overrides_flip_source(self) -> None:
         base = mp.build_profile_registry({})["primary"]
@@ -308,6 +323,10 @@ class CapabilityTests(unittest.TestCase):
         )
         self.assertEqual(
             caps.structured_output.source, mp.CAPABILITY_SOURCE_CONFIG_OVERRIDE,
+        )
+        # An override keeps the basis of the adapter default it replaced.
+        self.assertEqual(
+            caps.structured_output.basis, mp.STRUCTURED_OUTPUT_BASIS_BUILTIN,
         )
         self.assertEqual(caps.context_limit_tokens, 1048576)
         self.assertEqual(
@@ -462,10 +481,85 @@ class ValidateRoutingPlanTests(unittest.TestCase):
         self.assertIsInstance(error, SystemExit)
         self.assertEqual(error.code_name, mp.MODEL_ROUTE_CAPABILITY_MISSING)
         self.assertFalse(error.retryable)
-        self.assertEqual(error.suggested_action, "fix_translator_config")
+        # The next action is mapped per code, not hard-coded: a capability
+        # mismatch asks for a different fix than an invalid profile.
+        self.assertEqual(
+            error.suggested_action, "choose_supported_strategy_or_profile",
+        )
         self.assertEqual(error.details["missing_capabilities"], [
             "gemini_adapter", "remote_batch",
         ])
+
+    def test_suggested_action_per_code(self) -> None:
+        registry = mp.build_profile_registry(
+            {"sync": {"backend": "litellm", "model": "opencode-go/glm-5.3"}},
+            custom_providers=_custom_providers(),
+        )
+        caps = mp.resolve_capabilities(
+            registry["primary"], custom_providers=_custom_providers(),
+        )
+        routes = {
+            "translation": mp.TaskRoute(
+                "translation", "primary", mp.ExecutionStrategy.SYNC,
+                mp.ROUTE_SOURCE_STAGE_CONFIG,
+            ),
+        }
+        for code, expected_action in (
+            (mp.MODEL_PROFILE_INVALID, "fix_translator_config"),
+            (mp.MODEL_PROFILE_CREDENTIAL_REF_MISSING,
+             "inspect_configuration_and_artifacts"),
+        ):
+            if code == mp.MODEL_PROFILE_INVALID:
+                profile = replace(
+                    registry["primary"], capability_overrides={"nope": True},
+                )
+            else:
+                profile = replace(
+                    registry["primary"],
+                    credential_ref=mp.CredentialRef(
+                        mp.CREDENTIAL_KIND_ENV, "DEFINITELY_UNSET_ENV",
+                    ),
+                )
+            plan = mp.ModelRoutingPlan(
+                schema_version=mp.MODEL_PROFILE_SCHEMA_VERSION,
+                primary_profile_id="primary",
+                profiles={"primary": profile},
+                routes=routes,
+                capabilities={"primary": caps},
+            )
+            issues = tuple(
+                issue for issue in mp.validate_routing_plan(plan, environ={})
+                if issue.code == code
+            )
+            self.assertTrue(issues, code)
+            error = mp.routing_validation_error(issues)
+            self.assertEqual(error.code_name, code)
+            self.assertEqual(error.suggested_action, expected_action)
+
+
+class SlotIdNamespaceTests(unittest.TestCase):
+    """Resolver slot ids are reserved; #348 user ids must not collide."""
+
+    def test_reserved_slot_detection(self) -> None:
+        for slot in (
+            "primary", "batch",
+            "project_analysis_model", "final_review_model",
+            "project_analysis_override", "ab_experiment_override",
+        ):
+            self.assertTrue(mp.is_profile_slot_id(slot), slot)
+        for user_id in ("glm-main", "kimi-k3", "gemini33", "ds_v4", "x-y_z"):
+            self.assertFalse(mp.is_profile_slot_id(user_id), user_id)
+
+    def test_user_profile_id_rules(self) -> None:
+        self.assertEqual(mp.user_profile_id_error("glm-main"), "")
+        # Wrong shape.
+        self.assertIn("must match", mp.user_profile_id_error("GLM Main"))
+        self.assertIn("must match", mp.user_profile_id_error(""))
+        # Reserved slots are off-limits for user ids.
+        self.assertIn("reserved", mp.user_profile_id_error("primary"))
+        self.assertIn(
+            "reserved", mp.user_profile_id_error("translation_model"),
+        )
 
 
 class SerializationTests(unittest.TestCase):
@@ -486,6 +580,13 @@ class SerializationTests(unittest.TestCase):
             stage_overrides={"ab_experiment": "gemini-2.5-pro"},
             created_at="2026-08-16T00:00:00Z",
         )
+        plan = replace(plan, config_origins=(
+            mp.ConfigOrigin(
+                kind="translator_config",
+                path="work/translator_config.json",
+                fingerprint="sha256:abc123",
+            ),
+        ))
         restored = mp.ModelRoutingPlan.from_manifest_dict(
             plan.to_manifest_dict(),
         )


### PR DESCRIPTION
## Summary

Issue #345 P1（共三阶段中的第一阶段）：新增 Provider 无关、执行方式无关的模型路由契约模块，**纯新增，零生产行为变化**——运行时尚无任何入口导入该模块。

- `model_profile.py`：
  - `ModelProfile` / `ModelCapabilities` / `ExecutionStrategy`（`sync` / `gemini_batch`）/ `TaskRoute` / `ModelRoutingPlan`（不可变 run 快照），序列化版本 `MODEL_PROFILE_SCHEMA_VERSION = 1`
  - 凭据只存引用（`CredentialRef{kind,name,env_name}`），manifest 序列化经测试保证零凭据值泄露
  - 旧 `sync.*` / `batch.*` 配置只读解析；**显式阶段模型优先于 primary 回退**（issue 评审中批准的选项 B 语义，行为变更在 P2 接线时才生效）
  - 能力默认值来自 adapter 内置表（gemini / litellm 各一套），每项带来源（`adapter_default` / `probed` / `config_override`），无模型名字符串分支
  - `validate_routing_plan` 返回机器可判定问题清单；错误码 `MODEL_PROFILE_INVALID` / `MODEL_ROUTE_CAPABILITY_MISSING` / `MODEL_PROFILE_CREDENTIAL_REF_MISSING`（复用 `MachineContractError`；文档注册在 P3）
  - `build_sync_backend` 工厂镜像现行生产接线（gemini 直连 / LiteLLM + 自定义 provider registry）
- `tests/test_model_profile.py`：34 个测试，覆盖 registry 三类 profile（内置 Gemini / LiteLLM 内置 / 自定义 OpenAI 兼容）、路由组合矩阵、选项 B 语义、能力来源与覆盖、校验失败类别（含自定义 provider + gemini_batch、缺凭据引用）、序列化 round-trip、快照不可变性、工厂构造。

## 变更范围

| 文件 | 变化 |
|---|---|
| `model_profile.py` | 新增（~900 行含 docstring） |
| `tests/test_model_profile.py` | 新增 |

不触碰 `gemini_translate_batch.py` / `translator_runtime.py`，与进行中的 #363 完全错开。

## 与 #345 工作范围的对应

- [x] 定义 dataclass/schema 并明确序列化版本
- [x] profile registry 与统一 resolver（只读解析旧配置）
- [x] 静态校验，返回机器可判定的错误类别（连接诊断与 fail-fast 接线在 P3）
- [x] 单元测试：内置 Gemini、LiteLLM 内置 Provider、自定义 Provider、缺失凭据引用、不支持的策略组合
- [ ] Gemini/LiteLLM 统一 adapter 接口接线、五阶段入口收敛（P2）
- [ ] manifest 快照写回（P2）
- [ ] 文档/doctor/错误码注册（P3）

## 验证

- `python -m unittest tests.test_model_profile` — 34 passed
- `python -B tests/run_cli_tests.py -q` — 1302 passed (1 skipped)
- `python scripts/run_quality_gates.py all` — 全部 blocking gates 通过
- `git diff --check` — 干净

## 后续

- schema 摘要已贴 issue #345 请 K3 评审定稿：https://github.com/hu-border-collie/renpy-translation-lab/issues/345#issuecomment-5307546330
- P2（`codex/issue-345-p2-route-wiring`）：五阶段接线 + manifest `model_routing` 快照 + 删除 `SYNC_MODEL or model_name` 覆盖（含 2 处锁定测试更新与 CHANGELOG 行为变更记录），待 schema 定稿后开工。

Part of #345（P1/3 阶段交付；issue 整体在 P3 完成后手动关闭，本 PR 不使用 closing keyword）。


