### PR TITLE
feat(embedding): #341 adapters and store identity slice

### DIFF
--- a/docs/plans/issue-341-embedding-adapters-store-identity.md
+++ b/docs/plans/issue-341-embedding-adapters-store-identity.md
@@ -29,6 +29,8 @@ Published Project Analysis 注入，也不修改 GUI Project Analysis 订正页�
 - LiteLLM 的 OpenAI 官方缺省会固定并显式传递 `https://api.openai.com/v1`；
   其它 Provider、环境变量或预配置 transport 隐式提供的 endpoint 无法安全核验，
   必须显式声明，否则 adapter 在构造阶段 fail closed。
+- `openai_client` transport 视为已配置 client；adapter 不接受会被 client API
+  静默忽略的 `api_key` / `request_headers` 覆盖，调用方必须在 client 上配置它们。
 - 所有响应都经过 `EmbeddingBatchResult` 与 `validate_embedding_result`，因此数量、
   维度、非有限数和 request binding 漂移统一归类为 `invalid_response`。
 - Provider 异常只按 status/type 分类为稳定错误；公开异常不包含原始错误文本、

--- a/docs/plans/issue-341-embedding-adapters-store-identity.md
+++ b/docs/plans/issue-341-embedding-adapters-store-identity.md
@@ -1,0 +1,57 @@
+# Issue #341：Embedding adapters 与 store identity
+
+状态：独立可合并切片 · 基线 `origin/main@a7319aa`（2026-08-23）
+
+本切片承接 PR #388 冻结的纯核心合同，新增离线可测的 Provider adapter，
+并把完整 document identity 接入现有 JSON RAG / Source Index store。它不改变
+当前 Sync/Batch Gemini 生产调用，也不接入 translation plan 或 prompt。
+
+## 文件所有权与接缝
+
+- `embedding_adapters.py`：Gemini 与 OpenAI-compatible/LiteLLM adapter、稳定
+  provider endpoint/configuration identity、usage 归一化、封闭错误分类。
+- `embedding_backend.py`：安全 metadata 的公共校验入口，以及 persisted store
+  identity 缺失/损坏时的 fail-closed compatibility report。
+- `rag_memory.py`：`JsonRagStore` / `JsonSourceIndexStore` 的 identity 持久化与
+  compatibility-gated search。已有向量的 store 不允许静默补贴或替换 identity。
+
+本切片明确不修改 `translation_plan.py`、translation runtime prompt 接缝、
+Published Project Analysis 注入，也不修改 GUI Project Analysis 订正页。
+
+## Adapter 合同
+
+- Adapter 从显式 model、output dimension、provider、endpoint/configuration 构造
+  document/query `EmbeddingIdentity`；不得从生成模型推断 embedding model。
+- Gemini 将语义 task 映射为 `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY`，并把
+  timeout 放入 Google GenAI HTTP options。
+- OpenAI-compatible adapter 支持 LiteLLM callable 或已配置的
+  `embeddings.create` callable。API 不支持 task 参数时，task 仍保留在 identity。
+- 所有响应都经过 `EmbeddingBatchResult` 与 `validate_embedding_result`，因此数量、
+  维度、非有限数和 request binding 漂移统一归类为 `invalid_response`。
+- Provider 异常只按 status/type 分类为稳定错误；公开异常不包含原始错误文本、
+  URL、header、响应 body 或错误码。
+
+## Provider identity 与凭据边界
+
+持久化的 `provider` 是 provider id 加规范 endpoint/configuration 的 SHA-256，
+不保存原始 endpoint。API key 和 request headers 不进入 identity builder。
+credential-shaped configuration key，以及带 userinfo/query/fragment 的 endpoint 或
+configuration URL 会直接被拒绝，避免秘密影响 metadata 或 fingerprint。
+
+## Store compatibility 与迁移
+
+新 store 应在写入第一条向量前调用 `set_embedding_identity(document_identity)`。
+查询使用 `search_history_compatible` 或 `search_segments_compatible`，它们先按字段
+比较 backend/provider/model/task type/dimension，再决定是否计算相似度。
+
+旧 store 没有完整 identity，或 identity fingerprint 损坏时，查询返回空命中和
+字段级 diagnostics，action 固定为 `rebuild_store`。已有向量的 store 不能通过
+`set_embedding_identity` 被静默“升级”；必须由后续生产接线显式重建或使用新目录。
+
+## 后续阶段
+
+1. 增加完整 runtime/config/CLI/GUI/doctor 选择与诊断，并把 adapter 接到 Sync RAG
+   和 Batch RAG/Source Index 的构建、查询路径。
+2. 接普通 Sync Source Index，只有 compatibility-gated 命中可以交给 #346 冻结的
+   retrieval provider；本阶段不改 TranslationPlan provider 接缝。
+3. 单独接 fresh Published Project Analysis brief；不与向量 store identity 混为一层。

--- a/docs/plans/issue-341-embedding-adapters-store-identity.md
+++ b/docs/plans/issue-341-embedding-adapters-store-identity.md
@@ -26,6 +26,9 @@ Published Project Analysis 注入，也不修改 GUI Project Analysis 订正页�
   timeout 放入 Google GenAI HTTP options。
 - OpenAI-compatible adapter 支持 LiteLLM callable 或已配置的
   `embeddings.create` callable。API 不支持 task 参数时，task 仍保留在 identity。
+- LiteLLM 的 OpenAI 官方缺省会固定并显式传递 `https://api.openai.com/v1`；
+  其它 Provider、环境变量或预配置 transport 隐式提供的 endpoint 无法安全核验，
+  必须显式声明，否则 adapter 在构造阶段 fail closed。
 - 所有响应都经过 `EmbeddingBatchResult` 与 `validate_embedding_result`，因此数量、
   维度、非有限数和 request binding 漂移统一归类为 `invalid_response`。
 - Provider 异常只按 status/type 分类为稳定错误；公开异常不包含原始错误文本、
@@ -43,6 +46,10 @@ configuration URL 会直接被拒绝，避免秘密影响 metadata 或 fingerpri
 新 store 应在写入第一条向量前调用 `set_embedding_identity(document_identity)`。
 查询使用 `search_history_compatible` 或 `search_segments_compatible`，它们先按字段
 比较 backend/provider/model/task type/dimension，再决定是否计算相似度。
+
+通用 `set_metadata` 不接受 `embedding_identity`，避免绕过上述非空 store 防护。
+旧 store 只有纯文本记录而没有任何非空 embedding 时可以安全附加 identity；只要
+存在一个非空向量，就必须沿用完全相同的 identity 或显式重建。
 
 旧 store 没有完整 identity，或 identity fingerprint 损坏时，查询返回空命中和
 字段级 diagnostics，action 固定为 `rebuild_store`。已有向量的 store 不能通过

--- a/embedding_adapters.py
+++ b/embedding_adapters.py
@@ -1,0 +1,404 @@
+# -*- coding: utf-8 -*-
+"""Credential-safe provider adapters for the provider-neutral embedding core.
+
+The adapters accept injected transports, which keeps their contract testable
+offline. Provider SDK exceptions are reduced to closed error categories; raw
+messages, response bodies, URLs, headers, and credentials never cross the
+adapter boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import hashlib
+import re
+from urllib.parse import urlsplit, urlunsplit
+
+from embedding_backend import (
+    EmbeddingBackendError,
+    EmbeddingBatchRequest,
+    EmbeddingBatchResult,
+    EmbeddingContractError,
+    EmbeddingErrorCategory,
+    EmbeddingIdentity,
+    EmbeddingTaskType,
+    EmbeddingUsage,
+    canonical_json,
+    validate_embedding_result,
+    validate_safe_metadata,
+)
+
+
+_PROVIDER_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+_RETRYABLE_CATEGORIES = frozenset(
+    {
+        EmbeddingErrorCategory.RATE_LIMIT,
+        EmbeddingErrorCategory.TIMEOUT,
+        EmbeddingErrorCategory.UNAVAILABLE,
+    }
+)
+
+
+def _required_provider_id(value: object) -> str:
+    provider = str(value or "").strip().lower()
+    if not provider or not _PROVIDER_ID_PATTERN.fullmatch(provider):
+        raise EmbeddingContractError("provider must be a stable non-secret identifier")
+    return provider
+
+
+def _canonical_endpoint(value: str | None, *, default_endpoint: str) -> str:
+    endpoint = str(value or "").strip()
+    if not endpoint:
+        return _required_provider_id(default_endpoint)
+    parsed = urlsplit(endpoint)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise EmbeddingContractError("embedding endpoint must be an absolute http(s) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise EmbeddingContractError("embedding endpoint must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise EmbeddingContractError("embedding endpoint must not contain query or fragment data")
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname.lower()
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = parsed.port
+    if port is not None and not (
+        (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
+    ):
+        hostname = f"{hostname}:{port}"
+    path = parsed.path.rstrip("/") or "/"
+    return urlunsplit((scheme, hostname, path, "", ""))
+
+
+def _reject_secret_url_values(value: object) -> None:
+    if isinstance(value, Mapping):
+        for item in value.values():
+            _reject_secret_url_values(item)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _reject_secret_url_values(item)
+        return
+    if not isinstance(value, str) or "://" not in value:
+        return
+    parsed = urlsplit(value)
+    if parsed.scheme.lower() not in {"http", "https"}:
+        return
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise EmbeddingContractError(
+            "provider identity configuration must not contain secret-bearing URLs"
+        )
+
+
+def build_provider_identity(
+    *,
+    backend: str,
+    provider: str,
+    endpoint: str | None = None,
+    default_endpoint: str,
+    configuration: Mapping[str, object] | None = None,
+) -> str:
+    """Return a stable opaque identity for one endpoint/configuration.
+
+    Endpoint URLs are validated and hashed, never persisted verbatim. Optional
+    configuration is recursively checked for credential-shaped keys before it
+    participates in the hash. API keys and request headers are intentionally
+    not accepted by this function.
+    """
+
+    backend_id = _required_provider_id(backend)
+    provider_id = _required_provider_id(provider)
+    safe_configuration = validate_safe_metadata(
+        configuration or {},
+        field_name="provider_identity.configuration",
+    )
+    _reject_secret_url_values(safe_configuration)
+    payload = {
+        "schema_version": 1,
+        "backend": backend_id,
+        "provider": provider_id,
+        "endpoint": _canonical_endpoint(endpoint, default_endpoint=default_endpoint),
+        "configuration": safe_configuration,
+    }
+    digest = hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+    return f"{provider_id}@sha256:{digest}"
+
+
+def _field(value: object, name: str, default: object = None) -> object:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _status_code(exc: BaseException) -> int | None:
+    for name in ("status_code", "status", "http_status"):
+        value = getattr(exc, name, None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        numeric = getattr(value, "value", None)
+        if isinstance(numeric, int) and not isinstance(numeric, bool):
+            return numeric
+    return None
+
+
+def classify_provider_exception(exc: BaseException) -> EmbeddingErrorCategory:
+    """Classify an exception without copying provider-controlled text."""
+
+    if isinstance(exc, TimeoutError):
+        return EmbeddingErrorCategory.TIMEOUT
+    name = type(exc).__name__.lower()
+    if "cancel" in name:
+        return EmbeddingErrorCategory.CANCELLED
+    if "timeout" in name or "deadline" in name:
+        return EmbeddingErrorCategory.TIMEOUT
+    status = _status_code(exc)
+    if status == 401:
+        return EmbeddingErrorCategory.AUTHENTICATION
+    if status == 403:
+        return EmbeddingErrorCategory.PERMISSION
+    if status == 429:
+        return EmbeddingErrorCategory.RATE_LIMIT
+    if status in {400, 404, 409, 413, 422}:
+        return EmbeddingErrorCategory.INVALID_REQUEST
+    if status is not None and 500 <= status <= 599:
+        return EmbeddingErrorCategory.UNAVAILABLE
+    if any(marker in name for marker in ("connection", "unavailable", "serviceerror")):
+        return EmbeddingErrorCategory.UNAVAILABLE
+    return EmbeddingErrorCategory.PROVIDER_ERROR
+
+
+def _safe_backend_error(exc: BaseException) -> EmbeddingBackendError:
+    if isinstance(exc, EmbeddingBackendError):
+        return exc
+    category = classify_provider_exception(exc)
+    return EmbeddingBackendError(category, retryable=category in _RETRYABLE_CATEGORIES)
+
+
+def _usage(response: object) -> EmbeddingUsage:
+    usage = _field(response, "usage") or _field(response, "usage_metadata")
+    input_tokens = _field(usage, "prompt_tokens")
+    if input_tokens is None:
+        input_tokens = _field(usage, "input_tokens")
+    if input_tokens is None:
+        input_tokens = _field(usage, "prompt_token_count")
+    total_tokens = _field(usage, "total_tokens")
+    if total_tokens is None:
+        total_tokens = _field(usage, "total_token_count")
+    return EmbeddingUsage(input_tokens=input_tokens, total_tokens=total_tokens)
+
+
+def _gemini_usage(response: object, embeddings: Sequence[object]) -> EmbeddingUsage:
+    usage = _usage(response)
+    if usage.input_tokens is not None or usage.total_tokens is not None:
+        return usage
+    token_counts = [_field(_field(item, "statistics"), "token_count") for item in embeddings]
+    input_tokens = None
+    if token_counts and all(
+        isinstance(count, int) and not isinstance(count, bool) and count >= 0
+        for count in token_counts
+    ):
+        input_tokens = sum(token_counts)
+    metadata: dict[str, object] = {}
+    billable_characters = _field(_field(response, "metadata"), "billable_character_count")
+    if isinstance(billable_characters, int) and not isinstance(billable_characters, bool):
+        metadata["billable_character_count"] = billable_characters
+    truncated_count = sum(
+        1 for item in embeddings if _field(_field(item, "statistics"), "truncated") is True
+    )
+    if truncated_count:
+        metadata["truncated_input_count"] = truncated_count
+    return EmbeddingUsage(
+        input_tokens=input_tokens,
+        total_tokens=input_tokens,
+        metadata=metadata,
+    )
+
+
+class GeminiEmbeddingAdapter:
+    """Google GenAI embedding adapter with explicit retrieval task mapping."""
+
+    backend = "google_genai"
+
+    def __init__(
+        self,
+        *,
+        client: object,
+        model: str,
+        output_dimension: int,
+        provider: str = "google_ai",
+        endpoint: str | None = None,
+        identity_configuration: Mapping[str, object] | None = None,
+        config_factory: Callable[..., object] | None = None,
+    ) -> None:
+        self._client = client
+        self._model = str(model or "").strip()
+        self._output_dimension = output_dimension
+        self._provider_identity = build_provider_identity(
+            backend=self.backend,
+            provider=provider,
+            endpoint=endpoint,
+            default_endpoint="google-ai-api",
+            configuration=identity_configuration,
+        )
+        self._config_factory = config_factory or self._default_config_factory
+        # Validate model/dimension at construction without inventing a task.
+        self.identity(EmbeddingTaskType.DOCUMENT)
+
+    @staticmethod
+    def _default_config_factory(**kwargs: object) -> object:
+        from google.genai import types
+
+        timeout_ms = max(1, round(float(kwargs.pop("timeout_seconds")) * 1000))
+        return types.EmbedContentConfig(
+            **kwargs,
+            http_options=types.HttpOptions(timeout=timeout_ms),
+        )
+
+    def identity(self, task_type: EmbeddingTaskType) -> EmbeddingIdentity:
+        return EmbeddingIdentity(
+            backend=self.backend,
+            provider=self._provider_identity,
+            model=self._model,
+            task_type=task_type,
+            output_dimension=self._output_dimension,
+        )
+
+    def embed(self, request: EmbeddingBatchRequest) -> EmbeddingBatchResult:
+        expected = self.identity(request.identity.task_type)
+        if request.identity != expected:
+            raise EmbeddingBackendError(EmbeddingErrorCategory.INVALID_REQUEST)
+        native_task = {
+            EmbeddingTaskType.DOCUMENT: "RETRIEVAL_DOCUMENT",
+            EmbeddingTaskType.QUERY: "RETRIEVAL_QUERY",
+        }[request.identity.task_type]
+        try:
+            config = self._config_factory(
+                task_type=native_task,
+                output_dimensionality=request.identity.output_dimension,
+                timeout_seconds=request.timeout_seconds,
+            )
+            response = self._client.models.embed_content(
+                model=request.identity.model,
+                contents=list(request.inputs),
+                config=config,
+            )
+            embeddings = _field(response, "embeddings", ())
+            if isinstance(embeddings, (str, bytes)) or not isinstance(embeddings, Sequence):
+                raise EmbeddingContractError("provider embeddings must be a sequence")
+            vectors = tuple(_field(item, "values", ()) for item in embeddings)
+            result = EmbeddingBatchResult(
+                identity=request.identity,
+                request_fingerprint=request.fingerprint,
+                vectors=vectors,
+                usage=_gemini_usage(response, embeddings),
+                metadata={"adapter": self.backend},
+            )
+            return validate_embedding_result(request, result)
+        except EmbeddingBackendError:
+            raise
+        except EmbeddingContractError:
+            raise EmbeddingBackendError(EmbeddingErrorCategory.INVALID_RESPONSE) from None
+        except Exception as exc:
+            raise _safe_backend_error(exc) from None
+
+
+class OpenAICompatibleEmbeddingAdapter:
+    """Adapter for LiteLLM or an OpenAI-compatible ``embeddings.create`` callable."""
+
+    backend = "openai_compatible"
+
+    def __init__(
+        self,
+        *,
+        transport: Callable[..., object],
+        model: str,
+        output_dimension: int,
+        provider: str,
+        endpoint: str | None = None,
+        identity_configuration: Mapping[str, object] | None = None,
+        transport_kind: str = "litellm",
+        api_key: str | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not callable(transport):
+            raise EmbeddingContractError("transport must be callable")
+        if transport_kind not in {"litellm", "openai_client"}:
+            raise EmbeddingContractError("transport_kind must be litellm or openai_client")
+        self._transport = transport
+        self._transport_kind = transport_kind
+        self._model = str(model or "").strip()
+        self._output_dimension = output_dimension
+        self._endpoint = str(endpoint or "").strip() or None
+        self._api_key = api_key
+        self._request_headers = dict(request_headers or {})
+        self._provider_identity = build_provider_identity(
+            backend=self.backend,
+            provider=provider,
+            endpoint=endpoint,
+            default_endpoint=f"{str(provider or '').strip().lower()}-default",
+            configuration=identity_configuration,
+        )
+        self.identity(EmbeddingTaskType.DOCUMENT)
+
+    def identity(self, task_type: EmbeddingTaskType) -> EmbeddingIdentity:
+        return EmbeddingIdentity(
+            backend=self.backend,
+            provider=self._provider_identity,
+            model=self._model,
+            task_type=task_type,
+            output_dimension=self._output_dimension,
+        )
+
+    def _transport_kwargs(self, request: EmbeddingBatchRequest) -> dict[str, object]:
+        kwargs: dict[str, object] = {
+            "model": request.identity.model,
+            "input": list(request.inputs),
+            "dimensions": request.identity.output_dimension,
+            "timeout": request.timeout_seconds,
+        }
+        if self._transport_kind == "litellm":
+            if self._endpoint:
+                kwargs["api_base"] = self._endpoint
+            if self._api_key is not None:
+                kwargs["api_key"] = self._api_key
+            if self._request_headers:
+                kwargs["extra_headers"] = dict(self._request_headers)
+        return kwargs
+
+    def embed(self, request: EmbeddingBatchRequest) -> EmbeddingBatchResult:
+        expected = self.identity(request.identity.task_type)
+        if request.identity != expected:
+            raise EmbeddingBackendError(EmbeddingErrorCategory.INVALID_REQUEST)
+        try:
+            response = self._transport(**self._transport_kwargs(request))
+            data = _field(response, "data", ())
+            if isinstance(data, (str, bytes)) or not isinstance(data, Sequence):
+                raise EmbeddingContractError("provider data must be a sequence")
+            indexed: list[tuple[int, object]] = []
+            for offset, item in enumerate(data):
+                index = _field(item, "index", offset)
+                if isinstance(index, bool) or not isinstance(index, int):
+                    raise EmbeddingContractError("provider embedding index must be an integer")
+                indexed.append((index, _field(item, "embedding", ())))
+            if sorted(index for index, _vector in indexed) != list(range(len(indexed))):
+                raise EmbeddingContractError("provider embedding indices are invalid")
+            vectors = tuple(vector for _index, vector in sorted(indexed))
+            result = EmbeddingBatchResult(
+                identity=request.identity,
+                request_fingerprint=request.fingerprint,
+                vectors=vectors,
+                usage=_usage(response),
+                metadata={"adapter": self.backend},
+            )
+            return validate_embedding_result(request, result)
+        except EmbeddingBackendError:
+            raise
+        except EmbeddingContractError:
+            raise EmbeddingBackendError(EmbeddingErrorCategory.INVALID_RESPONSE) from None
+        except Exception as exc:
+            raise _safe_backend_error(exc) from None

--- a/embedding_adapters.py
+++ b/embedding_adapters.py
@@ -375,6 +375,10 @@ class OpenAICompatibleEmbeddingAdapter:
             endpoint=endpoint,
             transport_kind=transport_kind,
         )
+        if transport_kind == "openai_client" and (api_key is not None or bool(request_headers)):
+            raise EmbeddingContractError(
+                "api_key and request_headers must be configured on the OpenAI client transport"
+            )
         self._transport = transport
         self._transport_kind = transport_kind
         self._model = str(model or "").strip()

--- a/embedding_adapters.py
+++ b/embedding_adapters.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 import hashlib
+import math
 import re
 from urllib.parse import urlsplit, urlunsplit
 
@@ -30,6 +31,9 @@ from embedding_backend import (
 
 
 _PROVIDER_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+_OPENAI_COMPATIBLE_OFFICIAL_ENDPOINTS = {
+    "openai": "https://api.openai.com/v1",
+}
 _RETRYABLE_CATEGORIES = frozenset(
     {
         EmbeddingErrorCategory.RATE_LIMIT,
@@ -129,6 +133,36 @@ def build_provider_identity(
     return f"{provider_id}@sha256:{digest}"
 
 
+def _resolve_openai_compatible_endpoint(
+    *,
+    provider: str,
+    endpoint: str | None,
+    transport_kind: str,
+) -> tuple[str, str]:
+    """Resolve and pin the endpoint used by transport and provider identity.
+
+    LiteLLM's OpenAI default is safe only when the adapter explicitly passes
+    the official base URL, preventing environment variables from changing the
+    actual endpoint behind a stable identity. Other providers and preconfigured
+    OpenAI clients must declare their endpoint because it cannot be inferred
+    without reading transport/environment state that may contain credentials.
+    """
+
+    provider_id = _required_provider_id(provider)
+    explicit = str(endpoint or "").strip()
+    if explicit:
+        return provider_id, _canonical_endpoint(
+            explicit,
+            default_endpoint=f"{provider_id}-default",
+        )
+    official = _OPENAI_COMPATIBLE_OFFICIAL_ENDPOINTS.get(provider_id)
+    if transport_kind == "litellm" and official:
+        return provider_id, official
+    raise EmbeddingContractError(
+        "explicit embedding endpoint is required for this provider/transport"
+    )
+
+
 def _field(value: object, name: str, default: object = None) -> object:
     if isinstance(value, Mapping):
         return value.get(name, default)
@@ -136,7 +170,7 @@ def _field(value: object, name: str, default: object = None) -> object:
 
 
 def _status_code(exc: BaseException) -> int | None:
-    for name in ("status_code", "status", "http_status"):
+    for name in ("status_code", "code", "status", "http_status"):
         value = getattr(exc, name, None)
         if isinstance(value, int) and not isinstance(value, bool):
             return value
@@ -196,12 +230,19 @@ def _gemini_usage(response: object, embeddings: Sequence[object]) -> EmbeddingUs
     usage = _usage(response)
     if usage.input_tokens is not None or usage.total_tokens is not None:
         return usage
-    token_counts = [_field(_field(item, "statistics"), "token_count") for item in embeddings]
+    raw_token_counts = [_field(_field(item, "statistics"), "token_count") for item in embeddings]
+    token_counts: list[int] = []
+    for count in raw_token_counts:
+        if isinstance(count, bool) or not isinstance(count, (int, float)):
+            token_counts = []
+            break
+        numeric = float(count)
+        if not math.isfinite(numeric) or numeric < 0 or not numeric.is_integer():
+            token_counts = []
+            break
+        token_counts.append(int(numeric))
     input_tokens = None
-    if token_counts and all(
-        isinstance(count, int) and not isinstance(count, bool) and count >= 0
-        for count in token_counts
-    ):
+    if token_counts and len(token_counts) == len(raw_token_counts):
         input_tokens = sum(token_counts)
     metadata: dict[str, object] = {}
     billable_characters = _field(_field(response, "metadata"), "billable_character_count")
@@ -329,18 +370,23 @@ class OpenAICompatibleEmbeddingAdapter:
             raise EmbeddingContractError("transport must be callable")
         if transport_kind not in {"litellm", "openai_client"}:
             raise EmbeddingContractError("transport_kind must be litellm or openai_client")
+        provider_id, resolved_endpoint = _resolve_openai_compatible_endpoint(
+            provider=provider,
+            endpoint=endpoint,
+            transport_kind=transport_kind,
+        )
         self._transport = transport
         self._transport_kind = transport_kind
         self._model = str(model or "").strip()
         self._output_dimension = output_dimension
-        self._endpoint = str(endpoint or "").strip() or None
+        self._endpoint = resolved_endpoint
         self._api_key = api_key
         self._request_headers = dict(request_headers or {})
         self._provider_identity = build_provider_identity(
             backend=self.backend,
-            provider=provider,
-            endpoint=endpoint,
-            default_endpoint=f"{str(provider or '').strip().lower()}-default",
+            provider=provider_id,
+            endpoint=resolved_endpoint,
+            default_endpoint=f"{provider_id}-default",
             configuration=identity_configuration,
         )
         self.identity(EmbeddingTaskType.DOCUMENT)

--- a/embedding_backend.py
+++ b/embedding_backend.py
@@ -199,6 +199,25 @@ def _metadata_to_json(value: object) -> object:
     return value
 
 
+def validate_safe_metadata(
+    value: Mapping[str, object],
+    *,
+    field_name: str = 'metadata',
+) -> dict[str, object]:
+    """Return detached JSON metadata after recursive credential-shape checks.
+
+    Provider adapters use this before configuration data participates in an
+    endpoint identity. Credential-shaped fields are rejected rather than
+    redacted so secrets can never influence a persisted fingerprint.
+    """
+
+    frozen = _validate_metadata_mapping(value, field_name)
+    normalized = _metadata_to_json(frozen)
+    if not isinstance(normalized, dict):  # pragma: no cover - mapping guaranteed above
+        raise EmbeddingContractError(f'{field_name} must be an object')
+    return normalized
+
+
 def _task_type(value: object, field_name: str = 'task_type') -> EmbeddingTaskType:
     if isinstance(value, EmbeddingTaskType):
         return value
@@ -443,6 +462,8 @@ class EmbeddingBackend(Protocol):
 
 class CompatibilityCode(str, Enum):
     COMPATIBLE = 'compatible'
+    STORE_IDENTITY_MISSING = 'store_identity_missing'
+    STORE_IDENTITY_INVALID = 'store_identity_invalid'
     STORE_TASK_NOT_DOCUMENT = 'store_task_not_document'
     QUERY_TASK_NOT_QUERY = 'query_task_not_query'
     BACKEND_MISMATCH = 'backend_mismatch'
@@ -550,4 +571,43 @@ def check_store_query_compatibility(
             'Embedding identity mismatch; do not compare these vectors. '
             f'Rebuild the store with the selected query backend configuration ({fields}).'
         ),
+    )
+
+
+def check_persisted_store_query_compatibility(
+    store_identity_payload: object,
+    query_identity: EmbeddingIdentity,
+) -> EmbeddingCompatibilityReport:
+    """Fail closed when persisted store identity is absent, corrupt, or incompatible.
+
+    Invalid persisted fields are deliberately not echoed into the report, so
+    the diagnostic is safe to expose through logs or future doctor/GUI paths.
+    """
+
+    if not isinstance(query_identity, EmbeddingIdentity):
+        raise EmbeddingContractError('query_identity must be an EmbeddingIdentity')
+    if store_identity_payload is None:
+        mismatch = CompatibilityMismatch(
+            CompatibilityCode.STORE_IDENTITY_MISSING,
+            'embedding_identity',
+            'missing',
+            'required',
+        )
+    else:
+        try:
+            store_identity = EmbeddingIdentity.from_dict(store_identity_payload)
+        except (EmbeddingContractError, TypeError, ValueError):
+            mismatch = CompatibilityMismatch(
+                CompatibilityCode.STORE_IDENTITY_INVALID,
+                'embedding_identity',
+                'invalid',
+                'valid',
+            )
+        else:
+            return check_store_query_compatibility(store_identity, query_identity)
+    return EmbeddingCompatibilityReport(
+        compatible=False,
+        mismatches=(mismatch,),
+        action='rebuild_store',
+        message='Embedding store identity is unavailable; rebuild the store before retrieval.',
     )

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -8,6 +8,13 @@ import socket
 import stat
 from datetime import datetime
 
+from embedding_backend import (
+    EmbeddingContractError,
+    EmbeddingIdentity,
+    EmbeddingTaskType,
+    check_persisted_store_query_compatibility,
+)
+
 
 LOCK_STALE_AFTER_SECONDS = 60 * 60
 
@@ -64,7 +71,55 @@ class JsonRagStoreLockError(RuntimeError):
     pass
 
 
-class JsonRagStore(object):
+class EmbeddingStoreIdentityError(RuntimeError):
+    """Raised when identity metadata would silently bless existing vectors."""
+
+    action = 'rebuild_store'
+
+    def __init__(self):
+        super().__init__('embedding store identity cannot change; rebuild the store')
+
+
+class _EmbeddingIdentityStoreMixin:
+    def _embedding_record_count(self):
+        raise NotImplementedError
+
+    def set_embedding_identity(self, identity):
+        """Persist a document identity without silently migrating existing vectors."""
+
+        if not isinstance(identity, EmbeddingIdentity):
+            raise EmbeddingContractError('identity must be an EmbeddingIdentity')
+        if identity.task_type is not EmbeddingTaskType.DOCUMENT:
+            raise EmbeddingContractError('store embedding identity must use document task type')
+        with self._locked('set_embedding_identity') as lock_info:
+            self._refresh_from_disk_if_changed()
+            existing_payload = self.metadata.get('embedding_identity')
+            if existing_payload is not None:
+                try:
+                    existing = EmbeddingIdentity.from_dict(existing_payload)
+                except EmbeddingContractError:
+                    existing = None
+                if existing == identity:
+                    return
+            if self._embedding_record_count() > 0:
+                raise EmbeddingStoreIdentityError()
+            self._update_metadata_unlocked(
+                'set_embedding_identity',
+                {'embedding_identity': identity.to_dict()},
+                lock_info,
+            )
+
+    def embedding_compatibility(self, query_identity):
+        """Return a fail-closed, field-level compatibility/rebuild diagnostic."""
+
+        self.load()
+        return check_persisted_store_query_compatibility(
+            self.metadata.get('embedding_identity'),
+            query_identity,
+        )
+
+
+class JsonRagStore(_EmbeddingIdentityStoreMixin, object):
     def __init__(self, store_dir):
         self.store_dir = os.path.abspath(store_dir)
         self.metadata_path = os.path.join(self.store_dir, 'metadata.json')
@@ -143,6 +198,9 @@ class JsonRagStore(object):
 
     def count_history(self):
         self.load()
+        return len(self.history)
+
+    def _embedding_record_count(self):
         return len(self.history)
 
     def get_history_record(self, memory_id):
@@ -507,6 +565,20 @@ class JsonRagStore(object):
         if top_k > 0:
             return results[:top_k]
         return results
+
+    def search_history_compatible(self, query_vector, query_identity, top_k=4, min_similarity=0.72):
+        """Search only when the persisted document and query identities match."""
+
+        compatibility = self.embedding_compatibility(query_identity)
+        diagnostics = {'embedding_compatibility': compatibility.to_dict()}
+        if not compatibility.compatible:
+            return [], diagnostics
+        return self.search_history(
+            query_vector,
+            top_k=top_k,
+            min_similarity=min_similarity,
+        ), diagnostics
+
     def _sort_key(self, record):
         quality_state = record.get('quality_state') or ''
         quality_rank = {
@@ -523,7 +595,7 @@ class JsonSourceIndexStoreLockError(RuntimeError):
     pass
 
 
-class JsonSourceIndexStore(object):
+class JsonSourceIndexStore(_EmbeddingIdentityStoreMixin, object):
     def __init__(self, store_dir):
         self.store_dir = os.path.abspath(store_dir)
         self.metadata_path = os.path.join(self.store_dir, 'source_metadata.json')
@@ -604,6 +676,9 @@ class JsonSourceIndexStore(object):
 
     def count_segments(self):
         self.load()
+        return len(self.segments)
+
+    def _embedding_record_count(self):
         return len(self.segments)
 
     def get_segment(self, source_id):
@@ -1048,3 +1123,31 @@ class JsonSourceIndexStore(object):
         if return_diagnostics:
             return results, diagnostics
         return results
+
+    def search_segments_compatible(
+        self,
+        query_vector,
+        query_identity,
+        top_k=4,
+        min_similarity=0.72,
+        embedding_model=None,
+        embedding_task_type=None,
+        embedding_dim=None,
+    ):
+        """Search only when store metadata identifies the same vector space."""
+
+        compatibility = self.embedding_compatibility(query_identity)
+        diagnostics = {'embedding_compatibility': compatibility.to_dict()}
+        if not compatibility.compatible:
+            return [], diagnostics
+        results, search_diagnostics = self.search_segments(
+            query_vector,
+            top_k=top_k,
+            min_similarity=min_similarity,
+            embedding_model=embedding_model,
+            embedding_task_type=embedding_task_type,
+            embedding_dim=embedding_dim,
+            return_diagnostics=True,
+        )
+        diagnostics.update(search_diagnostics)
+        return results, diagnostics

--- a/rag_memory.py
+++ b/rag_memory.py
@@ -118,6 +118,20 @@ class _EmbeddingIdentityStoreMixin:
             query_identity,
         )
 
+    @staticmethod
+    def _validate_metadata_updates(updates):
+        if 'embedding_identity' in updates:
+            raise EmbeddingContractError(
+                'embedding_identity must be written with set_embedding_identity'
+            )
+
+
+def _record_has_embedding(record):
+    if not isinstance(record, dict):
+        return False
+    embedding = record.get('embedding')
+    return isinstance(embedding, (list, tuple)) and bool(embedding)
+
 
 class JsonRagStore(_EmbeddingIdentityStoreMixin, object):
     def __init__(self, store_dir):
@@ -201,13 +215,14 @@ class JsonRagStore(_EmbeddingIdentityStoreMixin, object):
         return len(self.history)
 
     def _embedding_record_count(self):
-        return len(self.history)
+        return sum(1 for record in self.history.values() if _record_has_embedding(record))
 
     def get_history_record(self, memory_id):
         self.load()
         return self.history.get(memory_id)
 
     def set_metadata(self, **updates):
+        self._validate_metadata_updates(updates)
         with self._locked('set_metadata') as lock_info:
             self._refresh_from_disk_if_changed()
             self._update_metadata_unlocked('set_metadata', updates, lock_info)
@@ -679,13 +694,14 @@ class JsonSourceIndexStore(_EmbeddingIdentityStoreMixin, object):
         return len(self.segments)
 
     def _embedding_record_count(self):
-        return len(self.segments)
+        return sum(1 for record in self.segments.values() if _record_has_embedding(record))
 
     def get_segment(self, source_id):
         self.load()
         return self.segments.get(source_id)
 
     def set_metadata(self, **updates):
+        self._validate_metadata_updates(updates)
         with self._locked('set_metadata') as lock_info:
             self._refresh_from_disk_if_changed()
             self._update_metadata_unlocked('set_metadata', updates, lock_info)

--- a/tests/test_embedding_adapters.py
+++ b/tests/test_embedding_adapters.py
@@ -1,8 +1,11 @@
 import json
 import math
+import os
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from embedding_adapters import (
     GeminiEmbeddingAdapter,
@@ -42,6 +45,13 @@ class _StatusError(Exception):
         super().__init__(secret)
 
 
+class _GoogleAPIError(Exception):
+    def __init__(self, code, status, secret):
+        self.code = code
+        self.status = status
+        super().__init__(secret)
+
+
 class EmbeddingAdapterTests(unittest.TestCase):
     @staticmethod
     def request(adapter, task=EmbeddingTaskType.DOCUMENT, inputs=("alpha", "beta")):
@@ -57,11 +67,11 @@ class EmbeddingAdapterTests(unittest.TestCase):
             embeddings=[
                 SimpleNamespace(
                     values=[1, 0],
-                    statistics=SimpleNamespace(token_count=3, truncated=False),
+                    statistics=SimpleNamespace(token_count=3.0, truncated=False),
                 ),
                 SimpleNamespace(
                     values=[0, 1],
-                    statistics=SimpleNamespace(token_count=4, truncated=True),
+                    statistics=SimpleNamespace(token_count=4.0, truncated=True),
                 ),
             ],
             metadata=SimpleNamespace(billable_character_count=11),
@@ -85,6 +95,29 @@ class EmbeddingAdapterTests(unittest.TestCase):
         self.assertEqual(configs[0]["task_type"], "RETRIEVAL_DOCUMENT")
         self.assertEqual(configs[0]["timeout_seconds"], 12.5)
         self.assertEqual(models.calls[0]["contents"], ["alpha", "beta"])
+
+    def test_gemini_non_integral_usage_is_not_reported(self):
+        models = _GeminiModels(
+            response=SimpleNamespace(
+                embeddings=[
+                    SimpleNamespace(
+                        values=[1, 0],
+                        statistics=SimpleNamespace(token_count=1.5, truncated=False),
+                    )
+                ]
+            )
+        )
+        adapter = GeminiEmbeddingAdapter(
+            client=SimpleNamespace(models=models),
+            model="gemini-embedding-001",
+            output_dimension=2,
+            config_factory=lambda **kwargs: kwargs,
+        )
+
+        result = adapter.embed(self.request(adapter, inputs=("alpha",)))
+
+        self.assertIsNone(result.usage.input_tokens)
+        self.assertIsNone(result.usage.total_tokens)
 
     def test_gemini_maps_query_task(self):
         models = _GeminiModels(
@@ -131,7 +164,79 @@ class EmbeddingAdapterTests(unittest.TestCase):
         self.assertEqual(result.usage.total_tokens, 5)
         self.assertEqual(calls[0]["timeout"], 12.5)
         self.assertEqual(calls[0]["dimensions"], 2)
+        self.assertEqual(calls[0]["api_base"], "https://api.example.test/v1")
         self.assertEqual(calls[0]["api_key"], "fake-key-value")
+
+    def test_openai_official_default_is_pinned_and_matches_explicit_endpoint(self):
+        calls = []
+
+        def transport(**kwargs):
+            calls.append(kwargs)
+            return {"data": [{"index": 0, "embedding": [1, 0]}]}
+
+        default_adapter = OpenAICompatibleEmbeddingAdapter(
+            transport=transport,
+            model="openai/text-embedding-3-small",
+            output_dimension=2,
+            provider="openai",
+        )
+        explicit_adapter = OpenAICompatibleEmbeddingAdapter(
+            transport=transport,
+            model="openai/text-embedding-3-small",
+            output_dimension=2,
+            provider="openai",
+            endpoint="https://api.openai.com:443/v1/",
+        )
+
+        default_adapter.embed(self.request(default_adapter, inputs=("alpha",)))
+
+        self.assertEqual(calls[0]["api_base"], "https://api.openai.com/v1")
+        self.assertEqual(
+            default_adapter.identity(EmbeddingTaskType.DOCUMENT),
+            explicit_adapter.identity(EmbeddingTaskType.DOCUMENT),
+        )
+
+    def test_custom_and_implicit_endpoints_are_fail_closed(self):
+        def transport(**_kwargs):
+            return {"data": []}
+
+        transport.base_url = "https://transport-private.example.test/v1"
+
+        with mock.patch.dict(
+            os.environ,
+            {"OPENAI_API_BASE": "https://environment-private.example.test/v1"},
+        ):
+            with self.assertRaises(EmbeddingContractError) as environment_error:
+                OpenAICompatibleEmbeddingAdapter(
+                    transport=transport,
+                    model="embed-model",
+                    output_dimension=2,
+                    provider="local",
+                )
+        with self.assertRaises(EmbeddingContractError) as transport_error:
+            OpenAICompatibleEmbeddingAdapter(
+                transport=transport,
+                transport_kind="openai_client",
+                model="embed-model",
+                output_dimension=2,
+                provider="openai",
+            )
+
+        for public in (str(environment_error.exception), str(transport_error.exception)):
+            self.assertIn("explicit embedding endpoint", public)
+            self.assertNotIn("private.example.test", public)
+
+        custom = OpenAICompatibleEmbeddingAdapter(
+            transport=transport,
+            model="embed-model",
+            output_dimension=2,
+            provider="local",
+            endpoint="https://explicit.example.test/v1",
+        )
+        self.assertNotIn(
+            "explicit.example.test",
+            custom.identity(EmbeddingTaskType.DOCUMENT).provider,
+        )
 
     def test_count_dimension_and_non_finite_drift_are_invalid_response(self):
         bad_payloads = (
@@ -156,6 +261,7 @@ class EmbeddingAdapterTests(unittest.TestCase):
                     model="embed-model",
                     output_dimension=2,
                     provider="local",
+                    endpoint="https://local.example.test/v1",
                 )
                 with self.assertRaises(EmbeddingBackendError) as raised:
                     adapter.embed(self.request(adapter))
@@ -177,6 +283,7 @@ class EmbeddingAdapterTests(unittest.TestCase):
                     model="embed-model",
                     output_dimension=2,
                     provider="local",
+                    endpoint="https://local.example.test/v1",
                 )
                 with self.assertRaises(EmbeddingBackendError) as raised:
                     adapter.embed(self.request(adapter))
@@ -185,6 +292,34 @@ class EmbeddingAdapterTests(unittest.TestCase):
                 self.assertNotIn("secret", public.lower())
                 self.assertNotIn("authorization", public.lower())
                 self.assertNotIn("http", public.lower())
+
+    def test_google_api_error_code_is_classified_and_redacted(self):
+        cases = (
+            (401, "UNAUTHENTICATED", EmbeddingErrorCategory.AUTHENTICATION, False),
+            (429, "RESOURCE_EXHAUSTED", EmbeddingErrorCategory.RATE_LIMIT, True),
+            (503, "UNAVAILABLE", EmbeddingErrorCategory.UNAVAILABLE, True),
+        )
+        for code, status, category, retryable in cases:
+            with self.subTest(code=code):
+                adapter = GeminiEmbeddingAdapter(
+                    client=SimpleNamespace(
+                        models=_GeminiModels(
+                            error=_GoogleAPIError(
+                                code,
+                                status,
+                                "https://provider-private.example.test/?key=hidden",
+                            )
+                        )
+                    ),
+                    model="gemini-embedding-001",
+                    output_dimension=2,
+                    config_factory=lambda **kwargs: kwargs,
+                )
+                with self.assertRaises(EmbeddingBackendError) as raised:
+                    adapter.embed(self.request(adapter))
+                self.assertEqual(raised.exception.category, category)
+                self.assertEqual(raised.exception.retryable, retryable)
+                self.assertNotIn("private.example.test", str(raised.exception))
 
     def test_provider_identity_is_stable_endpoint_specific_and_credential_free(self):
         first = build_provider_identity(
@@ -257,6 +392,7 @@ class EmbeddingStoreIdentityTests(unittest.TestCase):
             model="embed-model",
             output_dimension=dimension,
             provider=provider,
+            endpoint=f"https://{provider}.example.test/v1",
         )
 
     def test_rag_store_persists_identity_and_allows_compatible_search(self):
@@ -312,6 +448,43 @@ class EmbeddingStoreIdentityTests(unittest.TestCase):
                 ["provider", "output_dimension"],
             )
 
+    def test_endpoint_identity_mismatch_fails_store_compatibility(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            official = OpenAICompatibleEmbeddingAdapter(
+                transport=lambda **_kwargs: {"data": []},
+                model="embed-model",
+                output_dimension=2,
+                provider="openai",
+            )
+            custom = OpenAICompatibleEmbeddingAdapter(
+                transport=lambda **_kwargs: {"data": []},
+                model="embed-model",
+                output_dimension=2,
+                provider="openai",
+                endpoint="https://custom.example.test/v1",
+            )
+            store = JsonRagStore(tmp)
+            store.set_embedding_identity(official.identity(EmbeddingTaskType.DOCUMENT))
+            store.upsert_history(
+                [{"memory_id": "m1", "embedding": [1.0, 0.0], "source_text": "alpha"}]
+            )
+
+            results, diagnostics = store.search_history_compatible(
+                [1.0, 0.0],
+                custom.identity(EmbeddingTaskType.QUERY),
+                min_similarity=0.0,
+            )
+
+            self.assertEqual(results, [])
+            self.assertEqual(
+                diagnostics["embedding_compatibility"]["codes"],
+                ["provider_mismatch"],
+            )
+            self.assertEqual(
+                diagnostics["embedding_compatibility"]["action"],
+                "rebuild_store",
+            )
+
     def test_missing_and_invalid_identity_fail_closed_without_echoing_payload(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = JsonRagStore(tmp)
@@ -321,8 +494,12 @@ class EmbeddingStoreIdentityTests(unittest.TestCase):
                 missing["embedding_compatibility"]["codes"],
                 ["store_identity_missing"],
             )
-            store.set_metadata(embedding_identity={"api_key": "do-not-echo"})
-            _results, invalid = store.search_history_compatible([1, 0], query_identity)
+            Path(tmp, "metadata.json").write_text(
+                json.dumps({"embedding_identity": {"api_key": "do-not-echo"}}),
+                encoding="utf-8",
+            )
+            reloaded = JsonRagStore(tmp)
+            _results, invalid = reloaded.search_history_compatible([1, 0], query_identity)
             serialized = json.dumps(invalid)
             self.assertIn("store_identity_invalid", serialized)
             self.assertNotIn("do-not-echo", serialized)
@@ -350,6 +527,55 @@ class EmbeddingStoreIdentityTests(unittest.TestCase):
                 store.set_embedding_identity(
                     self.adapter(provider="beta").identity(EmbeddingTaskType.DOCUMENT)
                 )
+
+    def test_text_only_legacy_stores_can_adopt_identity_safely(self):
+        identity = self.adapter().identity(EmbeddingTaskType.DOCUMENT)
+        cases = (
+            (JsonRagStore, "history.jsonl", {"memory_id": "text-only", "source_text": "alpha"}),
+            (
+                JsonSourceIndexStore,
+                "source_segments.jsonl",
+                {"source_id": "text-only", "source_text": "alpha", "embedding": []},
+            ),
+        )
+        for store_type, filename, record in cases:
+            with self.subTest(store_type=store_type.__name__), tempfile.TemporaryDirectory() as tmp:
+                Path(tmp, filename).write_text(json.dumps(record) + "\n", encoding="utf-8")
+                store = store_type(tmp)
+
+                store.set_embedding_identity(identity)
+
+                self.assertTrue(
+                    store.embedding_compatibility(
+                        self.adapter().identity(EmbeddingTaskType.QUERY)
+                    ).compatible
+                )
+
+    def test_set_metadata_cannot_bypass_identity_guard(self):
+        identity = self.adapter().identity(EmbeddingTaskType.DOCUMENT)
+        cases = (
+            (
+                JsonRagStore,
+                lambda store: store.upsert_history([{"memory_id": "m1", "embedding": [1.0, 0.0]}]),
+            ),
+            (
+                JsonSourceIndexStore,
+                lambda store: store.upsert_segments([{"source_id": "s1", "embedding": [1.0, 0.0]}]),
+            ),
+        )
+        for store_type, add_vector in cases:
+            with self.subTest(store_type=store_type.__name__), tempfile.TemporaryDirectory() as tmp:
+                store = store_type(tmp)
+                add_vector(store)
+
+                with self.assertRaises(EmbeddingContractError):
+                    store.set_metadata(embedding_identity=identity.to_dict())
+
+                report = store.embedding_compatibility(
+                    self.adapter().identity(EmbeddingTaskType.QUERY)
+                )
+                self.assertEqual(report.codes, ("store_identity_missing",))
+                self.assertEqual(report.action, "rebuild_store")
 
 
 if __name__ == "__main__":

--- a/tests/test_embedding_adapters.py
+++ b/tests/test_embedding_adapters.py
@@ -1,0 +1,356 @@
+import json
+import math
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from embedding_adapters import (
+    GeminiEmbeddingAdapter,
+    OpenAICompatibleEmbeddingAdapter,
+    build_provider_identity,
+)
+from embedding_backend import (
+    EmbeddingBackendError,
+    EmbeddingBatchRequest,
+    EmbeddingContractError,
+    EmbeddingErrorCategory,
+    EmbeddingTaskType,
+)
+from rag_memory import (
+    EmbeddingStoreIdentityError,
+    JsonRagStore,
+    JsonSourceIndexStore,
+)
+
+
+class _GeminiModels:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def embed_content(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class _StatusError(Exception):
+    def __init__(self, status_code, secret):
+        self.status_code = status_code
+        super().__init__(secret)
+
+
+class EmbeddingAdapterTests(unittest.TestCase):
+    @staticmethod
+    def request(adapter, task=EmbeddingTaskType.DOCUMENT, inputs=("alpha", "beta")):
+        return EmbeddingBatchRequest(
+            identity=adapter.identity(task),
+            inputs=inputs,
+            timeout_seconds=12.5,
+            metadata={"purpose": "offline-test"},
+        )
+
+    def test_gemini_maps_document_task_timeout_usage_and_batch(self):
+        response = SimpleNamespace(
+            embeddings=[
+                SimpleNamespace(
+                    values=[1, 0],
+                    statistics=SimpleNamespace(token_count=3, truncated=False),
+                ),
+                SimpleNamespace(
+                    values=[0, 1],
+                    statistics=SimpleNamespace(token_count=4, truncated=True),
+                ),
+            ],
+            metadata=SimpleNamespace(billable_character_count=11),
+        )
+        models = _GeminiModels(response=response)
+        configs = []
+        adapter = GeminiEmbeddingAdapter(
+            client=SimpleNamespace(models=models),
+            model="gemini-embedding-001",
+            output_dimension=2,
+            config_factory=lambda **kwargs: configs.append(kwargs) or kwargs,
+        )
+
+        result = adapter.embed(self.request(adapter))
+
+        self.assertEqual(result.vectors, ((1.0, 0.0), (0.0, 1.0)))
+        self.assertEqual(result.usage.input_tokens, 7)
+        self.assertEqual(result.usage.total_tokens, 7)
+        self.assertEqual(result.usage.metadata["billable_character_count"], 11)
+        self.assertEqual(result.usage.metadata["truncated_input_count"], 1)
+        self.assertEqual(configs[0]["task_type"], "RETRIEVAL_DOCUMENT")
+        self.assertEqual(configs[0]["timeout_seconds"], 12.5)
+        self.assertEqual(models.calls[0]["contents"], ["alpha", "beta"])
+
+    def test_gemini_maps_query_task(self):
+        models = _GeminiModels(
+            response=SimpleNamespace(embeddings=[SimpleNamespace(values=[1, 0])])
+        )
+        configs = []
+        adapter = GeminiEmbeddingAdapter(
+            client=SimpleNamespace(models=models),
+            model="gemini-embedding-001",
+            output_dimension=2,
+            config_factory=lambda **kwargs: configs.append(kwargs) or kwargs,
+        )
+
+        adapter.embed(self.request(adapter, EmbeddingTaskType.QUERY, ("query",)))
+
+        self.assertEqual(configs[0]["task_type"], "RETRIEVAL_QUERY")
+
+    def test_openai_compatible_reorders_batch_and_forwards_timeout(self):
+        calls = []
+
+        def transport(**kwargs):
+            calls.append(kwargs)
+            return {
+                "data": [
+                    {"index": 1, "embedding": [0, 1]},
+                    {"index": 0, "embedding": [1, 0]},
+                ],
+                "usage": {"prompt_tokens": 5, "total_tokens": 5},
+            }
+
+        adapter = OpenAICompatibleEmbeddingAdapter(
+            transport=transport,
+            model="openai/text-embedding-3-small",
+            output_dimension=2,
+            provider="openai",
+            endpoint="https://api.example.test/v1/",
+            api_key="fake-key-value",
+            request_headers={"Authorization": "Bearer super-secret"},
+        )
+
+        result = adapter.embed(self.request(adapter))
+
+        self.assertEqual(result.vectors, ((1.0, 0.0), (0.0, 1.0)))
+        self.assertEqual(result.usage.total_tokens, 5)
+        self.assertEqual(calls[0]["timeout"], 12.5)
+        self.assertEqual(calls[0]["dimensions"], 2)
+        self.assertEqual(calls[0]["api_key"], "fake-key-value")
+
+    def test_count_dimension_and_non_finite_drift_are_invalid_response(self):
+        bad_payloads = (
+            {"data": [{"index": 0, "embedding": [1, 0]}]},
+            {
+                "data": [
+                    {"index": 0, "embedding": [1, 0, 0]},
+                    {"index": 1, "embedding": [0, 1, 0]},
+                ]
+            },
+            {
+                "data": [
+                    {"index": 0, "embedding": [math.nan, 0]},
+                    {"index": 1, "embedding": [0, 1]},
+                ]
+            },
+        )
+        for payload in bad_payloads:
+            with self.subTest(payload=payload):
+                adapter = OpenAICompatibleEmbeddingAdapter(
+                    transport=lambda **_kwargs: payload,
+                    model="embed-model",
+                    output_dimension=2,
+                    provider="local",
+                )
+                with self.assertRaises(EmbeddingBackendError) as raised:
+                    adapter.embed(self.request(adapter))
+                self.assertEqual(raised.exception.category, EmbeddingErrorCategory.INVALID_RESPONSE)
+
+    def test_timeout_and_provider_error_are_classified_and_redacted(self):
+        secrets = (
+            (TimeoutError("https://secret.test/?api_key=oops"), EmbeddingErrorCategory.TIMEOUT),
+            (
+                _StatusError(401, "Authorization: Bearer hidden"),
+                EmbeddingErrorCategory.AUTHENTICATION,
+            ),
+            (_StatusError(429, "provider raw body secret"), EmbeddingErrorCategory.RATE_LIMIT),
+        )
+        for error, category in secrets:
+            with self.subTest(category=category):
+                adapter = OpenAICompatibleEmbeddingAdapter(
+                    transport=lambda **_kwargs: (_ for _ in ()).throw(error),
+                    model="embed-model",
+                    output_dimension=2,
+                    provider="local",
+                )
+                with self.assertRaises(EmbeddingBackendError) as raised:
+                    adapter.embed(self.request(adapter))
+                public = str(raised.exception)
+                self.assertEqual(raised.exception.category, category)
+                self.assertNotIn("secret", public.lower())
+                self.assertNotIn("authorization", public.lower())
+                self.assertNotIn("http", public.lower())
+
+    def test_provider_identity_is_stable_endpoint_specific_and_credential_free(self):
+        first = build_provider_identity(
+            backend="openai_compatible",
+            provider="custom",
+            endpoint="HTTPS://Example.Test:443/v1/",
+            default_endpoint="unused",
+            configuration={"deployment": "blue", "routing": {"region": "east"}},
+        )
+        second = build_provider_identity(
+            backend="openai_compatible",
+            provider="custom",
+            endpoint="https://example.test/v1",
+            default_endpoint="unused",
+            configuration={"routing": {"region": "east"}, "deployment": "blue"},
+        )
+        changed = build_provider_identity(
+            backend="openai_compatible",
+            provider="custom",
+            endpoint="https://example.test/v2",
+            default_endpoint="unused",
+        )
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, changed)
+        self.assertNotIn("example.test", first)
+
+        with self.assertRaises(EmbeddingContractError):
+            build_provider_identity(
+                backend="openai_compatible",
+                provider="custom",
+                endpoint="https://example.test/v1?token=secret",
+                default_endpoint="unused",
+            )
+        with self.assertRaises(EmbeddingContractError):
+            build_provider_identity(
+                backend="openai_compatible",
+                provider="custom",
+                default_endpoint="default",
+                configuration={"Authorization": "Bearer hidden"},
+            )
+        with self.assertRaises(EmbeddingContractError):
+            build_provider_identity(
+                backend="openai_compatible",
+                provider="custom",
+                default_endpoint="default",
+                configuration={"routing": {"fallback": "https://example.test/v1?signature=hidden"}},
+            )
+
+    def test_adapter_identity_does_not_include_key_header_or_endpoint(self):
+        adapter = OpenAICompatibleEmbeddingAdapter(
+            transport=lambda **_kwargs: {"data": []},
+            model="embed-model",
+            output_dimension=2,
+            provider="custom",
+            endpoint="https://private.example.test/v1",
+            api_key="fake-key-value",
+            request_headers={"Authorization": "Bearer hidden"},
+        )
+        serialized = json.dumps(adapter.identity(EmbeddingTaskType.DOCUMENT).to_dict())
+        self.assertNotIn("hidden", serialized)
+        self.assertNotIn("private.example.test", serialized)
+        self.assertNotIn("Authorization", serialized)
+
+
+class EmbeddingStoreIdentityTests(unittest.TestCase):
+    @staticmethod
+    def adapter(provider="local", dimension=2):
+        return OpenAICompatibleEmbeddingAdapter(
+            transport=lambda **_kwargs: {"data": []},
+            model="embed-model",
+            output_dimension=dimension,
+            provider=provider,
+        )
+
+    def test_rag_store_persists_identity_and_allows_compatible_search(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JsonRagStore(tmp)
+            adapter = self.adapter()
+            store.set_embedding_identity(adapter.identity(EmbeddingTaskType.DOCUMENT))
+            store.upsert_history(
+                [{"memory_id": "m1", "embedding": [1.0, 0.0], "source_text": "alpha"}]
+            )
+
+            results, diagnostics = store.search_history_compatible(
+                [1.0, 0.0],
+                adapter.identity(EmbeddingTaskType.QUERY),
+                min_similarity=0.0,
+            )
+
+            self.assertEqual([item["memory_id"] for item in results], ["m1"])
+            self.assertTrue(diagnostics["embedding_compatibility"]["compatible"])
+            reloaded = JsonRagStore(tmp)
+            reloaded.load()
+            self.assertEqual(
+                reloaded.metadata["embedding_identity"]["backend"],
+                "openai_compatible",
+            )
+
+    def test_source_store_mismatch_fails_closed_with_field_rebuild_diagnostic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JsonSourceIndexStore(tmp)
+            document_adapter = self.adapter(provider="alpha")
+            query_adapter = self.adapter(provider="beta", dimension=3)
+            store.set_embedding_identity(document_adapter.identity(EmbeddingTaskType.DOCUMENT))
+            store.upsert_segments(
+                [{"source_id": "s1", "embedding": [1.0, 0.0], "source_text": "alpha"}]
+            )
+
+            results, diagnostics = store.search_segments_compatible(
+                [1.0, 0.0, 0.0],
+                query_adapter.identity(EmbeddingTaskType.QUERY),
+                min_similarity=0.0,
+            )
+
+            report = diagnostics["embedding_compatibility"]
+            self.assertEqual(results, [])
+            self.assertFalse(report["compatible"])
+            self.assertEqual(report["action"], "rebuild_store")
+            self.assertEqual(
+                report["codes"],
+                ["provider_mismatch", "dimension_mismatch"],
+            )
+            self.assertEqual(
+                [item["field"] for item in report["mismatches"]],
+                ["provider", "output_dimension"],
+            )
+
+    def test_missing_and_invalid_identity_fail_closed_without_echoing_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JsonRagStore(tmp)
+            query_identity = self.adapter().identity(EmbeddingTaskType.QUERY)
+            _results, missing = store.search_history_compatible([1, 0], query_identity)
+            self.assertEqual(
+                missing["embedding_compatibility"]["codes"],
+                ["store_identity_missing"],
+            )
+            store.set_metadata(embedding_identity={"api_key": "do-not-echo"})
+            _results, invalid = store.search_history_compatible([1, 0], query_identity)
+            serialized = json.dumps(invalid)
+            self.assertIn("store_identity_invalid", serialized)
+            self.assertNotIn("do-not-echo", serialized)
+            self.assertEqual(invalid["embedding_compatibility"]["action"], "rebuild_store")
+
+    def test_nonempty_store_identity_cannot_be_silently_attached_or_changed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JsonRagStore(tmp)
+            store.upsert_history(
+                [{"memory_id": "legacy", "embedding": [1.0, 0.0], "source_text": "alpha"}]
+            )
+            with self.assertRaises(EmbeddingStoreIdentityError) as missing:
+                store.set_embedding_identity(self.adapter().identity(EmbeddingTaskType.DOCUMENT))
+            self.assertEqual(missing.exception.action, "rebuild_store")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JsonSourceIndexStore(tmp)
+            first = self.adapter(provider="alpha")
+            store.set_embedding_identity(first.identity(EmbeddingTaskType.DOCUMENT))
+            store.upsert_segments(
+                [{"source_id": "s1", "embedding": [1.0, 0.0], "source_text": "alpha"}]
+            )
+            store.set_embedding_identity(first.identity(EmbeddingTaskType.DOCUMENT))
+            with self.assertRaises(EmbeddingStoreIdentityError):
+                store.set_embedding_identity(
+                    self.adapter(provider="beta").identity(EmbeddingTaskType.DOCUMENT)
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_embedding_adapters.py
+++ b/tests/test_embedding_adapters.py
@@ -238,6 +238,28 @@ class EmbeddingAdapterTests(unittest.TestCase):
             custom.identity(EmbeddingTaskType.DOCUMENT).provider,
         )
 
+    def test_openai_client_rejects_ignored_auth_overrides(self):
+        cases = (
+            {"api_key": "fake-client-key"},
+            {"request_headers": {"X-Test-Authorization": "fake-header-value"}},
+        )
+        for overrides in cases:
+            with self.subTest(overrides=tuple(overrides)):
+                with self.assertRaises(EmbeddingContractError) as raised:
+                    OpenAICompatibleEmbeddingAdapter(
+                        transport=lambda **_kwargs: {"data": []},
+                        transport_kind="openai_client",
+                        model="embed-model",
+                        output_dimension=2,
+                        provider="openai",
+                        endpoint="https://client.example.test/v1",
+                        **overrides,
+                    )
+                public = str(raised.exception)
+                self.assertIn("configured on the OpenAI client transport", public)
+                self.assertNotIn("fake-client-key", public)
+                self.assertNotIn("fake-header-value", public)
+
     def test_count_dimension_and_non_finite_drift_are_invalid_response(self):
         bad_payloads = (
             {"data": [{"index": 0, "embedding": [1, 0]}]},


### PR DESCRIPTION
## 摘要

- 基于 PR #388 的 `EmbeddingBackend` 纯核心，新增可离线测试的 Gemini 与 OpenAI-compatible/LiteLLM adapter。
- 统一 document/query task 语义、batch、timeout、usage 和封闭的错误分类；Gemini 映射到 `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY`。
- 为 provider endpoint/configuration 生成稳定且不含凭据的 opaque identity；API key、request headers、原始 endpoint 与 Provider 原始错误文本不进入 metadata、fingerprint、日志或公开异常。
- 将完整 document identity 接入 `JsonRagStore` 与 `JsonSourceIndexStore`；查询按 backend/provider/model/task type/dimension 做字段级兼容检查，不比较 query/document fingerprint。
- identity 缺失、损坏或不兼容时 fail closed，返回空命中和 `rebuild_store` diagnostics；已有向量的旧 store 不能被静默补贴或改写 identity。

## 边界

本 PR 是独立 adapters/store identity 切片，未接生产配置选择、Sync RAG/Batch RAG/Source Index 的 adapter 调用，也未接普通 Sync Source Index 或 Published Project Analysis。未修改 #346 的 TranslationPlan/runtime prompt provider 接缝，也未修改 #322 的 GUI 订正路径。

因此本 PR 未新增用户配置键，不需要局部修改 translator config、settings schema、GUI、doctor 或 user copy；这些会随生产接线切片一起同步交付。

## 安全与迁移

- endpoint 在规范化后只参与 SHA-256，持久化 identity 不含原始 URL。
- credential-shaped 配置键以及带 userinfo/query/fragment 的 URL 会在 identity 构建前被拒绝。
- Provider 异常只按 type/status 分类，公开字符串不回显 response body、URL、header、错误码或原始文本。
- 旧 store 没有完整 identity；未来切换到 compatibility-gated 生产路径后必须显式 rebuild，不会静默迁移。

## 验证

本次 PR 整理复跑：

- `python -m unittest tests.test_embedding_backend tests.test_embedding_adapters tests.test_rag_memory tests.test_source_index`：67 passed
- CLI-without-GUI import smoke：passed
- Ruff changed paths：passed
- Ruff lint-critical `E9,F63,F7,F82`：passed
- Ruff format check（新增文件）：passed
- `git diff --check origin/main...HEAD`：passed
- `git merge-tree --write-tree origin/main HEAD`：clean

本切片实现期间在同一分支完成的完整门禁：CLI 1513 passed / 1 skipped；GUI 1155 passed；`scripts/run_quality_gates.py all` 全部 blocking gates passed。

Refs #341