### PR TITLE
feat(model): wire #345 P2 TaskRoute into all sync entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 变更
 
+- 同步请求不再用 `sync.model` 覆盖调用方传入的阶段模型。显式 `TaskRoute` / 阶段配置优先，`sync.model` 只作为未单独配置阶段的 primary 回退；一次 run 开始时冻结 `ModelRoutingPlan`，中途改配置或重试不会换 profile。sync 与 translation / keyword / revision / final_review 四类 batch manifest 写入 `model_routing` 快照（仅凭据引用，不含凭据值）。
 - GUI 异步任务完成时会比对项目路径、配置 digest 和 LiteLLM 连接参数身份；过期结果只做清理，不再覆盖当前界面。
 - GUI 改为统一侧边导航与任务页自有状态，项目列表、上下文库、关键词、订正、同步翻译和批量翻译各自展示当前任务结果。
 - 同步翻译默认只生成 diff 与 manifest 预览，必须显式确认后才写回；写回时重新校验项目、源快照和预览制品。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 变更
 
-- 同步请求不再用 `sync.model` 覆盖调用方传入的阶段模型。显式 `TaskRoute` / 阶段配置优先，`sync.model` 只作为未单独配置阶段的 primary 回退；一次 run 开始时冻结 `ModelRoutingPlan`，中途改配置或重试不会换 profile。sync 与 translation / keyword / revision / final_review 四类 batch manifest 写入 `model_routing` 快照（仅凭据引用，不含凭据值）。
+- 同步请求不再用 `sync.model` 覆盖调用方传入的阶段模型。显式 `TaskRoute` / 阶段配置优先，`sync.model` 只作为未单独配置阶段的 primary 回退；一次 run 开始时冻结 `ModelRoutingPlan`，中途改配置或重试不会换 profile。sync 与 translation / keyword / revision / final_review 四类 batch manifest 写入 `model_routing` 快照（仅凭据引用，不含凭据值）。没有 `model_routing` 的旧 manifest 在 probe / resume / execute 时继续使用当时记录的 `model` / `batch_model` / `provider`，不会改用当前运行时模型。
 - GUI 异步任务完成时会比对项目路径、配置 digest 和 LiteLLM 连接参数身份；过期结果只做清理，不再覆盖当前界面。
 - GUI 改为统一侧边导航与任务页自有状态，项目列表、上下文库、关键词、订正、同步翻译和批量翻译各自展示当前任务结果。
 - 同步翻译默认只生成 diff 与 manifest 预览，必须显式确认后才写回；写回时重新校验项目、源快照和预览制品。

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -12456,6 +12456,14 @@ def _routing_config_origins():
     )
 
 
+def _runtime_custom_providers():
+    return {
+        key: value
+        for key, value in (getattr(legacy, 'CUSTOM_LITELLM_PROVIDERS', None) or {}).items()
+        if getattr(value, 'requires_key', None) is not None
+    } or None
+
+
 def freeze_runtime_routing_plan(
     *,
     execution=model_profile.ExecutionStrategy.SYNC,
@@ -12470,11 +12478,7 @@ def freeze_runtime_routing_plan(
         project_analysis_model=PROJECT_ANALYSIS_MODEL,
         final_review_model=FINAL_REVIEW_MODEL,
         sync_models=tuple(getattr(legacy, 'MODELS', ()) or ()),
-        custom_providers={
-            key: value
-            for key, value in (getattr(legacy, 'CUSTOM_LITELLM_PROVIDERS', None) or {}).items()
-            if getattr(value, 'requires_key', None) is not None
-        } or None,
+        custom_providers=_runtime_custom_providers(),
         execution=execution,
         stage_overrides=stage_overrides,
         created_at=created_at,
@@ -12495,8 +12499,23 @@ def attach_model_routing(manifest, plan):
     return plan
 
 
+def _legacy_manifest_recorded_models(manifest):
+    """Return ``(model, batch_model, provider)`` persisted on a pre-snapshot run."""
+    payload = manifest or {}
+    return (
+        str(payload.get('model') or '').strip(),
+        str(payload.get('batch_model') or '').strip(),
+        str(payload.get('provider') or '').strip(),
+    )
+
+
 def resolve_manifest_routing_plan(manifest, *, execution=None, stage_overrides=None):
-    """Return the frozen plan for a run, preferring the manifest snapshot."""
+    """Return the frozen plan for a run, preferring the manifest snapshot.
+
+    Old manifests without ``model_routing`` keep the model recorded on that
+    manifest (``model`` / ``batch_model`` / ``provider``). Live ``SYNC_MODEL``
+    / ``BATCH_MODEL`` are used only when those fields are also missing.
+    """
     plan = routing_plan_from_manifest(manifest)
     if plan is not None:
         return plan
@@ -12506,9 +12525,29 @@ def resolve_manifest_routing_plan(manifest, *, execution=None, stage_overrides=N
             if str((manifest or {}).get('execution') or '') == 'sync'
             else model_profile.ExecutionStrategy.GEMINI_BATCH
         )
-    return freeze_runtime_routing_plan(
+    persisted_model, persisted_batch, persisted_provider = (
+        _legacy_manifest_recorded_models(manifest)
+    )
+    recorded = persisted_model or persisted_batch
+    merged_overrides = dict(stage_overrides or {})
+    if not recorded:
+        return freeze_runtime_routing_plan(
+            execution=execution,
+            stage_overrides=merged_overrides or None,
+        )
+    stage = model_profile.stage_for_manifest_mode(manifest_mode(manifest))
+    merged_overrides.setdefault(stage, recorded)
+    return model_profile.resolve_routing_plan_from_runtime(
+        sync_backend=persisted_provider or SYNC_BACKEND,
+        sync_model=persisted_model,
+        batch_model=persisted_batch or persisted_model,
+        project_analysis_model=PROJECT_ANALYSIS_MODEL,
+        final_review_model=FINAL_REVIEW_MODEL,
+        sync_models=tuple(getattr(legacy, 'MODELS', ()) or ()),
+        custom_providers=_runtime_custom_providers(),
         execution=execution,
-        stage_overrides=stage_overrides,
+        stage_overrides=merged_overrides or None,
+        config_origins=_routing_config_origins(),
     )
 
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -57,6 +57,7 @@ from engine_adapters.writeback import (
 )
 import keyword_glossary_merge
 import keyword_history
+import model_profile
 import model_usage_ledger
 import prompt_context
 import revision_corpus
@@ -76,7 +77,6 @@ from project_version import __version__
 from sync_model_backend import (
     DEFAULT_SYNC_RETRY_ATTEMPTS,
     DEFAULT_SYNC_TIMEOUT_SECONDS,
-    GeminiSyncBackend,
     SyncGenerationRequest,
     normalize_sync_timeout_seconds,
     sync_recovery_decision,
@@ -2803,6 +2803,8 @@ def create_batch_package_dir(package_name):
 
 
 def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
+    if source_manifest.get('model_routing'):
+        part_manifest['model_routing'] = copy.deepcopy(source_manifest.get('model_routing'))
     if source_manifest.get('keyword_settings'):
         part_manifest['keyword_settings'] = dict(source_manifest.get('keyword_settings') or {})
     if source_manifest.get('revision_settings'):
@@ -3515,6 +3517,12 @@ def create_batch_package(display_name_override='', skip_prepare=False):
         },
         'chunks': chunks,
     }
+    attach_model_routing(
+        manifest,
+        freeze_runtime_routing_plan(
+            execution=model_profile.ExecutionStrategy.GEMINI_BATCH,
+        ),
+    )
 
     manifest_path = os.path.join(package_dir, 'manifest.json')
     manifest['_manifest_path'] = manifest_path
@@ -4581,6 +4589,13 @@ def create_revision_package(display_name_override='', skip_prepare=False, chunk_
         }
         manifest['story_memory_summary'] = summarize_batch_story_memory(chunks)
 
+    attach_model_routing(
+        manifest,
+        freeze_runtime_routing_plan(
+            execution=model_profile.ExecutionStrategy.GEMINI_BATCH,
+        ),
+    )
+
     manifest_path = os.path.join(package_dir, 'manifest.json')
     with open(manifest_path, 'w', encoding='utf-8') as handle:
         json.dump(manifest, handle, ensure_ascii=False, indent=2)
@@ -5244,6 +5259,9 @@ def create_final_review_package(
             'build_warnings': get_batch_risk_warnings(),
             'input_jsonl_path': requests_path,
             'request_count': request_count,
+            'model_routing': freeze_runtime_routing_plan(
+                execution=model_profile.ExecutionStrategy.GEMINI_BATCH,
+            ).to_manifest_dict(),
         },
     )
     # batch_cost_estimate uses summary.chunk_count for max output tokens.
@@ -5646,6 +5664,12 @@ def create_keyword_package(display_name_override='', skip_prepare=True, chunk_si
         },
         'chunks': chunks,
     }
+    attach_model_routing(
+        manifest,
+        freeze_runtime_routing_plan(
+            execution=model_profile.ExecutionStrategy.GEMINI_BATCH,
+        ),
+    )
 
     manifest_path = os.path.join(package_dir, 'manifest.json')
     with open(manifest_path, 'w', encoding='utf-8') as handle:
@@ -10626,7 +10650,8 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
             str(manifest.get('_manifest_path') or '').encode('utf-8')
         ).hexdigest()[:20]
     )
-    client = create_batch_client(api_key_index=api_key_index)
+    routing_plan = resolve_manifest_routing_plan(manifest)
+    probe_route = route_for_manifest(routing_plan, manifest)
     summary = {
         'sample_count': len(sample),
         'parse_ok': 0,
@@ -10640,7 +10665,7 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
     for index, (row, chunk) in enumerate(zip(sample, sample_chunks), start=1):
         key = str(row.get('key') or '')
         request_payload = row.get('request') or {}
-        model_name = str(manifest.get('batch_model') or BATCH_MODEL or '')
+        model_name = route_model(routing_plan, probe_route)
         config = filter_gemini_generation_config(
             model_name,
             request_payload.get('generation_config') or {},
@@ -10661,22 +10686,20 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
         finish_reason = ''
         usage_metadata = {}
         response_text = ''
+        result = None
         try:
-            backend = GeminiSyncBackend(
-                client,
-                serialize_response=serialize_unknown,
-                extract_text=extract_text_from_response_payload,
-                extract_finish_reason=extract_finish_reason,
-                extract_usage=lambda payload: summarize_usage_metadata(extract_usage_metadata(payload)),
+            probe_payload = dict(request_payload)
+            probe_payload['generation_config'] = config
+            raw = run_sync_request(
+                probe_payload,
+                probe_route,
+                plan=routing_plan,
+                api_key_index=api_key_index,
             )
-            result = backend.generate(SyncGenerationRequest(
-                model=model_name,
-                contents=request_payload.get('contents') or [],
-                config=config,
-            ))
-            finish_reason = result.finish_reason
-            usage_metadata = dict(result.usage_metadata)
-            response_text = result.response_text
+            finish_reason = raw.get('finish_reason') or ''
+            usage_metadata = dict(raw.get('usage_metadata') or {})
+            response_text = raw.get('response_text') or ''
+            result = raw
         except Exception as exc:
             summary['request_errors'] += 1
             parse_error = str(exc)
@@ -10684,7 +10707,7 @@ def probe_requests(target=None, limit=3, offset=0, api_key_index=None):
             record_generation_usage_best_effort(
                 task_mode='analysis',
                 stage='probe',
-                result=_sync_result_to_dict(result),
+                result=result if isinstance(result, dict) else _sync_result_to_dict(result),
                 operation_id=usage_operation_id,
                 run_id=usage_run_id,
                 source_key=str(key),
@@ -12406,7 +12429,160 @@ def _run_sync_backend_with_retry(
     raise RuntimeError('Sync request failed without a captured exception.')
 
 
-def run_sync_request(request_payload, model_name, api_key_index=None):
+def _routing_config_origins():
+    path = str(getattr(legacy, 'TRANSLATOR_CONFIG', '') or '')
+    if not path:
+        return ()
+    view = {
+        'sync': {
+            'backend': SYNC_BACKEND,
+            'model': SYNC_MODEL,
+        },
+        'batch': {
+            'model': BATCH_MODEL,
+            'project_analysis': {'model': PROJECT_ANALYSIS_MODEL},
+            'final_review': {'model': FINAL_REVIEW_MODEL},
+        },
+    }
+    fingerprint = 'sha256:' + hashlib.sha256(
+        json.dumps(view, ensure_ascii=False, sort_keys=True, separators=(',', ':')).encode('utf-8')
+    ).hexdigest()
+    return (
+        model_profile.ConfigOrigin(
+            kind='translator_config',
+            path=path,
+            fingerprint=fingerprint,
+        ),
+    )
+
+
+def freeze_runtime_routing_plan(
+    *,
+    execution=model_profile.ExecutionStrategy.SYNC,
+    stage_overrides=None,
+    created_at='',
+):
+    """Snapshot routing from currently loaded globals. Call once at run start."""
+    return model_profile.resolve_routing_plan_from_runtime(
+        sync_backend=SYNC_BACKEND,
+        sync_model=SYNC_MODEL,
+        batch_model=BATCH_MODEL,
+        project_analysis_model=PROJECT_ANALYSIS_MODEL,
+        final_review_model=FINAL_REVIEW_MODEL,
+        sync_models=tuple(getattr(legacy, 'MODELS', ()) or ()),
+        custom_providers={
+            key: value
+            for key, value in (getattr(legacy, 'CUSTOM_LITELLM_PROVIDERS', None) or {}).items()
+            if getattr(value, 'requires_key', None) is not None
+        } or None,
+        execution=execution,
+        stage_overrides=stage_overrides,
+        created_at=created_at,
+        config_origins=_routing_config_origins(),
+    )
+
+
+def routing_plan_from_manifest(manifest):
+    payload = (manifest or {}).get('model_routing')
+    if not isinstance(payload, dict) or not payload:
+        return None
+    return model_profile.ModelRoutingPlan.from_manifest_dict(payload)
+
+
+def attach_model_routing(manifest, plan):
+    """Write the frozen plan snapshot onto a manifest dict."""
+    manifest['model_routing'] = plan.to_manifest_dict()
+    return plan
+
+
+def resolve_manifest_routing_plan(manifest, *, execution=None, stage_overrides=None):
+    """Return the frozen plan for a run, preferring the manifest snapshot."""
+    plan = routing_plan_from_manifest(manifest)
+    if plan is not None:
+        return plan
+    if execution is None:
+        execution = (
+            model_profile.ExecutionStrategy.SYNC
+            if str((manifest or {}).get('execution') or '') == 'sync'
+            else model_profile.ExecutionStrategy.GEMINI_BATCH
+        )
+    return freeze_runtime_routing_plan(
+        execution=execution,
+        stage_overrides=stage_overrides,
+    )
+
+
+def route_for_manifest(plan, manifest):
+    stage = model_profile.stage_for_manifest_mode(manifest_mode(manifest))
+    try:
+        return plan.routes[stage]
+    except KeyError as exc:
+        raise ValueError(
+            f'Frozen routing plan has no route for stage {stage}.'
+        ) from exc
+
+
+def route_model(plan, route):
+    return model_profile.profile_for_route(plan, route).model
+
+
+def _require_task_route(route):
+    if not isinstance(route, model_profile.TaskRoute):
+        raise TypeError(
+            'run_sync_request requires an explicit TaskRoute; '
+            f'got {type(route).__name__}.'
+        )
+    return route
+
+
+def build_project_analysis_sync_runner(plan, route):
+    """Return the shipped project-analysis generate callback.
+
+    Freezes the TaskRoute/plan at construction time so retries and later
+    config mutations cannot switch profiles.
+    """
+    from sync_model_backend import SYNC_EXECUTION_MODE, SyncGenerationResult
+
+    route = _require_task_route(route)
+
+    def _generate(request):
+        payload = {
+            'contents': request.contents,
+            'generation_config': dict(request.config or {}),
+        }
+        system = (request.config or {}).get('system_instruction')
+        if system:
+            payload['system_instruction'] = system
+        raw = run_sync_request(payload, route, plan=plan)
+        return SyncGenerationResult(
+            provider=str(raw.get('provider') or SYNC_BACKEND or 'gemini'),
+            model=str(raw.get('model') or route_model(plan, route)),
+            execution_mode=str(raw.get('execution_mode') or SYNC_EXECUTION_MODE),
+            response_payload=raw.get('response_payload') or raw,
+            response_text=str(raw.get('response_text') or ''),
+            finish_reason=str(raw.get('finish_reason') or ''),
+            usage_metadata=dict(raw.get('usage_metadata') or {}),
+            output_diagnostics=dict(raw.get('output_diagnostics') or {}),
+            request_metadata=dict(raw.get('request_metadata') or {}),
+        )
+
+    return _generate
+
+
+def run_sync_request(request_payload, route, plan=None, *, api_key_index=None):
+    """Execute one sync request using a frozen TaskRoute.
+
+    The model comes from ``plan.profiles[route.profile_id]``. ``SYNC_MODEL``
+    is never consulted here; callers must freeze a :class:`ModelRoutingPlan`
+    at run start and pass that snapshot.
+    """
+    route = _require_task_route(route)
+    if plan is None:
+        raise TypeError(
+            'run_sync_request requires the frozen ModelRoutingPlan from run start.'
+        )
+    profile = model_profile.profile_for_route(plan, route)
+    effective_model = profile.model
     config = dict(request_payload.get('generation_config') or {})
     config['timeout'] = SYNC_TIMEOUT_SECONDS
     system_instruction = request_payload.get('system_instruction')
@@ -12415,15 +12591,13 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
     safety_settings = request_payload.get('safety_settings')
     if safety_settings:
         config['safety_settings'] = safety_settings
-    effective_model = SYNC_MODEL or model_name
     config = filter_gemini_generation_config(effective_model, config)
 
-    if SYNC_BACKEND == 'litellm':
+    if profile.adapter == model_profile.ADAPTER_LITELLM:
         if api_key_index is not None:
             raise SystemExit('--api-key-index is only supported by the Gemini sync backend.')
-        from litellm_sync_backend import LiteLLMSyncBackend
-
-        backend = LiteLLMSyncBackend(
+        backend = model_profile.build_sync_backend(
+            profile,
             custom_providers=legacy.CUSTOM_LITELLM_PROVIDERS,
         )
         request = SyncGenerationRequest(
@@ -12452,12 +12626,15 @@ def run_sync_request(request_payload, model_name, api_key_index=None):
     for attempt in range(1, attempts + 1):
         client = create_batch_client(api_key_index=api_key_index)
         try:
-            backend = GeminiSyncBackend(
-                client,
+            backend = model_profile.build_sync_backend(
+                profile,
+                client=client,
                 serialize_response=serialize_unknown,
                 extract_text=extract_text_from_response_payload,
                 extract_finish_reason=extract_finish_reason,
-                extract_usage=lambda payload: summarize_usage_metadata(extract_usage_metadata(payload)),
+                extract_usage=lambda payload: summarize_usage_metadata(
+                    extract_usage_metadata(payload)
+                ),
             )
             result = backend.generate(SyncGenerationRequest(
                 model=effective_model,
@@ -12529,9 +12706,16 @@ def _contract_mode_for_manifest(manifest):
     return translation_core.MODE_TRANSLATION
 
 
-def _effective_sync_model(manifest):
-    """Return the one model used to build and execute every sync attempt."""
-    return str(SYNC_MODEL or manifest.get('batch_model') or BATCH_MODEL or '')
+def _effective_sync_model(manifest, plan=None):
+    """Return the frozen model for this sync manifest.
+
+    After a run starts, live ``SYNC_MODEL`` is ignored. Old manifests without
+    a ``model_routing`` snapshot fall back to the persisted model fields.
+    """
+    resolved = plan or routing_plan_from_manifest(manifest)
+    if resolved is not None:
+        return route_model(resolved, route_for_manifest(resolved, manifest))
+    return str(manifest.get('model') or manifest.get('batch_model') or BATCH_MODEL or '')
 
 
 def _targeted_sync_request_row(manifest, chunk, item_ids, *, model=None):
@@ -12666,15 +12850,24 @@ def write_manifest_file(package_dir, manifest, update_latest=True):
     return manifest_path
 
 
-def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
+def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None, *, routing_plan=None):
     """Execute one complete, unique request row for every manifest chunk.
 
     Full coverage is validated before any provider call so the rewritten result
     JSONL and the manifest's terminal sync status always describe the same run.
+    The routing plan is frozen before the first request; later config changes
+    and targeted retries reuse that snapshot.
     """
     manifest = load_manifest(manifest_path)
     result_path = resolve_manifest_result_path(manifest)
-    effective_model = _effective_sync_model(manifest)
+    plan = routing_plan or resolve_manifest_routing_plan(
+        manifest,
+        execution=model_profile.ExecutionStrategy.SYNC,
+    )
+    route = route_for_manifest(plan, manifest)
+    effective_model = route_model(plan, route)
+    if not manifest.get('model_routing'):
+        attach_model_routing(manifest, plan)
     manifest_chunks = list(manifest.get('chunks') or [])
     chunk_map = {chunk.get('key'): chunk for chunk in manifest_chunks}
     contract_mode = _contract_mode_for_manifest(manifest)
@@ -12766,7 +12959,8 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
         try:
             result = run_sync_request(
                 row.get('request') or {},
-                effective_model,
+                route,
+                plan=plan,
                 api_key_index=api_key_index,
             )
             result_row['response'] = result.get('response_payload') or {}
@@ -12788,7 +12982,7 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                     )
                 )
             result_row['provider'] = result.get('provider') or SYNC_BACKEND
-            result_row['model'] = result.get('model') or SYNC_MODEL or BATCH_MODEL
+            result_row['model'] = result.get('model') or effective_model
             result_row['execution_mode'] = result.get('execution_mode') or 'sync'
             summary['successful_request_count'] += 1
             result_row['provider_response_attempts'] = [{
@@ -12861,7 +13055,8 @@ def execute_sync_request_rows(manifest_path, request_rows, api_key_index=None):
                 try:
                     retry_result = run_sync_request(
                         retry_row.get('request') or {},
-                        effective_model,
+                        route,
+                        plan=plan,
                         api_key_index=api_key_index,
                     )
                     result_row['provider_response_attempts'].append({
@@ -13055,12 +13250,18 @@ def make_sync_manifest(
     request_rows,
     settings,
     extra_fields=None,
+    routing_plan=None,
 ):
     settings = dict(settings or {})
     settings.setdefault('timeout_seconds', SYNC_TIMEOUT_SECONDS)
     input_jsonl_path = os.path.join(package_dir, 'requests.jsonl')
     result_jsonl_path = os.path.join(package_dir, 'results.jsonl')
     write_request_rows(input_jsonl_path, request_rows)
+    plan = routing_plan or freeze_runtime_routing_plan(
+        execution=model_profile.ExecutionStrategy.SYNC,
+    )
+    route = plan.routes[model_profile.stage_for_manifest_mode(mode)]
+    profile = model_profile.profile_for_route(plan, route)
     manifest = {
         'version': 2,
         'manifest_version': 2,
@@ -13069,10 +13270,11 @@ def make_sync_manifest(
         'execution': 'sync',
         'created_at': datetime.now().isoformat(timespec='seconds'),
         'display_name': display_name,
-        'batch_model': SYNC_MODEL or BATCH_MODEL,
+        'batch_model': profile.model,
         'provider': SYNC_BACKEND,
-        'model': SYNC_MODEL or BATCH_MODEL,
+        'model': profile.model,
         'execution_mode': 'sync',
+        'model_routing': plan.to_manifest_dict(),
         'model_response_contract': {
             'version': 1,
             'mode': mode,
@@ -13102,6 +13304,8 @@ def make_sync_manifest(
     }
     if extra_fields:
         manifest.update(extra_fields)
+    if 'model_routing' not in manifest or not manifest.get('model_routing'):
+        attach_model_routing(manifest, plan)
     return write_manifest_file(package_dir, manifest, update_latest=manifest.get('execution') != 'sync')
 
 
@@ -13139,7 +13343,13 @@ def sync_keyword_candidates(
     display_name = display_name_override.strip() if display_name_override else ''
     if not display_name:
         display_name = f'sync-{KEYWORD_DISPLAY_NAME_PREFIX}-{guess_project_slug()}-{timestamp}'
-    effective_model = SYNC_MODEL or BATCH_MODEL
+    routing_plan = freeze_runtime_routing_plan(
+        execution=model_profile.ExecutionStrategy.SYNC,
+    )
+    effective_model = route_model(
+        routing_plan,
+        routing_plan.routes[model_profile.STAGE_KEYWORD],
+    )
     request_rows = [
         build_keyword_request(chunk, max_candidates, model=effective_model)
         for chunk in chunks
@@ -13163,8 +13373,14 @@ def sync_keyword_candidates(
                 'max_candidates_per_chunk': max_candidates,
             },
         },
+        routing_plan=routing_plan,
     )
-    manifest = execute_sync_request_rows(manifest_path, request_rows, api_key_index=api_key_index)
+    manifest = execute_sync_request_rows(
+        manifest_path,
+        request_rows,
+        api_key_index=api_key_index,
+        routing_plan=routing_plan,
+    )
     print(f"Sync keyword run: {manifest['_package_dir']}")
     return export_keyword_candidates(
         target=manifest['_manifest_path'],
@@ -13208,7 +13424,13 @@ def sync_revisions(
     display_name = display_name_override.strip() if display_name_override else ''
     if not display_name:
         display_name = f'sync-{REVISION_DISPLAY_NAME_PREFIX}-{guess_project_slug()}-{timestamp}'
-    effective_model = SYNC_MODEL or BATCH_MODEL
+    routing_plan = freeze_runtime_routing_plan(
+        execution=model_profile.ExecutionStrategy.SYNC,
+    )
+    effective_model = route_model(
+        routing_plan,
+        routing_plan.routes[model_profile.STAGE_REVISION],
+    )
     request_rows = [
         build_revision_request(chunk, model=effective_model)
         for chunk in chunks
@@ -13251,8 +13473,14 @@ def sync_revisions(
             'thinking_level': BATCH_THINKING_LEVEL,
         },
         extra_fields=extra_fields,
+        routing_plan=routing_plan,
     )
-    manifest = execute_sync_request_rows(manifest_path, request_rows, api_key_index=api_key_index)
+    manifest = execute_sync_request_rows(
+        manifest_path,
+        request_rows,
+        api_key_index=api_key_index,
+        routing_plan=routing_plan,
+    )
     print(f"Sync revision run: {manifest['_package_dir']}")
     preview_manifest = preview_revisions(
         target=manifest['_manifest_path'],
@@ -13366,7 +13594,11 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
             }
         )
 
-    effective_model = SYNC_MODEL or BATCH_MODEL
+    routing_plan = freeze_runtime_routing_plan(
+        execution=model_profile.ExecutionStrategy.SYNC,
+    )
+    repair_route = routing_plan.routes[model_profile.STAGE_TRANSLATION]
+    effective_model = route_model(routing_plan, repair_route)
     request_rows = [build_repair_request(job, model=effective_model) for job in jobs]
     write_jsonl_file(request_log_path, request_rows)
 
@@ -13382,7 +13614,8 @@ def repair_remaining_items(report_path, limit=0, offset=0, batch_size=2, context
         try:
             response_data = run_sync_request(
                 request_row['request'],
-                model_name=BATCH_MODEL,
+                repair_route,
+                plan=routing_plan,
                 api_key_index=api_key_index,
             )
             finish_reason = response_data['finish_reason']
@@ -16071,7 +16304,6 @@ def dispatch_command(parser, args):
             ingest_keyword_summaries,
         )
         from project_analysis_llm import run_mapreduce_drafts
-        from sync_model_backend import SyncGenerationRequest
 
         store_dir = getattr(args, 'store_dir', None) or None
         as_json = bool(getattr(args, 'json', False))
@@ -16106,39 +16338,27 @@ def dispatch_command(parser, args):
                     entry_labels=args.entry_label or None,
                 )
             if command == 'project-analysis-generate':
-                model = (
-                    getattr(args, 'model', '') or PROJECT_ANALYSIS_MODEL or BATCH_MODEL or SYNC_MODEL
+                cli_model = str(getattr(args, 'model', '') or '').strip()
+                analysis_overrides = (
+                    {model_profile.STAGE_PROJECT_ANALYSIS: cli_model}
+                    if cli_model
+                    else None
                 )
+                analysis_plan = freeze_runtime_routing_plan(
+                    execution=model_profile.ExecutionStrategy.SYNC,
+                    stage_overrides=analysis_overrides,
+                )
+                analysis_route = analysis_plan.routes[model_profile.STAGE_PROJECT_ANALYSIS]
+                model = route_model(analysis_plan, analysis_route)
                 analysis_usage_run_id = model_usage_ledger.new_run_id('project-analysis')
                 analysis_usage_operation_id = (
                     'project-analysis-'
                     + hashlib.sha256(str(legacy.BASE_DIR or '').encode('utf-8')).hexdigest()[:20]
                 )
-
-
-                def _generate(request: SyncGenerationRequest):
-                    # Reuse production sync path (Gemini / LiteLLM).
-                    payload = {
-                        'contents': request.contents,
-                        'generation_config': dict(request.config or {}),
-                    }
-                    system = (request.config or {}).get('system_instruction')
-                    if system:
-                        payload['system_instruction'] = system
-                    raw = run_sync_request(payload, model)
-                    from sync_model_backend import SyncGenerationResult, SYNC_EXECUTION_MODE
-
-                    return SyncGenerationResult(
-                        provider=str(raw.get('provider') or SYNC_BACKEND or 'gemini'),
-                        model=str(raw.get('model') or model),
-                        execution_mode=str(raw.get('execution_mode') or SYNC_EXECUTION_MODE),
-                        response_payload=raw.get('response_payload') or raw,
-                        response_text=str(raw.get('response_text') or ''),
-                        finish_reason=str(raw.get('finish_reason') or ''),
-                        usage_metadata=dict(raw.get('usage_metadata') or {}),
-                        output_diagnostics=dict(raw.get('output_diagnostics') or {}),
-                        request_metadata=dict(raw.get('request_metadata') or {}),
-                    )
+                _generate = build_project_analysis_sync_runner(
+                    analysis_plan,
+                    analysis_route,
+                )
 
                 pricing_config = batch_cost_estimate.load_pricing_config(
                     _read_translator_config_object()

--- a/model_profile.py
+++ b/model_profile.py
@@ -16,8 +16,9 @@ Resolution semantics (approved with issue #345, option B):
   ``gemini_batch`` runs.
 
 The production entry points (``run_sync_request``, ``call_gemini_sdk``, ...)
-adopt this resolver in follow-up PRs; until then nothing in the runtime
-imports this module besides tests.
+freeze one :class:`ModelRoutingPlan` at run start and pass the stage
+:class:`TaskRoute` into every sync call. ``sync.model`` is only the
+inherited primary; an explicit stage route always wins.
 
 Profile ids are **resolver slot ids** (``primary``, ``batch``,
 ``<stage>_model``, ``<stage>_override``) — an internal compatibility layer
@@ -32,7 +33,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Mapping
@@ -702,6 +703,8 @@ def _sync_profile(
     if sync_backend == SYNC_BACKEND_LITELLM:
         provider = provider_from_model(model)
         custom = (custom_providers or {}).get(provider)
+        if custom is not None and getattr(custom, "requires_key", None) is None:
+            custom = None
         if custom is not None:
             credential = CredentialRef(
                 CREDENTIAL_KIND_NONE if not custom.requires_key
@@ -942,6 +945,15 @@ def resolve_routing_plan(
         route(STAGE_KEYWORD, "primary", strategy, ROUTE_SOURCE_INHERITED)
         route(STAGE_REVISION, "primary", strategy, ROUTE_SOURCE_INHERITED)
 
+    for stage in (STAGE_TRANSLATION, STAGE_KEYWORD, STAGE_REVISION):
+        if stage in overrides:
+            route(
+                stage,
+                f"{stage}_override",
+                routes[stage].strategy,
+                ROUTE_SOURCE_EXPLICIT,
+            )
+
     if STAGE_PROJECT_ANALYSIS in overrides:
         route(
             STAGE_PROJECT_ANALYSIS,
@@ -1156,30 +1168,121 @@ def validate_routing_plan(
     return tuple(issues)
 
 
+_MANIFEST_MODE_TO_STAGE = {
+    "translation": STAGE_TRANSLATION,
+    "keyword_extraction": STAGE_KEYWORD,
+    "revision": STAGE_REVISION,
+    "final_review": STAGE_FINAL_REVIEW,
+}
+
+
+def stage_for_manifest_mode(mode: str) -> str:
+    """Map a package/manifest mode string to a routing stage."""
+    text = str(mode or "").strip()
+    if text in _MANIFEST_MODE_TO_STAGE:
+        return _MANIFEST_MODE_TO_STAGE[text]
+    if text in KNOWN_STAGES:
+        return text
+    return STAGE_TRANSLATION
+
+
+def profile_for_route(plan: ModelRoutingPlan, route: TaskRoute) -> ModelProfile:
+    """Return the frozen profile a route points at."""
+    try:
+        return plan.profiles[route.profile_id]
+    except KeyError as exc:
+        raise ValueError(
+            f"Route for stage {route.stage} references unknown profile "
+            f"{route.profile_id}."
+        ) from exc
+
+
+def resolve_routing_plan_from_runtime(
+    *,
+    sync_backend: str,
+    sync_model: str = "",
+    batch_model: str = "",
+    project_analysis_model: str = "",
+    final_review_model: str = "",
+    sync_models: tuple[str, ...] | list[str] = (),
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+    execution: str | ExecutionStrategy = ExecutionStrategy.SYNC,
+    stage_overrides: Mapping[str, str] | None = None,
+    created_at: str = "",
+    config_origins: tuple[ConfigOrigin, ...] = (),
+) -> ModelRoutingPlan:
+    """Build a plan from already-loaded runtime settings.
+
+    Callers snapshot ``SYNC_MODEL`` / ``BATCH_MODEL`` / stage models into
+    this helper *once* at run start. Later mutations of those globals must
+    not be re-read.
+    """
+    translator_config: dict[str, Any] = {
+        "sync": {"backend": _clean_str(sync_backend) or SYNC_BACKEND_GEMINI},
+        "batch": {},
+    }
+    if _clean_str(sync_model):
+        translator_config["sync"]["model"] = _clean_str(sync_model)
+    models = tuple(
+        _clean_str(item) for item in (sync_models or ()) if _clean_str(item)
+    )
+    if models:
+        translator_config["sync"]["models"] = list(models)
+    if _clean_str(batch_model):
+        translator_config["batch"]["model"] = _clean_str(batch_model)
+    if _clean_str(project_analysis_model):
+        translator_config["batch"]["project_analysis"] = {
+            "model": _clean_str(project_analysis_model),
+        }
+    if _clean_str(final_review_model):
+        translator_config["batch"]["final_review"] = {
+            "model": _clean_str(final_review_model),
+        }
+    plan = resolve_routing_plan(
+        translator_config,
+        custom_providers=custom_providers,
+        execution=execution,
+        stage_overrides=stage_overrides,
+        created_at=created_at,
+    )
+    if config_origins:
+        plan = replace(plan, config_origins=tuple(config_origins))
+    return plan
+
+
 def build_sync_backend(
     profile: ModelProfile,
     *,
     custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+    client: Any = None,
+    serialize_response: Callable[..., Any] | None = None,
+    extract_text: Callable[..., Any] | None = None,
+    extract_finish_reason: Callable[..., Any] | None = None,
+    extract_usage: Callable[..., Any] | None = None,
 ):
     """Construct the sync backend for one profile.
 
-    Deferred imports keep this module free of heavy SDK imports; the gemini
-    branch mirrors the production wiring in ``translator_runtime`` and the
-    litellm branch forwards the custom provider registry exactly like
-    ``run_sync_request`` does today.
+    Deferred imports keep this module free of heavy SDK imports. Production
+    sync callers must go through this function; they may pass a pre-built
+    Gemini ``client`` (for API-key rotation) and usage extractors that match
+    the existing request contract.
     """
     if profile.adapter == ADAPTER_GEMINI:
         import model_usage_ledger
         import translator_runtime as runtime
         from sync_model_backend import GeminiSyncBackend
 
-        runtime.configure_genai()
+        if client is None:
+            runtime.configure_genai()
+            client = runtime.create_genai_client()
         return GeminiSyncBackend(
-            runtime.create_genai_client(),
-            serialize_response=runtime.serialize_unknown,
-            extract_text=runtime.extract_text_from_response_payload,
-            extract_finish_reason=runtime.extract_finish_reason,
-            extract_usage=model_usage_ledger.extract_provider_usage,
+            client,
+            serialize_response=serialize_response or runtime.serialize_unknown,
+            extract_text=extract_text or runtime.extract_text_from_response_payload,
+            extract_finish_reason=(
+                extract_finish_reason or runtime.extract_finish_reason
+            ),
+            extract_usage=extract_usage or model_usage_ledger.extract_provider_usage,
         )
     if profile.adapter == ADAPTER_LITELLM:
         from litellm_sync_backend import LiteLLMSyncBackend

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -1312,7 +1312,11 @@ class BatchRepairRegressionTests(unittest.TestCase):
                     },
                 ],
             }
-            request_rows = [batch_mod.build_batch_request(chunk, model='gemini-test')]
+            request_rows = [batch_mod.build_batch_request(chunk, model='stage-explicit-model')]
+            routing_plan = batch_mod.model_profile.resolve_routing_plan(
+                {'sync': {'backend': 'gemini', 'model': 'primary-should-lose'}},
+                stage_overrides={'translation': 'stage-explicit-model'},
+            )
             manifest_path = batch_mod.make_sync_manifest(
                 package_dir=str(package_dir),
                 mode=batch_mod.MANIFEST_MODE_TRANSLATION,
@@ -1320,6 +1324,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
                 chunks=[chunk],
                 request_rows=request_rows,
                 settings={},
+                routing_plan=routing_plan,
             )
             responses = [
                 {'translations': [{'id': 'a', 'translation': '你好'}]},
@@ -1327,10 +1332,12 @@ class BatchRepairRegressionTests(unittest.TestCase):
             ]
             seen_requests = []
             seen_models = []
+            seen_routes = []
 
-            def fake_sync(request, model_name, **_kwargs):
+            def fake_sync(request, route, plan=None, **_kwargs):
                 seen_requests.append(request)
-                seen_models.append(model_name)
+                seen_routes.append(route)
+                seen_models.append(plan.profiles[route.profile_id].model)
                 payload = responses[len(seen_requests) - 1]
                 text = json.dumps(payload, ensure_ascii=False)
                 return {
@@ -1341,7 +1348,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
                     'finish_reason': 'STOP',
                     'usage_metadata': {'totalTokenCount': 1},
                     'provider': 'gemini',
-                    'model': 'gemini-test',
+                    'model': 'stage-explicit-model',
                     'execution_mode': 'sync',
                 }
 
@@ -1386,7 +1393,12 @@ class BatchRepairRegressionTests(unittest.TestCase):
             )
 
         self.assertEqual(len(seen_requests), 2)
-        self.assertEqual(seen_models, ['sync-override', 'sync-override'])
+        self.assertEqual(seen_models, ['stage-explicit-model', 'stage-explicit-model'])
+        self.assertTrue(all(
+            isinstance(route, batch_mod.model_profile.TaskRoute)
+            for route in seen_routes
+        ))
+        self.assertNotIn('sync-override', seen_models)
         self.assertNotIn('"id":"a"', retry_prompt)
         self.assertIn('"id":"b"', retry_prompt)
         self.assertEqual(

--- a/tests/test_litellm_sync_integration.py
+++ b/tests/test_litellm_sync_integration.py
@@ -5,7 +5,16 @@ from pathlib import Path
 from unittest import mock
 
 import gemini_translate_batch as batch_mod
+import model_profile as mp
 from litellm_sync_backend import LiteLLMBackendError
+
+
+def _explicit_translation_plan(stage_model, *, backend="litellm", primary="sync-primary-should-lose"):
+    plan = mp.resolve_routing_plan(
+        {"sync": {"backend": backend, "model": primary}},
+        stage_overrides={"translation": stage_model},
+    )
+    return plan.routes["translation"], plan
 
 
 class LiteLLMSyncIntegrationTests(unittest.TestCase):
@@ -21,15 +30,17 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
             "execution_mode": "sync",
         })()
 
-    def test_sync_runner_uses_litellm_only_when_explicitly_selected(self):
-        fake_result = self._fake_result()
+    def test_sync_runner_uses_explicit_route_model_not_sync_model(self):
+        explicit_model = "openai/explicit-stage"
+        route, plan = _explicit_translation_plan(explicit_model)
+        fake_result = self._fake_result(model=explicit_model)
         fake_backend = mock.Mock()
         fake_backend.generate.return_value = fake_result
         custom_providers = {"opencode-go": object()}
 
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
-            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/sync-overlay"),
             mock.patch.object(batch_mod, "SYNC_TIMEOUT_SECONDS", 45),
             mock.patch.object(
                 batch_mod.legacy,
@@ -37,56 +48,74 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
                 custom_providers,
             ),
             mock.patch.object(batch_mod, "create_batch_client") as create_client,
-            mock.patch(
-                "litellm_sync_backend.LiteLLMSyncBackend",
+            mock.patch.object(
+                mp,
+                "build_sync_backend",
                 return_value=fake_backend,
-            ) as backend_cls,
+            ) as backend_builder,
         ):
             result = batch_mod.run_sync_request(
                 {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
-                model_name="gemini-default",
+                route,
+                plan=plan,
             )
 
         create_client.assert_not_called()
+        backend_builder.assert_called_once()
+        built_profile = backend_builder.call_args.args[0]
+        self.assertEqual(built_profile.model, explicit_model)
         self.assertEqual(
-            backend_cls.call_args.kwargs["custom_providers"],
+            backend_builder.call_args.kwargs["custom_providers"],
             custom_providers,
         )
         request = fake_backend.generate.call_args.args[0]
-        self.assertEqual(request.model, "openai/test")
+        self.assertEqual(request.model, explicit_model)
+        self.assertNotEqual(request.model, "openai/sync-overlay")
         self.assertEqual(request.config["timeout"], 45)
         self.assertEqual(result["provider"], "litellm")
         self.assertEqual(result["execution_mode"], "sync")
 
     def test_sync_runner_passes_timeout_to_gemini_backend(self):
+        route, plan = _explicit_translation_plan(
+            "gemini-explicit",
+            backend="gemini",
+            primary="gemini-primary-should-lose",
+        )
         fake_backend = mock.Mock()
         fake_backend.generate.return_value = self._fake_result(
             provider="gemini",
-            model="gemini-test",
+            model="gemini-explicit",
         )
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "gemini"),
-            mock.patch.object(batch_mod, "SYNC_MODEL", "gemini-test"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "gemini-sync-overlay"),
             mock.patch.object(batch_mod, "SYNC_TIMEOUT_SECONDS", 45),
-            mock.patch.object(batch_mod, "create_batch_client"),
+            mock.patch.object(batch_mod, "create_batch_client", return_value=object()),
             mock.patch.object(
-                batch_mod,
-                "GeminiSyncBackend",
+                mp,
+                "build_sync_backend",
                 return_value=fake_backend,
             ),
         ):
-            batch_mod.run_sync_request({"contents": []}, "gemini-default")
+            batch_mod.run_sync_request({"contents": []}, route, plan=plan)
 
         request = fake_backend.generate.call_args.args[0]
+        self.assertEqual(request.model, "gemini-explicit")
         self.assertEqual(request.config["timeout"], 45)
 
     def test_litellm_rejects_gemini_api_key_index(self):
+        route, plan = _explicit_translation_plan("openai/test")
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
-            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/sync-overlay"),
         ):
             with self.assertRaises(SystemExit) as captured:
-                batch_mod.run_sync_request({}, "gemini-default", api_key_index=0)
+                batch_mod.run_sync_request(
+                    {},
+                    route,
+                    plan=plan,
+                    api_key_index=0,
+                )
         self.assertIn("only supported by the Gemini", str(captured.exception))
 
     def test_sync_manifest_records_effective_request_timeout(self):
@@ -107,8 +136,10 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
             manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
 
         self.assertEqual(manifest["settings"]["timeout_seconds"], 45)
+        self.assertIn("model_routing", manifest)
 
     def test_litellm_authentication_failure_is_not_retried(self):
+        route, plan = _explicit_translation_plan("openai/test")
         fake_backend = mock.Mock()
         fake_backend.generate.side_effect = LiteLLMBackendError(
             "provider echoed secret-value",
@@ -116,18 +147,20 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
         )
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
-            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
-            mock.patch(
-                "litellm_sync_backend.LiteLLMSyncBackend",
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/sync-overlay"),
+            mock.patch.object(
+                mp,
+                "build_sync_backend",
                 return_value=fake_backend,
             ),
         ):
             with self.assertRaises(LiteLLMBackendError):
-                batch_mod.run_sync_request({"contents": []}, "gemini-default")
+                batch_mod.run_sync_request({"contents": []}, route, plan=plan)
 
         self.assertEqual(fake_backend.generate.call_count, 1)
 
     def test_litellm_timeout_retry_is_bounded(self):
+        route, plan = _explicit_translation_plan("openai/test")
         fake_backend = mock.Mock()
         fake_backend.generate.side_effect = [
             LiteLLMBackendError("timeout one", category="timeout"),
@@ -136,20 +169,24 @@ class LiteLLMSyncIntegrationTests(unittest.TestCase):
         ]
         with (
             mock.patch.object(batch_mod, "SYNC_BACKEND", "litellm"),
-            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/test"),
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/sync-overlay"),
             mock.patch.object(batch_mod.time, "sleep"),
-            mock.patch(
-                "litellm_sync_backend.LiteLLMSyncBackend",
+            mock.patch.object(
+                mp,
+                "build_sync_backend",
                 return_value=fake_backend,
             ),
         ):
             result = batch_mod.run_sync_request(
                 {"contents": []},
-                "gemini-default",
+                route,
+                plan=plan,
             )
 
         self.assertEqual(fake_backend.generate.call_count, 3)
         self.assertEqual(result["provider"], "litellm")
+        request = fake_backend.generate.call_args.args[0]
+        self.assertEqual(request.model, "openai/test")
 
 
 if __name__ == "__main__":

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -1,14 +1,20 @@
-"""Tests for the model routing contract module (issue #345 P1)."""
+"""Tests for the model routing contract module (issue #345 P1/P2)."""
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 import unittest
 from dataclasses import replace
+from pathlib import Path
 from unittest import mock
 
+import gemini_translate_batch as batch_mod
 import litellm_provider_config as lpc
 import model_profile as mp
-from sync_model_backend import GeminiSyncBackend
+import translation_ab_experiment as ab_mod
+from litellm_sync_backend import LiteLLMBackendError
+from sync_model_backend import GeminiSyncBackend, SyncGenerationRequest
 
 
 def _custom_providers() -> dict[str, lpc.CustomLiteLLMProvider]:
@@ -227,6 +233,16 @@ class ResolveRoutingPlanTests(unittest.TestCase):
             plan.profiles["project_analysis_override"].model,
             "deepseek/deepseek-chat",
         )
+
+    def test_translation_stage_override_wins_over_primary(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "gemini", "model": "gemini-primary"}},
+            stage_overrides={"translation": "gemini-explicit"},
+        )
+        route = plan.routes["translation"]
+        self.assertEqual(route.profile_id, "translation_override")
+        self.assertEqual(route.source, mp.ROUTE_SOURCE_EXPLICIT)
+        self.assertEqual(plan.profiles["translation_override"].model, "gemini-explicit")
 
     def test_ab_experiment_override(self) -> None:
         plan = mp.resolve_routing_plan(
@@ -664,6 +680,505 @@ class BuildSyncBackendTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             mp.build_sync_backend(profile)
+
+
+def _translation_chunk(package_dir: Path) -> dict:
+    return {
+        "key": "chunk-1",
+        "file_path": str(package_dir / "script.rpy"),
+        "file_rel_path": "script.rpy",
+        "chunk_index": 1,
+        "context_past": [],
+        "context_future": [],
+        "items": [
+            {
+                "id": "a",
+                "text": "Hello",
+                "file_rel_path": "script.rpy",
+                "line": 0,
+                "line_number": 1,
+                "start": 4,
+                "end": 11,
+                "prefix": "",
+                "quote": '"',
+            },
+            {
+                "id": "b",
+                "text": "World",
+                "file_rel_path": "script.rpy",
+                "line": 1,
+                "line_number": 2,
+                "start": 4,
+                "end": 11,
+                "prefix": "",
+                "quote": '"',
+            },
+        ],
+    }
+
+
+def _walk_forbid_credential_slots(payload: object) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            unittest.TestCase().assertNotIn(
+                str(key).lower(),
+                {"api_key", "apikey", "value", "secret", "token"},
+            )
+            _walk_forbid_credential_slots(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            _walk_forbid_credential_slots(item)
+
+
+class SyncEntryWiringTests(unittest.TestCase):
+    def _sync_response(self, payload, *, model="stage-explicit-model"):
+        text = json.dumps(payload, ensure_ascii=False)
+        return {
+            "response_payload": {
+                "candidates": [{"content": {"parts": [{"text": text}]}}],
+            },
+            "response_text": text,
+            "finish_reason": "STOP",
+            "usage_metadata": {"totalTokenCount": 1},
+            "provider": "gemini",
+            "model": model,
+            "execution_mode": "sync",
+        }
+
+    def test_execute_sync_rows_use_explicit_route_on_first_pass_and_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package_dir = Path(tmp) / "sync-run"
+            package_dir.mkdir()
+            chunk = _translation_chunk(package_dir)
+            plan = mp.resolve_routing_plan(
+                {"sync": {"backend": "gemini", "model": "primary-should-lose"}},
+                stage_overrides={"translation": "stage-explicit-model"},
+            )
+            request_rows = [
+                batch_mod.build_batch_request(chunk, model="stage-explicit-model"),
+            ]
+            manifest_path = batch_mod.make_sync_manifest(
+                package_dir=str(package_dir),
+                mode=batch_mod.MANIFEST_MODE_TRANSLATION,
+                display_name="explicit-route-test",
+                chunks=[chunk],
+                request_rows=request_rows,
+                settings={},
+                routing_plan=plan,
+            )
+            payloads = [
+                {"translations": [{"id": "a", "translation": "你好"}]},
+                {"translations": [{"id": "b", "translation": "世界"}]},
+            ]
+            seen_routes: list[mp.TaskRoute] = []
+            seen_models: list[str] = []
+
+            def fake_sync(request, route, plan=None, **_kwargs):
+                seen_routes.append(route)
+                seen_models.append(plan.profiles[route.profile_id].model)
+                return self._sync_response(payloads[len(seen_routes) - 1])
+
+            with (
+                mock.patch.object(batch_mod, "SYNC_MODEL", "sync-overlay"),
+                mock.patch.object(
+                    batch_mod, "run_sync_request", side_effect=fake_sync,
+                ),
+            ):
+                batch_mod.execute_sync_request_rows(manifest_path, request_rows)
+
+        self.assertEqual(len(seen_routes), 2)
+        self.assertTrue(all(isinstance(route, mp.TaskRoute) for route in seen_routes))
+        self.assertEqual(seen_models, ["stage-explicit-model", "stage-explicit-model"])
+        self.assertEqual({route.stage for route in seen_routes}, {"translation"})
+
+    def test_keyword_revision_analysis_and_ab_callers_pass_task_route(self) -> None:
+        captured: dict[str, list] = {
+            "keyword": [],
+            "revision": [],
+            "project_analysis": [],
+            "ab_experiment": [],
+        }
+
+        def record(stage):
+            def _fake(request, route, plan=None, **_kwargs):
+                captured[stage].append(route)
+                if stage == "keyword":
+                    payload = {
+                        "candidates": [{
+                            "source": "Void Gate",
+                            "suggested_target": "虚空门",
+                            "category": "term",
+                            "confidence": 0.9,
+                            "evidence": "script.rpy:2:keyword:0",
+                            "source_item_ids": ["script.rpy:2:keyword:0"],
+                        }],
+                        "chunk_summary": "ok",
+                        "summary_evidence_item_ids": ["script.rpy:2:keyword:0"],
+                    }
+                else:
+                    payload = {"translations": [{"id": "a", "translation": "你好"}]}
+                return self._sync_response(payload)
+            return _fake
+
+        old = {
+            "tl_dir": batch_mod.legacy.TL_DIR,
+            "log_dir": batch_mod.LOG_DIR,
+            "jobs_dir": batch_mod.BATCH_JOBS_DIR,
+            "repair_dir": batch_mod.REPAIR_RUNS_DIR,
+            "sync_dir": batch_mod.SYNC_RUNS_DIR,
+            "latest": batch_mod.LATEST_MANIFEST_FILE,
+        }
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / "tl"
+                jobs_dir = root / "batch_jobs"
+                tl_dir.mkdir()
+                jobs_dir.mkdir()
+                (tl_dir / "script.rpy").write_text(
+                    "translate schinese start:\n"
+                    '    old "Void Gate"\n'
+                    '    new "虚空门"\n',
+                    encoding="utf-8",
+                )
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.LOG_DIR = str(root / "logs")
+                batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+                batch_mod.REPAIR_RUNS_DIR = str(root / "repair")
+                batch_mod.SYNC_RUNS_DIR = str(root / "sync")
+                batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / "latest.txt")
+
+                with mock.patch.object(
+                    batch_mod, "run_sync_request", side_effect=record("keyword"),
+                ):
+                    batch_mod.sync_keyword_candidates(
+                        skip_prepare=True, chunk_size=1, limit=1,
+                    )
+                with mock.patch.object(
+                    batch_mod, "run_sync_request", side_effect=record("revision"),
+                ), mock.patch.object(batch_mod, "preview_revisions", return_value={
+                    "_manifest_path": "unused",
+                }):
+                    batch_mod.sync_revisions(skip_prepare=True, chunk_size=1, limit=1)
+        finally:
+            batch_mod.legacy.TL_DIR = old["tl_dir"]
+            batch_mod.LOG_DIR = old["log_dir"]
+            batch_mod.BATCH_JOBS_DIR = old["jobs_dir"]
+            batch_mod.REPAIR_RUNS_DIR = old["repair_dir"]
+            batch_mod.SYNC_RUNS_DIR = old["sync_dir"]
+            batch_mod.LATEST_MANIFEST_FILE = old["latest"]
+
+        analysis_plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "gemini", "model": "primary-should-lose"}},
+            stage_overrides={"project_analysis": "analysis-explicit"},
+        )
+        analysis_route = analysis_plan.routes["project_analysis"]
+        runner = batch_mod.build_project_analysis_sync_runner(
+            analysis_plan, analysis_route,
+        )
+        with mock.patch.object(
+            batch_mod, "run_sync_request", side_effect=record("project_analysis"),
+        ):
+            runner(SyncGenerationRequest(model="ignored", contents=[], config={}))
+
+        fixture = (
+            Path(__file__).parent / "fixtures" / "golden_batch_minimal"
+            / "expected" / "manifest_snapshot.json"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            manifest = json.loads(fixture.read_text(encoding="utf-8"))
+            manifest["mode"] = batch_mod.MANIFEST_MODE_TRANSLATION
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False), encoding="utf-8",
+            )
+            loaded = batch_mod.load_manifest(str(manifest_path))
+            variants = ab_mod.load_variants_file(
+                str(Path(__file__).parent / "fixtures" / "ab_variants_minimal.json"),
+            )
+            with mock.patch.object(
+                batch_mod, "run_sync_request", side_effect=record("ab_experiment"),
+            ), mock.patch.object(
+                ab_mod, "enrich_chunk_for_current_settings", side_effect=lambda chunk, **_: chunk,
+            ):
+                ab_mod.run_translation_ab_experiment(
+                    loaded,
+                    variants,
+                    limit=1,
+                    offset=0,
+                    output_dir=str(Path(tmp) / "ab"),
+                    model_override="ab-explicit-model",
+                    dry_run=False,
+                )
+
+        self.assertTrue(captured["keyword"])
+        self.assertTrue(all(
+            isinstance(route, mp.TaskRoute) and route.stage == "keyword"
+            for route in captured["keyword"]
+        ))
+        self.assertTrue(captured["revision"])
+        self.assertTrue(all(
+            isinstance(route, mp.TaskRoute) and route.stage == "revision"
+            for route in captured["revision"]
+        ))
+        self.assertTrue(captured["project_analysis"])
+        self.assertEqual(captured["project_analysis"][0].stage, "project_analysis")
+        self.assertTrue(captured["ab_experiment"])
+        self.assertTrue(all(
+            isinstance(route, mp.TaskRoute) and route.stage == "ab_experiment"
+            for route in captured["ab_experiment"]
+        ))
+
+    def test_production_sync_backends_come_from_build_sync_backend(self) -> None:
+        route, plan = (
+            mp.resolve_routing_plan(
+                {"sync": {"backend": "litellm", "model": "openai/primary-lose"}},
+                stage_overrides={"translation": "openai/explicit-stage"},
+            ).routes["translation"],
+            mp.resolve_routing_plan(
+                {"sync": {"backend": "litellm", "model": "openai/primary-lose"}},
+                stage_overrides={"translation": "openai/explicit-stage"},
+            ),
+        )
+        fake_backend = mock.Mock()
+        fake_backend.generate.return_value = type("Result", (), {
+            "response_payload": {"choices": []},
+            "response_text": "[]",
+            "finish_reason": "stop",
+            "usage_metadata": {},
+            "provider": "litellm",
+            "model": "openai/explicit-stage",
+            "execution_mode": "sync",
+        })()
+        with (
+            mock.patch.object(batch_mod, "SYNC_MODEL", "openai/sync-overlay"),
+            mock.patch.object(
+                mp, "build_sync_backend", return_value=fake_backend,
+            ) as builder,
+        ):
+            batch_mod.run_sync_request({"contents": []}, route, plan=plan)
+        builder.assert_called_once()
+        self.assertEqual(builder.call_args.args[0].model, "openai/explicit-stage")
+        self.assertEqual(
+            fake_backend.generate.call_args.args[0].model,
+            "openai/explicit-stage",
+        )
+
+        repo = Path(__file__).resolve().parents[1]
+        hits: list[str] = []
+        for path in repo.rglob("*.py"):
+            rel = path.relative_to(repo).as_posix()
+            if rel.startswith(("gui_qt/", "tests/", "scripts/")):
+                continue
+            text = path.read_text(encoding="utf-8")
+            for index, line in enumerate(text.splitlines(), start=1):
+                stripped = line.strip()
+                if "LiteLLMSyncBackend(" not in stripped and "GeminiSyncBackend(" not in stripped:
+                    continue
+                if rel == "model_profile.py" and "return " in stripped:
+                    continue
+                hits.append(f"{rel}:{index}:{stripped}")
+        self.assertEqual(hits, [])
+        overlay = (repo / "gemini_translate_batch.py").read_text(encoding="utf-8")
+        self.assertNotIn("effective_model = SYNC_MODEL or model_name", overlay)
+
+    def test_mid_run_config_mutation_and_retry_keep_frozen_profile(self) -> None:
+        previous_batch_model = batch_mod.BATCH_MODEL
+        previous_sync_model = batch_mod.SYNC_MODEL
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                package_dir = Path(tmp) / "sync-run"
+                package_dir.mkdir()
+                chunk = _translation_chunk(package_dir)
+                plan = mp.resolve_routing_plan(
+                    {"sync": {"backend": "gemini", "model": "primary-should-lose"}},
+                    stage_overrides={"translation": "frozen-stage-model"},
+                    created_at="2026-08-18T00:00:00Z",
+                )
+                request_rows = [
+                    batch_mod.build_batch_request(chunk, model="frozen-stage-model"),
+                ]
+                manifest_path = batch_mod.make_sync_manifest(
+                    package_dir=str(package_dir),
+                    mode=batch_mod.MANIFEST_MODE_TRANSLATION,
+                    display_name="freeze-retry-test",
+                    chunks=[chunk],
+                    request_rows=request_rows,
+                    settings={},
+                    routing_plan=plan,
+                )
+                seen: list[tuple[str, str, str]] = []
+                payloads = [
+                    {"translations": [{"id": "a", "translation": "你好"}]},
+                    {"translations": [{"id": "b", "translation": "世界"}]},
+                ]
+
+                def fake_sync(request, route, plan=None, **_kwargs):
+                    batch_mod.SYNC_MODEL = "mutated-sync-model"
+                    batch_mod.BATCH_MODEL = "mutated-batch-model"
+                    seen.append((
+                        route.profile_id,
+                        plan.profiles[route.profile_id].model,
+                        plan.created_at,
+                    ))
+                    return self._sync_response(
+                        payloads[len(seen) - 1],
+                        model=plan.profiles[route.profile_id].model,
+                    )
+
+                with (
+                    mock.patch.object(batch_mod, "SYNC_MODEL", "live-sync-model"),
+                    mock.patch.object(
+                        batch_mod, "run_sync_request", side_effect=fake_sync,
+                    ),
+                ):
+                    batch_mod.execute_sync_request_rows(manifest_path, request_rows)
+
+            self.assertEqual(len(seen), 2)
+            self.assertEqual({item[1] for item in seen}, {"frozen-stage-model"})
+            self.assertEqual({item[2] for item in seen}, {"2026-08-18T00:00:00Z"})
+            self.assertEqual(seen[0], seen[1])
+
+            retry_plan = mp.resolve_routing_plan(
+                {"sync": {"backend": "litellm", "model": "openai/primary-lose"}},
+                stage_overrides={"translation": "openai/frozen-retry"},
+            )
+            route = retry_plan.routes["translation"]
+            models_seen: list[str] = []
+            fake_backend = mock.Mock()
+
+            def generate(request):
+                batch_mod.SYNC_MODEL = "openai/mutated-after-start"
+                models_seen.append(request.model)
+                if len(models_seen) == 1:
+                    raise LiteLLMBackendError("timeout one", category="timeout")
+                return type("Result", (), {
+                    "response_payload": {},
+                    "response_text": "[]",
+                    "finish_reason": "stop",
+                    "usage_metadata": {},
+                    "provider": "litellm",
+                    "model": request.model,
+                    "execution_mode": "sync",
+                })()
+
+            fake_backend.generate.side_effect = generate
+            with (
+                mock.patch.object(batch_mod, "SYNC_MODEL", "openai/live-overlay"),
+                mock.patch.object(batch_mod.time, "sleep"),
+                mock.patch.object(mp, "build_sync_backend", return_value=fake_backend),
+            ):
+                batch_mod.run_sync_request({"contents": []}, route, plan=retry_plan)
+            self.assertEqual(models_seen, ["openai/frozen-retry", "openai/frozen-retry"])
+        finally:
+            batch_mod.BATCH_MODEL = previous_batch_model
+            batch_mod.SYNC_MODEL = previous_sync_model
+
+    def test_shipped_manifests_write_model_routing_without_credentials(self) -> None:
+        planted = "sk-test-secret"
+        old = {
+            "tl_dir": batch_mod.legacy.TL_DIR,
+            "log_dir": batch_mod.LOG_DIR,
+            "jobs_dir": batch_mod.BATCH_JOBS_DIR,
+            "repair_dir": batch_mod.REPAIR_RUNS_DIR,
+            "sync_dir": batch_mod.SYNC_RUNS_DIR,
+            "latest": batch_mod.LATEST_MANIFEST_FILE,
+            "final_enabled": batch_mod.FINAL_REVIEW_ENABLED,
+            "require_zero": batch_mod.FINAL_REVIEW_REQUIRE_ZERO_PENDING,
+            "include_files": set(batch_mod.legacy.INCLUDE_FILES),
+            "include_prefixes": set(batch_mod.legacy.INCLUDE_PREFIXES),
+            "base_dir": batch_mod.legacy.BASE_DIR,
+        }
+        written: list[dict] = []
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                tl_dir = root / "tl"
+                jobs_dir = root / "batch_jobs"
+                tl_dir.mkdir()
+                jobs_dir.mkdir()
+                (tl_dir / "script.rpy").write_text(
+                    "translate schinese start:\n"
+                    '    old "Hello"\n'
+                    '    new "你好"\n',
+                    encoding="utf-8",
+                )
+                pending_tl = root / "game" / "tl" / "schinese"
+                pending_tl.parent.mkdir(parents=True)
+                shutil.copytree(
+                    Path(__file__).parent / "fixtures" / "golden_batch_minimal" / "tl",
+                    pending_tl,
+                )
+                batch_mod.legacy.BASE_DIR = str(root)
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                batch_mod.legacy.INCLUDE_FILES = set()
+                batch_mod.legacy.INCLUDE_PREFIXES = set()
+                batch_mod.LOG_DIR = str(root / "logs")
+                batch_mod.BATCH_JOBS_DIR = str(jobs_dir)
+                batch_mod.REPAIR_RUNS_DIR = str(root / "repair")
+                batch_mod.SYNC_RUNS_DIR = str(root / "sync")
+                batch_mod.LATEST_MANIFEST_FILE = str(jobs_dir / "latest.txt")
+                batch_mod.FINAL_REVIEW_ENABLED = True
+                batch_mod.FINAL_REVIEW_REQUIRE_ZERO_PENDING = False
+
+                sync_pkg = root / "sync-pkg"
+                sync_pkg.mkdir()
+                sync_path = batch_mod.make_sync_manifest(
+                    package_dir=str(sync_pkg),
+                    mode=batch_mod.MANIFEST_MODE_TRANSLATION,
+                    display_name="routing-scan",
+                    chunks=[],
+                    request_rows=[],
+                    settings={},
+                )
+                written.append(json.loads(Path(sync_path).read_text(encoding="utf-8")))
+
+                keyword_path = batch_mod.create_keyword_package(
+                    skip_prepare=True, chunk_size=1,
+                )
+                written.append(json.loads(Path(keyword_path).read_text(encoding="utf-8")))
+
+                revision_path = batch_mod.create_revision_package(
+                    skip_prepare=True, chunk_size=1,
+                )
+                written.append(json.loads(Path(revision_path).read_text(encoding="utf-8")))
+
+                batch_mod.legacy.TL_DIR = str(pending_tl)
+                translation_path = batch_mod.create_batch_package(skip_prepare=True)
+                self.assertIsNotNone(translation_path)
+                written.append(
+                    json.loads(Path(translation_path).read_text(encoding="utf-8"))
+                )
+
+                batch_mod.legacy.TL_DIR = str(tl_dir)
+                review_path = batch_mod.create_final_review_package(
+                    skip_prepare=True,
+                    chunk_size=1,
+                    allow_pending=True,
+                )
+                written.append(json.loads(Path(review_path).read_text(encoding="utf-8")))
+        finally:
+            batch_mod.legacy.TL_DIR = old["tl_dir"]
+            batch_mod.LOG_DIR = old["log_dir"]
+            batch_mod.BATCH_JOBS_DIR = old["jobs_dir"]
+            batch_mod.REPAIR_RUNS_DIR = old["repair_dir"]
+            batch_mod.SYNC_RUNS_DIR = old["sync_dir"]
+            batch_mod.LATEST_MANIFEST_FILE = old["latest"]
+            batch_mod.FINAL_REVIEW_ENABLED = old["final_enabled"]
+            batch_mod.FINAL_REVIEW_REQUIRE_ZERO_PENDING = old["require_zero"]
+            batch_mod.legacy.INCLUDE_FILES = old["include_files"]
+            batch_mod.legacy.INCLUDE_PREFIXES = old["include_prefixes"]
+            batch_mod.legacy.BASE_DIR = old["base_dir"]
+
+        self.assertEqual(len(written), 5)
+        for manifest in written:
+            self.assertIn("model_routing", manifest)
+            snapshot = manifest["model_routing"]
+            _walk_forbid_credential_slots(snapshot)
+            text = json.dumps(snapshot)
+            self.assertNotIn(planted, text)
+            self.assertIn("profiles", snapshot)
+            self.assertIn("routes", snapshot)
 
 
 if __name__ == "__main__":

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -1180,6 +1180,85 @@ class SyncEntryWiringTests(unittest.TestCase):
             self.assertIn("profiles", snapshot)
             self.assertIn("routes", snapshot)
 
+    def test_old_manifest_without_model_routing_keeps_recorded_model(self) -> None:
+        recorded = "gemini-old-recorded"
+        live = "gemini-live-new"
+        previous_batch = batch_mod.BATCH_MODEL
+        previous_sync = batch_mod.SYNC_MODEL
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                package_dir = Path(tmp) / "old-run"
+                package_dir.mkdir()
+                chunk = _translation_chunk(package_dir)
+                request_rows = [
+                    batch_mod.build_batch_request(chunk, model=recorded),
+                ]
+                plan = mp.resolve_routing_plan(
+                    {"sync": {"backend": "gemini", "model": recorded}},
+                )
+                manifest_path = batch_mod.make_sync_manifest(
+                    package_dir=str(package_dir),
+                    mode=batch_mod.MANIFEST_MODE_TRANSLATION,
+                    display_name="old-manifest-test",
+                    chunks=[chunk],
+                    request_rows=request_rows,
+                    settings={},
+                    routing_plan=plan,
+                )
+                raw = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+                raw.pop("model_routing", None)
+                raw["model"] = recorded
+                raw["batch_model"] = recorded
+                raw["provider"] = "gemini"
+                Path(manifest_path).write_text(
+                    json.dumps(raw, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+                batch_mod.SYNC_MODEL = live
+                batch_mod.BATCH_MODEL = live
+
+                loaded = batch_mod.load_manifest(manifest_path)
+                self.assertNotIn("model_routing", loaded)
+                resolved = batch_mod.resolve_manifest_routing_plan(loaded)
+                self.assertEqual(
+                    batch_mod.route_model(
+                        resolved,
+                        batch_mod.route_for_manifest(resolved, loaded),
+                    ),
+                    recorded,
+                )
+
+                seen: list[str] = []
+
+                def fake_sync(request, route, plan=None, **_kwargs):
+                    seen.append(plan.profiles[route.profile_id].model)
+                    return self._sync_response(
+                        {
+                            "translations": [
+                                {"id": "a", "translation": "你好"},
+                                {"id": "b", "translation": "世界"},
+                            ]
+                        },
+                        model=plan.profiles[route.profile_id].model,
+                    )
+
+                with mock.patch.object(
+                    batch_mod, "run_sync_request", side_effect=fake_sync,
+                ):
+                    batch_mod.probe_requests(manifest_path, limit=1)
+                    batch_mod.execute_sync_request_rows(
+                        manifest_path,
+                        request_rows,
+                    )
+
+                self.assertGreaterEqual(len(seen), 2)
+                self.assertEqual(set(seen), {recorded})
+                self.assertNotIn(live, seen)
+        finally:
+            batch_mod.BATCH_MODEL = previous_batch
+            batch_mod.SYNC_MODEL = previous_sync
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_model_usage_ledger.py
+++ b/tests/test_model_usage_ledger.py
@@ -663,18 +663,22 @@ class ModelUsageLedgerTests(unittest.TestCase):
                 usage_metadata={"totalTokenCount": 9},
             )
 
-            class SuccessBackend:
-                def __init__(self, *_args, **_kwargs):
-                    pass
-
-                def generate(self, _request):
-                    return success
+            success_response = {
+                "response_payload": success.response_payload,
+                "response_text": success.response_text,
+                "finish_reason": success.finish_reason,
+                "usage_metadata": success.usage_metadata,
+                "provider": success.provider,
+                "model": success.model,
+                "execution_mode": success.execution_mode,
+            }
 
             with (
                 mock.patch.object(batch, "load_manifest", return_value=manifest),
                 mock.patch.object(batch, "load_request_rows", return_value=request_rows),
-                mock.patch.object(batch, "create_batch_client", return_value=object()),
-                mock.patch.object(batch, "GeminiSyncBackend", SuccessBackend),
+                mock.patch.object(
+                    batch, "run_sync_request", return_value=success_response
+                ),
                 mock.patch.object(
                     batch, "record_generation_usage_best_effort"
                 ) as recorder,
@@ -686,18 +690,14 @@ class ModelUsageLedgerTests(unittest.TestCase):
             recorder.assert_called_once()
             self.assertEqual(recorder.call_args.kwargs["stage"], "probe")
 
-            class FailingBackend:
-                def __init__(self, *_args, **_kwargs):
-                    pass
-
-                def generate(self, _request):
-                    raise RuntimeError("provider failed")
-
             with (
                 mock.patch.object(batch, "load_manifest", return_value=manifest),
                 mock.patch.object(batch, "load_request_rows", return_value=request_rows),
-                mock.patch.object(batch, "create_batch_client", return_value=object()),
-                mock.patch.object(batch, "GeminiSyncBackend", FailingBackend),
+                mock.patch.object(
+                    batch,
+                    "run_sync_request",
+                    side_effect=RuntimeError("provider failed"),
+                ),
                 mock.patch.object(
                     batch, "record_generation_usage_best_effort"
                 ) as failed_recorder,

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -358,6 +358,51 @@ class TranslationAbExperimentTests(unittest.TestCase):
             }
             self.assertEqual(categories['story_memory'], 'provider_error')
 
+    def test_run_variant_for_chunk_does_not_mask_new_runner_typeerror(self):
+        calls: list[tuple[object, object]] = []
+
+        def new_runner(request_payload, route, plan=None, api_key_index=None):
+            calls.append((route, plan))
+            raise TypeError("payload is missing 'contents'")
+
+        with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as handle:
+            chunk = json.load(handle)['chunks'][0]
+        result = ab_mod.run_variant_for_chunk(
+            chunk,
+            variant_name='baseline',
+            settings={'model': 'gemini-test'},
+            sync_runner=new_runner,
+        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(result.error)
+        self.assertEqual(result.error_category, 'provider_error')
+        self.assertFalse(result.translations)
+
+    def test_run_variant_for_chunk_still_accepts_old_sync_runner_signature(self):
+        calls: list[str] = []
+
+        def old_runner(request_payload, model_name, api_key_index=None):
+            calls.append(model_name)
+            return {
+                'response_text': _full_chunk_translations(),
+                'finish_reason': 'STOP',
+                'usage_metadata': {'total_tokens': 3},
+            }
+
+        with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as handle:
+            chunk = json.load(handle)['chunks'][0]
+        result = ab_mod.run_variant_for_chunk(
+            chunk,
+            variant_name='baseline',
+            settings={'model': 'gemini-test'},
+            sync_runner=old_runner,
+        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(result.error, '')
+        self.assertEqual(result.translations[SAMPLE_ITEM_ID], '你好')
+
     def test_run_translation_ab_experiment_writes_partial_outputs_on_experiment_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest_path = os.path.join(tmp, 'manifest.json')

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -403,6 +403,59 @@ class TranslationAbExperimentTests(unittest.TestCase):
         self.assertEqual(result.error, '')
         self.assertEqual(result.translations[SAMPLE_ITEM_ID], '你好')
 
+    def test_uninspectable_runner_typeerror_is_not_retried_as_old_signature(self):
+        calls: list[object] = []
+
+        def new_runner(request_payload, route, plan=None, api_key_index=None):
+            calls.append(route)
+            raise TypeError("run_sync_request() takes 2 positional arguments but 3 were given")
+
+        with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as handle:
+            chunk = json.load(handle)['chunks'][0]
+        with mock.patch.object(ab_mod.inspect, 'signature', side_effect=ValueError('no sig')):
+            result = ab_mod.run_variant_for_chunk(
+                chunk,
+                variant_name='baseline',
+                settings={'model': 'gemini-test'},
+                sync_runner=new_runner,
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(result.error)
+        self.assertFalse(result.translations)
+
+    def test_run_variant_for_chunk_defaults_to_batch_model(self):
+        captured: list[str] = []
+        previous_sync = batch_mod.SYNC_MODEL
+        previous_batch = batch_mod.BATCH_MODEL
+
+        def new_runner(request_payload, route, plan=None, api_key_index=None):
+            captured.append(batch_mod.route_model(plan, route))
+            return {
+                'response_text': _full_chunk_translations(),
+                'finish_reason': 'STOP',
+                'usage_metadata': {'total_tokens': 3},
+            }
+
+        with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as handle:
+            chunk = json.load(handle)['chunks'][0]
+        try:
+            batch_mod.SYNC_MODEL = ''
+            batch_mod.BATCH_MODEL = 'gemini-batch-default'
+            result = ab_mod.run_variant_for_chunk(
+                chunk,
+                variant_name='baseline',
+                settings={},
+                sync_runner=new_runner,
+            )
+        finally:
+            batch_mod.SYNC_MODEL = previous_sync
+            batch_mod.BATCH_MODEL = previous_batch
+
+        self.assertEqual(captured, ['gemini-batch-default'])
+        self.assertEqual(result.error, '')
+        self.assertEqual(result.translations[SAMPLE_ITEM_ID], '你好')
+
     def test_run_translation_ab_experiment_writes_partial_outputs_on_experiment_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest_path = os.path.join(tmp, 'manifest.json')

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -556,11 +556,21 @@ def run_variant_for_chunk(
     dry_run: bool = False,
     sync_runner: Callable[..., dict] | None = None,
     usage_context: dict | None = None,
+    route=None,
+    plan=None,
 ) -> VariantRunResult:
-    model_name = model_override.strip() or settings.get('model') or _batch().BATCH_MODEL
+    batch_mod = _batch()
+    if plan is None or route is None:
+        overrides = {}
+        explicit = model_override.strip() or str(settings.get('model') or '').strip()
+        if explicit:
+            overrides[batch_mod.model_profile.STAGE_AB_EXPERIMENT] = explicit
+        plan = batch_mod.freeze_runtime_routing_plan(stage_overrides=overrides or None)
+        route = plan.routes[batch_mod.model_profile.STAGE_AB_EXPERIMENT]
+    model_name = batch_mod.route_model(plan, route)
     try:
         enriched = enrich_chunk_for_current_settings(chunk, dry_run=dry_run)
-        request_row = _batch().build_batch_request(enriched, model=model_name)
+        request_row = batch_mod.build_batch_request(enriched, model=model_name)
         request_payload = request_row.get('request') or {}
         if dry_run:
             return VariantRunResult(
@@ -569,8 +579,27 @@ def run_variant_for_chunk(
                 dry_run=True,
             )
 
-        runner = sync_runner or _batch().run_sync_request
-        response = runner(request_payload, model_name, api_key_index=api_key_index)
+        if sync_runner is None:
+            response = batch_mod.run_sync_request(
+                request_payload,
+                route,
+                plan=plan,
+                api_key_index=api_key_index,
+            )
+        else:
+            try:
+                response = sync_runner(
+                    request_payload,
+                    route,
+                    plan=plan,
+                    api_key_index=api_key_index,
+                )
+            except TypeError:
+                response = sync_runner(
+                    request_payload,
+                    model_name,
+                    api_key_index=api_key_index,
+                )
         output_diagnostics = _batch().sync_output_diagnostics(
             response,
             request_payload,
@@ -650,6 +679,14 @@ def run_translation_ab_experiment(
     batch_mod.require_manifest_mode(manifest, batch_mod.MANIFEST_MODE_TRANSLATION, 'compare-variants')
     chunks = select_manifest_chunks(manifest, limit=limit, offset=offset)
     default_model = model_override.strip() or manifest.get('batch_model') or batch_mod.BATCH_MODEL
+    ab_overrides = {}
+    if str(default_model or '').strip():
+        ab_overrides[batch_mod.model_profile.STAGE_AB_EXPERIMENT] = str(default_model).strip()
+    routing_plan = batch_mod.freeze_runtime_routing_plan(
+        stage_overrides=ab_overrides or None,
+    )
+    ab_route = routing_plan.routes[batch_mod.model_profile.STAGE_AB_EXPERIMENT]
+    default_model = batch_mod.route_model(routing_plan, ab_route)
 
     if not output_dir:
         slug = batch_mod.guess_project_slug()
@@ -690,6 +727,8 @@ def run_translation_ab_experiment(
                             dry_run=dry_run,
                             sync_runner=sync_runner,
                             usage_context=usage_context,
+                            route=ab_route,
+                            plan=routing_plan,
                         )
                     )
     except Exception as exc:

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -546,6 +547,86 @@ def write_experiment_outputs(
     }
 
 
+_SIGNATURE_TYPEERROR_MARKERS = (
+    'unexpected keyword argument',
+    'got an unexpected keyword argument',
+    'takes 2 positional arguments but',
+    'takes 1 positional argument but',
+    'missing a required argument',
+    'required positional argument',
+)
+
+
+def _sync_runner_uses_task_route(sync_runner: Callable[..., object]) -> bool | None:
+    """Return whether ``sync_runner`` accepts the TaskRoute calling convention.
+
+    ``True`` means call with ``(payload, route, plan=..., api_key_index=...)``.
+    ``False`` means the pre-#345 ``(payload, model_name, api_key_index=...)``
+    convention. ``None`` means the signature could not be inspected.
+    """
+    try:
+        signature = inspect.signature(sync_runner)
+    except (TypeError, ValueError):
+        return None
+    parameters = signature.parameters
+    if 'route' in parameters or 'plan' in parameters:
+        return True
+    if 'model_name' in parameters:
+        return False
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    ):
+        return True
+    return True
+
+
+def _is_calling_convention_typeerror(exc: TypeError) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in _SIGNATURE_TYPEERROR_MARKERS)
+
+
+def _invoke_ab_sync_runner(
+    sync_runner: Callable[..., dict],
+    request_payload: dict,
+    *,
+    route,
+    plan,
+    model_name: str,
+    api_key_index: int | None,
+) -> dict:
+    """Call a sync runner without treating a real TypeError as an old signature."""
+    convention = _sync_runner_uses_task_route(sync_runner)
+    if convention is False:
+        return sync_runner(
+            request_payload,
+            model_name,
+            api_key_index=api_key_index,
+        )
+    if convention is True:
+        return sync_runner(
+            request_payload,
+            route,
+            plan=plan,
+            api_key_index=api_key_index,
+        )
+    try:
+        return sync_runner(
+            request_payload,
+            route,
+            plan=plan,
+            api_key_index=api_key_index,
+        )
+    except TypeError as exc:
+        if not _is_calling_convention_typeerror(exc):
+            raise
+        return sync_runner(
+            request_payload,
+            model_name,
+            api_key_index=api_key_index,
+        )
+
+
 def run_variant_for_chunk(
     chunk: dict,
     *,
@@ -587,19 +668,14 @@ def run_variant_for_chunk(
                 api_key_index=api_key_index,
             )
         else:
-            try:
-                response = sync_runner(
-                    request_payload,
-                    route,
-                    plan=plan,
-                    api_key_index=api_key_index,
-                )
-            except TypeError:
-                response = sync_runner(
-                    request_payload,
-                    model_name,
-                    api_key_index=api_key_index,
-                )
+            response = _invoke_ab_sync_runner(
+                sync_runner,
+                request_payload,
+                route=route,
+                plan=plan,
+                model_name=model_name,
+                api_key_index=api_key_index,
+            )
         output_diagnostics = _batch().sync_output_diagnostics(
             response,
             request_payload,

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -547,43 +547,24 @@ def write_experiment_outputs(
     }
 
 
-_SIGNATURE_TYPEERROR_MARKERS = (
-    'unexpected keyword argument',
-    'got an unexpected keyword argument',
-    'takes 2 positional arguments but',
-    'takes 1 positional argument but',
-    'missing a required argument',
-    'required positional argument',
-)
-
-
-def _sync_runner_uses_task_route(sync_runner: Callable[..., object]) -> bool | None:
+def _sync_runner_uses_task_route(sync_runner: Callable[..., object]) -> bool:
     """Return whether ``sync_runner`` accepts the TaskRoute calling convention.
 
     ``True`` means call with ``(payload, route, plan=..., api_key_index=...)``.
     ``False`` means the pre-#345 ``(payload, model_name, api_key_index=...)``
-    convention. ``None`` means the signature could not be inspected.
+    convention. An uninspectable signature is treated as the current
+    TaskRoute convention; never guess from a later TypeError message.
     """
     try:
         signature = inspect.signature(sync_runner)
     except (TypeError, ValueError):
-        return None
+        return True
     parameters = signature.parameters
     if 'route' in parameters or 'plan' in parameters:
         return True
     if 'model_name' in parameters:
         return False
-    if any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD
-        for parameter in parameters.values()
-    ):
-        return True
     return True
-
-
-def _is_calling_convention_typeerror(exc: TypeError) -> bool:
-    message = str(exc).lower()
-    return any(marker in message for marker in _SIGNATURE_TYPEERROR_MARKERS)
 
 
 def _invoke_ab_sync_runner(
@@ -595,36 +576,19 @@ def _invoke_ab_sync_runner(
     model_name: str,
     api_key_index: int | None,
 ) -> dict:
-    """Call a sync runner without treating a real TypeError as an old signature."""
-    convention = _sync_runner_uses_task_route(sync_runner)
-    if convention is False:
-        return sync_runner(
-            request_payload,
-            model_name,
-            api_key_index=api_key_index,
-        )
-    if convention is True:
+    """Call a sync runner using only the inspected calling convention."""
+    if _sync_runner_uses_task_route(sync_runner):
         return sync_runner(
             request_payload,
             route,
             plan=plan,
             api_key_index=api_key_index,
         )
-    try:
-        return sync_runner(
-            request_payload,
-            route,
-            plan=plan,
-            api_key_index=api_key_index,
-        )
-    except TypeError as exc:
-        if not _is_calling_convention_typeerror(exc):
-            raise
-        return sync_runner(
-            request_payload,
-            model_name,
-            api_key_index=api_key_index,
-        )
+    return sync_runner(
+        request_payload,
+        model_name,
+        api_key_index=api_key_index,
+    )
 
 
 def run_variant_for_chunk(
@@ -643,7 +607,11 @@ def run_variant_for_chunk(
     batch_mod = _batch()
     if plan is None or route is None:
         overrides = {}
-        explicit = model_override.strip() or str(settings.get('model') or '').strip()
+        explicit = (
+            model_override.strip()
+            or str(settings.get('model') or '').strip()
+            or str(batch_mod.BATCH_MODEL or '').strip()
+        )
         if explicit:
             overrides[batch_mod.model_profile.STAGE_AB_EXPERIMENT] = explicit
         plan = batch_mod.freeze_runtime_routing_plan(stage_overrides=overrides or None)

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -59,6 +59,7 @@ from rpa_safety import (
     member_output_size,
     read_bounded_compressed_index,
 )
+import model_profile
 import model_usage_ledger
 import prompt_context
 import story_memory
@@ -69,7 +70,6 @@ from sync_model_backend import (
     DEFAULT_SYNC_TIMEOUT_SECONDS,
     MAX_SYNC_TIMEOUT_SECONDS,
     MIN_SYNC_TIMEOUT_SECONDS,
-    GeminiSyncBackend,
     SyncGenerationRequest,
     normalize_sync_timeout_seconds,
     sync_error_detail,
@@ -4549,6 +4549,32 @@ def normalize_result_items(payload):
     )
 
 
+def _routing_custom_providers(custom_providers):
+    """Keep only real provider records for the resolver; mocks stay on the backend."""
+    if not custom_providers:
+        return None
+    return {
+        key: value
+        for key, value in custom_providers.items()
+        if getattr(value, "requires_key", None) is not None
+    } or None
+
+
+def freeze_translation_routing_plan(*, stage_overrides=None):
+    """Snapshot the translation TaskRoute from currently loaded sync settings."""
+    current = get_current_model()
+    overrides = dict(stage_overrides or {})
+    overrides.setdefault(model_profile.STAGE_TRANSLATION, current)
+    return model_profile.resolve_routing_plan_from_runtime(
+        sync_backend=SYNC_BACKEND,
+        sync_model=current,
+        sync_models=tuple(MODELS),
+        custom_providers=_routing_custom_providers(CUSTOM_LITELLM_PROVIDERS),
+        execution=model_profile.ExecutionStrategy.SYNC,
+        stage_overrides=overrides,
+    )
+
+
 def call_gemini_sdk(
     prompt,
     items,
@@ -4556,9 +4582,20 @@ def call_gemini_sdk(
     usage_buffer=None,
     usage_operation_id='',
     return_contract=False,
+    route=None,
+    plan=None,
 ):
     """Calls the explicitly configured synchronous backend."""
-    model_name = get_current_model()
+    if plan is None or route is None:
+        plan = freeze_translation_routing_plan()
+        route = plan.routes[model_profile.STAGE_TRANSLATION]
+    if not isinstance(route, model_profile.TaskRoute):
+        raise TypeError(
+            'call_gemini_sdk requires an explicit TaskRoute; '
+            f'got {type(route).__name__}.'
+        )
+    profile = model_profile.profile_for_route(plan, route)
+    model_name = profile.model
     generation_config = {
         "temperature": 0.2,
         "max_output_tokens": SYNC_MAX_OUTPUT_TOKENS,
@@ -4568,21 +4605,10 @@ def call_gemini_sdk(
     }
     generation_config = filter_gemini_generation_config(model_name, generation_config)
 
-    if SYNC_BACKEND == "litellm":
-        from litellm_sync_backend import LiteLLMSyncBackend
-
-        backend = LiteLLMSyncBackend(
-            custom_providers=CUSTOM_LITELLM_PROVIDERS
-        )
-    else:
-        configure_genai()
-        backend = GeminiSyncBackend(
-            create_genai_client(),
-            serialize_response=serialize_unknown,
-            extract_text=extract_text_from_response_payload,
-            extract_finish_reason=extract_finish_reason,
-            extract_usage=model_usage_ledger.extract_provider_usage,
-        )
+    backend = model_profile.build_sync_backend(
+        profile,
+        custom_providers=CUSTOM_LITELLM_PROVIDERS,
+    )
     request = SyncGenerationRequest(
             model=model_name,
             contents=prompt,
@@ -4678,6 +4704,8 @@ def process_batch(
     translation_validator=None,
     context_window=None,
     return_contract=False,
+    route=None,
+    plan=None,
 ):
     # Local glossary matches are lexical and must not depend on the RAG
     # switch: normalize_map / preserve / non-translatable hits always reach
@@ -4721,6 +4749,8 @@ def process_batch(
         usage_buffer=usage_buffer,
         usage_operation_id=usage_operation_id,
         return_contract=True,
+        route=route,
+        plan=plan,
     )
     if isinstance(contract, list):
         # Compatibility for injected/test callables that still return the
@@ -4947,6 +4977,8 @@ def process_batch_with_retry(
     contract_failures=None,
     retry_kind='first_pass',
     context_window=None,
+    route=None,
+    plan=None,
 ):
     if contract_diagnostics is not None and retry_kind == 'first_pass':
         original_ids = [
@@ -4986,6 +5018,8 @@ def process_batch_with_retry(
                 usage_operation_id=usage_operation_id,
                 context_window=context_window,
                 return_contract=True,
+                route=route,
+                plan=plan,
             )
             _record_sync_contract_report(
                 contract_diagnostics,
@@ -5067,6 +5101,8 @@ def process_batch_with_retry(
                 # context window; reuse it so missing items keep the same
                 # surrounding context as the first request.
                 context_window=context_window,
+                route=route,
+                plan=plan,
             )
             return successful + retried
 
@@ -5176,6 +5212,8 @@ def process_batch_with_retry(
             retry_kind='split_retry',
             # Split children no longer line up with the original local context
             # window, so it is intentionally omitted (issue #338).
+            route=route,
+            plan=plan,
         )
         r2 = process_batch_with_retry(
             right_batch, replacements, retry_depth + 1,
@@ -5187,6 +5225,8 @@ def process_batch_with_retry(
             contract_failures=contract_failures,
             retry_kind='split_retry',
             # See the split-left call above: context window is not reused.
+            route=route,
+            plan=plan,
         )
         return r1 + r2
 
@@ -5791,6 +5831,8 @@ def run_translation(*, prepare=False):
     print(f"TL dir: {TL_DIR} (exists: {os.path.isdir(TL_DIR)})")
     print(f"Progress log: {PROGRESS_LOG}")
     print("=" * 60)
+    routing_plan = freeze_translation_routing_plan()
+    translation_route = routing_plan.routes[model_profile.STAGE_TRANSLATION]
 
     try:
         if prepare:
@@ -5898,6 +5940,8 @@ def run_translation(*, prepare=False):
                         contract_diagnostics=contract_diagnostics,
                         contract_failures=contract_failures,
                         context_window=context_window,
+                        route=translation_route,
+                        plan=routing_plan,
                     ))
                     batch = []
                     batch_start = batch_index
@@ -5923,6 +5967,8 @@ def run_translation(*, prepare=False):
                     contract_diagnostics=contract_diagnostics,
                     contract_failures=contract_failures,
                     context_window=context_window,
+                    route=translation_route,
+                    plan=routing_plan,
                 ))
             # Persist attempted-batch diagnostics even when the file produced
             # no preview (all items rejected or adapter writeback blocked), so


### PR DESCRIPTION
## Summary

This is **#345 P2 only** (CLI wiring). It does **not** start #345 P3 (task-start fail-fast / doctor-docs / GUI `litellm_worker`), #346 TranslationPlan, or #347 durable executor.

`run_sync_request` no longer does `effective_model = SYNC_MODEL or model_name`. Every translation, keyword, revision, project-analysis, and A/B sync caller now passes an explicit `TaskRoute`. Production sync backends (outside `gui_qt/`, tests, and scripts) are obtained only from `build_sync_backend`.

Each run freezes one `ModelRoutingPlan` at start. After that freeze, mutating live config / `SYNC_MODEL` and performing retries still use the same profile. Sync manifests and the four batch manifests (translation, keyword, revision, final_review) persist a `model_routing` snapshot of credential **references** only.

**Behavior change (option B):** an explicit stage / caller `TaskRoute` model wins. `sync.model` is only the inherited primary for stages that have no own route.

## CONTRIBUTING exception

Staged CLI-only delivery for #345 P2. GUI stays on later #345 work (`gui_qt/litellm_worker` resolver wiring is P3). This PR does not edit `gui_qt/`.

## Test plan

- [x] `python -m unittest tests.test_model_profile tests.test_litellm_sync_integration tests.test_batch_repair -q` (twice)
- [x] `python -B tests/run_cli_tests.py -q` (twice)
- [x] `git diff --check`
- [x] Locked assertions now require the explicit stage model on first pass and targeted retry
- [x] Mid-run `SYNC_MODEL` mutation and retries keep the frozen profile
- [x] Serialized `model_routing` has no credential values / `api_key` slots

## Non-goals

- Do not merge this PR as part of this change.
- Do not push `main`.
- Do not change default models or default execution strategies.