### PR TITLE
feat(quality): 新增 #364 A3 离线校准报告工具与执行手册

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -23,6 +23,9 @@
 - [#346 实施分步计划：Sync / Batch 共用 TranslationPlan、ContextAssembler 与请求合同](issue-346-implementation-plan.md)：
   基于 `main@fa69d14` 的 P0–P5 分阶段实施计划；P0–P4 不依赖 #341，P5 与 #341
   联动收口。决策表 D1–D7 需在 issue #346 内定稿后方可进入 P1 编码。
+- [#364 真实项目质量规则校准执行手册](issue-364-calibration-runbook.md)：
+  A1 离线语料与 A3 校准报告工具的使用方法，以及 B 线真实项目统计、
+  抽样标注、A2 调参与重跑对比的执行步骤。
 - [视觉小说引擎本地化能力矩阵与后续 Adapter 路线](visual_novel_localization_matrix.md)：
   #272 针对 Naninovel、Godot+Dialogic 2、Visual Novel Maker、Monogatari、
   KiriKiri/KAG、RPG Maker MV/MZ 六大引擎的 12 维本地化能力评估矩阵与第三 Adapter 路线决策。

--- a/docs/plans/issue-364-calibration-runbook.md
+++ b/docs/plans/issue-364-calibration-runbook.md
@@ -41,6 +41,10 @@ python scripts/quality_calibration_report.py /path/to/quality_findings.jsonl \
 脚本以 `translation_quality.load_findings(strict=True)` 读取，报告文件格式
 损坏会直接报错，避免静默产出失真的基线。
 
+基线文件始终以 LF 换行写出；生成要提交或跨机器对比的基线时，用
+`--generated-at` 固定头部时间戳（可沿用上一版基线的取值），保证重跑字节
+一致，两版基线 diff 只反映 findings 变化。
+
 ## B 线：真实项目执行步骤
 
 1. 在真实项目包上运行 `check`，从标准输出或 manifest 的

--- a/docs/plans/issue-364-calibration-runbook.md
+++ b/docs/plans/issue-364-calibration-runbook.md
@@ -1,0 +1,84 @@
+# #364 真实项目质量规则校准执行手册
+
+> **状态：进行中。** A1（离线回归语料）已随 PR #381 合入 main；
+> A3（校准报告工具）就绪；A2 的白名单/disposition 取值与 B 线的真实项目
+> 统计、人工标注、重跑验证仍待真实项目数据。
+> 以 issue #364 正文、当前 checkout 和 `scripts/quality_calibration_report.py --help` 为准。
+
+文档地图：[规划与设计草案](README.md) · [项目文档](../README.md) ·
+[Batch 工作流与安全检查](../batch_workflows.md)
+
+## 范围
+
+对 #359 首版机械质量规则做真实项目校准，产出可复现的离线质量基线。
+本手册只描述执行路径；规则细节见 `translation_quality.py`，首版 reason code
+的离线正反例见 `tests/fixtures/quality_real_samples/`。
+
+## 仓库内已完成（无需私有数据）
+
+- A1：`tests/fixtures/quality_real_samples/samples.json` + `tests/test_quality_real_samples.py`，
+  每个首版 reason code 一个脱敏正例和一个白名单/合法反例。
+- A3：`scripts/quality_calibration_report.py`，从 `quality_findings.jsonl`
+  生成 Markdown 校准基线。
+
+## 生成校准报告
+
+```bash
+# 直接输出到 stdout
+python scripts/quality_calibration_report.py /path/to/quality_findings.jsonl
+
+# 写入基线文件，每个 reason code 最多带 10 条样本
+python scripts/quality_calibration_report.py /path/to/quality_findings.jsonl \
+  --sample-limit 10 -o docs/plans/quality_calibration_baseline.md
+```
+
+报告按 finding 数降序排列每个 reason code，并包含：
+
+- Summary：reason code / rule_id / finding 数 / 文件数；
+- File distribution：每个文件的 finding 数；
+- Samples：文件、行号、原文、译文的代表性样本。
+
+脚本以 `translation_quality.load_findings(strict=True)` 读取，报告文件格式
+损坏会直接报错，避免静默产出失真的基线。
+
+## B 线：真实项目执行步骤
+
+1. 在真实项目包上运行 `check`，从标准输出或 manifest 的
+   `last_quality_findings_path` 找到 `quality_findings.jsonl`。
+2. 用 A3 工具生成第一版基线报告，得到每个 reason code 的数量与文件分布。
+3. 抽样人工标注，重点审查 issue #364 指定的
+   `suspicious_english_residue`、`cjk_latin_spacing`、
+   `english_suffix_adjacent`、`speaker_label_untranslated`。建议每类至少
+   标注 20–30 条，按下面模板记录：
+
+   | reason code | 判定 | 样本（文件:行 原文→译文） | 处理建议 |
+   |---|---|---|---|
+   | `quality.language.suspicious_english_residue` | 误报 | `dialogue.rpy:42 Hello → TA也说过` | 加白名单 `TA` |
+   | `quality.language.english_suffix_adjacent` | 真实正例 | `skill.rpy:7 … → 迷踪步ping` | 保持 warning |
+
+4. 把标注结论拆成两类动作：
+   - 误报且确定属于合法专名/缩写/混排 → A2 加 `allowed_latin_tokens`；
+   - 整条规则误报高、确定性低 → A2 把默认 disposition 改为 `off`，作为项目 opt-in；
+   - 漏报的新规则需求 → 记录回 issue #313，不在此 issue 扩展规则集。
+5. 落 A2 diff 并同步 `translator_config.example.json`、文档和测试。
+6. 在真实项目上重跑 `check`，生成第二版基线报告，对比第一版证明误报下降、
+   已知正例仍能报告。
+7. 把代表性样本脱敏后回流 `tests/fixtures/quality_real_samples/samples.json`，
+   重新跑 `test_quality_real_samples` 和 `test_quality_calibration_report`。
+
+## 脱敏与提交边界
+
+- 私有游戏脚本原文、Batch 产物和 `logs/` 不得进入仓库；
+- 进入 fixture 的样本必须改写或脱敏，只保留规则可复现所需的最小文本；
+- 质量基线报告若含私有文本，只在 issue 评论中给摘要，不直接提交原文样本。
+
+## 验收映射
+
+| #364 验收标准 | 落地位置 |
+|---|---|
+| 每个首版 reason code 有数量统计 | A3 基线报告 |
+| 抽样标注结论记录 | 本手册第 3 步 + issue/文档 |
+| 白名单/默认 disposition 调整有 diff 和测试 | A2 PR |
+| 真实样本 fixture 可离线运行且不含私有文本 | A1 + 本手册第 7 步 |
+| 重跑后误报下降且正例仍报告 | 两份基线报告对比 |
+| 质量报告作为回归基线 | `docs/plans/quality_calibration_baseline.md` 或等价路径 |

--- a/scripts/quality_calibration_report.py
+++ b/scripts/quality_calibration_report.py
@@ -1,0 +1,257 @@
+"""Build an offline Markdown calibration report from ``quality_findings.jsonl``.
+
+This is an issue #364 development/calibration helper (CLI-only, scripts
+scope).  It turns a findings report produced by ``check``, sync preview,
+revision preview, or final review into a reproducible baseline showing, per
+reason code: finding count, file distribution, and a bounded set of
+file/line/source/translation samples for manual misreport / miss annotation.
+
+Usage::
+
+    python scripts/quality_calibration_report.py path/to/quality_findings.jsonl
+    python scripts/quality_calibration_report.py path/to/quality_findings.jsonl \\
+        --sample-limit 10 -o docs/plans/quality_calibration_baseline.md
+
+Rows are loaded with ``translation_quality.load_findings(strict=True)`` so a
+malformed report fails loudly instead of silently skewing the baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_SAMPLE_LIMIT = 5
+UNLOCATED_FILE = "(unlocated)"
+
+
+def _quality_module() -> Any:
+    """Import the shared quality module after repository path bootstrap."""
+
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    import translation_quality
+
+    return translation_quality
+
+
+class CalibrationReportError(RuntimeError):
+    """Raised when a calibration report input cannot be loaded safely."""
+
+
+def _file_label(finding: Mapping[str, Any]) -> str:
+    value = str(finding.get("file") or "").strip()
+    return value or UNLOCATED_FILE
+
+
+def _md_cell(value: Any) -> str:
+    """Escape one Markdown table cell while preserving readable samples."""
+    text = str(value or "")
+    return (
+        text.replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\r", "")
+        .replace("\n", "<br>")
+    )
+
+
+def load_report_findings(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    """Load and contract-validate a findings report for calibration use."""
+
+    raw_path = os.fspath(path)
+    if not raw_path or not os.path.isfile(raw_path):
+        raise CalibrationReportError(
+            f"quality findings file not found: {raw_path or '<empty path>'}"
+        )
+    try:
+        return _quality_module().load_findings(raw_path, strict=True)
+    except (OSError, ValueError) as exc:
+        raise CalibrationReportError(
+            f"could not load quality findings report: {raw_path}: {exc}"
+        ) from exc
+
+
+def reason_counters(
+    findings: list[dict[str, Any]],
+) -> tuple[Counter[str], dict[str, Counter[str]]]:
+    """Return global reason counts and per-reason file counts."""
+
+    reason_counts: Counter[str] = Counter()
+    file_counts: dict[str, Counter[str]] = {}
+    for finding in findings:
+        reason_code = str(finding.get("reason_code") or "quality.unknown").strip()
+        reason_counts[reason_code] += 1
+        file_counts.setdefault(reason_code, Counter())[_file_label(finding)] += 1
+    return reason_counts, file_counts
+
+
+def ordered_reason_codes(reason_counts: Counter[str]) -> list[str]:
+    """Order codes by findings descending, then by code for stable output."""
+
+    return sorted(reason_counts, key=lambda code: (-reason_counts[code], code))
+
+
+def samples_for_reason(
+    findings: list[dict[str, Any]],
+    reason_code: str,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return deterministic, bounded samples for one reason code."""
+
+    matching = [
+        finding
+        for finding in findings
+        if str(finding.get("reason_code") or "") == reason_code
+    ]
+    matching.sort(
+        key=lambda finding: (
+            _file_label(finding),
+            int(finding.get("line") or 0),
+            str(finding.get("item_id") or ""),
+        )
+    )
+    return matching[: max(limit, 0)]
+
+
+def render_report(
+    findings: list[dict[str, Any]],
+    *,
+    source_path: str,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    generated_at: str | None = None,
+) -> str:
+    """Render the calibration baseline as Markdown."""
+
+    quality = _quality_module()
+    reason_counts, file_counts = reason_counters(findings)
+    generated_at = generated_at or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    lines: list[str] = [
+        "# Quality calibration report",
+        "",
+        f"- Source: `{_md_cell(source_path)}`",
+        f"- Generated: {generated_at}",
+        f"- Findings: {len(findings)}",
+        f"- Reason codes: {len(reason_counts)}",
+        f"- Files: {len({_file_label(finding) for finding in findings})}",
+        f"- Samples per reason code: {max(sample_limit, 0)}",
+        "",
+        "## Summary",
+        "",
+        "| rank | reason_code | rule_id | findings | files |",
+        "|---:|---|---|---:|---:|",
+    ]
+    for rank, reason_code in enumerate(ordered_reason_codes(reason_counts), start=1):
+        lines.append(
+            "| {rank} | `{code}` | `{rule}` | {count} | {files} |".format(
+                rank=rank,
+                code=_md_cell(reason_code),
+                rule=_md_cell(quality.REASON_TO_RULE_KEY.get(reason_code, reason_code)),
+                count=reason_counts[reason_code],
+                files=len(file_counts.get(reason_code, {})),
+            )
+        )
+
+    for reason_code in ordered_reason_codes(reason_counts):
+        code_counts = file_counts.get(reason_code, Counter())
+        samples = samples_for_reason(
+            findings,
+            reason_code,
+            limit=sample_limit,
+        )
+        lines.extend(
+            [
+                "",
+                f"## {_md_cell(reason_code)}",
+                "",
+                f"- Rule: `{quality.REASON_TO_RULE_KEY.get(reason_code, reason_code)}`",
+                f"- Findings: {reason_counts[reason_code]}",
+                f"- Files: {len(code_counts)}",
+                "",
+                "### File distribution",
+                "",
+                "| file | findings |",
+                "|---|---:|",
+            ]
+        )
+        for file_label, count in code_counts.most_common():
+            lines.append(f"| {_md_cell(file_label)} | {count} |")
+        if samples:
+            lines.extend(
+                [
+                    "",
+                    "### Samples",
+                    "",
+                    "| file | line | source | translation |",
+                    "|---|---:|---|---|",
+                ]
+            )
+            for finding in samples:
+                lines.append(
+                    "| {file} | {line} | {source} | {translation} |".format(
+                        file=_md_cell(_file_label(finding)),
+                        line=int(finding.get("line") or 0),
+                        source=_md_cell(finding.get("source")),
+                        translation=_md_cell(finding.get("translation")),
+                    )
+                )
+        else:
+            lines.extend(["", "### Samples", "", "_No samples for this reason code._"])
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "findings",
+        help="Path to a quality_findings.jsonl report produced by check/sync/revision/final review",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Write the Markdown report to this path instead of stdout",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=DEFAULT_SAMPLE_LIMIT,
+        help=f"Maximum sample rows per reason code (default: {DEFAULT_SAMPLE_LIMIT})",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.sample_limit < 0:
+        parser.error("--sample-limit must be >= 0")
+    try:
+        findings = load_report_findings(args.findings)
+        markdown = render_report(
+            findings,
+            source_path=args.findings,
+            sample_limit=args.sample_limit,
+        )
+        if args.output:
+            output_path = Path(args.output)
+            output_path.write_text(markdown, encoding="utf-8")
+            print(f"Calibration report written to: {output_path}")
+        else:
+            sys.stdout.write(markdown)
+        return 0
+    except CalibrationReportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality_calibration_report.py
+++ b/scripts/quality_calibration_report.py
@@ -14,6 +14,10 @@ Usage::
 
 Rows are loaded with ``translation_quality.load_findings(strict=True)`` so a
 malformed report fails loudly instead of silently skewing the baseline.
+
+Baseline files are written with LF line endings on every platform, and
+``--generated-at`` pins the header timestamp so reruns (or runs on different
+machines) stay byte-identical for diffing.
 """
 
 from __future__ import annotations
@@ -226,6 +230,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SAMPLE_LIMIT,
         help=f"Maximum sample rows per reason code (default: {DEFAULT_SAMPLE_LIMIT})",
     )
+    parser.add_argument(
+        "--generated-at",
+        default=None,
+        help=(
+            "Pin the header timestamp (e.g. reuse the value from an earlier"
+            " baseline) so reruns are byte-identical; defaults to current UTC time"
+        ),
+    )
     return parser
 
 
@@ -240,10 +252,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             findings,
             source_path=args.findings,
             sample_limit=args.sample_limit,
+            generated_at=args.generated_at,
         )
         if args.output:
             output_path = Path(args.output)
-            output_path.write_text(markdown, encoding="utf-8")
+            try:
+                output_path.write_text(
+                    markdown, encoding="utf-8", newline="\n"
+                )
+            except OSError as exc:
+                raise CalibrationReportError(
+                    f"could not write calibration report: {output_path}: {exc}"
+                ) from exc
             print(f"Calibration report written to: {output_path}")
         else:
             sys.stdout.write(markdown)

--- a/tests/fixtures/quality_real_samples/README.md
+++ b/tests/fixtures/quality_real_samples/README.md
@@ -15,6 +15,9 @@ python -m unittest tests.test_quality_real_samples -v
 
 覆盖范围与 `translation_quality.ALL_REASON_CODES` 强制一致，新增首版规则时测试会提醒补样本。
 
+真实项目校准基线的数量统计用 `scripts/quality_calibration_report.py` 生成，完整执行流程见
+[#364 校准执行手册](../../../docs/plans/issue-364-calibration-runbook.md)。
+
 ## 格式
 
 `samples.json` 的 `cases` 每个元素：

--- a/tests/test_quality_calibration_report.py
+++ b/tests/test_quality_calibration_report.py
@@ -1,0 +1,156 @@
+"""Tests for the issue #364 offline quality calibration report helper."""
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+import translation_quality as quality
+from scripts import quality_calibration_report as report
+
+
+def write_findings(path: Path) -> Path:
+    """Write a deterministic synthetic findings report and return its path."""
+    rows = [
+        {
+            "reason_code": quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
+            "file": "chapter01/dialogue.rpy",
+            "line": 2,
+            "source": "She said yes.",
+            "translation": "TA也说过",
+        },
+        {
+            "reason_code": quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
+            "file": "chapter01/dialogue.rpy",
+            "line": 3,
+            "source": "Use your HP.",
+            "translation": "当前HP为100",
+        },
+        {
+            "reason_code": quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
+            "file": "chapter02/events.rpy",
+            "line": 7,
+            "source": "Welcome back, Sir.",
+            "translation": "欢迎回来，Sir。",
+        },
+        {
+            "reason_code": quality.REASON_SPEAKER_LABEL_UNTRANSLATED,
+            "file": "chapter02/events.rpy",
+            "line": 9,
+            "source": "Welcome.",
+            "translation": "欢迎。",
+        },
+        {
+            "reason_code": quality.REASON_CJK_LATIN_SPACING,
+            "file": "chapter01/dialogue.rpy",
+            "line": 2,
+            "source": "An iPhone.",
+            "translation": "这是iPhone手机",
+        },
+    ]
+    quality.write_findings(path, rows)
+    return path
+
+
+class QualityCalibrationReportTests(unittest.TestCase):
+    def test_summary_counts_and_file_distribution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            markdown = report.render_report(
+                report.load_report_findings(path),
+                source_path=str(path),
+                generated_at="2026-08-22T00:00:00+00:00",
+            )
+
+        self.assertIn("- Findings: 5", markdown)
+        self.assertIn("- Reason codes: 3", markdown)
+        self.assertIn("- Files: 2", markdown)
+        self.assertIn(
+            "| `quality.language.suspicious_english_residue` "
+            "| `suspicious_english_residue` | 3 | 2 |",
+            markdown,
+        )
+        self.assertIn("| chapter01/dialogue.rpy | 2 |", markdown)
+        self.assertIn("| chapter02/events.rpy | 1 |", markdown)
+
+    def test_reason_sections_are_ordered_by_finding_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            markdown = report.render_report(
+                report.load_report_findings(path),
+                source_path=str(path),
+                generated_at="2026-08-22T00:00:00+00:00",
+            )
+
+        residue = markdown.index(
+            "## quality.language.suspicious_english_residue"
+        )
+        speaker = markdown.index("## quality.speaker.label_untranslated")
+        spacing = markdown.index("## quality.typography.cjk_latin_spacing")
+
+        self.assertLess(residue, speaker)
+        self.assertLess(speaker, spacing)
+
+    def test_sample_limit_bounds_each_reason_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            markdown = report.render_report(
+                report.load_report_findings(path),
+                source_path=str(path),
+                sample_limit=1,
+                generated_at="2026-08-22T00:00:00+00:00",
+            )
+
+        self.assertIn(
+            "| chapter01/dialogue.rpy | 2 | She said yes. | TA也说过 |",
+            markdown,
+        )
+        self.assertNotIn(
+            "| chapter01/dialogue.rpy | 3 | Use your HP. |",
+            markdown,
+        )
+        self.assertNotIn(
+            "| chapter02/events.rpy | 7 | Welcome back, Sir. |",
+            markdown,
+        )
+
+    def test_markdown_cells_escape_pipes_backslashes_and_newlines(self) -> None:
+        self.assertEqual(
+            report._md_cell("a|b\\c\nd"),
+            "a\\|b\\\\c<br>d",
+        )
+
+    def test_main_writes_output_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            output = Path(tmp) / "calibration.md"
+
+            exit_code = report.main([str(path), "-o", str(output)])
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn(
+                "# Quality calibration report",
+                output.read_text(encoding="utf-8"),
+            )
+
+    def test_main_missing_input_returns_error_exit_code(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = report.main(["/nonexistent/quality_findings.jsonl"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("file not found", stderr.getvalue())
+
+    def test_load_report_findings_rejects_malformed_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "quality_findings.jsonl"
+            path.write_text('{"reason_code": broken\n', encoding="utf-8")
+
+            with self.assertRaises(report.CalibrationReportError):
+                report.load_report_findings(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_calibration_report.py
+++ b/tests/test_quality_calibration_report.py
@@ -143,6 +143,47 @@ class QualityCalibrationReportTests(unittest.TestCase):
         self.assertEqual(exit_code, 2)
         self.assertIn("file not found", stderr.getvalue())
 
+    def test_main_unwritable_output_returns_error_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            missing_dir_output = Path(tmp) / "missing-dir" / "calibration.md"
+
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                exit_code = report.main([str(path), "-o", str(missing_dir_output)])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("could not write calibration report", stderr.getvalue())
+
+    def test_output_file_uses_lf_line_endings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            output = Path(tmp) / "calibration.md"
+
+            exit_code = report.main([str(path), "-o", str(output)])
+            data = output.read_bytes()
+
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn(b"\r\n", data)
+        self.assertNotIn(b"\r", data)
+        self.assertTrue(data.endswith(b"\n"))
+
+    def test_pinned_generated_at_makes_reruns_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_findings(Path(tmp) / "quality_findings.jsonl")
+            first = Path(tmp) / "first.md"
+            second = Path(tmp) / "second.md"
+            argv = [str(path), "--generated-at", "2026-01-01T00:00:00+00:00"]
+
+            self.assertEqual(report.main([*argv, "-o", str(first)]), 0)
+            self.assertEqual(report.main([*argv, "-o", str(second)]), 0)
+
+            first_bytes = first.read_bytes()
+            second_bytes = second.read_bytes()
+
+        self.assertIn(b"- Generated: 2026-01-01T00:00:00+00:00", first_bytes)
+        self.assertEqual(first_bytes, second_bytes)
+
     def test_load_report_findings_rejects_malformed_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "quality_findings.jsonl"


### PR DESCRIPTION
Refs #364

## 范围

本 PR 交付 #364 A3（无需私有数据的部分）：可复现的离线质量校准报告工具，以及后续 B 线真实项目校准的执行手册。

## 实现

- 新增 `scripts/quality_calibration_report.py`：
  - 读取 `check` / sync / revision / final review 产出的 `quality_findings.jsonl`；
  - 按 finding 数降序输出每个 reason code 的数量、文件分布、以及文件/行号/原文/译文样本；
  - 支持 `--sample-limit`（默认 5）与 `-o` 写 Markdown 基线；
  - 以 `translation_quality.load_findings(strict=True)` 读取，坏行/坏文件直接报错，避免静默产出失真基线。
- 新增 `tests/test_quality_calibration_report.py`：统计分布、排序、样本上限、Markdown 转义、输出文件、错误退出码、坏行拒绝共 7 个测试。
- 新增 `docs/plans/issue-364-calibration-runbook.md`：B 线真实项目统计、抽样标注模板、A2 调参、重跑对比与样本回流步骤，并映射 #364 六条验收标准。
- 同步 `docs/plans/README.md` 索引与 `tests/fixtures/quality_real_samples/README.md` 工具入口。
- 该工具是 scripts-scope 的开发/校准辅助（非 CLI 子命令、无 GUI 等价入口），按 CONTRIBUTING 的「仅 CLI / 脚本」例外处理，不更新 CHANGELOG 与用户文档。

## 验证

- 新增测试 7 passed；连同 A1 语料回归共 11 passed；
- 相关质量回归（`test_translation_quality` + `test_unified_quality_findings` 等）：82 passed；
- 端到端冒烟：用真实机械规则生成的 findings 运行脚本，Markdown 报告统计与样本正确；
- `py_compile`、JSON 解析、`git diff --check` 通过；
- 本机完整 `run_cli_tests.py` 仍只有两个 main 基线既有的环境性失败（site-packages `tests` 命名空间遮蔽、无 PySide6 时 GUI suite 含 `_FailedTest`），无新增失败。

## 后续（#364 剩余工作）

- A2：根据真实项目抽样结论调整 `allowed_latin_tokens` 与默认 disposition；
- B1/B2：在真实项目上运行 `check`，用本工具生成前后两份基线，完成抽样标注、重跑对比，并把脱敏样本回流 A1 语料。
