### PR TITLE
feat(cli): add machine output for final review P1 commands

### DIFF
--- a/cli_contract.py
+++ b/cli_contract.py
@@ -237,13 +237,14 @@ def strict_exit_code(envelope: Mapping[str, Any]) -> int:
             return EXIT_BLOCKED
         return EXIT_INVALID_STATE
     if command in {
+        "final-review-build",
         "final-review-status",
         "final-review-export",
         "final-review-resume",
         "final-review-ingest-results",
         "final-review-create-revisions",
     }:
-        if status in {"done", "completed", "previewed"}:
+        if status in {"done", "completed", "previewed", "no_work", "local_only"}:
             return EXIT_OK
         if status in {"pending", "running", "ready"}:
             return EXIT_OK

--- a/cli_contract.py
+++ b/cli_contract.py
@@ -236,6 +236,20 @@ def strict_exit_code(envelope: Mapping[str, Any]) -> int:
         if status in {"blocked", "stale"}:
             return EXIT_BLOCKED
         return EXIT_INVALID_STATE
+    if command in {
+        "final-review-status",
+        "final-review-export",
+        "final-review-resume",
+        "final-review-ingest-results",
+        "final-review-create-revisions",
+    }:
+        if status in {"done", "completed", "previewed"}:
+            return EXIT_OK
+        if status in {"pending", "running", "ready"}:
+            return EXIT_OK
+        if status in {"failed", "stale", "blocked"}:
+            return EXIT_NEEDS_ACTION
+        return EXIT_INVALID_STATE
     if command in {"submit", "status"} and status in {
         "failed",
         "cancelled",

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -71,7 +71,7 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 ```
 
 只需关闭 target 回退时可单独使用 `--require-explicit-target`。默认模式保持现有 latest-manifest 和 submit-build 行为；`doctor / build` 不消费 manifest，不受显式 target 要求影响。
-结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply / quality-ack / quality-unack`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
+结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply / final-review-build / final-review-status / final-review-export / final-review-resume / final-review-ingest-results / final-review-create-revisions / quality-ack / quality-unack` 以及版本资产/复用命令；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
 核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.writeback_gate.decision result.check.quality_gate` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -30,6 +30,17 @@ python gemini_translate_batch.py check <manifest> --output json
 python gemini_translate_batch.py apply <manifest> --output json
 ```
 
+最终审校（final review）命令也使用同一 envelope：
+
+```powershell
+python gemini_translate_batch.py final-review-build --output json
+python gemini_translate_batch.py final-review-status <manifest> --output json
+python gemini_translate_batch.py final-review-export <manifest> --output json
+python gemini_translate_batch.py final-review-resume <manifest> --output json
+python gemini_translate_batch.py final-review-ingest-results <manifest> --output json
+python gemini_translate_batch.py final-review-create-revisions <manifest> --output json
+```
+
 P3/P4 的版本资产与译文复用命令也使用同一 envelope：
 
 ```powershell
@@ -173,8 +184,7 @@ python gemini_translate_batch.py schema status
 `capabilities` 与 `schema` 本身就是 JSON 命令，也接受 `--compact / --fields / --output-file`，但不需要也不提供冗余的 `--output json`。
 
 没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪是公开参数，不存在 discovery schema 之外的隐藏 Agent 行为。
-没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的七个
-核心命令和两个版本资产命令；其他子命令以各自 `--help` 和落盘产物为准。
+没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的核心流程、最终审校命令和版本资产/复用命令；其余子命令以各自 `--help`、`capabilities` 和落盘产物为准。
 
 ## 1. 安装核心依赖
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -16440,7 +16440,10 @@ def dispatch_command(parser, args):
                 allow_pending=bool(getattr(args, 'allow_pending', False)),
             )
         if command == 'final-review-status':
-            if not getattr(args, 'json', False):
+            machine_output = (
+                str(getattr(args, 'output', 'text') or 'text') == 'json'
+            )
+            if not machine_output and not getattr(args, 'json', False):
                 print_banner()
             return run_final_review_status(
                 getattr(args, 'target', '') or None,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -118,6 +118,12 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'check',
         'apply',
         'apply-revisions',
+        'final-review-build',
+        'final-review-status',
+        'final-review-export',
+        'final-review-resume',
+        'final-review-ingest-results',
+        'final-review-create-revisions',
         'export-revision-corpus',
         'import-revision-proposals',
         'export-project-snapshot',
@@ -15621,6 +15627,7 @@ def build_arg_parser():
             '(not recommended; results may be incomplete).'
         ),
     )
+    add_machine_output_argument(final_review_build_parser)
 
     final_review_status_parser = subparsers.add_parser(
         'final-review-status',
@@ -15637,6 +15644,7 @@ def build_arg_parser():
         action='store_true',
         help='Print machine-readable JSON status.',
     )
+    add_machine_output_argument(final_review_status_parser)
 
     final_review_export_parser = subparsers.add_parser(
         'final-review-export',
@@ -15658,6 +15666,7 @@ def build_arg_parser():
         default='',
         help='Output report Markdown path (default: package report.md).',
     )
+    add_machine_output_argument(final_review_export_parser)
 
     final_review_resume_parser = subparsers.add_parser(
         'final-review-resume',
@@ -15678,6 +15687,7 @@ def build_arg_parser():
         action='store_true',
         help='Re-queue all units, including done units with matching digests.',
     )
+    add_machine_output_argument(final_review_resume_parser)
 
     final_review_ingest_parser = subparsers.add_parser(
         'final-review-ingest-results',
@@ -15709,6 +15719,7 @@ def build_arg_parser():
             'resume (escape hatch / re-parse). Prefer a fresh download or --result.'
         ),
     )
+    add_machine_output_argument(final_review_ingest_parser)
 
     final_review_revisions_parser = subparsers.add_parser(
         'final-review-create-revisions',
@@ -15732,6 +15743,8 @@ def build_arg_parser():
             'already marked selection_state=selected.'
         ),
     )
+    add_machine_output_argument(final_review_revisions_parser)
+
     project_analysis_status_parser = subparsers.add_parser(
         'project-analysis-status',
         help=(
@@ -16420,52 +16433,46 @@ def dispatch_command(parser, args):
         load_batch_settings()
         if command == 'final-review-build':
             print_banner()
-            create_final_review_package(
+            return create_final_review_package(
                 display_name_override=getattr(args, 'display_name', '') or '',
                 skip_prepare=bool(getattr(args, 'skip_prepare', False)),
                 chunk_size=getattr(args, 'chunk_size', 0) or None,
                 allow_pending=bool(getattr(args, 'allow_pending', False)),
             )
-            return
         if command == 'final-review-status':
             if not getattr(args, 'json', False):
                 print_banner()
-            run_final_review_status(
+            return run_final_review_status(
                 getattr(args, 'target', '') or None,
                 as_json=bool(getattr(args, 'json', False)),
             )
-            return
         if command == 'final-review-export':
             print_banner()
-            run_final_review_export(
+            return run_final_review_export(
                 getattr(args, 'target', '') or None,
                 output_jsonl=getattr(args, 'jsonl', '') or '',
                 output_markdown=getattr(args, 'markdown', '') or '',
             )
-            return
         if command == 'final-review-resume':
             print_banner()
-            run_final_review_resume(
+            return run_final_review_resume(
                 getattr(args, 'target', '') or None,
                 force=bool(getattr(args, 'force', False)),
             )
-            return
         if command == 'final-review-ingest-results':
             print_banner()
-            run_final_review_ingest_results(
+            return run_final_review_ingest_results(
                 getattr(args, 'target', '') or None,
                 result_path=getattr(args, 'result', '') or '',
                 allow_stale_results=bool(getattr(args, 'allow_stale_results', False)),
             )
-            return
 
         if command == 'final-review-create-revisions':
             print_banner()
-            run_final_review_create_revisions(
+            return run_final_review_create_revisions(
                 getattr(args, 'target', '') or None,
                 finding_ids=getattr(args, 'finding_id', []) or [],
             )
-            return
     if command in {
         'project-analysis-status',
         'project-analysis-ingest-keywords',
@@ -17114,7 +17121,7 @@ def _machine_manifest_summary(manifest):
 def _load_machine_manifest(command, value, args):
     if isinstance(value, dict):
         return value
-    if command in {'build', 'submit'} and value:
+    if command in {'build', 'final-review-build', 'submit'} and value:
         return load_manifest(value)
     return load_manifest(getattr(args, 'target', '') or None)
 
@@ -17138,11 +17145,17 @@ def build_machine_success_envelope(command, value, args):
             warnings=report.get('warnings') or [],
         )
 
-    if command in {'build', 'submit'} and not value:
+    if command in {'build', 'submit', 'final-review-build'} and not value:
         return cli_contract.success_envelope(
             command,
             status='no_work',
-            result={'reason': 'no_pending_translation_work'},
+            result={
+                'reason': (
+                    'no_pending_final_review_work'
+                    if command == 'final-review-build'
+                    else 'no_pending_translation_work'
+                )
+            },
         )
 
     if command in {'quality-ack', 'quality-unack'}:
@@ -17214,7 +17227,7 @@ def build_machine_success_envelope(command, value, args):
     warnings = list(manifest.get('build_warnings') or [])
     status = 'completed'
 
-    if command == 'build':
+    if command in {'build', 'final-review-build'}:
         status = str(manifest.get('job_state') or 'LOCAL_ONLY')
         result['cost_estimate'] = dict(manifest.get('cost_estimate') or {})
     elif command in {'submit', 'status'}:
@@ -17246,6 +17259,134 @@ def build_machine_success_envelope(command, value, args):
         status = str(
             manifest.get('revision_apply_state')
             or ('applied' if manifest.get('revision_applied_at') else 'completed')
+        )
+    elif command == 'final-review-status':
+        payload = dict(value or {})
+        campaign_status = str(payload.get('status') or 'completed')
+        return cli_contract.success_envelope(
+            command,
+            status=campaign_status,
+            result=payload,
+            artifacts=_nonempty_artifacts(
+                manifest=payload.get('manifest_path') or '',
+                package_dir=payload.get('package_dir') or '',
+            ),
+        )
+    elif command == 'final-review-export':
+        payload = dict(value or {})
+        status = dict(payload.get('status') or {})
+        campaign_status = str(status.get('status') or 'completed')
+        result = {
+            'finding_count': int(payload.get('finding_count') or 0),
+            'status': status,
+        }
+        return cli_contract.success_envelope(
+            command,
+            status=campaign_status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                findings_jsonl=payload.get('jsonl_path') or '',
+                report_markdown=payload.get('markdown_path') or '',
+                manifest=status.get('manifest_path') or '',
+                package_dir=status.get('package_dir') or '',
+            ),
+        )
+    elif command == 'final-review-resume':
+        payload = dict(value or {})
+        status = dict(payload.get('status') or {})
+        paths = dict(payload.get('paths') or {})
+        campaign_status = str(status.get('status') or 'completed')
+        result = {
+            'run_count': int(payload.get('run_count') or 0),
+            'skip_count': int(payload.get('skip_count') or 0),
+            'to_run_unit_ids': list(payload.get('to_run_unit_ids') or []),
+            'status': status,
+        }
+        return cli_contract.success_envelope(
+            command,
+            status=campaign_status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                manifest=paths.get('manifest') or '',
+                package_dir=paths.get('package_dir') or '',
+                review_units=paths.get('review_units') or '',
+                findings=paths.get('findings') or '',
+                report=paths.get('report') or '',
+            ),
+        )
+    elif command == 'final-review-ingest-results':
+        payload = dict(value or {})
+        summary = dict(payload.get('summary') or {})
+        status = dict(payload.get('status') or {})
+        paths = dict(payload.get('paths') or {})
+        campaign_status = str(status.get('status') or 'completed')
+        result = {
+            'result_rows': int(summary.get('result_rows') or 0),
+            'done_units': int(summary.get('done_units') or 0),
+            'failed_units': int(summary.get('failed_units') or 0),
+            'finding_count': int(summary.get('finding_count') or 0),
+            'status': status,
+        }
+        return cli_contract.success_envelope(
+            command,
+            status=campaign_status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                manifest=paths.get('manifest') or '',
+                package_dir=paths.get('package_dir') or '',
+                review_units=paths.get('review_units') or '',
+                findings=paths.get('findings') or '',
+                quality_findings=paths.get('quality_findings') or '',
+                report=paths.get('report') or '',
+            ),
+        )
+    elif command == 'final-review-create-revisions':
+        preview = dict(manifest.get('last_revision_preview') or {})
+        preview_summary = dict(preview.get('summary') or {})
+        result = {
+            'generated_at': preview.get('generated_at') or '',
+            'jsonl_path': preview.get('jsonl_path') or '',
+            'markdown_path': preview.get('markdown_path') or '',
+            'results_path': preview.get('results_path') or '',
+            'results_sha256': preview.get('results_sha256') or '',
+            'quality_findings_path': preview.get('quality_findings_path') or '',
+            'quality_findings_count': int(preview.get('quality_findings_count') or 0),
+            'quality_findings_digest': preview.get('quality_findings_digest') or '',
+            'quality_gate': dict(preview.get('quality_gate') or {}),
+            'writeback_gate': dict(preview.get('writeback_gate') or {}),
+            'check_status': preview.get('check_status') or '',
+            'summary': {
+                'expected_items': int(preview_summary.get('expected_items') or 0),
+                'valid_items': int(preview_summary.get('valid_items') or 0),
+                'failure_items': int(preview_summary.get('failure_items') or 0),
+                'skipped_items': int(preview_summary.get('skipped_items') or 0),
+                'source_mismatch_items': int(
+                    preview_summary.get('source_mismatch_items') or 0
+                ),
+                'recoverable_items': int(
+                    preview_summary.get('recoverable_items') or 0
+                ),
+                'unchanged_items': int(preview_summary.get('unchanged_items') or 0),
+                'already_applied_items': int(
+                    preview_summary.get('already_applied_items') or 0
+                ),
+            },
+        }
+        status = str(
+            preview.get('check_status')
+            or preview_summary.get('check_status')
+            or 'previewed'
+        )
+        return cli_contract.success_envelope(
+            command,
+            status=status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                manifest=manifest.get('_manifest_path'),
+                revision_preview_jsonl=preview.get('jsonl_path') or '',
+                revision_preview_markdown=preview.get('markdown_path') or '',
+                quality_findings=preview.get('quality_findings_path') or '',
+            ),
         )
     elif command == 'export-project-snapshot':
         snapshot = dict(value or {})

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -166,6 +166,12 @@ class CliContractTests(unittest.TestCase):
         final_review_blocked = cli_contract.success_envelope(
             "final-review-ingest-results", status="blocked"
         )
+        final_review_build_local = cli_contract.success_envelope(
+            "final-review-build", status="LOCAL_ONLY"
+        )
+        final_review_build_no_work = cli_contract.success_envelope(
+            "final-review-build", status="no_work"
+        )
 
         self.assertEqual(
             cli_contract.strict_exit_code(warn),
@@ -207,6 +213,14 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(
             cli_contract.strict_exit_code(final_review_blocked),
             cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_build_local),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_build_no_work),
+            cli_contract.EXIT_OK,
         )
         unknown = cli_contract.success_envelope("check", status="unknown")
         unclassified_error = cli_contract.error_envelope(

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -154,6 +154,18 @@ class CliContractTests(unittest.TestCase):
         proposal_stale = cli_contract.success_envelope(
             "import-revision-proposals", status="stale"
         )
+        final_review_done = cli_contract.success_envelope(
+            "final-review-status", status="done"
+        )
+        final_review_failed = cli_contract.success_envelope(
+            "final-review-status", status="failed"
+        )
+        final_review_pending = cli_contract.success_envelope(
+            "final-review-status", status="pending"
+        )
+        final_review_blocked = cli_contract.success_envelope(
+            "final-review-ingest-results", status="blocked"
+        )
 
         self.assertEqual(
             cli_contract.strict_exit_code(warn),
@@ -179,6 +191,22 @@ class CliContractTests(unittest.TestCase):
         self.assertEqual(
             cli_contract.strict_exit_code(proposal_stale),
             cli_contract.EXIT_BLOCKED,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_done),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_failed),
+            cli_contract.EXIT_NEEDS_ACTION,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_pending),
+            cli_contract.EXIT_OK,
+        )
+        self.assertEqual(
+            cli_contract.strict_exit_code(final_review_blocked),
+            cli_contract.EXIT_NEEDS_ACTION,
         )
         unknown = cli_contract.success_envelope("check", status="unknown")
         unclassified_error = cli_contract.error_envelope(

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -904,6 +904,34 @@ class BatchCliContractTests(unittest.TestCase):
             "C:/jobs/demo/revision_preview.jsonl",
         )
 
+    def test_final_review_status_machine_mode_suppresses_banner_and_returns_envelope(self):
+        status = {"status": "done", "manifest_path": "C:/jobs/demo/manifest.json"}
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "run_final_review_status", return_value=status),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner") as banner,
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "final-review-status",
+                    "C:/jobs/demo/manifest.json",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        banner.assert_not_called()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "final-review-status")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "done")
+
     def test_final_review_status_machine_cli_returns_json_envelope(self):
         status = {"status": "done", "manifest_path": "C:/jobs/demo/manifest.json"}
         stdout = io.StringIO()

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -719,6 +719,218 @@ class BatchCliContractTests(unittest.TestCase):
         )
         self.assertEqual(args.output, "json")
 
+    def test_final_review_commands_are_registered_for_machine_output(self):
+        for command in (
+            "final-review-build",
+            "final-review-status",
+            "final-review-export",
+            "final-review-resume",
+            "final-review-ingest-results",
+            "final-review-create-revisions",
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, batch.MACHINE_OUTPUT_COMMANDS)
+                if command == "final-review-create-revisions":
+                    argv = [command, "C:/jobs/demo/manifest.json", "--output", "json"]
+                elif command == "final-review-build":
+                    argv = [command, "--output", "json"]
+                else:
+                    argv = [command, "C:/jobs/demo/manifest.json", "--output", "json"]
+                args = batch.build_arg_parser().parse_args(argv)
+                self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_final_review_build(self):
+        args = SimpleNamespace(target="")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "final_review",
+            "job_state": "LOCAL_ONLY",
+            "input_jsonl_path": "C:/jobs/demo/requests.jsonl",
+            "summary": {"unit_count": 2, "item_count": 3},
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-build",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "LOCAL_ONLY")
+        self.assertEqual(envelope["result"]["summary"]["unit_count"], 2)
+        self.assertEqual(
+            envelope["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+
+    def test_final_review_build_no_work_returns_no_work_envelope(self):
+        envelope = batch.build_machine_success_envelope(
+            "final-review-build",
+            None,
+            SimpleNamespace(target=""),
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "no_work")
+        self.assertEqual(
+            envelope["result"]["reason"],
+            "no_pending_final_review_work",
+        )
+
+    def test_machine_result_builder_covers_final_review_status(self):
+        args = SimpleNamespace(target="")
+        status = {
+            "status": "done",
+            "manifest_path": "C:/jobs/demo/manifest.json",
+            "package_dir": "C:/jobs/demo",
+            "unit_count": 2,
+            "finding_count": 1,
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-status",
+            dict(status),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "done")
+        self.assertEqual(envelope["result"]["unit_count"], 2)
+        self.assertEqual(
+            envelope["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+
+    def test_machine_result_builder_covers_final_review_export(self):
+        args = SimpleNamespace(target="")
+        payload = {
+            "jsonl_path": "C:/jobs/demo/findings.jsonl",
+            "markdown_path": "C:/jobs/demo/report.md",
+            "finding_count": 3,
+            "status": {
+                "status": "done",
+                "manifest_path": "C:/jobs/demo/manifest.json",
+                "package_dir": "C:/jobs/demo",
+            },
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-export",
+            dict(payload),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "done")
+        self.assertEqual(envelope["result"]["finding_count"], 3)
+        self.assertEqual(
+            envelope["artifacts"]["findings_jsonl"],
+            "C:/jobs/demo/findings.jsonl",
+        )
+
+    def test_machine_result_builder_covers_final_review_resume(self):
+        args = SimpleNamespace(target="")
+        payload = {
+            "run_count": 2,
+            "skip_count": 3,
+            "to_run_unit_ids": ["u1", "u2"],
+            "status": {"status": "running"},
+            "paths": {
+                "manifest": "C:/jobs/demo/manifest.json",
+                "package_dir": "C:/jobs/demo",
+                "review_units": "C:/jobs/demo/review_units.jsonl",
+                "report": "C:/jobs/demo/report.md",
+            },
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-resume",
+            dict(payload),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "running")
+        self.assertEqual(envelope["result"]["run_count"], 2)
+        self.assertEqual(
+            envelope["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+
+    def test_machine_result_builder_covers_final_review_ingest(self):
+        args = SimpleNamespace(target="")
+        payload = {
+            "summary": {
+                "result_rows": 4,
+                "done_units": 2,
+                "failed_units": 0,
+                "finding_count": 5,
+            },
+            "status": {"status": "done"},
+            "paths": {
+                "manifest": "C:/jobs/demo/manifest.json",
+                "package_dir": "C:/jobs/demo",
+                "findings": "C:/jobs/demo/findings.jsonl",
+                "quality_findings": "C:/jobs/demo/quality_findings.jsonl",
+                "report": "C:/jobs/demo/report.md",
+            },
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-ingest-results",
+            dict(payload),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "done")
+        self.assertEqual(envelope["result"]["finding_count"], 5)
+        self.assertEqual(
+            envelope["artifacts"]["quality_findings"],
+            "C:/jobs/demo/quality_findings.jsonl",
+        )
+
+    def test_machine_result_builder_covers_final_review_create_revisions(self):
+        args = SimpleNamespace(target="C:/jobs/demo/manifest.json")
+        manifest = {
+            "_manifest_path": "C:/jobs/demo/manifest.json",
+            "mode": "revision",
+            "last_revision_preview": {
+                "jsonl_path": "C:/jobs/demo/revision_preview.jsonl",
+                "markdown_path": "C:/jobs/demo/revision_preview.md",
+                "quality_findings_path": "C:/jobs/demo/quality_findings.jsonl",
+                "check_status": "ready",
+                "summary": {"valid_items": 3},
+            },
+        }
+        envelope = batch.build_machine_success_envelope(
+            "final-review-create-revisions",
+            dict(manifest),
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "ready")
+        self.assertEqual(
+            envelope["result"]["jsonl_path"],
+            "C:/jobs/demo/revision_preview.jsonl",
+        )
+
+    def test_final_review_status_machine_cli_returns_json_envelope(self):
+        status = {"status": "done", "manifest_path": "C:/jobs/demo/manifest.json"}
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=status),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "final-review-status",
+                    "C:/jobs/demo/manifest.json",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "final-review-status")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "done")
+        self.assertEqual(
+            payload["artifacts"]["manifest"],
+            "C:/jobs/demo/manifest.json",
+        )
+
     def test_proposal_import_machine_envelope_exposes_status_actions_and_artifacts(self):
         args = SimpleNamespace(command="import-revision-proposals")
         envelope = batch.build_machine_success_envelope(


### PR DESCRIPTION
## Summary

Implements issue #296 P1 machine output for the final-review command family:

- `final-review-build`
- `final-review-status`
- `final-review-export`
- `final-review-resume`
- `final-review-ingest-results`
- `final-review-create-revisions`

All commands now support `--output json`, `--strict-exit-codes`, `--fields`, and `--output-file`.

## Changes

- Add machine output arguments to final-review argparse subcommands.
- Return structured command results from dispatch so machine envelopes can be built.
- Add result/artifact envelope branches for final-review status/export/resume/ingest/create-revisions.
- Add strict exit code mappings for final-review campaign statuses.
- Add contract tests and update CLI docs.

## Testing

- `tests/test_gemini_translate_batch_cli_contract.py`: 62 passed
- `tests/test_cli_contract.py`: 9 passed
- `tests/test_cli_discovery.py`: 5 passed
- `tests/test_final_review.py`: 23 passed
- `tests/test_final_review_llm.py`: 22 passed
- `git diff --check` passed
- Markdown link check passed