### PR TITLE
feat(cli): add machine output for merge-keywords-to-glossary

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -71,7 +71,7 @@ python gemini_translate_batch.py apply logs/batch_jobs/<package>/manifest.json -
 ```
 
 只需关闭 target 回退时可单独使用 `--require-explicit-target`。默认模式保持现有 latest-manifest 和 submit-build 行为；`doctor / build` 不消费 manifest，不受显式 target 要求影响。
-结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply / quality-ack / quality-unack`；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
+结构化输出当前覆盖 `doctor / build / submit / status / download / check / apply / merge-keywords-to-glossary / quality-ack / quality-unack` 以及版本资产/复用命令；其它命令继续以各自帮助和落盘 JSON/JSONL 为准。
 
 机器发现使用 `capabilities` 与 `schema <command>`；两者在加载项目配置前直接输出 JSON。`capabilities.commands` 已提供完整命令索引，因此不另设重复的 `commands`。单命令 schema 从当前 argparse action 动态生成，包含参数类型、required、repeatable、choices、默认值和帮助文本，避免文档与实际 parser 漂移。
 核心 JSON 命令可用 `--compact` 压缩序列化、用 `--fields status result.check.writeback_gate.decision result.check.quality_gate` 按点路径保留必要字段，或用 `--output-file <path>` 将最终文档原子写入文件并保持 stdout 为空。三者只接受显式 `--output json`；裁剪不影响业务状态和严格退出码，文件结果会在未被投影掉时记录 `artifacts.output_file` 绝对路径。空路径或连续点等非法字段路径会在 workflow 执行前返回 `INVALID_FIELD_PATH` 和退出码 `2`。

--- a/docs/quickstart_agent.md
+++ b/docs/quickstart_agent.md
@@ -30,6 +30,13 @@ python gemini_translate_batch.py check <manifest> --output json
 python gemini_translate_batch.py apply <manifest> --output json
 ```
 
+关键词合并命令也使用同一 envelope：
+
+```powershell
+python gemini_translate_batch.py merge-keywords-to-glossary <candidates.jsonl> --dry-run --output json
+python gemini_translate_batch.py merge-keywords-to-glossary <candidates.jsonl> --yes --output json
+```
+
 P3/P4 的版本资产与译文复用命令也使用同一 envelope：
 
 ```powershell
@@ -173,8 +180,7 @@ python gemini_translate_batch.py schema status
 `capabilities` 与 `schema` 本身就是 JSON 命令，也接受 `--compact / --fields / --output-file`，但不需要也不提供冗余的 `--output json`。
 
 没有单独提供 `commands` 命令，因为 `capabilities.commands` 已覆盖同一用途。输出裁剪是公开参数，不存在 discovery schema 之外的隐藏 Agent 行为。
-没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的七个
-核心命令和两个版本资产命令；其他子命令以各自 `--help` 和落盘产物为准。
+没有 `--output json` 时仍使用原有人类可读文本。当前结构化模式承诺覆盖上面的核心流程、关键词合并命令和版本资产/复用命令；其余子命令以各自 `--help`、`capabilities` 和落盘产物为准。
 
 ## 1. 安装核心依赖
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import time
 import tokenize
-from dataclasses import replace
+from dataclasses import asdict, replace
 import traceback
 from datetime import datetime
 from pathlib import Path
@@ -120,6 +120,7 @@ MACHINE_OUTPUT_COMMANDS = frozenset(
         'apply-revisions',
         'export-revision-corpus',
         'import-revision-proposals',
+        'merge-keywords-to-glossary',
         'export-project-snapshot',
         'reconcile-project-snapshots',
         'build-translation-records',
@@ -16112,6 +16113,7 @@ def build_arg_parser():
         action='store_true',
         help='Skip creating a timestamped glossary backup before writing.',
     )
+    add_machine_output_argument(merge_keywords_parser)
 
     compare_variants_parser = subparsers.add_parser(
         'compare-variants',
@@ -16976,7 +16978,7 @@ def dispatch_command(parser, args):
         candidates_path = keyword_glossary_merge.resolve_keyword_candidates_path(args.target)
         glossary_path = args.glossary.strip() if args.glossary else legacy.GLOSSARY_FILE
         dry_run = args.dry_run or args.preview
-        keyword_glossary_merge.merge_keywords_to_glossary(
+        return keyword_glossary_merge.merge_keywords_to_glossary(
             candidates_path,
             glossary_path,
             dry_run=dry_run,
@@ -16987,7 +16989,6 @@ def dispatch_command(parser, args):
             backup=not args.no_backup,
             allow_history_review=bool(args.yes),
         )
-        return
 
     if command == 'compare-variants':
         manifest = load_manifest(args.target or None)
@@ -17192,6 +17193,46 @@ def build_machine_success_envelope(command, value, args):
                     if isinstance(manifest, dict)
                     else ''
                 ),
+            ),
+        )
+
+    if command == 'merge-keywords-to-glossary':
+        if hasattr(value, 'candidates_read'):
+            summary = asdict(value)
+        else:
+            summary = dict(value or {})
+        result = {
+            'candidates_read': int(summary.get('candidates_read') or 0),
+            'accepted': int(summary.get('accepted') or 0),
+            'skipped_duplicate': int(summary.get('skipped_duplicate') or 0),
+            'skipped_low_confidence': int(
+                summary.get('skipped_low_confidence') or 0
+            ),
+            'skipped_empty': int(summary.get('skipped_empty') or 0),
+            'skipped_user': int(summary.get('skipped_user') or 0),
+            'overwritten': int(summary.get('overwritten') or 0),
+            'dry_run': bool(summary.get('dry_run')),
+            'wrote_glossary': bool(summary.get('wrote_glossary')),
+            'backup_path': summary.get('backup_path') or '',
+            'glossary_path': summary.get('glossary_path') or '',
+            'candidates_path': summary.get('candidates_path') or '',
+        }
+        if summary.get('dry_run'):
+            status = 'dry_run'
+        elif summary.get('wrote_glossary'):
+            status = 'updated'
+        elif int(summary.get('accepted') or 0) == 0:
+            status = 'no_work'
+        else:
+            status = 'reviewed'
+        return cli_contract.success_envelope(
+            command,
+            status=status,
+            result=result,
+            artifacts=_nonempty_artifacts(
+                candidates=summary.get('candidates_path') or '',
+                glossary=summary.get('glossary_path') or '',
+                backup=summary.get('backup_path') or '',
             ),
         )
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -16978,6 +16978,9 @@ def dispatch_command(parser, args):
         candidates_path = keyword_glossary_merge.resolve_keyword_candidates_path(args.target)
         glossary_path = args.glossary.strip() if args.glossary else legacy.GLOSSARY_FILE
         dry_run = args.dry_run or args.preview
+        machine_output = (
+            str(getattr(args, 'output', 'text') or 'text') == 'json'
+        )
         return keyword_glossary_merge.merge_keywords_to_glossary(
             candidates_path,
             glossary_path,
@@ -16985,7 +16988,7 @@ def dispatch_command(parser, args):
             min_confidence=max(0.0, float(args.min_confidence or 0.0)),
             accept_confidence=args.accept_confidence,
             overwrite=args.overwrite,
-            interactive=not args.yes and not dry_run,
+            interactive=(not machine_output) and (not args.yes) and not dry_run,
             backup=not args.no_backup,
             allow_history_review=bool(args.yes),
         )

--- a/keyword_glossary_merge.py
+++ b/keyword_glossary_merge.py
@@ -1010,4 +1010,5 @@ def build_merge_keywords_cli_command(
         command.append('--yes')
     if no_backup:
         command.append('--no-backup')
+    command.extend(['--output', 'json'])
     return command

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -35,6 +35,8 @@ class BatchCliContractTests(unittest.TestCase):
             return [command, "reuse.json", "manifest.json"]
         if command == "import-revision-proposals":
             return [command, "proposals.jsonl"]
+        if command == "merge-keywords-to-glossary":
+            return [command, "candidates.jsonl"]
         return [command]
 
     def test_core_commands_accept_json_output_after_subcommand(self):
@@ -718,6 +720,105 @@ class BatchCliContractTests(unittest.TestCase):
             ["apply-revisions", "C:/jobs/demo/manifest.json", "--output", "json"]
         )
         self.assertEqual(args.output, "json")
+
+    def test_merge_keywords_to_glossary_is_registered_for_machine_output(self):
+        self.assertIn("merge-keywords-to-glossary", batch.MACHINE_OUTPUT_COMMANDS)
+        args = batch.build_arg_parser().parse_args(
+            [
+                "merge-keywords-to-glossary",
+                "C:/jobs/demo/candidates.jsonl",
+                "--yes",
+                "--output",
+                "json",
+            ]
+        )
+        self.assertEqual(args.output, "json")
+
+    def test_machine_result_builder_covers_merge_keywords_to_glossary(self):
+        args = SimpleNamespace(target="")
+        summary = batch.keyword_glossary_merge.MergeSummary(
+            candidates_read=4,
+            accepted=2,
+            skipped_duplicate=1,
+            skipped_low_confidence=0,
+            skipped_empty=0,
+            skipped_user=1,
+            overwritten=1,
+            backup_path="C:/jobs/demo/glossary.backup.json",
+            glossary_path="C:/jobs/demo/glossary.json",
+            candidates_path="C:/jobs/demo/candidates.jsonl",
+            dry_run=False,
+            wrote_glossary=True,
+        )
+        envelope = batch.build_machine_success_envelope(
+            "merge-keywords-to-glossary",
+            summary,
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "updated")
+        self.assertEqual(envelope["result"]["accepted"], 2)
+        self.assertEqual(envelope["result"]["overwritten"], 1)
+        self.assertEqual(
+            envelope["artifacts"]["glossary"],
+            "C:/jobs/demo/glossary.json",
+        )
+        self.assertEqual(
+            envelope["artifacts"]["backup"],
+            "C:/jobs/demo/glossary.backup.json",
+        )
+
+    def test_machine_result_builder_covers_merge_keywords_dry_run(self):
+        args = SimpleNamespace(target="")
+        summary = batch.keyword_glossary_merge.MergeSummary(
+            candidates_read=2,
+            accepted=1,
+            glossary_path="C:/jobs/demo/glossary.json",
+            candidates_path="C:/jobs/demo/candidates.jsonl",
+            dry_run=True,
+            wrote_glossary=False,
+        )
+        envelope = batch.build_machine_success_envelope(
+            "merge-keywords-to-glossary",
+            summary,
+            args,
+        )
+        self.assertTrue(envelope["ok"])
+        self.assertEqual(envelope["status"], "dry_run")
+        self.assertTrue(envelope["result"]["dry_run"])
+        self.assertFalse(envelope["result"]["wrote_glossary"])
+
+    def test_merge_keywords_machine_cli_returns_json_envelope(self):
+        summary = batch.keyword_glossary_merge.MergeSummary(
+            candidates_read=1,
+            accepted=0,
+            glossary_path="C:/jobs/demo/glossary.json",
+            candidates_path="C:/jobs/demo/candidates.jsonl",
+            dry_run=True,
+            wrote_glossary=False,
+        )
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(batch, "dispatch_command", return_value=summary),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "merge-keywords-to-glossary",
+                    "C:/jobs/demo/candidates.jsonl",
+                    "--dry-run",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "merge-keywords-to-glossary")
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "dry_run")
+        self.assertEqual(payload["result"]["candidates_read"], 1)
 
     def test_proposal_import_machine_envelope_exposes_status_actions_and_artifacts(self):
         args = SimpleNamespace(command="import-revision-proposals")

--- a/tests/test_gemini_translate_batch_cli_contract.py
+++ b/tests/test_gemini_translate_batch_cli_contract.py
@@ -788,6 +788,50 @@ class BatchCliContractTests(unittest.TestCase):
         self.assertTrue(envelope["result"]["dry_run"])
         self.assertFalse(envelope["result"]["wrote_glossary"])
 
+    def test_merge_keywords_machine_mode_forces_non_interactive(self):
+        summary = batch.keyword_glossary_merge.MergeSummary(
+            candidates_read=1,
+            accepted=0,
+            glossary_path="C:/jobs/demo/glossary.json",
+            candidates_path="C:/jobs/demo/candidates.jsonl",
+            dry_run=True,
+            wrote_glossary=False,
+        )
+        stdout = io.StringIO()
+
+        with (
+            mock.patch.object(
+                batch.keyword_glossary_merge,
+                "resolve_keyword_candidates_path",
+                return_value="candidates.jsonl",
+            ),
+            mock.patch.object(
+                batch.keyword_glossary_merge,
+                "merge_keywords_to_glossary",
+                return_value=summary,
+            ) as merge,
+            mock.patch.object(batch.legacy, "load_config"),
+            mock.patch.object(batch.legacy, "load_translator_settings"),
+            mock.patch.object(batch.legacy, "load_glossary"),
+            mock.patch.object(batch, "load_batch_settings"),
+            mock.patch.object(batch, "print_banner"),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = batch.main(
+                [
+                    "merge-keywords-to-glossary",
+                    "C:/jobs/demo/candidates.jsonl",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(merge.call_args.kwargs["interactive"])
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["command"], "merge-keywords-to-glossary")
+        self.assertTrue(payload["ok"])
+
     def test_merge_keywords_machine_cli_returns_json_envelope(self):
         summary = batch.keyword_glossary_merge.MergeSummary(
             candidates_read=1,

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -344,7 +344,11 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertIn("合并候选到 glossary", by_label)
         self.assertIn("merge-keywords-to-glossary", by_label["合并候选到 glossary（预览）"])
         self.assertIn("--dry-run", by_label["合并候选到 glossary（预览）"])
+        self.assertIn("--output", by_label["合并候选到 glossary（预览）"])
+        self.assertIn("json", by_label["合并候选到 glossary（预览）"])
         self.assertIn(manifest_path, by_label["合并候选到 glossary"])
+        self.assertIn("--output", by_label["合并候选到 glossary"])
+        self.assertIn("json", by_label["合并候选到 glossary"])
 
     def test_build_diagnostics_context_idle_without_manifest(self):
         context = build_diagnostics_context(


### PR DESCRIPTION
## Summary

Implements issue #296 P1 machine output for `merge-keywords-to-glossary`.

Supports `--output json`, `--strict-exit-codes`, `--fields`, and `--output-file`.

## Changes

- Add machine output arguments to `merge-keywords-to-glossary`.
- Return structured merge summary from dispatch.
- Add result/artifact envelope branch with statuses `dry_run`, `updated`, `no_work`, `reviewed`.
- Add contract tests and update CLI docs.

## Testing

- `tests/test_gemini_translate_batch_cli_contract.py`: 57 passed
- `tests/test_cli_contract.py`: 9 passed
- `tests/test_cli_discovery.py`: 5 passed
- `tests/test_keyword_glossary_merge.py`: passed
- `git diff --check` passed
- Markdown link check passed