### PR TITLE
#341: add first provider-neutral Embedding core slice

### DIFF
--- a/docs/plans/issue-341-provider-neutral-embedding-core.md
+++ b/docs/plans/issue-341-provider-neutral-embedding-core.md
@@ -1,13 +1,15 @@
 # Issue #341：Provider-neutral Embedding 纯核心
 
+状态：core v1 合同已冻结、尚未接入生产路径 · Issue #341 · 基线 `main@ed07a99`（2026-08-23）
+
 本阶段只冻结可独立合并的核心合同，不接入生产调用路径，也不改变现有 Gemini 行为。实现位于 `embedding_backend.py`，不依赖 Provider SDK、LiteLLM、PySide6、凭据或网络。
 
 ## 核心合同
 
-- `EmbeddingBackend` 是最小同步 protocol：adapter 接收一个已校验的 `EmbeddingBatchRequest`，返回 `EmbeddingBatchResult`，失败时映射为带稳定 `EmbeddingErrorCategory` 的 `EmbeddingBackendError`。
+- `EmbeddingBackend` 是最小同步 protocol：adapter 接收一个已校验的 `EmbeddingBatchRequest`，返回 `EmbeddingBatchResult`，失败时映射为带稳定 `EmbeddingErrorCategory` 的 `EmbeddingBackendError`。公开错误字符串按类别封闭映射，不携带 Provider 原始响应、URL、header 或错误码。
 - `EmbeddingTaskType` 只表达跨 Provider 的 `document` / `query` 语义。后续 Gemini adapter 负责映射到 `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY`；OpenAI-compatible adapter 可在 API 不支持 task 参数时仅保留该语义用于 identity。
 - `EmbeddingIdentity` 固定 `backend`、`provider`、`model`、`task_type` 和 `output_dimension`，并提供包含 schema version 的规范 JSON 与无凭据 SHA-256 fingerprint。store 应完整保存 document identity 的 `to_dict()`，不能只保存 model 名称。
-- batch request 固定 identity、输入顺序、有限正 timeout 和安全 metadata；result 绑定 request fingerprint，并校验向量数、每条维度、有限数值与 usage metadata。
+- batch request 固定 identity、输入顺序、有限正 timeout 和安全 metadata；metadata 会在入口校验后递归冻结，防止事后注入凭据或改变 fingerprint；result 绑定 request fingerprint，并校验向量数、每条维度、有限数值与 usage metadata。
 - metadata 中任何 credential-shaped key（包括嵌套的 API key、authorization、secret、password、credential ref、单数 token 等）都会在入口被拒绝，不会脱敏后继续参与持久化或指纹。
 
 ## Store / query 兼容性

--- a/docs/plans/issue-341-provider-neutral-embedding-core.md
+++ b/docs/plans/issue-341-provider-neutral-embedding-core.md
@@ -1,0 +1,30 @@
+# Issue #341：Provider-neutral Embedding 纯核心
+
+本阶段只冻结可独立合并的核心合同，不接入生产调用路径，也不改变现有 Gemini 行为。实现位于 `embedding_backend.py`，不依赖 Provider SDK、LiteLLM、PySide6、凭据或网络。
+
+## 核心合同
+
+- `EmbeddingBackend` 是最小同步 protocol：adapter 接收一个已校验的 `EmbeddingBatchRequest`，返回 `EmbeddingBatchResult`，失败时映射为带稳定 `EmbeddingErrorCategory` 的 `EmbeddingBackendError`。
+- `EmbeddingTaskType` 只表达跨 Provider 的 `document` / `query` 语义。后续 Gemini adapter 负责映射到 `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY`；OpenAI-compatible adapter 可在 API 不支持 task 参数时仅保留该语义用于 identity。
+- `EmbeddingIdentity` 固定 `backend`、`provider`、`model`、`task_type` 和 `output_dimension`，并提供包含 schema version 的规范 JSON 与无凭据 SHA-256 fingerprint。store 应完整保存 document identity 的 `to_dict()`，不能只保存 model 名称。
+- batch request 固定 identity、输入顺序、有限正 timeout 和安全 metadata；result 绑定 request fingerprint，并校验向量数、每条维度、有限数值与 usage metadata。
+- metadata 中任何 credential-shaped key（包括嵌套的 API key、authorization、secret、password、credential ref、单数 token 等）都会在入口被拒绝，不会脱敏后继续参与持久化或指纹。
+
+## Store / query 兼容性
+
+`check_store_query_compatibility(store_identity, query_identity)` 要求：
+
+1. store identity 的 task type 为 `document`；
+2. query identity 的 task type 为 `query`；
+3. backend、provider、model、output dimension 完全相同。
+
+通过时 action 为 `none`。任何差异都会返回有序、字段级 mismatch code，action 固定为 `rebuild_store`，并明确禁止比较这两组向量。identity 反序列化还会核验持久化 fingerprint，避免字段被修改后仍冒充旧 store。
+
+## 后续接线边界
+
+- Gemini adapter：把现有 `embed_content` 参数和异常映射到本合同；保留当前默认模型、维度和重试行为。adapter 返回后必须调用 `validate_embedding_result`。
+- OpenAI-compatible adapter：必须显式取得 embedding model、provider/config identity 和维度，不能从生成模型推断；endpoint、header 和 credential 只留在 adapter 配置，不得进入 request/store metadata。
+- Sync RAG / Source Index：构建或更新 store 时写入 document identity；查询前由所选 adapter 生成 query identity并执行兼容检查。若 action 为 `rebuild_store`，跳过检索并把 codes/message 交给 diagnostics，绝不计算相似度。
+- `translation_plan.py`：后续 retrieval provider 消费已经通过兼容检查的命中与诊断；本核心不导入 plan，也不组装 prompt，从而避免与 #346 P2/P3 并行工作发生耦合。
+
+尚未包含：Provider adapter、异步/流式 API、重试策略、配置/doctor/GUI、store 迁移、Sync Source Index 与 Published Project Analysis 生产接线。这些应在后续阶段分别落地，并保持旧 store 不被静默迁移或重写。

--- a/embedding_backend.py
+++ b/embedding_backend.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+"""Provider-neutral embedding contracts (issue #341).
+
+This module is deliberately pure: it imports no provider SDK, LiteLLM, GUI
+package, or networking code.  Provider adapters translate the semantic
+``document`` / ``query`` task into their native API shape and return values
+through these validated batch contracts.
+
+Persisted stores should serialize the document :class:`EmbeddingIdentity`.
+At query time, :func:`check_store_query_compatibility` prevents vectors from
+different embedding spaces from being compared and provides a stable rebuild
+diagnostic when the identities do not match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from typing import Protocol, runtime_checkable
+
+
+EMBEDDING_IDENTITY_SCHEMA_VERSION = 1
+EMBEDDING_REQUEST_SCHEMA_VERSION = 1
+EMBEDDING_RESULT_SCHEMA_VERSION = 1
+
+
+class EmbeddingTaskType(str, Enum):
+    """Provider-independent intent for an embedding request."""
+
+    DOCUMENT = 'document'
+    QUERY = 'query'
+
+
+class EmbeddingErrorCategory(str, Enum):
+    """Stable adapter error categories for retry and diagnostics policy."""
+
+    INVALID_REQUEST = 'invalid_request'
+    AUTHENTICATION = 'authentication'
+    PERMISSION = 'permission'
+    RATE_LIMIT = 'rate_limit'
+    TIMEOUT = 'timeout'
+    UNAVAILABLE = 'unavailable'
+    CANCELLED = 'cancelled'
+    INVALID_RESPONSE = 'invalid_response'
+    PROVIDER_ERROR = 'provider_error'
+
+
+class EmbeddingContractError(ValueError):
+    """Raised before provider I/O when a core contract is invalid."""
+
+
+class EmbeddingBackendError(RuntimeError):
+    """Provider adapter failure expressed with a stable category."""
+
+    def __init__(
+        self,
+        category: EmbeddingErrorCategory,
+        message: str,
+        *,
+        retryable: bool = False,
+        provider_code: str = '',
+    ) -> None:
+        if not isinstance(category, EmbeddingErrorCategory):
+            raise EmbeddingContractError('category must be an EmbeddingErrorCategory')
+        clean_message = str(message).strip()
+        if not clean_message:
+            raise EmbeddingContractError('embedding error message must not be empty')
+        super().__init__(clean_message)
+        self.category = category
+        self.retryable = bool(retryable)
+        self.provider_code = str(provider_code).strip()
+
+
+def canonical_json(value: object) -> str:
+    """Return deterministic JSON suitable for persisted identities and hashes."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+        allow_nan=False,
+    )
+
+
+def _fingerprint(payload: Mapping[str, object]) -> str:
+    encoded = canonical_json(payload).encode('utf-8')
+    return 'sha256:' + hashlib.sha256(encoded).hexdigest()
+
+
+def _required_text(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EmbeddingContractError(f'{field_name} must be a non-empty string')
+    return value.strip()
+
+
+def _positive_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise EmbeddingContractError(f'{field_name} must be a positive integer')
+    return value
+
+
+def _non_negative_int_or_none(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise EmbeddingContractError(f'{field_name} must be a non-negative integer or null')
+    return value
+
+
+_CREDENTIAL_KEY_MARKERS = (
+    'apikey',
+    'authorization',
+    'authsecret',
+    'accesstoken',
+    'authtoken',
+    'refreshtoken',
+    'idtoken',
+    'secret',
+    'password',
+    'credential',
+    'bearer',
+    'accesskey',
+    'privatekey',
+    'clientkey',
+    'signingkey',
+)
+
+
+def _normalized_key(key: object) -> str:
+    return re.sub(r'[-_ ]', '', str(key).lower())
+
+
+def _credential_shaped_key(key: object) -> bool:
+    normalized = _normalized_key(key)
+    if normalized.endswith('token') and not normalized.endswith('tokens'):
+        return True
+    return any(marker in normalized for marker in _CREDENTIAL_KEY_MARKERS)
+
+
+def _validate_metadata(value: object, path: str = 'metadata') -> object:
+    """Validate and normalize JSON metadata, rejecting credential-shaped keys."""
+
+    if isinstance(value, Mapping):
+        normalized: dict[str, object] = {}
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            if _credential_shaped_key(key):
+                raise EmbeddingContractError(
+                    f'{path}.{key} is credential-shaped and must not enter embedding metadata'
+                )
+            normalized[key] = _validate_metadata(item, f'{path}.{key}')
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_validate_metadata(item, f'{path}[]') for item in value]
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise EmbeddingContractError(f'{path} must not contain NaN or Infinity')
+        return value
+    raise EmbeddingContractError(f'{path} must contain only JSON-compatible values')
+
+
+def _validate_metadata_mapping(value: object, path: str = 'metadata') -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise EmbeddingContractError(f'{path} must be an object')
+    normalized = _validate_metadata(value, path)
+    # The Mapping check above fixes the recursive validator's return shape.
+    return dict(normalized)
+
+
+def _task_type(value: object, field_name: str = 'task_type') -> EmbeddingTaskType:
+    if isinstance(value, EmbeddingTaskType):
+        return value
+    try:
+        return EmbeddingTaskType(value)
+    except (TypeError, ValueError) as exc:
+        allowed = ', '.join(item.value for item in EmbeddingTaskType)
+        raise EmbeddingContractError(f'{field_name} must be one of: {allowed}') from exc
+
+
+@dataclass(frozen=True)
+class EmbeddingIdentity:
+    """Identity of one vector space and semantic task.
+
+    ``backend`` names the adapter implementation (for example
+    ``google_genai`` or ``openai_compatible``); ``provider`` names the routed
+    service/configuration.  Both are persisted so two endpoints exposing an
+    identically named model are not assumed compatible.
+    """
+
+    backend: str
+    provider: str
+    model: str
+    task_type: EmbeddingTaskType
+    output_dimension: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'backend', _required_text(self.backend, 'backend'))
+        object.__setattr__(self, 'provider', _required_text(self.provider, 'provider'))
+        object.__setattr__(self, 'model', _required_text(self.model, 'model'))
+        object.__setattr__(self, 'task_type', _task_type(self.task_type))
+        object.__setattr__(
+            self,
+            'output_dimension',
+            _positive_int(self.output_dimension, 'output_dimension'),
+        )
+
+    def identity_payload(self) -> dict[str, object]:
+        return {
+            'schema_version': EMBEDDING_IDENTITY_SCHEMA_VERSION,
+            'backend': self.backend,
+            'provider': self.provider,
+            'model': self.model,
+            'task_type': self.task_type.value,
+            'output_dimension': self.output_dimension,
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(self.identity_payload())
+
+    def to_dict(self) -> dict[str, object]:
+        payload = self.identity_payload()
+        payload['fingerprint'] = self.fingerprint
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> 'EmbeddingIdentity':
+        if not isinstance(payload, Mapping):
+            raise EmbeddingContractError('embedding identity must be an object')
+        version = payload.get('schema_version')
+        if version != EMBEDDING_IDENTITY_SCHEMA_VERSION:
+            raise EmbeddingContractError(f'unsupported embedding identity schema_version: {version!r}')
+        identity = cls(
+            backend=payload.get('backend'),
+            provider=payload.get('provider'),
+            model=payload.get('model'),
+            task_type=payload.get('task_type'),
+            output_dimension=payload.get('output_dimension'),
+        )
+        claimed = payload.get('fingerprint')
+        if claimed is not None and claimed != identity.fingerprint:
+            raise EmbeddingContractError('embedding identity fingerprint does not match its fields')
+        return identity
+
+
+@dataclass(frozen=True)
+class EmbeddingBatchRequest:
+    """Validated, auditable batch request passed to an adapter."""
+
+    identity: EmbeddingIdentity
+    inputs: tuple[str, ...]
+    timeout_seconds: float
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, EmbeddingIdentity):
+            raise EmbeddingContractError('identity must be an EmbeddingIdentity')
+        if isinstance(self.inputs, (str, bytes)) or not isinstance(self.inputs, Sequence):
+            raise EmbeddingContractError('inputs must be a non-empty sequence of strings')
+        normalized_inputs = tuple(self.inputs)
+        if not normalized_inputs:
+            raise EmbeddingContractError('inputs must not be empty')
+        for index, text in enumerate(normalized_inputs):
+            _required_text(text, f'inputs[{index}]')
+        timeout = self.timeout_seconds
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+            raise EmbeddingContractError('timeout_seconds must be a positive finite number')
+        timeout = float(timeout)
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise EmbeddingContractError('timeout_seconds must be a positive finite number')
+        object.__setattr__(self, 'inputs', normalized_inputs)
+        object.__setattr__(self, 'timeout_seconds', timeout)
+        object.__setattr__(self, 'metadata', _validate_metadata_mapping(self.metadata))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'schema_version': EMBEDDING_REQUEST_SCHEMA_VERSION,
+            'identity': self.identity.to_dict(),
+            'inputs': list(self.inputs),
+            'timeout_seconds': self.timeout_seconds,
+            'metadata': dict(self.metadata),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(self.to_dict())
+
+
+@dataclass(frozen=True)
+class EmbeddingUsage:
+    """Provider-neutral counts plus safe provider-specific usage metadata."""
+
+    input_tokens: int | None = None
+    total_tokens: int | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            'input_tokens',
+            _non_negative_int_or_none(self.input_tokens, 'input_tokens'),
+        )
+        object.__setattr__(
+            self,
+            'total_tokens',
+            _non_negative_int_or_none(self.total_tokens, 'total_tokens'),
+        )
+        object.__setattr__(
+            self,
+            'metadata',
+            _validate_metadata_mapping(self.metadata, 'usage.metadata'),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'input_tokens': self.input_tokens,
+            'total_tokens': self.total_tokens,
+            'metadata': dict(self.metadata),
+        }
+
+
+def _validated_vector(vector: object, index: int, dimension: int) -> tuple[float, ...]:
+    if isinstance(vector, (str, bytes)) or not isinstance(vector, Sequence):
+        raise EmbeddingContractError(f'vectors[{index}] must be a numeric sequence')
+    if len(vector) != dimension:
+        raise EmbeddingContractError(
+            f'vectors[{index}] dimension mismatch: expected {dimension}, got {len(vector)}'
+        )
+    values: list[float] = []
+    for offset, value in enumerate(vector):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise EmbeddingContractError(f'vectors[{index}][{offset}] must be numeric')
+        number = float(value)
+        if not math.isfinite(number):
+            raise EmbeddingContractError(f'vectors[{index}][{offset}] must be finite')
+        values.append(number)
+    return tuple(values)
+
+
+@dataclass(frozen=True)
+class EmbeddingBatchResult:
+    """Validated adapter output; count is bound to its request fingerprint."""
+
+    identity: EmbeddingIdentity
+    request_fingerprint: str
+    vectors: tuple[tuple[float, ...], ...]
+    usage: EmbeddingUsage = field(default_factory=EmbeddingUsage)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, EmbeddingIdentity):
+            raise EmbeddingContractError('identity must be an EmbeddingIdentity')
+        request_fp = _required_text(self.request_fingerprint, 'request_fingerprint')
+        if isinstance(self.vectors, (str, bytes)) or not isinstance(self.vectors, Sequence):
+            raise EmbeddingContractError('vectors must be a sequence')
+        vectors = tuple(
+            _validated_vector(vector, index, self.identity.output_dimension)
+            for index, vector in enumerate(self.vectors)
+        )
+        if not isinstance(self.usage, EmbeddingUsage):
+            raise EmbeddingContractError('usage must be EmbeddingUsage')
+        object.__setattr__(self, 'request_fingerprint', request_fp)
+        object.__setattr__(self, 'vectors', vectors)
+        object.__setattr__(self, 'metadata', _validate_metadata_mapping(self.metadata))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'schema_version': EMBEDDING_RESULT_SCHEMA_VERSION,
+            'identity': self.identity.to_dict(),
+            'request_fingerprint': self.request_fingerprint,
+            'vectors': [list(vector) for vector in self.vectors],
+            'usage': self.usage.to_dict(),
+            'metadata': dict(self.metadata),
+        }
+
+
+def validate_embedding_result(
+    request: EmbeddingBatchRequest,
+    result: EmbeddingBatchResult,
+) -> EmbeddingBatchResult:
+    """Reject response identity, request binding, count, or dimension drift."""
+
+    if not isinstance(request, EmbeddingBatchRequest):
+        raise EmbeddingContractError('request must be an EmbeddingBatchRequest')
+    if not isinstance(result, EmbeddingBatchResult):
+        raise EmbeddingContractError('result must be an EmbeddingBatchResult')
+    if result.identity != request.identity:
+        raise EmbeddingContractError('result identity does not match request identity')
+    if result.request_fingerprint != request.fingerprint:
+        raise EmbeddingContractError('result request_fingerprint does not match request')
+    if len(result.vectors) != len(request.inputs):
+        raise EmbeddingContractError(
+            f'embedding count mismatch: expected {len(request.inputs)}, got {len(result.vectors)}'
+        )
+    return result
+
+
+@runtime_checkable
+class EmbeddingBackend(Protocol):
+    """Minimal protocol implemented by Gemini/OpenAI-compatible adapters."""
+
+    def embed(self, request: EmbeddingBatchRequest) -> EmbeddingBatchResult:
+        """Embed one validated batch or raise :class:`EmbeddingBackendError`."""
+
+
+class CompatibilityCode(str, Enum):
+    COMPATIBLE = 'compatible'
+    STORE_TASK_NOT_DOCUMENT = 'store_task_not_document'
+    QUERY_TASK_NOT_QUERY = 'query_task_not_query'
+    BACKEND_MISMATCH = 'backend_mismatch'
+    PROVIDER_MISMATCH = 'provider_mismatch'
+    MODEL_MISMATCH = 'model_mismatch'
+    DIMENSION_MISMATCH = 'dimension_mismatch'
+
+
+@dataclass(frozen=True)
+class CompatibilityMismatch:
+    code: CompatibilityCode
+    field: str
+    store_value: object
+    query_value: object
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'code': self.code.value,
+            'field': self.field,
+            'store_value': self.store_value,
+            'query_value': self.query_value,
+        }
+
+
+@dataclass(frozen=True)
+class EmbeddingCompatibilityReport:
+    """Machine-readable compatibility decision and deterministic remediation."""
+
+    compatible: bool
+    mismatches: tuple[CompatibilityMismatch, ...]
+    action: str
+    message: str
+
+    @property
+    def codes(self) -> tuple[str, ...]:
+        if self.compatible:
+            return (CompatibilityCode.COMPATIBLE.value,)
+        return tuple(item.code.value for item in self.mismatches)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'compatible': self.compatible,
+            'codes': list(self.codes),
+            'mismatches': [item.to_dict() for item in self.mismatches],
+            'action': self.action,
+            'message': self.message,
+        }
+
+
+def check_store_query_compatibility(
+    store_identity: EmbeddingIdentity,
+    query_identity: EmbeddingIdentity,
+) -> EmbeddingCompatibilityReport:
+    """Check whether query vectors may be compared with persisted documents."""
+
+    if not isinstance(store_identity, EmbeddingIdentity):
+        raise EmbeddingContractError('store_identity must be an EmbeddingIdentity')
+    if not isinstance(query_identity, EmbeddingIdentity):
+        raise EmbeddingContractError('query_identity must be an EmbeddingIdentity')
+
+    mismatches: list[CompatibilityMismatch] = []
+
+    def add(code: CompatibilityCode, field_name: str, store: object, query: object) -> None:
+        mismatches.append(CompatibilityMismatch(code, field_name, store, query))
+
+    if store_identity.task_type is not EmbeddingTaskType.DOCUMENT:
+        add(
+            CompatibilityCode.STORE_TASK_NOT_DOCUMENT,
+            'task_type',
+            store_identity.task_type.value,
+            query_identity.task_type.value,
+        )
+    if query_identity.task_type is not EmbeddingTaskType.QUERY:
+        add(
+            CompatibilityCode.QUERY_TASK_NOT_QUERY,
+            'task_type',
+            store_identity.task_type.value,
+            query_identity.task_type.value,
+        )
+    comparisons = (
+        (CompatibilityCode.BACKEND_MISMATCH, 'backend'),
+        (CompatibilityCode.PROVIDER_MISMATCH, 'provider'),
+        (CompatibilityCode.MODEL_MISMATCH, 'model'),
+        (CompatibilityCode.DIMENSION_MISMATCH, 'output_dimension'),
+    )
+    for code, field_name in comparisons:
+        store_value = getattr(store_identity, field_name)
+        query_value = getattr(query_identity, field_name)
+        if store_value != query_value:
+            add(code, field_name, store_value, query_value)
+
+    if not mismatches:
+        return EmbeddingCompatibilityReport(
+            compatible=True,
+            mismatches=(),
+            action='none',
+            message='Embedding query identity is compatible with the document store.',
+        )
+    fields = ', '.join(item.field for item in mismatches)
+    return EmbeddingCompatibilityReport(
+        compatible=False,
+        mismatches=tuple(mismatches),
+        action='rebuild_store',
+        message=(
+            'Embedding identity mismatch; do not compare these vectors. '
+            f'Rebuild the store with the selected query backend configuration ({fields}).'
+        ),
+    )

--- a/embedding_backend.py
+++ b/embedding_backend.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import math
 import re
+from types import MappingProxyType
 from collections.abc import Mapping, Sequence
 from typing import Protocol, runtime_checkable
 
@@ -55,25 +56,37 @@ class EmbeddingContractError(ValueError):
 
 
 class EmbeddingBackendError(RuntimeError):
-    """Provider adapter failure expressed with a stable category."""
+    """Provider adapter failure with a closed, credential-safe public string.
+
+    Adapters classify raw SDK exceptions but must not attach provider bodies,
+    URLs, request headers, or codes to this cross-layer error.  This keeps
+    ``str(exc)`` safe for logs and future doctor/GUI diagnostics.
+    """
 
     def __init__(
         self,
         category: EmbeddingErrorCategory,
-        message: str,
         *,
         retryable: bool = False,
-        provider_code: str = '',
     ) -> None:
         if not isinstance(category, EmbeddingErrorCategory):
             raise EmbeddingContractError('category must be an EmbeddingErrorCategory')
-        clean_message = str(message).strip()
-        if not clean_message:
-            raise EmbeddingContractError('embedding error message must not be empty')
-        super().__init__(clean_message)
         self.category = category
         self.retryable = bool(retryable)
-        self.provider_code = str(provider_code).strip()
+        super().__init__(_SAFE_ERROR_MESSAGES[category])
+
+
+_SAFE_ERROR_MESSAGES = {
+    EmbeddingErrorCategory.INVALID_REQUEST: 'embedding request was rejected',
+    EmbeddingErrorCategory.AUTHENTICATION: 'embedding authentication failed',
+    EmbeddingErrorCategory.PERMISSION: 'embedding permission denied',
+    EmbeddingErrorCategory.RATE_LIMIT: 'embedding request was rate limited',
+    EmbeddingErrorCategory.TIMEOUT: 'embedding request timed out',
+    EmbeddingErrorCategory.UNAVAILABLE: 'embedding service temporarily unavailable',
+    EmbeddingErrorCategory.CANCELLED: 'embedding request was cancelled',
+    EmbeddingErrorCategory.INVALID_RESPONSE: 'embedding provider returned an invalid response',
+    EmbeddingErrorCategory.PROVIDER_ERROR: 'embedding provider request failed',
+}
 
 
 def canonical_json(value: object) -> str:
@@ -144,7 +157,7 @@ def _credential_shaped_key(key: object) -> bool:
 
 
 def _validate_metadata(value: object, path: str = 'metadata') -> object:
-    """Validate and normalize JSON metadata, rejecting credential-shaped keys."""
+    """Validate and recursively freeze JSON metadata after credential checks."""
 
     if isinstance(value, Mapping):
         normalized: dict[str, object] = {}
@@ -155,9 +168,9 @@ def _validate_metadata(value: object, path: str = 'metadata') -> object:
                     f'{path}.{key} is credential-shaped and must not enter embedding metadata'
                 )
             normalized[key] = _validate_metadata(item, f'{path}.{key}')
-        return normalized
+        return MappingProxyType(normalized)
     if isinstance(value, (list, tuple)):
-        return [_validate_metadata(item, f'{path}[]') for item in value]
+        return tuple(_validate_metadata(item, f'{path}[]') for item in value)
     if value is None or isinstance(value, (str, int, bool)):
         return value
     if isinstance(value, float):
@@ -167,12 +180,23 @@ def _validate_metadata(value: object, path: str = 'metadata') -> object:
     raise EmbeddingContractError(f'{path} must contain only JSON-compatible values')
 
 
-def _validate_metadata_mapping(value: object, path: str = 'metadata') -> dict[str, object]:
+def _validate_metadata_mapping(value: object, path: str = 'metadata') -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         raise EmbeddingContractError(f'{path} must be an object')
     normalized = _validate_metadata(value, path)
-    # The Mapping check above fixes the recursive validator's return shape.
-    return dict(normalized)
+    if not isinstance(normalized, Mapping):  # pragma: no cover - narrowed by the input check
+        raise EmbeddingContractError(f'{path} must be an object')
+    return normalized
+
+
+def _metadata_to_json(value: object) -> object:
+    """Return a detached mutable JSON shape from recursively frozen metadata."""
+
+    if isinstance(value, Mapping):
+        return {str(key): _metadata_to_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_metadata_to_json(item) for item in value]
+    return value
 
 
 def _task_type(value: object, field_name: str = 'task_type') -> EmbeddingTaskType:
@@ -236,7 +260,11 @@ class EmbeddingIdentity:
         if not isinstance(payload, Mapping):
             raise EmbeddingContractError('embedding identity must be an object')
         version = payload.get('schema_version')
-        if version != EMBEDDING_IDENTITY_SCHEMA_VERSION:
+        if (
+            isinstance(version, bool)
+            or not isinstance(version, int)
+            or version != EMBEDDING_IDENTITY_SCHEMA_VERSION
+        ):
             raise EmbeddingContractError(f'unsupported embedding identity schema_version: {version!r}')
         identity = cls(
             backend=payload.get('backend'),
@@ -246,7 +274,9 @@ class EmbeddingIdentity:
             output_dimension=payload.get('output_dimension'),
         )
         claimed = payload.get('fingerprint')
-        if claimed is not None and claimed != identity.fingerprint:
+        if not isinstance(claimed, str) or not claimed.strip():
+            raise EmbeddingContractError('embedding identity fingerprint is required')
+        if claimed != identity.fingerprint:
             raise EmbeddingContractError('embedding identity fingerprint does not match its fields')
         return identity
 
@@ -286,7 +316,7 @@ class EmbeddingBatchRequest:
             'identity': self.identity.to_dict(),
             'inputs': list(self.inputs),
             'timeout_seconds': self.timeout_seconds,
-            'metadata': dict(self.metadata),
+            'metadata': _metadata_to_json(self.metadata),
         }
 
     @property
@@ -323,7 +353,7 @@ class EmbeddingUsage:
         return {
             'input_tokens': self.input_tokens,
             'total_tokens': self.total_tokens,
-            'metadata': dict(self.metadata),
+            'metadata': _metadata_to_json(self.metadata),
         }
 
 
@@ -378,7 +408,7 @@ class EmbeddingBatchResult:
             'request_fingerprint': self.request_fingerprint,
             'vectors': [list(vector) for vector in self.vectors],
             'usage': self.usage.to_dict(),
-            'metadata': dict(self.metadata),
+            'metadata': _metadata_to_json(self.metadata),
         }
 
 

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -52,6 +52,23 @@ class IdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(embedding.EmbeddingContractError, 'fingerprint'):
             embedding.EmbeddingIdentity.from_dict(payload)
 
+    def test_from_dict_requires_persisted_fingerprint(self):
+        for fingerprint in (None, '', '   '):
+            with self.subTest(fingerprint=fingerprint):
+                payload = identity().to_dict()
+                if fingerprint is None:
+                    payload.pop('fingerprint')
+                else:
+                    payload['fingerprint'] = fingerprint
+                with self.assertRaisesRegex(embedding.EmbeddingContractError, 'required'):
+                    embedding.EmbeddingIdentity.from_dict(payload)
+
+    def test_from_dict_rejects_boolean_schema_version(self):
+        payload = identity().to_dict()
+        payload['schema_version'] = True
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'schema_version'):
+            embedding.EmbeddingIdentity.from_dict(payload)
+
     def test_rejects_empty_model_and_invalid_dimension(self):
         with self.assertRaisesRegex(embedding.EmbeddingContractError, 'model'):
             identity(model='  ')
@@ -131,6 +148,44 @@ class RequestResultTests(unittest.TestCase):
         request = self.request(inputs=('one',))
         with self.assertRaisesRegex(embedding.EmbeddingContractError, 'metadata must be an object'):
             self.result(request, metadata=('not', 'an', 'object'))
+
+    def test_metadata_is_recursively_immutable_and_fingerprint_stays_stable(self):
+        source = {
+            'nested': {'trace_id': 'trace-1'},
+            'items': [{'kind': 'safe'}],
+        }
+        request = self.request(metadata=source)
+        fingerprint = request.fingerprint
+
+        with self.assertRaises(TypeError):
+            request.metadata['new'] = 'value'
+        with self.assertRaises(TypeError):
+            request.metadata['nested']['api_key'] = 'injected'
+        with self.assertRaises(AttributeError):
+            request.metadata['items'].append({'api_key': 'injected'})
+        with self.assertRaises(TypeError):
+            request.metadata['items'][0]['api_key'] = 'injected'
+
+        source['nested']['trace_id'] = 'changed-outside'
+        source['items'].append({'api_key': 'changed-outside'})
+        self.assertEqual(request.metadata['nested']['trace_id'], 'trace-1')
+        self.assertEqual(len(request.metadata['items']), 1)
+        self.assertEqual(request.fingerprint, fingerprint)
+        self.assertEqual(
+            request.to_dict()['metadata'],
+            {'nested': {'trace_id': 'trace-1'}, 'items': [{'kind': 'safe'}]},
+        )
+
+    def test_usage_and_result_metadata_are_recursively_immutable(self):
+        usage = embedding.EmbeddingUsage(metadata={'nested': {'count': 1}})
+        request = self.request(inputs=('one',))
+        result = self.result(request, usage=usage, metadata={'nested': {'attempt': 1}})
+        with self.assertRaises(TypeError):
+            usage.metadata['nested']['count'] = 2
+        with self.assertRaises(TypeError):
+            result.metadata['nested']['attempt'] = 2
+        self.assertEqual(usage.to_dict()['metadata'], {'nested': {'count': 1}})
+        self.assertEqual(result.to_dict()['metadata'], {'nested': {'attempt': 1}})
 
     def test_rejects_vector_dimension_and_non_finite_values(self):
         request = self.request(inputs=('one',))
@@ -214,13 +269,16 @@ class ErrorAndProtocolTests(unittest.TestCase):
     def test_backend_error_exposes_stable_category(self):
         error = embedding.EmbeddingBackendError(
             embedding.EmbeddingErrorCategory.RATE_LIMIT,
-            'quota exceeded',
             retryable=True,
-            provider_code='429',
         )
         self.assertEqual(error.category.value, 'rate_limit')
         self.assertTrue(error.retryable)
-        self.assertEqual(error.provider_code, '429')
+        self.assertEqual(str(error), 'embedding request was rate limited')
+        self.assertNotIn('quota', str(error))
+
+    def test_backend_error_rejects_unstable_category(self):
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'category'):
+            embedding.EmbeddingBackendError('rate_limit')
 
     def test_runtime_protocol_accepts_minimal_backend(self):
         class FakeBackend:

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""Pure unit tests for the provider-neutral embedding core (issue #341)."""
+
+import json
+import math
+import unittest
+
+import embedding_backend as embedding
+
+
+def identity(task=embedding.EmbeddingTaskType.DOCUMENT, **overrides):
+    values = dict(
+        backend='google_genai',
+        provider='gemini',
+        model='gemini-embedding-001',
+        task_type=task,
+        output_dimension=768,
+    )
+    values.update(overrides)
+    return embedding.EmbeddingIdentity(**values)
+
+
+class IdentityTests(unittest.TestCase):
+    def test_identity_serialization_and_fingerprint_are_deterministic(self):
+        first = identity()
+        second = embedding.EmbeddingIdentity.from_dict(
+            json.loads(json.dumps(first.to_dict(), ensure_ascii=False))
+        )
+        self.assertEqual(first, second)
+        self.assertEqual(first.fingerprint, second.fingerprint)
+        self.assertRegex(first.fingerprint, r'^sha256:[0-9a-f]{64}$')
+        self.assertEqual(
+            embedding.canonical_json(first.to_dict()),
+            embedding.canonical_json(second.to_dict()),
+        )
+
+    def test_fingerprint_covers_every_vector_space_field(self):
+        baseline = identity()
+        variants = (
+            identity(backend='openai_compatible'),
+            identity(provider='custom-openai'),
+            identity(model='text-embedding-3-small'),
+            identity(task=embedding.EmbeddingTaskType.QUERY),
+            identity(output_dimension=1536),
+        )
+        for variant in variants:
+            self.assertNotEqual(baseline.fingerprint, variant.fingerprint)
+
+    def test_from_dict_rejects_tampered_fingerprint(self):
+        payload = identity().to_dict()
+        payload['model'] = 'different-model'
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'fingerprint'):
+            embedding.EmbeddingIdentity.from_dict(payload)
+
+    def test_rejects_empty_model_and_invalid_dimension(self):
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'model'):
+            identity(model='  ')
+        for value in (0, -1, True, 1.5, '768'):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(embedding.EmbeddingContractError, 'output_dimension'):
+                    identity(output_dimension=value)
+
+
+class RequestResultTests(unittest.TestCase):
+    def request(self, **overrides):
+        values = dict(
+            identity=identity(),
+            inputs=('first document', 'second document'),
+            timeout_seconds=15,
+            metadata={'trace_id': 'local-1', 'attempt': 1},
+        )
+        values.update(overrides)
+        return embedding.EmbeddingBatchRequest(**values)
+
+    def result(self, request, **overrides):
+        values = dict(
+            identity=request.identity,
+            request_fingerprint=request.fingerprint,
+            vectors=tuple((0.0,) * 768 for _ in request.inputs),
+            usage=embedding.EmbeddingUsage(input_tokens=4, total_tokens=4),
+            metadata={'provider_request_id': 'request-1'},
+        )
+        values.update(overrides)
+        return embedding.EmbeddingBatchResult(**values)
+
+    def test_valid_batch_round_trip_and_usage_metadata(self):
+        request = self.request()
+        result = self.result(request)
+        self.assertIs(embedding.validate_embedding_result(request, result), result)
+        self.assertEqual(result.usage.to_dict()['input_tokens'], 4)
+        self.assertEqual(len(result.to_dict()['vectors']), 2)
+
+    def test_request_fingerprint_is_stable_across_metadata_key_order(self):
+        first = self.request(metadata={'b': 2, 'a': {'z': 1, 'x': 0}})
+        second = self.request(metadata={'a': {'x': 0, 'z': 1}, 'b': 2})
+        self.assertEqual(first.fingerprint, second.fingerprint)
+
+    def test_rejects_empty_input_and_invalid_timeout(self):
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'inputs must not be empty'):
+            self.request(inputs=())
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, r'inputs\[0\]'):
+            self.request(inputs=(' ',))
+        for value in (0, -1, math.inf, math.nan, True, '10'):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(embedding.EmbeddingContractError, 'timeout_seconds'):
+                    self.request(timeout_seconds=value)
+
+    def test_rejects_credential_shaped_metadata_recursively(self):
+        unsafe_values = (
+            {'api_key': 'secret'},
+            {'headers': {'Authorization': 'Bearer secret'}},
+            {'nested': [{'session_token': 'secret'}]},
+            {'credential_ref': {'name': 'ENV_NAME'}},
+        )
+        for metadata in unsafe_values:
+            with self.subTest(metadata=metadata):
+                with self.assertRaisesRegex(embedding.EmbeddingContractError, 'credential-shaped'):
+                    self.request(metadata=metadata)
+
+    def test_allows_token_counts_but_rejects_non_finite_metadata(self):
+        request = self.request(metadata={'usage_tokens': 10, 'prompt_tokens': 5})
+        self.assertEqual(request.metadata['usage_tokens'], 10)
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'NaN or Infinity'):
+            self.request(metadata={'score': math.nan})
+
+    def test_metadata_must_be_an_object_at_each_contract_boundary(self):
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'metadata must be an object'):
+            self.request(metadata=['not', 'an', 'object'])
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'usage.metadata must be an object'):
+            embedding.EmbeddingUsage(metadata='not-an-object')
+        request = self.request(inputs=('one',))
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'metadata must be an object'):
+            self.result(request, metadata=('not', 'an', 'object'))
+
+    def test_rejects_vector_dimension_and_non_finite_values(self):
+        request = self.request(inputs=('one',))
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'dimension mismatch'):
+            self.result(request, vectors=((0.0, 1.0),))
+        bad_vector = [0.0] * 768
+        bad_vector[-1] = math.inf
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'must be finite'):
+            self.result(request, vectors=(bad_vector,))
+
+    def test_rejects_result_count_request_binding_and_identity_mismatch(self):
+        request = self.request()
+        one_vector = ((0.0,) * 768,)
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'count mismatch'):
+            embedding.validate_embedding_result(
+                request,
+                self.result(request, vectors=one_vector),
+            )
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'request_fingerprint'):
+            embedding.validate_embedding_result(
+                request,
+                self.result(request, request_fingerprint='sha256:wrong'),
+            )
+        other_identity = identity(provider='other-provider')
+        with self.assertRaisesRegex(embedding.EmbeddingContractError, 'identity'):
+            embedding.validate_embedding_result(
+                request,
+                self.result(request, identity=other_identity),
+            )
+
+
+class CompatibilityTests(unittest.TestCase):
+    def test_document_store_and_matching_query_are_compatible(self):
+        report = embedding.check_store_query_compatibility(
+            identity(embedding.EmbeddingTaskType.DOCUMENT),
+            identity(embedding.EmbeddingTaskType.QUERY),
+        )
+        self.assertTrue(report.compatible)
+        self.assertEqual(report.codes, ('compatible',))
+        self.assertEqual(report.action, 'none')
+
+    def test_every_identity_mismatch_returns_rebuild_diagnostic(self):
+        store = identity(embedding.EmbeddingTaskType.QUERY, backend='stored-backend')
+        query = identity(
+            embedding.EmbeddingTaskType.DOCUMENT,
+            backend='query-backend',
+            provider='other-provider',
+            model='other-model',
+            output_dimension=1536,
+        )
+        report = embedding.check_store_query_compatibility(store, query)
+        self.assertFalse(report.compatible)
+        self.assertEqual(report.action, 'rebuild_store')
+        self.assertEqual(
+            report.codes,
+            (
+                'store_task_not_document',
+                'query_task_not_query',
+                'backend_mismatch',
+                'provider_mismatch',
+                'model_mismatch',
+                'dimension_mismatch',
+            ),
+        )
+        self.assertIn('do not compare', report.message)
+        self.assertIn('Rebuild the store', report.message)
+        self.assertEqual(
+            [item['field'] for item in report.to_dict()['mismatches']],
+            ['task_type', 'task_type', 'backend', 'provider', 'model', 'output_dimension'],
+        )
+
+    def test_model_mismatch_alone_is_explicit(self):
+        report = embedding.check_store_query_compatibility(
+            identity(),
+            identity(embedding.EmbeddingTaskType.QUERY, model='new-model'),
+        )
+        self.assertEqual(report.codes, ('model_mismatch',))
+
+
+class ErrorAndProtocolTests(unittest.TestCase):
+    def test_backend_error_exposes_stable_category(self):
+        error = embedding.EmbeddingBackendError(
+            embedding.EmbeddingErrorCategory.RATE_LIMIT,
+            'quota exceeded',
+            retryable=True,
+            provider_code='429',
+        )
+        self.assertEqual(error.category.value, 'rate_limit')
+        self.assertTrue(error.retryable)
+        self.assertEqual(error.provider_code, '429')
+
+    def test_runtime_protocol_accepts_minimal_backend(self):
+        class FakeBackend:
+            def embed(self, request):
+                return request
+
+        self.assertIsInstance(FakeBackend(), embedding.EmbeddingBackend)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a dependency-free provider-neutral Embedding core
- define document/query semantics, backend/provider/model/dimension identity, deterministic serialization and fingerprints
- define validated batch request/result, usage metadata, timeout, stable error categories, and a minimal backend protocol
- reject credential-shaped metadata and invalid model/dimension/count/vector data at the core boundary
- recursively freeze validated metadata so credentials cannot be injected and fingerprints cannot drift after construction
- return field-level query/store compatibility diagnostics with an explicit rebuild_store action

## Scope and safety contract

This is the first independently mergeable core slice for #341. It does not import google-genai, LiteLLM, PySide6, or networking code. Store identities persist schema version, backend, provider, model, task type, output dimension, and a verified SHA-256 fingerprint. Identity deserialization requires that persisted fingerprint and fails closed on missing, blank, tampered, or invalid-version records.

Request/result/usage metadata recursively rejects credential-shaped keys and is frozen after validation. Public backend error strings come only from a closed category mapping and cannot carry raw provider bodies, URLs, headers, or error codes.

The compatibility check requires a document store identity and query request identity with matching backend, provider, model, and dimension. Mismatches must skip vector comparison and return deterministic rebuild diagnostics.

## Tests

- python -m unittest tests.test_embedding_backend -q — 22 passed
- isolated import smoke with google, litellm, and PySide6 imports blocked — passed
- python scripts/run_quality_gates.py lint-critical — passed
- Ruff on embedding_backend.py and tests/test_embedding_backend.py — passed
- git diff --check — passed

An earlier optional full CLI suite attempt was interrupted after an accidental duplicate run caused prolonged CPU contention; it is not reported as passing and is not required for this dependency-free, unconnected core slice. GitHub's separate cli-without-gui CI job passed on the original revision and will rerun for review changes.

## Not implemented

- Gemini adapter or migration of current embed_content calls
- OpenAI-compatible adapter
- runtime/configuration, doctor, GUI, or user-documentation wiring
- Sync RAG, Source Index, Published Project Analysis, or TranslationPlan production integration
- existing store migration or rewriting

## Design risk

OpenAI-compatible endpoints must receive a stable, non-secret provider/configuration identity. Reusing the same provider identity for distinct endpoints with the same model name could incorrectly describe different vector spaces as compatible. Query and document fingerprints intentionally differ by task type, so callers must use the field-level compatibility API rather than compare those fingerprints directly.

Refs #341