### PR TITLE
fix(quality): calibrate noisy language rules (#364)

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -94,6 +94,13 @@ Discovery schema 与核心结果 envelope 当前都使用 `schema_version=1`，�
 
 `translator_config.example.json` 的 `batch.quality_gate` 控制机械质量检查：`rules` 可把每条规则设为 `warning` / `blocker` / `off`，`allowed_latin_tokens` 是拉丁词白名单，`garbled_phrases` 是已知错乱词黑名单。质量规则配置进入 `check_fingerprint`；修改配置后必须重新 `check`，旧检查会变 stale。每条 finding 记录稳定 `reason_code`、severity / disposition、item ID、文件与行号、原文/译文和证据，GUI 与 CLI 都只把 `disposition=blocker` 计入写回阻断。
 
+真实项目校准后，`suspicious_english_residue` 与 `english_suffix_adjacent` 因专名误报
+较高而默认 `off`，需要时可按项目显式设为 `warning` / `blocker`；
+`cjk_latin_spacing` 等其余首版规则继续默认 `warning`。不要仅为压低英文专名噪声
+就把称谓或专名加入全局 `allowed_latin_tokens`，因为该白名单也会屏蔽相同 token 的
+间距与词缀检查。聚合证据见
+[真实项目机械质量校准基线](plans/quality_calibration_baseline.md)。
+
 ### 提交前估算与异常恢复
 
 `build` 会把当前定价配置下的估算写入 manifest；提交前也可显式复算并查看 token / 成本上限：

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,8 +24,9 @@
   基于 `main@fa69d14` 的 P0–P5 分阶段实施计划；P0–P4 不依赖 #341，P5 与 #341
   联动收口。决策表 D1–D7 需在 issue #346 内定稿后方可进入 P1 编码。
 - [#364 真实项目质量规则校准执行手册](issue-364-calibration-runbook.md)：
-  A1 离线语料与 A3 校准报告工具的使用方法，以及 B 线真实项目统计、
-  抽样标注、A2 调参与重跑对比的执行步骤。
+  A1 离线语料与 A3 校准报告工具的使用方法，以及已完成的 B 线执行步骤；
+  三项目聚合统计、人工标注和 A2 前后对比见
+  [真实项目机械质量校准基线](quality_calibration_baseline.md)。
 - [视觉小说引擎本地化能力矩阵与后续 Adapter 路线](visual_novel_localization_matrix.md)：
   #272 针对 Naninovel、Godot+Dialogic 2、Visual Novel Maker、Monogatari、
   KiriKiri/KAG、RPG Maker MV/MZ 六大引擎的 12 维本地化能力评估矩阵与第三 Adapter 路线决策。

--- a/docs/plans/issue-364-calibration-runbook.md
+++ b/docs/plans/issue-364-calibration-runbook.md
@@ -1,8 +1,8 @@
 # #364 真实项目质量规则校准执行手册
 
-> **状态：进行中。** A1（离线回归语料）已随 PR #381 合入 main；
-> A3（校准报告工具）就绪；A2 的白名单/disposition 取值与 B 线的真实项目
-> 统计、人工标注、重跑验证仍待真实项目数据。
+> **状态：已完成（2026-08-23）。** A1（离线回归语料）、A3（校准报告工具）
+> 和真实项目 B 线均已完成；A2 根据三项目标注把两条高噪声语言规则默认设为
+> `off`。聚合基线和风险见 [真实项目机械质量校准基线](quality_calibration_baseline.md)。
 > 以 issue #364 正文、当前 checkout 和 `scripts/quality_calibration_report.py --help` 为准。
 
 文档地图：[规划与设计草案](README.md) · [项目文档](../README.md) ·
@@ -86,3 +86,5 @@ python scripts/quality_calibration_report.py /path/to/quality_findings.jsonl \
 | 真实样本 fixture 可离线运行且不含私有文本 | A1 + 本手册第 7 步 |
 | 重跑后误报下降且正例仍报告 | 两份基线报告对比 |
 | 质量报告作为回归基线 | `docs/plans/quality_calibration_baseline.md` 或等价路径 |
+
+上述验收项已由 2026-08-23 基线完成；私有 findings 和恢复沙箱不进入仓库。

--- a/docs/plans/quality_calibration_baseline.md
+++ b/docs/plans/quality_calibration_baseline.md
@@ -1,0 +1,75 @@
+# #364 真实项目机械质量校准基线
+
+> **状态：已完成（2026-08-23）。** 本文只保存聚合统计和彻底脱敏后的
+> 人工标注结论；真实脚本、finding 原文、Batch 产物和校准沙箱均不进入仓库。
+
+## 校准口径
+
+按 `Game_GloryHounds` → `Game_TemptationsBallad` → `Game_Dawntide` 的顺序，
+在私有副本中恢复与历史 manifest 匹配的未翻译 TL 快照，再对复制的 Batch 包运行
+现版 `check`。GloryHounds 的 687 个 identity 可由 live TL 的原文标记完整恢复；
+另外两个项目使用 Ren'Py 8.5.2 在完整项目副本中重新生成 TL 模板。
+
+所有进入统计的校准集都满足：预期 identity 100% 映射、`source_mismatch=0`、
+`quality_unmatched_items=0`、结构失败 0，且 `writeback_gate.decision=allow`。
+过程中从复制包排除的旧结构异常不计入质量规则精度：
+
+| 项目 | 原包项 | 模板可映射 | 最终校准项 | 排除说明 |
+|---|---:|---:|---:|---|
+| GloryHounds | 687 | 687 | 681 | 4 个字体/Python 路径项；2 个被现行字段校验拒绝的旧结果 |
+| TemptationsBallad | 21,307 | 21,268 | 20,953 | 39 个历史 identity；315 个现行结构校验失败 |
+| Dawntide | 4,158 | 4,141 | 3,783 | 17 个历史 identity/字体项；358 个旧结构或不完整结果项 |
+
+这些排除只发生在私有校准副本中；原始包和真实项目没有修改，也没有执行
+`apply`。
+
+## 调整前后统计
+
+A2 将 `suspicious_english_residue` 和 `english_suffix_adjacent` 的默认 disposition
+从 `warning` 改为 `off`；项目仍可显式设回 `warning` 或 `blocker`。其他规则及
+内建 `allowed_latin_tokens` 不变。
+
+| reason code | Glory 前→后 | Temptations 前→后 | Dawntide 前→后 | 合计前→后 |
+|---|---:|---:|---:|---:|
+| `quality.renpy.wait_tag_inside_cjk` | 0→0 | 902→902 | 28→28 | 930→930 |
+| `quality.structure.unclosed_delimiters` | 0→0 | 161→161 | 0→0 | 161→161 |
+| `quality.language.english_suffix_adjacent` | 2→0 | 127→0 | 43→0 | 172→0 |
+| `quality.language.suspicious_english_residue` | 267→0 | 8,990→0 | 1,076→0 | 10,333→0 |
+| `quality.typography.cjk_latin_spacing` | 35→35 | 1,301→1,301 | 283→283 | 1,619→1,619 |
+| `quality.typography.halfwidth_punctuation` | 0→0 | 74→74 | 5→5 | 79→79 |
+| `quality.typography.ascii_ellipsis` | 0→0 | 9→9 | 0→0 | 9→9 |
+| `quality.glossary.term_not_applied` | 20→20 | 613→613 | 0→0 | 633→633 |
+| `quality.speaker.label_untranslated` | 0→0 | 0→0 | 0→0 | 0→0 |
+| `quality.completeness.interjection_untranslated` | 0→0 | 0→0 | 0→0 | 0→0 |
+| `quality.garbled.known_bad_phrase` | 0→0 | 0→0 | 0→0 | 0→0 |
+| **全部 findings** | **324→55** | **12,177→3,060** | **1,435→316** | **13,936→3,431** |
+
+默认噪声下降 10,505 条（75.4%），同时 1,619 条 CJK/Latin 间距报警及其他默认
+warning 规则保持不变。
+
+## 人工标注结论
+
+每类按文件顺序做等距抽样，目标 30 条/项目；不足时全量标注。样本只在私有
+工作目录保存，本文仅记录判定数量。
+
+| 规则 | GloryHounds | TemptationsBallad | Dawntide | 结论 |
+|---|---:|---:|---:|---|
+| `suspicious_english_residue` | 0 TP / 30 FP | 6 TP / 24 FP | 0 TP / 30 FP | 84/90 为合法人名、地名或代码文本，默认 warning 噪声过高 |
+| `cjk_latin_spacing` | 30 TP / 0 FP | 29 TP / 1 FP | 28 TP / 2 FP | 87/90 为真实紧贴，继续默认 warning |
+| `english_suffix_adjacent` | 0 TP / 2 FP（全量） | 0 TP / 30 FP | 0 TP / 30 FP | 完整专名因 `-er/-ly/-s` 等结尾误触发，默认关闭 |
+| `speaker_label_untranslated` | 0 条 | 0 条 | 0 条 | 无真实 finding，证据不足，不改默认策略 |
+
+英文词缀规则的脱敏正例（如中文词后残留 `ping` / `s`）仍由离线 fixture 以显式
+`warning` 策略覆盖，证明项目 opt-in 后仍能报告。英文残留规则同样保留显式 opt-in
+正例。
+
+## 白名单决定与剩余风险
+
+本轮不增加默认 `allowed_latin_tokens`。跨项目出现的 `Mrs`、`Miss`、`Master`
+等词既可能是合法保留，也可能是真实未本地化；而当前白名单会同时屏蔽英文残留、
+间距和词缀规则，把它们加入全局白名单会制造已观察到的间距漏报。
+
+剩余风险：两条默认关闭的语言规则会降低开箱召回，需高要求项目显式 opt-in；
+speaker label 在本矩阵中没有 finding，尚不能证明真实项目精度；历史包中被现行
+结构合同拒绝的条目不属于本基线。若后续要提升英文残留/词缀召回，应在独立 issue
+中先区分“专名白名单”和“排版边界白名单”，不在 #364 扩展新规则。

--- a/tests/fixtures/quality_real_samples/samples.json
+++ b/tests/fixtures/quality_real_samples/samples.json
@@ -91,13 +91,21 @@
         }
       },
       "negative": {
-        "name": "proper name ending like a suffix stays quiet by default",
+        "name": "project allowlisted abbreviation ending in s does not look like a suffix",
         "subject": {
           "item_id": "issue-364/english-suffix/negative",
           "file_rel_path": "chapter01/dialogue.rpy",
           "line_number": 32,
           "source": "",
-          "translation": "Aster走了过来"
+          "translation": "中文cos"
+        },
+        "policy": {
+          "rules": {
+            "english_suffix_adjacent": "warning"
+          },
+          "allowed_latin_tokens": [
+            "cos"
+          ]
         }
       }
     },
@@ -120,13 +128,18 @@
         }
       },
       "negative": {
-        "name": "proper name does not create default residue noise",
+        "name": "default allowlisted acronym is not visible residue",
         "subject": {
           "item_id": "issue-364/english-residue/negative",
           "file_rel_path": "chapter01/dialogue.rpy",
           "line_number": 42,
           "source": "",
-          "translation": "Aster 已经离开了"
+          "translation": "当前HP为100"
+        },
+        "policy": {
+          "rules": {
+            "suspicious_english_residue": "warning"
+          }
         }
       }
     },

--- a/tests/fixtures/quality_real_samples/samples.json
+++ b/tests/fixtures/quality_real_samples/samples.json
@@ -91,21 +91,13 @@
         }
       },
       "negative": {
-        "name": "project allowlisted abbreviation ending in s does not look like a suffix",
+        "name": "proper name ending like a suffix stays quiet by default",
         "subject": {
           "item_id": "issue-364/english-suffix/negative",
           "file_rel_path": "chapter01/dialogue.rpy",
           "line_number": 32,
           "source": "",
-          "translation": "中文cos"
-        },
-        "policy": {
-          "rules": {
-            "english_suffix_adjacent": "warning"
-          },
-          "allowed_latin_tokens": [
-            "cos"
-          ]
+          "translation": "Aster走了过来"
         }
       }
     },
@@ -128,18 +120,13 @@
         }
       },
       "negative": {
-        "name": "default allowlisted acronym is not visible residue",
+        "name": "proper name does not create default residue noise",
         "subject": {
           "item_id": "issue-364/english-residue/negative",
           "file_rel_path": "chapter01/dialogue.rpy",
           "line_number": 42,
           "source": "",
-          "translation": "当前HP为100"
-        },
-        "policy": {
-          "rules": {
-            "suspicious_english_residue": "warning"
-          }
+          "translation": "Aster 已经离开了"
         }
       }
     },

--- a/tests/test_translation_quality.py
+++ b/tests/test_translation_quality.py
@@ -142,6 +142,14 @@ class QualityRuleTests(unittest.TestCase):
                     {finding['reason_code'] for finding in findings},
                 )
 
+    def test_calibrated_default_suppresses_proper_name_language_noise(self):
+        findings = quality.check_subject(subject(translation='Aster走了过来'))
+        codes = {finding['reason_code'] for finding in findings}
+
+        self.assertNotIn(quality.REASON_ENGLISH_SUFFIX_ADJACENT, codes)
+        self.assertNotIn(quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE, codes)
+        self.assertIn(quality.REASON_CJK_LATIN_SPACING, codes)
+
     def test_suspicious_english_residue_excludes_allowlisted_tokens(self):
         allowed = quality.check_subject(
             subject(translation='当前HP为100'),

--- a/tests/test_translation_quality.py
+++ b/tests/test_translation_quality.py
@@ -25,13 +25,18 @@ def subject(**overrides):
 
 
 class QualityPolicyTests(unittest.TestCase):
-    def test_normalize_policy_defaults_all_rules_to_warning(self):
+    def test_normalize_policy_defaults_high_noise_language_rules_to_off(self):
         policy = quality.normalize_policy(None)
 
         self.assertTrue(policy['enabled'])
-        self.assertEqual(
-            set(policy['rules'].values()),
-            {quality.DISPOSITION_WARNING},
+        self.assertEqual(policy['rules']['english_suffix_adjacent'], quality.DISPOSITION_OFF)
+        self.assertEqual(policy['rules']['suspicious_english_residue'], quality.DISPOSITION_OFF)
+        self.assertTrue(
+            all(
+                disposition == quality.DISPOSITION_WARNING
+                for rule, disposition in policy['rules'].items()
+                if rule not in {'english_suffix_adjacent', 'suspicious_english_residue'}
+            )
         )
         self.assertIn('Ren\'Py', policy['allowed_latin_tokens'])
 
@@ -70,6 +75,13 @@ class QualityPolicyTests(unittest.TestCase):
         )
 
         self.assertNotEqual(quality.policy_digest(base), quality.policy_digest(changed))
+
+    def test_example_config_matches_calibrated_default_dispositions(self):
+        example_path = Path(__file__).parents[1] / 'translator_config.example.json'
+        with example_path.open('r', encoding='utf-8') as handle:
+            configured = json.load(handle)['batch']['quality_gate']['rules']
+
+        self.assertEqual(configured, quality.DEFAULT_RULE_DISPOSITIONS)
 
     def test_effective_policy_prefers_manifest_snapshot(self):
         manifest_policy = quality.normalize_policy(
@@ -116,9 +128,15 @@ class QualityRuleTests(unittest.TestCase):
                 )
 
     def test_english_suffix_adjacent_reports_ping_and_s(self):
+        policy = quality.normalize_policy(
+            {'rules': {'english_suffix_adjacent': 'warning'}}
+        )
         for translation in ('迷踪步ping', '残片s'):
             with self.subTest(translation=translation):
-                findings = quality.check_subject(subject(translation=translation))
+                findings = quality.check_subject(
+                    subject(translation=translation),
+                    policy=policy,
+                )
                 self.assertIn(
                     quality.REASON_ENGLISH_SUFFIX_ADJACENT,
                     {finding['reason_code'] for finding in findings},
@@ -127,7 +145,9 @@ class QualityRuleTests(unittest.TestCase):
     def test_suspicious_english_residue_excludes_allowlisted_tokens(self):
         allowed = quality.check_subject(
             subject(translation='当前HP为100'),
-            policy=quality.normalize_policy(None),
+            policy=quality.normalize_policy(
+                {'rules': {'suspicious_english_residue': 'warning'}}
+            ),
         )
         self.assertNotIn(
             quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
@@ -136,7 +156,12 @@ class QualityRuleTests(unittest.TestCase):
 
         flagged = quality.check_subject(
             subject(translation='迷踪步ping'),
-            policy=quality.normalize_policy({'allowed_latin_tokens': []}),
+            policy=quality.normalize_policy(
+                {
+                    'rules': {'suspicious_english_residue': 'warning'},
+                    'allowed_latin_tokens': [],
+                }
+            ),
         )
         self.assertIn(
             quality.REASON_SUSPICIOUS_ENGLISH_RESIDUE,
@@ -156,7 +181,12 @@ class QualityRuleTests(unittest.TestCase):
 
     def test_markup_stripped_evidence_spans_still_point_at_original_text(self):
         translation = '中文{w}iPhone'
-        findings = quality.check_subject(subject(translation=translation))
+        findings = quality.check_subject(
+            subject(translation=translation),
+            policy=quality.normalize_policy(
+                {'rules': {'suspicious_english_residue': 'warning'}}
+            ),
+        )
 
         residue = [
             finding
@@ -178,7 +208,12 @@ class QualityRuleTests(unittest.TestCase):
                 )
 
     def test_english_suffix_adjacent_honors_allowlist(self):
-        policy = quality.normalize_policy({'allowed_latin_tokens': ['cos']})
+        policy = quality.normalize_policy(
+            {
+                'rules': {'english_suffix_adjacent': 'warning'},
+                'allowed_latin_tokens': ['cos'],
+            }
+        )
         findings = quality.check_subject(
             subject(translation='中文cos'),
             policy=policy,

--- a/translation_quality.py
+++ b/translation_quality.py
@@ -248,10 +248,19 @@ SPEAKER_HINT_SUFFIXES: tuple[str, ...] = tuple(
     )
 )
 
+DEFAULT_RULE_DISPOSITIONS: dict[str, str] = {
+    key: (
+        DISPOSITION_OFF
+        if key in {'english_suffix_adjacent', 'suspicious_english_residue'}
+        else DISPOSITION_WARNING
+    )
+    for key in RULE_KEYS
+}
+
 DEFAULT_POLICY: dict[str, Any] = {
     'schema_version': QUALITY_RULE_SCHEMA_VERSION,
     'enabled': True,
-    'rules': {key: DISPOSITION_WARNING for key in RULE_KEYS},
+    'rules': dict(DEFAULT_RULE_DISPOSITIONS),
     'allowed_latin_tokens': list(DEFAULT_ALLOWED_LATIN_TOKENS),
     'garbled_phrases': [],
 }
@@ -295,7 +304,7 @@ def normalize_policy(configured: Any) -> dict[str, Any]:
     policy = {
         'schema_version': QUALITY_RULE_SCHEMA_VERSION,
         'enabled': True,
-        'rules': {key: DISPOSITION_WARNING for key in RULE_KEYS},
+        'rules': dict(DEFAULT_RULE_DISPOSITIONS),
         'allowed_latin_tokens': list(DEFAULT_ALLOWED_LATIN_TOKENS),
         'garbled_phrases': [],
     }

--- a/translator_config.example.json
+++ b/translator_config.example.json
@@ -166,8 +166,8 @@
       "rules": {
         "renpy_wait_inside_cjk": "warning",
         "unclosed_delimiters": "warning",
-        "english_suffix_adjacent": "warning",
-        "suspicious_english_residue": "warning",
+        "english_suffix_adjacent": "off",
+        "suspicious_english_residue": "off",
         "cjk_latin_spacing": "warning",
         "halfwidth_punctuation": "warning",
         "ascii_ellipsis": "warning",


### PR DESCRIPTION
## 概要

完成 #364 的 A2 与真实项目 B 线校准：在三个隔离的 Ren'Py 项目副本上恢复历史 Batch manifest 对应的未翻译模板，用现版 `check` 生成基线、抽样人工标注，并在同一可信样本上重跑验证。

根据跨项目证据：

- 将 `suspicious_english_residue` 默认 disposition 从 `warning` 改为 `off`；
- 将 `english_suffix_adjacent` 默认 disposition 从 `warning` 改为 `off`；
- 两条规则仍可由项目显式设为 `warning` / `blocker`；
- `cjk_latin_spacing` 及其他首版规则继续默认 `warning`；
- 不扩充默认 `allowed_latin_tokens`。

同时同步 `translator_config.example.json`、单元测试、Batch 文档、执行手册与聚合校准基线，并复用现有脱敏 fixture 验证白名单反例。

## 可信校准集

所有进入统计的最终校准集均满足：预期 identity 100% 映射、`source_mismatch=0`、`quality_unmatched_items=0`、结构失败 0、`writeback_gate.decision=allow`。

| 项目 | 原包项 | 模板可映射 | 最终校准项 | 排除项 |
|---|---:|---:|---:|---|
| GloryHounds | 687 | 687 | 681 | 4 个字体/Python 路径项；2 个被现行字段校验拒绝的旧结果 |
| TemptationsBallad | 21,307 | 21,268 | 20,953 | 39 个历史 identity；315 个现行结构校验失败 |
| Dawntide | 4,158 | 4,141 | 3,783 | 17 个历史 identity/字体项；358 个旧结构或不完整结果项 |

恢复和 `check` 只发生在私有副本上；未在任何真实项目或复制包上执行 `apply`。

## 调整前后聚合

| reason code | 调整前 | 调整后 |
|---|---:|---:|
| `quality.renpy.wait_tag_inside_cjk` | 930 | 930 |
| `quality.structure.unclosed_delimiters` | 161 | 161 |
| `quality.language.english_suffix_adjacent` | 172 | 0 |
| `quality.language.suspicious_english_residue` | 10,333 | 0 |
| `quality.typography.cjk_latin_spacing` | 1,619 | 1,619 |
| `quality.typography.halfwidth_punctuation` | 79 | 79 |
| `quality.typography.ascii_ellipsis` | 9 | 9 |
| `quality.glossary.term_not_applied` | 633 | 633 |
| `quality.speaker.label_untranslated` | 0 | 0 |
| `quality.completeness.interjection_untranslated` | 0 | 0 |
| `quality.garbled.known_bad_phrase` | 0 | 0 |
| **全部 findings** | **13,936** | **3,431** |

默认报警下降 10,505 条（75.4%），其余默认 warning 规则数量保持不变。

## 人工抽样

| 规则 | GloryHounds | TemptationsBallad | Dawntide | 结论 |
|---|---:|---:|---:|---|
| `suspicious_english_residue` | 0 TP / 30 FP | 6 TP / 24 FP | 0 TP / 30 FP | 84/90 为合法专名、地名或代码文本，默认噪声过高 |
| `cjk_latin_spacing` | 30 TP / 0 FP | 29 TP / 1 FP | 28 TP / 2 FP | 87/90 为真实紧贴，继续默认 warning |
| `english_suffix_adjacent` | 0 TP / 2 FP（全量） | 0 TP / 30 FP | 0 TP / 30 FP | 完整专名被 `-er/-ly/-s` 等结尾误触发，默认关闭 |
| `speaker_label_untranslated` | 0 条 | 0 条 | 0 条 | 无真实 finding，证据不足，不调整默认策略 |

英文词缀和英文残留的脱敏正例均显式 opt-in `warning`，继续验证 `ping` / `s` 等已知真阳性仍能报告。

## 为什么不扩充 `allowed_latin_tokens`

跨项目出现的 `Mrs`、`Miss`、`Master` 等既可能是合法保留，也可能是真实未本地化。当前白名单还会同时屏蔽英文残留、间距和词缀规则；加入这些 token 会掩盖本轮已观察到的真实 CJK/Latin 间距问题。因此本 PR 只调整高噪声规则的默认 disposition，不增加全局白名单。

## 隐私与安全边界

- 提交不包含真实样本；离线回归复用现有彻底脱敏的最小 fixture；
- 不包含真实游戏脚本、原始 findings、Batch 产物、logs、私有绝对路径、项目配置或校准沙箱；
- 未修改 `Game_*`、主 checkout、`games_registry.json` 或 `GAMES.md`；
- 未执行真实写回。

## 验证

- 针对性质量测试：53 passed；
- 质量合同、统一 findings、golden corpus：63 passed；
- CLI：1,473 passed，1 skipped；
- GUI：1,139 passed；
- `python scripts/run_quality_gates.py all`：全部 blocking gates 通过；
- tracked Markdown 本地链接检查：通过；
- `git diff --check origin/main...HEAD`：通过；
- 三个真实项目隔离样本调整后重跑：全部 `failure=0`、`source_mismatch=0`、`quality_unmatched=0`、`writeback=allow`。

Closes #364


