### PR TITLE
fix(gui): isolate GUI tests from user LiteLLM cache (#370)

### DIFF
--- a/docs/gui_tests_sandbox_notes.md
+++ b/docs/gui_tests_sandbox_notes.md
@@ -1,7 +1,8 @@
 # GUI 测试在 Codex 沙箱环境卡住：调查报告
 
-> 结论先行：**不是测试代码问题，也不是机器负载问题，而是 Codex 沙箱的写限制**。
-> GUI 测试在运行时会真实写入 `%LOCALAPPDATA%\renpy-translation-lab\litellm_catalog_cache.json`
+> 结论先行：历史根因是 **Codex 沙箱的写限制**，不是测试代码逻辑或机器负载问题。
+> 在 issue #370 的测试隔离落地前，GUI 测试会真实写入
+> `%LOCALAPPDATA%\renpy-translation-lab\litellm_catalog_cache.json`
 > （LiteLLM 模型选择缓存，属 GUI 正常运行行为）。该路径不在 Codex 沙箱的可写范围内，
 > 写入被拦截后表现为挂起或 `PermissionError`，导致整个 GUI 测试套件卡死。
 
@@ -98,20 +99,22 @@ tempfile._mkstemp_inner
 
 ### 在 Codex 会话内
 
-- 自 #369 起，GUI 运行时的 LiteLLM 缓存会在默认目录不可写时自动回退到系统临时目录，
-  沙箱内跑 GUI 全量测试不再卡在缓存写入上；如仍想缩小范围，可只跑改动相关文件（如
-  `python -m unittest tests.test_gui_settings_schema tests.test_gui_sync_translation_report`）。
-- 确需排除运行时环境因素时，可在沙箱外运行（需要用户批准 escalation），例如直接在本机终端执行
-  `python -B tests/run_gui_tests.py -q`。
+- 自 #370 起，GUI 测试通过 `tests/gui_test_support.py` 使用一次性临时目录缓存，
+  不再读取/写入用户级 `%LOCALAPPDATA%\renpy-translation-lab\litellm_catalog_cache.json`，
+  因此可以直接运行 GUI 全量测试，例如 `python -B tests/run_gui_tests.py -q`。
+- 自 #369 起，真实 GUI 运行时的 LiteLLM 缓存会在默认目录不可写时自动回退到系统临时目录，
+  沙箱内跑真实 GUI 也不再卡在缓存写入上。
+- 在 #369 / #370 修复落地前的旧版本上，建议只跑改动相关文件（如
+  `python -m unittest tests.test_gui_settings_schema tests.test_gui_sync_translation_report`）；
+  确需全量时在沙箱外运行（需要用户批准 escalation）。
 
 ### 长期建议（可选）
 
-- 代码已实现自动回退（默认目录不可写时改用系统临时目录），沙箱与只读 home 场景都
-  不再依赖修改 Codex 沙箱配置；若仍希望缓存跨重启持久化，可在 Codex 沙箱配置中把
-  `%LOCALAPPDATA%\renpy-translation-lab` 加入可写范围；
+- 自 #370 起，GUI 测试通过 `tests/gui_test_support.py` 将默认 LiteLLM 缓存指向一次性临时目录，
+  不再读取/写入用户级 `%LOCALAPPDATA%\renpy-translation-lab\litellm_catalog_cache.json`；
+  因此在沙箱内跑 GUI 全量测试时，无需再为测试进程放行该路径。
+- 真实 GUI 运行时仍会写入用户级缓存；代码已实现自动回退（默认目录不可写时改用系统临时目录），
+  沙箱与只读 home 场景都不再依赖修改 Codex 沙箱配置。若仍希望缓存跨重启持久化，可在 Codex
+  沙箱配置中把 `%LOCALAPPDATA%\renpy-translation-lab` 加入可写范围；
 - 注意：shell 命令超时**不会杀死残留的 Python 测试进程**，排查时先
   `Get-Process | Where-Object { $_.ProcessName -like '*python*' }` 确认无残留再重跑。
-- 测试隔离提醒：GUI 测试共享用户级 LiteLLM 缓存（默认目录不可写时位于系统临时目录），
-  若缓存中存在历史 provider/model 选择，`test_workspace_action_bar_uses_immediate_save_context`
-  可能偶发判定“有未保存的更改”而失败；清理缓存（如删除 `%TEMP%\renpy-translation-lab`）后
-  全量可稳定通过。该问题在正常 Windows 环境同样存在，属于测试共享状态的既有隔离缺陷。

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -14497,6 +14497,14 @@ class MainWindow(QMainWindow):
             # Partial tab loads must not rewrite the whole baseline — that would
             # treat dirty widgets on other open pages as "already saved".
             self._update_config_ui_saved_snapshot(pages=want)
+        # A settings page load can pass through a transient "unsaved changes"
+        # state (for example while cached LiteLLM selections are populated
+        # before the saved baseline is captured).  Re-sync the workspace action
+        # bar now that loading is finished and the saved snapshot is current.
+        if "settings_action_context_label" in self.__dict__:
+            self._sync_settings_action_bar_enabled(
+                task_running=bool(getattr(self, "_task_running", False))
+            )
         if refresh_task_gates and "translate_btn" in self.__dict__:
             self._set_task_running(bool(getattr(self, "_task_running", False)))
 

--- a/tests/gui_test_support.py
+++ b/tests/gui_test_support.py
@@ -18,7 +18,9 @@ Use in test modules::
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import sys
+import tempfile
 import unittest
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -31,6 +33,33 @@ _T = TypeVar("_T", bound=type)
 # thread: the import takes ~10s on machines with the optional dependency and a
 # QThread destroyed while still importing aborts the process.
 os.environ.setdefault("RTL_DISABLE_LITELLM_WARMUP", "1")
+
+# Isolate GUI tests from the developer/user-level LiteLLM catalog cache.
+# MainWindow constructs LiteLLMCatalogCache() without an explicit path, so on
+# machines with real cached provider/model selections the settings layout tests
+# could pick up stale state and report transient "unsaved changes".  Point the
+# default cache at a fresh per-run temp directory instead.
+_GUI_TEST_LITELLM_CACHE_DIR = Path(
+    tempfile.mkdtemp(prefix="renpy-translation-lab-test-litellm-cache-")
+)
+os.environ["LOCALAPPDATA"] = str(_GUI_TEST_LITELLM_CACHE_DIR)
+os.environ["XDG_STATE_HOME"] = str(_GUI_TEST_LITELLM_CACHE_DIR)
+
+
+def _test_litellm_catalog_cache_path() -> Path:
+    return _GUI_TEST_LITELLM_CACHE_DIR / "litellm_catalog_cache.json"
+
+
+try:
+    import gui_qt.litellm_catalog_cache as _litellm_catalog_cache_module
+except ImportError:
+    # The environment overrides above cover Windows/Linux even when the GUI
+    # package has not been imported yet (e.g. non-GUI helper tests).
+    pass
+else:
+    _litellm_catalog_cache_module.default_litellm_catalog_cache_path = (
+        _test_litellm_catalog_cache_path
+    )
 
 
 class GuiTestModalGuard:

--- a/tests/test_gui_settings_layout.py
+++ b/tests/test_gui_settings_layout.py
@@ -135,6 +135,47 @@ class GuiSettingsLayoutTests(unittest.TestCase):
         ):
             self.assertFalse(button.isHidden())
 
+    def test_workspace_action_bar_refreshes_after_config_load_completes(self) -> None:
+        workspace_row = self.window._settings_nav_rows["workspace"]
+        self.window.settings_nav.setCurrentRow(workspace_row)
+        _process(self._app, 5)
+        self.assertEqual(
+            self.window.settings_action_context_label.property("tone"),
+            "muted",
+        )
+
+        # Simulate the stale UNSAVED label that can appear while a settings page
+        # is populated from the user-level LiteLLM catalog cache.
+        original = self.window._config_tab_has_unsaved_changes
+        self.window._config_tab_has_unsaved_changes = lambda: True
+        try:
+            self.window._sync_settings_action_bar_enabled(
+                task_running=False,
+                nav_row=workspace_row,
+            )
+            self.assertEqual(
+                self.window.settings_action_context_label.text(),
+                "其他设置有未保存的更改；可保存、重新加载放弃，或切换项目时再处理。",
+            )
+            self.assertEqual(
+                self.window.settings_action_context_label.property("tone"),
+                "warning",
+            )
+        finally:
+            self.window._config_tab_has_unsaved_changes = original
+
+        # Loading config again must refresh the saved snapshot and recompute the
+        # action bar, dropping the stale UNSAVED variant.
+        self.window._load_config_to_ui(refresh_task_gates=False)
+        self.assertEqual(
+            self.window.settings_action_context_label.text(),
+            "项目列表操作即时保存，不受设置保存按钮影响。",
+        )
+        self.assertEqual(
+            self.window.settings_action_context_label.property("tone"),
+            "muted",
+        )
+
     def test_shortcuts_section_lists_core_bindings(self) -> None:
         from PySide6.QtWidgets import QLabel
 


### PR DESCRIPTION
## Summary

Fixes #370.

- Isolate GUI tests from the developer/user-level LiteLLM catalog cache in `tests/gui_test_support.py` by pointing the default cache at a fresh temporary directory.
- Re-sync the Settings workspace action bar after config loading finishes in `gui_qt/app.py`, so a stale UNSAVED label is dropped once the saved snapshot is current.
- Add a regression test covering the action-bar refresh path.
- Update `docs/gui_tests_sandbox_notes.md` to reflect that GUI tests no longer write to the user-level cache.

## Verification

- `python3 -m py_compile` passes for modified files.
- Verified `gui_test_support` redirects the default LiteLLM cache to a per-run temp directory.
- The current sandbox does not have PySide6 installed, so the GUI test suite could not be run locally; CI should run the GUI tests.