### PR TITLE
test(quality): 新增 #364 A1 离线真实样本回归语料

### DIFF
--- a/tests/fixtures/quality_real_samples/README.md
+++ b/tests/fixtures/quality_real_samples/README.md
@@ -1,0 +1,48 @@
+# quality_real_samples
+
+Issue #364（真实项目质量规则校准）的离线回归样本。这里**不包含任何私有游戏文本**：所有样本都是从公开 issue #313 / #364 中已知问题示例重建、或人工编写的脱敏代表句。
+
+## 运行
+
+```bash
+python -m unittest tests.test_quality_real_samples -v
+```
+
+测试对每个首版 reason code 断言：
+
+- `positive`：必须被报告；
+- `negative`：白名单 / 合法混排 / 已翻译证据，必须对该 reason code 保持沉默。
+
+覆盖范围与 `translation_quality.ALL_REASON_CODES` 强制一致，新增首版规则时测试会提醒补样本。
+
+## 格式
+
+`samples.json` 的 `cases` 每个元素：
+
+```json
+{
+  "rule_id": "cjk_latin_spacing",
+  "reason_code": "quality.typography.cjk_latin_spacing",
+  "positive": {
+    "name": "…",
+    "subject": {"translation": "这是iPhone手机"},
+    "policy": {"rules": {"cjk_latin_spacing": "warning"}}
+  },
+  "negative": {
+    "name": "…",
+    "subject": {"translation": "这是VIP通道"},
+    "policy": {"rules": {"cjk_latin_spacing": "warning"}}
+  }
+}
+```
+
+- `subject`：传给 `translation_quality.check_subject` 的机械质量主语；`glossary_map` 按需提供。
+- `policy`：只写与运行时默认策略的差异，经 `normalize_policy` 合并，使样本独立于将来默认 disposition 的调整。
+- `reason_code` 必须与 `rule_id` 对应，未知 code 会被测试拒绝。
+
+## 校准后如何刷新
+
+1. 在真实项目上运行 `check`，从 `quality_findings.jsonl` 抽样标注误报 / 漏报；
+2. 摘录代表性样本时**改写或脱敏原文**，不得把私有游戏脚本原文直接提交到仓库；
+3. 把标注为真实正例的句子写入对应 `positive`，把白名单 / 合法反例写入 `negative`；
+4. 若抽样发现某 reason code 误报高，在默认 disposition 调整（issue #364 A2）之后重新运行本测试，确保「已知正例仍能报告」。

--- a/tests/fixtures/quality_real_samples/samples.json
+++ b/tests/fixtures/quality_real_samples/samples.json
@@ -1,0 +1,400 @@
+{
+  "schema_version": 1,
+  "purpose": "Offline, privacy-safe regression corpus for the first-version mechanical quality rules (issue #364).",
+  "provenance": "Samples are sanitized representative cases reconstructed from the public issue #313 / #364 descriptions. They contain no private game script text. After real-project sampling (issue #364 line B), replace or extend these entries with anonymized findings from the calibration report.",
+  "conventions": "Each case maps one first-version reason_code to a positive sample that must report it and a negative sample that must stay silent for it. Optional policy and glossary_map are normalized with translation_quality.normalize_policy, so entries only need to specify deltas from the runtime defaults.",
+  "cases": [
+    {
+      "rule_id": "renpy_wait_inside_cjk",
+      "reason_code": "quality.renpy.wait_tag_inside_cjk",
+      "positive": {
+        "name": "wait tag inserted inside a Chinese word",
+        "subject": {
+          "item_id": "issue-364/wait-tag/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 12,
+          "source": "",
+          "translation": "你{w=0.5}好"
+        },
+        "policy": {
+          "rules": {
+            "renpy_wait_inside_cjk": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "wait tag at a sentence boundary is legitimate",
+        "subject": {
+          "item_id": "issue-364/wait-tag/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 13,
+          "source": "",
+          "translation": "……{w=0.3}走吧"
+        },
+        "policy": {
+          "rules": {
+            "renpy_wait_inside_cjk": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "unclosed_delimiters",
+      "reason_code": "quality.structure.unclosed_delimiters",
+      "positive": {
+        "name": "unclosed Ren'Py tag delimiter",
+        "subject": {
+          "item_id": "issue-364/unclosed-delimiters/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 21,
+          "source": "",
+          "translation": "你好 {w=0.5"
+        },
+        "policy": {
+          "rules": {
+            "unclosed_delimiters": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "Ren'Py escaped literal brackets are not broken delimiters",
+        "subject": {
+          "item_id": "issue-364/unclosed-delimiters/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 22,
+          "source": "",
+          "translation": "这是[[说明文字]]"
+        },
+        "policy": {
+          "rules": {
+            "unclosed_delimiters": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "english_suffix_adjacent",
+      "reason_code": "quality.language.english_suffix_adjacent",
+      "positive": {
+        "name": "English morphology suffix glued to a Chinese word",
+        "subject": {
+          "item_id": "issue-364/english-suffix/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 31,
+          "source": "",
+          "translation": "迷踪步ping"
+        },
+        "policy": {
+          "rules": {
+            "english_suffix_adjacent": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "project allowlisted abbreviation ending in s does not look like a suffix",
+        "subject": {
+          "item_id": "issue-364/english-suffix/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 32,
+          "source": "",
+          "translation": "中文cos"
+        },
+        "policy": {
+          "rules": {
+            "english_suffix_adjacent": "warning"
+          },
+          "allowed_latin_tokens": [
+            "cos"
+          ]
+        }
+      }
+    },
+    {
+      "rule_id": "suspicious_english_residue",
+      "reason_code": "quality.language.suspicious_english_residue",
+      "positive": {
+        "name": "visible English token left in a Chinese translation",
+        "subject": {
+          "item_id": "issue-364/english-residue/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 41,
+          "source": "",
+          "translation": "TA也说过"
+        },
+        "policy": {
+          "rules": {
+            "suspicious_english_residue": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "default allowlisted acronym is not visible residue",
+        "subject": {
+          "item_id": "issue-364/english-residue/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 42,
+          "source": "",
+          "translation": "当前HP为100"
+        },
+        "policy": {
+          "rules": {
+            "suspicious_english_residue": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "cjk_latin_spacing",
+      "reason_code": "quality.typography.cjk_latin_spacing",
+      "positive": {
+        "name": "Latin token touches CJK text without project spacing",
+        "subject": {
+          "item_id": "issue-364/cjk-latin-spacing/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 51,
+          "source": "",
+          "translation": "这是iPhone手机"
+        },
+        "policy": {
+          "rules": {
+            "cjk_latin_spacing": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "default allowlisted acronym may stay adjacent to CJK",
+        "subject": {
+          "item_id": "issue-364/cjk-latin-spacing/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 52,
+          "source": "",
+          "translation": "这是VIP通道"
+        },
+        "policy": {
+          "rules": {
+            "cjk_latin_spacing": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "halfwidth_punctuation",
+      "reason_code": "quality.typography.halfwidth_punctuation",
+      "positive": {
+        "name": "halfwidth comma sits between CJK characters",
+        "subject": {
+          "item_id": "issue-364/halfwidth-punctuation/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 61,
+          "source": "",
+          "translation": "你好,世界"
+        },
+        "policy": {
+          "rules": {
+            "halfwidth_punctuation": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "full-width punctuation follows the project convention",
+        "subject": {
+          "item_id": "issue-364/halfwidth-punctuation/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 62,
+          "source": "",
+          "translation": "你好，世界。"
+        },
+        "policy": {
+          "rules": {
+            "halfwidth_punctuation": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "ascii_ellipsis",
+      "reason_code": "quality.typography.ascii_ellipsis",
+      "positive": {
+        "name": "ASCII dots used as a Chinese ellipsis",
+        "subject": {
+          "item_id": "issue-364/ascii-ellipsis/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 71,
+          "source": "",
+          "translation": "你好..."
+        },
+        "policy": {
+          "rules": {
+            "ascii_ellipsis": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "full-width Chinese ellipsis follows the project convention",
+        "subject": {
+          "item_id": "issue-364/ascii-ellipsis/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 72,
+          "source": "",
+          "translation": "你好……"
+        },
+        "policy": {
+          "rules": {
+            "ascii_ellipsis": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "glossary_term_not_applied",
+      "reason_code": "quality.glossary.term_not_applied",
+      "positive": {
+        "name": "source glossary term is still visible instead of its target",
+        "subject": {
+          "item_id": "issue-364/glossary/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 81,
+          "source": "Church Knight says hello.",
+          "translation": "Church Knight说你好。"
+        },
+        "policy": {
+          "rules": {
+            "glossary_term_not_applied": "warning"
+          }
+        },
+        "glossary_map": {
+          "Church Knight": "教会骑士"
+        }
+      },
+      "negative": {
+        "name": "glossary target is applied and the source term is gone",
+        "subject": {
+          "item_id": "issue-364/glossary/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 82,
+          "source": "Church Knight says hello.",
+          "translation": "教会骑士说你好。"
+        },
+        "policy": {
+          "rules": {
+            "glossary_term_not_applied": "warning"
+          }
+        },
+        "glossary_map": {
+          "Church Knight": "教会骑士"
+        }
+      }
+    },
+    {
+      "rule_id": "speaker_label_untranslated",
+      "reason_code": "quality.speaker.label_untranslated",
+      "positive": {
+        "name": "occupation speaker label has no translation evidence",
+        "subject": {
+          "item_id": "issue-364/speaker-label/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 91,
+          "source": "Welcome.",
+          "translation": "欢迎。",
+          "speaker_name": "Church Knight"
+        },
+        "policy": {
+          "rules": {
+            "speaker_label_untranslated": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "translated speaker label evidence suppresses the rule",
+        "subject": {
+          "item_id": "issue-364/speaker-label/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 92,
+          "source": "Welcome.",
+          "translation": "欢迎。",
+          "speaker_name": "Church Knight",
+          "speaker_name_translation": "教会骑士"
+        },
+        "policy": {
+          "rules": {
+            "speaker_label_untranslated": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "interjection_untranslated",
+      "reason_code": "quality.completeness.interjection_untranslated",
+      "positive": {
+        "name": "short interjection is left unchanged",
+        "subject": {
+          "item_id": "issue-364/interjection/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 101,
+          "source": "Oh!",
+          "translation": "Oh!"
+        },
+        "policy": {
+          "rules": {
+            "interjection_untranslated": "warning"
+          }
+        }
+      },
+      "negative": {
+        "name": "interjection is translated into Chinese",
+        "subject": {
+          "item_id": "issue-364/interjection/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 102,
+          "source": "Oh!",
+          "translation": "哦！"
+        },
+        "policy": {
+          "rules": {
+            "interjection_untranslated": "warning"
+          }
+        }
+      }
+    },
+    {
+      "rule_id": "known_garbled_phrase",
+      "reason_code": "quality.garbled.known_bad_phrase",
+      "positive": {
+        "name": "project-configured garbled phrase appears verbatim",
+        "subject": {
+          "item_id": "issue-364/garbled-phrase/positive",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 111,
+          "source": "",
+          "translation": "这是迷踪步ping吗"
+        },
+        "policy": {
+          "rules": {
+            "known_garbled_phrase": "warning"
+          },
+          "garbled_phrases": [
+            "迷踪步ping"
+          ]
+        }
+      },
+      "negative": {
+        "name": "same line without the garbled phrase stays silent",
+        "subject": {
+          "item_id": "issue-364/garbled-phrase/negative",
+          "file_rel_path": "chapter01/dialogue.rpy",
+          "line_number": 112,
+          "source": "",
+          "translation": "这是迷踪步吗"
+        },
+        "policy": {
+          "rules": {
+            "known_garbled_phrase": "warning"
+          },
+          "garbled_phrases": [
+            "迷踪步ping"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/quality_real_samples/samples.json
+++ b/tests/fixtures/quality_real_samples/samples.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "purpose": "Offline, privacy-safe regression corpus for the first-version mechanical quality rules (issue #364).",
   "provenance": "Samples are sanitized representative cases reconstructed from the public issue #313 / #364 descriptions. They contain no private game script text. After real-project sampling (issue #364 line B), replace or extend these entries with anonymized findings from the calibration report.",
-  "conventions": "Each case maps one first-version reason_code to a positive sample that must report it and a negative sample that must stay silent for it. Optional policy and glossary_map are normalized with translation_quality.normalize_policy, so entries only need to specify deltas from the runtime defaults.",
+  "conventions": "Each case maps one first-version reason_code to a positive sample that must report it and a negative sample that must stay silent for it. Policy deltas are merged via translation_quality.normalize_policy; glossary_map, when present, is passed through to check_subject as a complete map.",
   "cases": [
     {
       "rule_id": "renpy_wait_inside_cjk",

--- a/tests/test_quality_real_samples.py
+++ b/tests/test_quality_real_samples.py
@@ -1,0 +1,105 @@
+"""Offline regression corpus tests for issue #364 real-sample calibration.
+
+The corpus lives in ``tests/fixtures/quality_real_samples/samples.json`` and
+contains one privacy-safe positive and one allowlist/legitimate negative sample
+per first-version mechanical reason code.  These tests are the in-repo half of
+the calibration baseline: they run without any private game text and prove both
+that known positives still report and that known negatives stay silent after
+allowlist / disposition tuning.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import translation_quality as quality
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "quality_real_samples"
+    / "samples.json"
+)
+
+
+def load_corpus() -> tuple[list[dict], dict]:
+    with FIXTURE_PATH.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    cases = payload.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise AssertionError("quality_real_samples/samples.json must contain a non-empty cases list")
+    if not all(isinstance(case, dict) for case in cases):
+        raise AssertionError("every entry in cases must be an object")
+    return cases, payload
+
+
+def findings_for_sample(sample: dict) -> list[dict]:
+    """Run one corpus sample through the shared mechanical quality checker."""
+    subject = sample.get("subject")
+    if not isinstance(subject, dict):
+        raise AssertionError("each sample must contain a subject object")
+    policy = quality.normalize_policy(sample.get("policy"))
+    glossary_map = sample.get("glossary_map") or {}
+    if not isinstance(glossary_map, dict):
+        raise AssertionError("glossary_map must be an object when present")
+    return quality.check_subject(
+        subject,
+        policy=policy,
+        glossary_map=dict(glossary_map),
+    )
+
+
+def reason_codes_for_sample(sample: dict) -> set[str]:
+    return {finding["reason_code"] for finding in findings_for_sample(sample)}
+
+
+class QualityRealSampleCorpusTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cases, cls.payload = load_corpus()
+
+    def test_corpus_schema_and_reason_codes_are_valid(self) -> None:
+        self.assertEqual(self.payload.get("schema_version"), 1)
+        reason_codes = [case.get("reason_code") for case in self.cases]
+        self.assertTrue(all(reason_codes), "each case needs a reason_code")
+        self.assertTrue(
+            all(code in quality.ALL_REASON_CODES for code in reason_codes),
+            "corpus contains an unknown reason_code",
+        )
+        for case in self.cases:
+            with self.subTest(reason_code=case.get("reason_code")):
+                self.assertEqual(
+                    quality.REASON_TO_RULE_KEY.get(case["reason_code"]),
+                    case.get("rule_id"),
+                    "rule_id must match translation_quality.REASON_TO_RULE_KEY",
+                )
+                for side in ("positive", "negative"):
+                    sample = case.get(side)
+                    self.assertIsInstance(sample, dict)
+                    self.assertIsInstance(sample.get("subject"), dict)
+
+    def test_every_first_version_reason_code_has_a_sample_pair(self) -> None:
+        covered = {case["reason_code"] for case in self.cases}
+
+        self.assertEqual(covered, set(quality.ALL_REASON_CODES))
+
+    def test_every_positive_sample_reports_its_reason_code(self) -> None:
+        for case in self.cases:
+            with self.subTest(reason_code=case["reason_code"]):
+                self.assertIn(
+                    case["reason_code"],
+                    reason_codes_for_sample(case["positive"]),
+                )
+
+    def test_every_negative_sample_stays_silent_for_its_reason_code(self) -> None:
+        for case in self.cases:
+            with self.subTest(reason_code=case["reason_code"]):
+                self.assertNotIn(
+                    case["reason_code"],
+                    reason_codes_for_sample(case["negative"]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #364

## 范围

本 PR 交付 #364 A1（仓库内、无需私有数据的一半）：建立可离线运行的真实样本质量规则回归语料。

## 实现

- 新增 `tests/fixtures/quality_real_samples/samples.json`：
  - 覆盖全部 11 个首版 reason code，与 `translation_quality.ALL_REASON_CODES` 强制一致；
  - 每个 reason code 一对样本：真实正例（必须报告）+ 白名单/合法反例（必须沉默）；
  - 所有文本为脱敏重建或人工编写，不含私有游戏脚本原文；
  - 每个样本可携带 `policy` / `glossary_map` 增量，其中 `policy` 经 `normalize_policy` 合并，使语料独立于将来默认 disposition 的调整（为 A2 铺路）。
- 新增 `tests/test_quality_real_samples.py`：语料 schema 与 rule_id 一致性、首版 reason code 全覆盖、逐条正例/反例四类断言。
- 新增 fixture README：运行方式、JSON 格式约定、脱敏要求，以及 B 线真实抽样后如何刷新语料。
- 不涉及 CLI/GUI 行为或配置变更，因此不更新 CHANGELOG 与用户文档。

## 验证

- `test_quality_real_samples`：4 passed。
- 相关回归 `test_translation_quality` + `test_unified_quality_findings`：70 passed。
- ruff（项目配置默认规则 + E9/F63/F7/F82）、`py_compile`、JSON 解析、`git diff --check` 通过。
- 本机完整 `run_cli_tests.py` 仍有两个与本 PR 无关的环境性失败（site-packages `tests` 包遮蔽仓库 `tests` 命名空间、无 PySide6 环境下 GUI suite 包含 `_FailedTest`），这两个失败在 main 基线同样存在。

## 后续（#364 剩余工作）

- A2：根据真实项目抽样结论调整 `allowed_latin_tokens` 与默认 disposition，并同步 example 配置与文档；
- B1/B2：在真实项目上运行 `check` 产出 reason code 分布，人工抽样标注误报/漏报后把代表性脱敏样本回流本语料。
