### PR TITLE
feat(cli): add machine output for revision and keyword P1 commands

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -245,7 +245,7 @@ def strict_exit_code(envelope: Mapping[str, Any]) -> int:
             return EXIT_BLOCKED
         return EXIT_INVALID_STATE
     if command == "sync-revisions":
-        if status in {"ready", "previewed", "applied", "no_op"}:
+        if status in {"ready", "previewed", "applied", "no_op", "no_work"}:
             return EXIT_OK
         if status in {"ready_with_warnings", "warn", "attention", "partial"}:
             return EXIT_NEEDS_ACTION

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -236,6 +236,22 @@ def strict_exit_code(envelope: Mapping[str, Any]) -> int:
         if status in {"blocked", "stale"}:
             return EXIT_BLOCKED
         return EXIT_INVALID_STATE
+    if command == "preview-revisions":
+        if status in {"ready", "previewed"}:
+            return EXIT_OK
+        if status in {"ready_with_warnings", "warn", "attention"}:
+            return EXIT_NEEDS_ACTION
+        if status in {"blocked"}:
+            return EXIT_BLOCKED
+        return EXIT_INVALID_STATE
+    if command == "sync-revisions":
+        if status in {"ready", "previewed", "applied", "no_op"}:
+            return EXIT_OK
+        if status in {"ready_with_warnings", "warn", "attention", "partial"}:
+            return EXIT_NEEDS_ACTION
+        if status in {"blocked", "stale"}:
+            return EXIT_BLOCKED
+        return EXIT_INVALID_STATE
     if command in {"submit", "status"} and status in {
         "failed",
         "cancelled",

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -64,14 +64,14 @@ python gemini_translate_batch.py check logs/batch_jobs/<package>/manifest.json -
 严格模式下也不能只看退出码：必须同时读取 envelope 的 `ok`、`status` 和 `error`。job pending/running 是成功查询，退出 `0`；`check` 在 `ready` 时退出 `0`，`ready_with_warnings` 退出 `3` 但仍满足写回门禁（`writeback_gate.decision=allow`），`blocked` 退出 `4`。错误时优先使用稳定的 `error.code`、`retryable`、`suggested_action` 与权威的 `details.semantic_exit_code`，不要解析自然语言 `message`。
 
 
-需要确定性调用时追加 `--non-interactive`。该选项保证核心命令不等待 stdin，并让 `submit / status / download / check / apply / quality-ack / quality-unack` 必须显式接收 manifest 或 package target；因此不会读取 latest manifest，`submit` 也不会隐式 build。缺少 target 时 JSON envelope 返回 `EXPLICIT_TARGET_REQUIRED`，配合 `--strict-exit-codes` 退出 `5`。
+需要确定性调用时追加 `--non-interactive`。该选项保证核心命令不等待 stdin，并让 `submit / status / download / check / apply / preview-revisions / apply-revisions / quality-ack / quality-unack` 必须显式接收 manifest 或 package target；因此不会读取 latest manifest，`submit` 也不会隐式 build。缺少 target 时 JSON envelope 返回 `EXPLICIT_TARGET_REQUIRED`，配合 `--strict-exit-codes` 退出 `5`。
 
 ```powershell
 python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json --output json --non-interactive --strict-exit-codes
 ```
 
 只需关闭 target 回退时可单独使用 `--require-explicit-target`。默认模式保持现有 latest-manifest 和 submit-build 行为；`doctor / build` 不消费 manifest，不受显式 target 要求影响。
-结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply / quality-ack / quality-unack`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
+结构化输出当前覆盖 `doctor / build / build-revisions / build-keywords / submit / status / download / check / apply / apply-revisions / preview-revisions / sync-revisions / export-revision-corpus / import-revision-proposals / export-keywords / sync-keywords / quality-ack / quality-unack` 以及版本资产/复用命令；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
 核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.writeback_gate.decision result.check.quality_gate` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -30,6 +30,23 @@ python gemini_translate_batch.py check <manifest> --output json
 python gemini_translate_batch.py apply <manifest> --output json
 ```
 
+订正流程的关键命令也使用同一 envelope：
+
+```powershell
+python gemini_translate_batch.py build-revisions --output json
+python gemini_translate_batch.py preview-revisions <manifest> --output json
+python gemini_translate_batch.py apply-revisions <manifest> --output json
+python gemini_translate_batch.py sync-revisions --output json
+```
+
+关键词流程的关键命令也使用同一 envelope：
+
+```powershell
+python gemini_translate_batch.py build-keywords --output json
+python gemini_translate_batch.py export-keywords <manifest> --output json
+python gemini_translate_batch.py sync-keywords --output json
+```
+
 P3/P4 的版本资产与译文复用命令也使用同一 envelope：
 
 ```powershell
@@ -110,7 +127,7 @@ ModelProfile 与 ExecutionStrategy。拒绝时使用以下稳定合同：
 python gemini_translate_batch.py status <manifest> --output json --non-interactive --strict-exit-codes
 ```
 
-在 `submit / status / download / check / apply` 中，`--non-interactive` 要求显式传入 manifest 路径或 package 目录：
+在 `submit / status / download / check / apply / preview-revisions / apply-revisions` 中，`--non-interactive` 要求显式传入 manifest 路径或 package 目录：
 
 - 不再读取 `latest_manifest.txt` 或扫描最新 package；
 - `submit` 不再因 target 为空而隐式执行 build；
@@ -173,8 +190,7 @@ python gemini_translate_batch.py schema status
 `capabilities` 与 `schema` 本身就是 JSON 命令，也接受 `--compact / --fields / --output-file`，但不需要也不提供冗余的 `--output json`。
 
 没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪是公开参数，不存在 discovery schema 之外的隐藏 Agent 行为。
-没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的七个
-核心命令和两个版本资产命令；其他子命令以各自 `--help` 和落盘产物为准。
+没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的核心流程、订正流程关键命令、版本资产/复用命令；其余子命令以各自 `--help`、`capabilities` 和落盘产物为准。
 
 ## 1. 安装核心依赖
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -112,12 +112,18 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
     {
         'doctor',
         'build',
+        'build-keywords',
+        'build-revisions',
+        'export-keywords',
+        'sync-keywords',
         'submit',
         'status',
         'download',
         'check',
         'apply',
         'apply-revisions',
+        'preview-revisions',
+        'sync-revisions',
         'export-revision-corpus',
         'import-revision-proposals',
         'export-project-snapshot',
@@ -130,7 +136,19 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'quality-unack',
     }
 )
-EXPLICIT_TARGET_COMMANDS = frozenset({'submit', 'status', 'download', 'check', 'apply', 'quality-ack', 'quality-unack'})
+EXPLICIT_TARGET_COMMANDS = frozenset(
+    {
+        'submit',
+        'status',
+        'download',
+        'check',
+        'apply',
+        'preview-revisions',
+        'apply-revisions',
+        'quality-ack',
+        'quality-unack',
+    }
+)
 # Local-only batch commands must not be blocked by API-key preflight.
 OFFLINE_BATCH_COMMANDS = frozenset(
     {
@@ -15282,6 +15300,7 @@ def build_arg_parser():
         default=0,
         help='Maximum keyword candidates requested from each chunk.',
     )
+    add_machine_output_argument(keyword_build_parser)
 
     revision_build_parser = subparsers.add_parser(
         'build-revisions',
@@ -15299,6 +15318,7 @@ def build_arg_parser():
         default=0,
         help='Old/new pair count per revision chunk. Defaults to batch.revision.chunk_size.',
     )
+    add_machine_output_argument(revision_build_parser)
 
     export_revision_corpus_parser = subparsers.add_parser(
         'export-revision-corpus',
@@ -16054,6 +16074,7 @@ def build_arg_parser():
         default='',
         help='Relative chunk summary Markdown path inside the package.',
     )
+    add_machine_output_argument(keyword_export_parser)
 
     merge_keywords_parser = subparsers.add_parser(
         'merge-keywords-to-glossary',
@@ -16155,6 +16176,7 @@ def build_arg_parser():
     )
     revision_preview_parser.add_argument('--jsonl', default='', help='Relative output JSONL path inside the package.')
     revision_preview_parser.add_argument('--markdown', default='', help='Relative output Markdown path inside the package.')
+    add_machine_output_argument(revision_preview_parser)
 
     revision_apply_parser = subparsers.add_parser(
         'apply-revisions',
@@ -16218,6 +16240,7 @@ def build_arg_parser():
         help='Relative chunk summary Markdown path inside the sync run dir.',
     )
     sync_keyword_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
+    add_machine_output_argument(sync_keyword_parser)
 
     sync_revision_parser = subparsers.add_parser(
         'sync-revisions',
@@ -16253,6 +16276,7 @@ def build_arg_parser():
         ),
     )
     sync_revision_parser.add_argument('--api-key-index', type=int, default=None, help='Optional API key index override.')
+    add_machine_output_argument(sync_revision_parser)
 
     split_parser = subparsers.add_parser('split', help='Split an existing batch package into smaller local packages.')
     split_parser.add_argument(
@@ -16876,21 +16900,19 @@ def dispatch_command(parser, args):
         )
 
     if command == 'build-keywords':
-        create_keyword_package(
+        return create_keyword_package(
             display_name_override=args.display_name,
             skip_prepare=(not args.prepare) or args.skip_prepare,
             chunk_size=args.chunk_size,
             max_candidates_per_chunk=args.max_candidates_per_chunk,
         )
-        return
 
     if command == 'build-revisions':
-        create_revision_package(
+        return create_revision_package(
             display_name_override=args.display_name,
             skip_prepare=args.skip_prepare,
             chunk_size=args.chunk_size,
         )
-        return
 
     if command == 'bootstrap-rag':
         bootstrap_rag_store(skip_prepare=args.skip_prepare, seed_jsonl_paths=args.seed_jsonl)
@@ -16963,14 +16985,13 @@ def dispatch_command(parser, args):
         return apply_results(args.target or None, force=args.force)
 
     if command == 'export-keywords':
-        export_keyword_candidates(
+        return export_keyword_candidates(
             target=args.target or None,
             output_jsonl=args.jsonl,
             output_markdown=args.markdown,
             output_summary_jsonl=args.summary_jsonl,
             output_summary_markdown=args.summary_markdown,
         )
-        return
 
     if command == 'merge-keywords-to-glossary':
         candidates_path = keyword_glossary_merge.resolve_keyword_candidates_path(args.target)
@@ -17013,19 +17034,18 @@ def dispatch_command(parser, args):
         return
 
     if command == 'preview-revisions':
-        preview_revisions(
+        return preview_revisions(
             target=args.target or None,
             output_jsonl=args.jsonl,
             output_markdown=args.markdown,
         )
-        return
 
     if command == 'apply-revisions':
         apply_revisions(args.target or None, force=args.force)
         return
 
     if command == 'sync-keywords':
-        sync_keyword_candidates(
+        return sync_keyword_candidates(
             display_name_override=args.display_name,
             skip_prepare=(not args.prepare) or args.skip_prepare,
             chunk_size=args.chunk_size,
@@ -17038,10 +17058,9 @@ def dispatch_command(parser, args):
             output_summary_markdown=args.summary_markdown,
             api_key_index=args.api_key_index,
         )
-        return
 
     if command == 'sync-revisions':
-        sync_revisions(
+        return sync_revisions(
             display_name_override=args.display_name,
             skip_prepare=args.skip_prepare,
             chunk_size=args.chunk_size,
@@ -17053,7 +17072,6 @@ def dispatch_command(parser, args):
             force=args.force,
             api_key_index=args.api_key_index,
         )
-        return
 
     if command == 'split':
         split_manifest(
@@ -17114,7 +17132,7 @@ def _machine_manifest_summary(manifest):
 def _load_machine_manifest(command, value, args):
     if isinstance(value, dict):
         return value
-    if command in {'build', 'submit'} and value:
+    if command in {'build', 'build-keywords', 'build-revisions', 'submit'} and value:
         return load_manifest(value)
     return load_manifest(getattr(args, 'target', '') or None)
 
@@ -17138,11 +17156,28 @@ def build_machine_success_envelope(command, value, args):
             warnings=report.get('warnings') or [],
         )
 
-    if command in {'build', 'submit'} and not value:
+    if command in {
+        'build',
+        'submit',
+        'build-revisions',
+        'sync-revisions',
+        'build-keywords',
+        'sync-keywords',
+    } and not value:
         return cli_contract.success_envelope(
             command,
             status='no_work',
-            result={'reason': 'no_pending_translation_work'},
+            result={
+                'reason': (
+                    'no_pending_revision_work'
+                    if command in {'build-revisions', 'sync-revisions'}
+                    else (
+                        'no_pending_keyword_work'
+                        if command in {'build-keywords', 'sync-keywords'}
+                        else 'no_pending_translation_work'
+                    )
+                )
+            },
         )
 
     if command in {'quality-ack', 'quality-unack'}:
@@ -17214,7 +17249,7 @@ def build_machine_success_envelope(command, value, args):
     warnings = list(manifest.get('build_warnings') or [])
     status = 'completed'
 
-    if command == 'build':
+    if command in {'build', 'build-keywords', 'build-revisions'}:
         status = str(manifest.get('job_state') or 'LOCAL_ONLY')
         result['cost_estimate'] = dict(manifest.get('cost_estimate') or {})
     elif command in {'submit', 'status'}:
@@ -17246,6 +17281,139 @@ def build_machine_success_envelope(command, value, args):
         status = str(
             manifest.get('revision_apply_state')
             or ('applied' if manifest.get('revision_applied_at') else 'completed')
+        )
+    elif command == 'preview-revisions':
+        preview = dict(manifest.get('last_revision_preview') or {})
+        preview_summary = dict(preview.get('summary') or {})
+        result = {
+            'generated_at': preview.get('generated_at') or '',
+            'jsonl_path': preview.get('jsonl_path') or '',
+            'markdown_path': preview.get('markdown_path') or '',
+            'results_path': preview.get('results_path') or '',
+            'results_sha256': preview.get('results_sha256') or '',
+            'quality_findings_path': preview.get('quality_findings_path') or '',
+            'quality_findings_count': int(preview.get('quality_findings_count') or 0),
+            'quality_findings_digest': preview.get('quality_findings_digest') or '',
+            'quality_gate': dict(preview.get('quality_gate') or {}),
+            'writeback_gate': dict(preview.get('writeback_gate') or {}),
+            'check_status': preview.get('check_status') or '',
+            'summary': {
+                'expected_items': int(preview_summary.get('expected_items') or 0),
+                'valid_items': int(preview_summary.get('valid_items') or 0),
+                'failure_items': int(preview_summary.get('failure_items') or 0),
+                'skipped_items': int(preview_summary.get('skipped_items') or 0),
+                'source_mismatch_items': int(
+                    preview_summary.get('source_mismatch_items') or 0
+                ),
+                'recoverable_items': int(
+                    preview_summary.get('recoverable_items') or 0
+                ),
+                'unchanged_items': int(preview_summary.get('unchanged_items') or 0),
+                'already_applied_items': int(
+                    preview_summary.get('already_applied_items') or 0
+                ),
+            },
+        }
+        status = str(
+            preview.get('check_status')
+            or preview_summary.get('check_status')
+            or 'previewed'
+        )
+        return cli_contract.success_envelope(
+            command,
+            status=status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                manifest=manifest.get('_manifest_path'),
+                revision_preview_jsonl=preview.get('jsonl_path') or '',
+                revision_preview_markdown=preview.get('markdown_path') or '',
+                quality_findings=preview.get('quality_findings_path') or '',
+            ),
+        )
+    elif command == 'sync-revisions':
+        preview = dict(manifest.get('last_revision_preview') or {})
+        preview_summary = dict(preview.get('summary') or {})
+        apply_state = manifest.get('revision_apply_state') or ''
+        apply_summary = dict(manifest.get('revision_apply_summary') or {})
+        result = {
+            'generated_at': preview.get('generated_at') or '',
+            'jsonl_path': preview.get('jsonl_path') or '',
+            'markdown_path': preview.get('markdown_path') or '',
+            'results_path': preview.get('results_path') or '',
+            'results_sha256': preview.get('results_sha256') or '',
+            'quality_findings_path': preview.get('quality_findings_path') or '',
+            'quality_findings_count': int(preview.get('quality_findings_count') or 0),
+            'quality_findings_digest': preview.get('quality_findings_digest') or '',
+            'quality_gate': dict(preview.get('quality_gate') or {}),
+            'writeback_gate': dict(preview.get('writeback_gate') or {}),
+            'check_status': preview.get('check_status') or '',
+            'revision_apply_state': apply_state,
+            'revision_apply': dict(apply_summary),
+            'summary': {
+                'expected_items': int(preview_summary.get('expected_items') or 0),
+                'valid_items': int(preview_summary.get('valid_items') or 0),
+                'failure_items': int(preview_summary.get('failure_items') or 0),
+                'skipped_items': int(preview_summary.get('skipped_items') or 0),
+                'source_mismatch_items': int(
+                    preview_summary.get('source_mismatch_items') or 0
+                ),
+                'recoverable_items': int(
+                    preview_summary.get('recoverable_items') or 0
+                ),
+                'unchanged_items': int(preview_summary.get('unchanged_items') or 0),
+                'already_applied_items': int(
+                    preview_summary.get('already_applied_items') or 0
+                ),
+            },
+        }
+        status = str(
+            apply_state
+            or preview.get('check_status')
+            or preview_summary.get('check_status')
+            or 'previewed'
+        )
+        return cli_contract.success_envelope(
+            command,
+            status=status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                manifest=manifest.get('_manifest_path'),
+                revision_preview_jsonl=preview.get('jsonl_path') or '',
+                revision_preview_markdown=preview.get('markdown_path') or '',
+                quality_findings=preview.get('quality_findings_path') or '',
+            ),
+        )
+    elif command in {'export-keywords', 'sync-keywords'}:
+        payload = dict(value or {})
+        summary = dict(payload.get('summary') or {})
+        result = {
+            'candidate_count_raw': int(summary.get('candidate_count_raw') or 0),
+            'candidate_count_deduped': int(
+                summary.get('candidate_count_deduped') or 0
+            ),
+            'chunk_summary_count': int(summary.get('chunk_summary_count') or 0),
+            'processed_chunks': int(summary.get('processed_chunks') or 0),
+            'result_rows': int(summary.get('result_rows') or 0),
+            'history_scan_status': summary.get('history_scan_status') or '',
+            'history_occurrence_count': int(
+                summary.get('history_occurrence_count') or 0
+            ),
+            'history_candidate_status_counts': dict(
+                summary.get('history_candidate_status_counts') or {}
+            ),
+        }
+        return cli_contract.success_envelope(
+            command,
+            status='completed',
+            result=result,
+            artifacts=_nonempty_artifacts(
+                keyword_candidates_jsonl=payload.get('jsonl_path') or '',
+                keyword_candidates_markdown=payload.get('markdown_path') or '',
+                keyword_summaries_jsonl=payload.get('summary_jsonl_path') or '',
+                keyword_summaries_markdown=(
+                    payload.get('summary_markdown_path') or ''
+                ),
+            ),
         )
     elif command == 'export-project-snapshot':
         snapshot = dict(value or {})

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -377,6 +377,38 @@ def build_cli_commands(
                 ["final-review-ingest-results", manifest_path],
             ),
         ),
+        DiagnosticsCommand(
+            label="订正·构建任务",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["build-revisions"],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="订正·同步预览",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["sync-revisions"],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="关键词·构建任务",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["build-keywords"],
+            ),
+        ),
+        DiagnosticsCommand(
+            label="关键词·同步提取",
+            command=format_cli_command(
+                python_exe,
+                batch_script_path,
+                ["sync-keywords"],
+            ),
+        ),
     ]
     # Keep usage commands ahead of mode-specific early returns so revision /
     # keyword / retry packages expose the same import/report actions.

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -154,6 +154,27 @@ class CliContractTests(unittest.TestCase):
         proposal_stale = cli_contract.success_envelope(
             "import-revision-proposals", status="stale"
         )
+        preview_ready = cli_contract.success_envelope(
+            "preview-revisions", status="ready"
+        )
+        preview_warn = cli_contract.success_envelope(
+            "preview-revisions", status="ready_with_warnings"
+        )
+        preview_blocked = cli_contract.success_envelope(
+            "preview-revisions", status="blocked"
+        )
+        sync_ready = cli_contract.success_envelope(
+            "sync-revisions", status="previewed"
+        )
+        sync_applied = cli_contract.success_envelope(
+            "sync-revisions", status="applied"
+        )
+        sync_partial = cli_contract.success_envelope(
+            "sync-revisions", status="partial"
+        )
+        sync_blocked = cli_contract.success_envelope(
+            "sync-revisions", status="blocked"
+        )
 
         self.assertEqual(
             cli_contract.strict_exit_code(warn),
@@ -178,6 +199,34 @@ class CliContractTests(unittest.TestCase):
         )
         self.assertEqual(
             cli_contract.strict_exit_code(proposal_stale),
+            cli_contract.EXIT_BLOCKED,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(preview_ready),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(preview_warn),
+            cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(preview_blocked),
+            cli_contract.EXIT_BLOCKED,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(sync_ready),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(sync_applied),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(sync_partial),
+            cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(sync_blocked),
             cli_contract.EXIT_BLOCKED,
         )
         unknown = cli_contract.success_envelope("check", status="unknown")

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -166,6 +166,9 @@ class CliContractTests(unittest.TestCase):
         sync_ready = cli_contract.success_envelope(
             "sync-revisions", status="previewed"
         )
+        sync_no_work = cli_contract.success_envelope(
+            "sync-revisions", status="no_work"
+        )
         sync_applied = cli_contract.success_envelope(
             "sync-revisions", status="applied"
         )
@@ -215,6 +218,10 @@ class CliContractTests(unittest.TestCase):
         )
         self.assertEqual(
             cli_contract.strict_exit_code(sync_ready),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(sync_no_work),
             cli_contract.EXIT_OK,
         )
         self.assertEqual(

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -714,10 +714,402 @@ class BatchCliContractTests(unittest.TestCase):
 
     def test_apply_revisions_is_registered_for_machine_output(self):
         self.assertIn("apply-revisions", batch.MACHINE_OUTPUT_COMMANDS)
+        self.assertIn("apply-revisions", batch.EXPLICIT_TARGET_COMMANDS)
         args = batch.build_arg_parser().parse_args(
             ["apply-revisions", "C:/jobs/demo/manifest.json", "--output", "json"]
         )
         self.assertEqual(args.output, "json")
+
+    def test_preview_revisions_is_registered_for_machine_output(self):
+        self.assertIn("preview-revisions", batch.MACHINE_OUTPUT_COMMANDS)
+        self.assertIn("preview-revisions", batch.EXPLICIT_TARGET_COMMANDS)
+        args = batch.build_arg_parser().parse_args(
+            ["preview-revisions", "C:/jobs/demo/manifest.json", "--output", "json"]
+        )
+        self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_revision_preview(self):
+        args = SimpleNamespace(target="C:/jobs/demo/manifest.json")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "generated_at": "2026-08-22T00:00:00",
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "markdown_path": "C:/jobs/demo/revision_preview.md",
+                "results_path": "C:/jobs/demo/results.jsonl",
+                "results_sha256": "abc123",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "quality_findings_count": 2,
+                "quality_findings_digest": "def456",
+                "quality_gate": {
+                    "decision": "needs_review",
+                    "blocker_count": 0,
+                },
+                "writeback_gate": {"decision": "allow"},
+                "check_status": "ready",
+                "summary": {
+                    "expected_items": 2,
+                    "valid_items": 2,
+                    "failure_items": 0,
+                    "skipped_items": 0,
+                    "source_mismatch_items": 0,
+                    "recoverable_items": 2,
+                    "unchanged_items": 0,
+                    "already_applied_items": 0,
+                },
+            },
+        }
+        envelope = batch.build_machine_success_envelope(
+            "preview-revisions",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "ready")
+        self.assertEqual(
+            envelope["result"]["jsonl_path"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+        self.assertEqual(
+            envelope["result"]["quality_gate"]["decision"],
+            "needs_review",
+        )
+        self.assertEqual(envelope["result"]["writeback_gate"]["decision"], "allow")
+        self.assertEqual(envelope["result"]["summary"]["valid_items"], 2)
+        self.assertEqual(
+            envelope["artifacts"]["revision_preview_jsonl"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+        self.assertEqual(
+            envelope["artifacts"]["revision_preview_markdown"],
+            "C:/jobs/demo/revision_preview.md",
+        )
+
+    def test_preview_revisions_machine_cli_returns_json_envelope(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "markdown_path": "C:/jobs/demo/revision_preview.md",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "quality_gate": {"decision": "needs_review"},
+                "writeback_gate": {"decision": "allow"},
+                "check_status": "ready",
+                "summary": {"valid_items": 1},
+            },
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "preview-revisions",
+                    "C:/jobs/demo/manifest.json",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "preview-revisions")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            payload["result"]["jsonl_path"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+
+    def test_build_revisions_is_registered_for_machine_output(self):
+        self.assertIn("build-revisions", batch.MACHINE_OUTPUT_COMMANDS)
+        args = batch.build_arg_parser().parse_args(
+            ["build-revisions", "--output", "json"]
+        )
+        self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_revision_build(self):
+        args = SimpleNamespace(target="")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "job_state": "LOCAL_ONLY",
+            "input_jsonl_path": "C:/jobs/demo/requests.jsonl",
+            "summary": {"file_count": 1, "chunk_count": 2, "item_count": 3},
+            "build_warnings": ["warning"],
+        }
+        envelope = batch.build_machine_success_envelope(
+            "build-revisions",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "LOCAL_ONLY")
+        self.assertEqual(envelope["result"]["summary"]["item_count"], 3)
+        self.assertEqual(
+            envelope["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+        self.assertEqual(
+            envelope["artifacts"]["input_jsonl"],
+            "C:/jobs/demo/requests.jsonl",
+        )
+        self.assertEqual(envelope["warnings"], ["warning"])
+
+    def test_build_revisions_no_work_returns_no_work_envelope(self):
+        envelope = batch.build_machine_success_envelope(
+            "build-revisions",
+            None,
+            SimpleNamespace(target=""),
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "no_work")
+        self.assertEqual(
+            envelope["result"]["reason"],
+            "no_pending_revision_work",
+        )
+
+    def test_build_revisions_machine_cli_returns_json_envelope(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "job_state": "LOCAL_ONLY",
+            "input_jsonl_path": "C:/jobs/demo/requests.jsonl",
+            "summary": {"item_count": 3},
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                ["build-revisions", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "build-revisions")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "LOCAL_ONLY")
+        self.assertEqual(payload["result"]["summary"]["item_count"], 3)
+
+    def test_sync_revisions_is_registered_for_machine_output(self):
+        self.assertIn("sync-revisions", batch.MACHINE_OUTPUT_COMMANDS)
+        args = batch.build_arg_parser().parse_args(
+            ["sync-revisions", "--output", "json"]
+        )
+        self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_sync_revision_preview(self):
+        args = SimpleNamespace(target="")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "markdown_path": "C:/jobs/demo/revision_preview.md",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "quality_gate": {"decision": "needs_review"},
+                "writeback_gate": {"decision": "allow"},
+                "check_status": "ready",
+                "summary": {"valid_items": 1},
+            },
+            "revision_apply_state": "",
+        }
+        envelope = batch.build_machine_success_envelope(
+            "sync-revisions",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "ready")
+        self.assertEqual(envelope["result"]["revision_apply_state"], "")
+        self.assertEqual(
+            envelope["artifacts"]["revision_preview_jsonl"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+
+    def test_machine_result_builder_covers_sync_revision_applied(self):
+        args = SimpleNamespace(target="")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "check_status": "ready",
+                "summary": {"valid_items": 1},
+            },
+            "revision_apply_state": "partial",
+            "revision_apply_summary": {"applied_lines": 1},
+        }
+        envelope = batch.build_machine_success_envelope(
+            "sync-revisions",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "partial")
+        self.assertEqual(envelope["result"]["revision_apply_state"], "partial")
+        self.assertEqual(
+            envelope["result"]["revision_apply"]["applied_lines"],
+            1,
+        )
+
+    def test_sync_revisions_no_work_returns_no_work_envelope(self):
+        envelope = batch.build_machine_success_envelope(
+            "sync-revisions",
+            None,
+            SimpleNamespace(target=""),
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "no_work")
+        self.assertEqual(
+            envelope["result"]["reason"],
+            "no_pending_revision_work",
+        )
+
+    def test_sync_revisions_machine_cli_returns_json_envelope(self):
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "markdown_path": "C:/jobs/demo/revision_preview.md",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "check_status": "ready",
+                "summary": {"valid_items": 1},
+            },
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=manifest),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                ["sync-revisions", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "sync-revisions")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            payload["result"]["jsonl_path"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+
+    def test_keyword_commands_are_registered_for_machine_output(self):
+        for command in ("build-keywords", "export-keywords", "sync-keywords"):
+            with self.subTest(command=command):
+                self.assertIn(command, batch.MACHINE_OUTPUT_COMMANDS)
+                args = batch.build_arg_parser().parse_args(
+                    [command, "--output", "json"]
+                )
+                self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_keyword_build(self):
+        args = SimpleNamespace(target="")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "keyword_extraction",
+            "job_state": "LOCAL_ONLY",
+            "input_jsonl_path": "C:/jobs/demo/requests.jsonl",
+            "summary": {"file_count": 1, "chunk_count": 2, "item_count": 3},
+        }
+        envelope = batch.build_machine_success_envelope(
+            "build-keywords",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "LOCAL_ONLY")
+        self.assertEqual(envelope["result"]["summary"]["item_count"], 3)
+        self.assertEqual(
+            envelope["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+
+    def test_keyword_build_no_work_returns_no_work_envelope(self):
+        envelope = batch.build_machine_success_envelope(
+            "build-keywords",
+            None,
+            SimpleNamespace(target=""),
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "no_work")
+        self.assertEqual(
+            envelope["result"]["reason"],
+            "no_pending_keyword_work",
+        )
+
+    def test_machine_result_builder_covers_keyword_export(self):
+        args = SimpleNamespace(target="")
+        payload = {
+            "jsonl_path": "C:/jobs/demo/keyword_candidates.jsonl",
+            "markdown_path": "C:/jobs/demo/keyword_candidates.md",
+            "summary_jsonl_path": "C:/jobs/demo/keyword_chunk_summaries.jsonl",
+            "summary_markdown_path": "C:/jobs/demo/keyword_chunk_summaries.md",
+            "summary": {
+                "candidate_count_raw": 5,
+                "candidate_count_deduped": 4,
+                "chunk_summary_count": 2,
+                "processed_chunks": 2,
+                "result_rows": 6,
+                "history_scan_status": "ok",
+                "history_occurrence_count": 3,
+                "history_candidate_status_counts": {"consistent": 3},
+            },
+        }
+        for command in ("export-keywords", "sync-keywords"):
+            with self.subTest(command=command):
+                envelope = batch.build_machine_success_envelope(
+                    command,
+                    dict(payload),
+                    args,
+                )
+                self.assertTrue(envelope["ok"])
+                self.assertEqual(envelope["status"], "completed")
+                self.assertEqual(
+                    envelope["result"]["candidate_count_deduped"], 4
+                )
+                self.assertEqual(
+                    envelope["artifacts"]["keyword_candidates_jsonl"],
+                    "C:/jobs/demo/keyword_candidates.jsonl",
+                )
+
+    def test_keyword_export_machine_cli_returns_json_envelope(self):
+        payload = {
+            "jsonl_path": "C:/jobs/demo/keyword_candidates.jsonl",
+            "markdown_path": "C:/jobs/demo/keyword_candidates.md",
+            "summary_jsonl_path": "C:/jobs/demo/keyword_chunk_summaries.jsonl",
+            "summary_markdown_path": "C:/jobs/demo/keyword_chunk_summaries.md",
+            "summary": {"candidate_count_deduped": 4},
+        }
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=payload),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(["export-keywords", "--output", "json"])
+
+        self.assertEqual(exit_code, 0)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(result["command"], "export-keywords")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["result"]["candidate_count_deduped"], 4)
+        self.assertEqual(
+            result["artifacts"]["keyword_candidates_jsonl"],
+            "C:/jobs/demo/keyword_candidates.jsonl",
+        )
 
     def test_proposal_import_machine_envelope_exposes_status_actions_and_artifacts(self):
         args = SimpleNamespace(command="import-revision-proposals")

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -81,6 +81,23 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn("提交批量任务", labels)
         self.assertIn("查询任务状态", labels)
 
+    def test_build_cli_commands_includes_revision_keyword_build_sync_commands(self):
+        commands = build_cli_commands(
+            python_exe="python",
+            batch_script_path="gemini_translate_batch.py",
+            manifest_path=r"C:\jobs\manifest.json",
+            manifest={"mode": "translation", "job_name": ""},
+        )
+        by_label = {command.label: command.command for command in commands}
+        self.assertIn("订正·构建任务", by_label)
+        self.assertIn("build-revisions", by_label["订正·构建任务"])
+        self.assertIn("订正·同步预览", by_label)
+        self.assertIn("sync-revisions", by_label["订正·同步预览"])
+        self.assertIn("关键词·构建任务", by_label)
+        self.assertIn("build-keywords", by_label["关键词·构建任务"])
+        self.assertIn("关键词·同步提取", by_label)
+        self.assertIn("sync-keywords", by_label["关键词·同步提取"])
+
     def test_build_cli_commands_includes_compare_variants_dry_run(self):
         commands = build_cli_commands(
             python_exe="python",


### PR DESCRIPTION
## Summary

Implements issue #296 P1 machine output for the first batch of non-core commands:

- Revision: `preview-revisions`, `build-revisions`, `sync-revisions`
- Keyword: `build-keywords`, `export-keywords`, `sync-keywords`

All commands now support `--output json`, `--strict-exit-codes`, `--fields`, and `--output-file`.

## Changes

- Add machine output arguments to the relevant argparse subcommands.
- Return structured command results from dispatch so machine envelopes can be built.
- Add result/artifact envelope branches for revision and keyword commands.
- Add `preview-revisions` / `apply-revisions` to explicit target commands for non-interactive mode.
- Add strict exit code mappings for `preview-revisions` and `sync-revisions`.
- Add contract tests and update CLI docs.

## Testing

- `tests/test_gemini_translate_batch_cli_contract.py`: 70 passed
- `tests/test_cli_contract.py`: 9 passed
- `tests/test_cli_discovery.py`: 5 passed
- `git diff --check` passed
- Markdown link check passed

Closes #296? (not closing yet; P1 still has final-review remaining)