### PR TITLE
feat: close issue #346 P4 translation plan safeguards

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -17,6 +17,9 @@ Gemini Batch envelope。诊断页显示 plan 指纹、请求数与裁剪摘要�
 `requests.jsonl`、当前 source snapshot 与 adapter/version。任一绑定陈旧或被修改都会要求
 重新 build。缺少 `translation_plan` 的旧包仍可读取并按旧合同 check/apply，但会明确显示
 legacy compatibility：它没有新增的 plan/request freshness 保护，不应继续提交新的模型任务。
+`split` 子包会保存父 plan 的切片并重新签名；`build-retry` 的 D7 派生请求会保存带 lineage
+的 child plan。两者都继续执行相同的 submit/check/apply 请求内容与 freshness 校验，而不是
+复用无法与子包请求一一对应的父 plan summaries。
 
 ## 目标语言与 TL 路径
 

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -4,6 +4,20 @@
 
 本文档记录 Batch 流程中偏内部或高级的部分。日常入口见根目录 `README.md`。
 
+## TranslationPlan 与请求诊断
+
+普通初译的 `build` 与 Sync 共用同一套 `TranslationPlan`、chunk、canonical
+system/user prompt、response schema 与 ContextAssembler。manifest 的
+`translation_plan` 保存 plan/source/adapter identity、稳定 request ID、prompt/request
+fingerprint 及每个请求的上下文预算、裁剪和舍弃诊断；`requests.jsonl` 只在外层增加
+Gemini Batch envelope。诊断页显示 plan 指纹、请求数与裁剪摘要，完整请求仍只在本地
+产物中查看，不回显凭据。
+
+`submit` 在上传任何 JSONL 或创建云端任务前，会校验 plan fingerprint、manifest chunk、
+`requests.jsonl`、当前 source snapshot 与 adapter/version。任一绑定陈旧或被修改都会要求
+重新 build。缺少 `translation_plan` 的旧包仍可读取并按旧合同 check/apply，但会明确显示
+legacy compatibility：它没有新增的 plan/request freshness 保护，不应继续提交新的模型任务。
+
 ## 目标语言与 TL 路径
 
 - 默认目标语言为 `schinese`，对应 TL 路径 `game/tl/schinese`。
@@ -85,10 +99,10 @@ Discovery schema 与核心结果 envelope 当前都使用 `schema_version=1`，�
 - Batch 产物默认写到 `logs/batch_jobs/<package>/`。
 - `doctor` 只检查当前 `game_root` / `tl_subdir`、SDK/launcher、TL 模板和 `old/new` / 剧情块形态，不调用 Gemini，也不会写回 `.rpy`。
 - `probe` 会用同步请求做最小 smoke test；每个被抽样的 request row 必须能对应当前 manifest 中的非空 chunk，否则会在调用 Provider 前拒绝并提示重建 package，避免把过期或损坏的请求误判为成功。
-- `check` 是干跑校验，不会修改 `.rpy`；它会把当前 manifest、results、目标 item 形状、质量规则配置和 check contract version 写入 `last_check_summary.check_fingerprint`，输出 `writeback_gate` / `quality_gate` / `check_status`（文本模式仍保留 `Safety status` 兼容行），并在包目录写入 `check_failures.jsonl` 与 `quality_findings.jsonl`。
+- `check` 是干跑校验，不会修改 `.rpy`；它会把当前 manifest、results、目标 item 形状、TranslationPlan/request 绑定、质量规则配置和 check contract version 写入 `last_check_summary.check_fingerprint`，输出 `writeback_gate` / `quality_gate` / `check_status`（文本模式仍保留 `Safety status` 兼容行），并在包目录写入 `check_failures.jsonl` 与 `quality_findings.jsonl`。
 - `quality-ack` / `quality-unack` 只更新 manifest 里的 `quality_acknowledged_finding_ids` 并重算 `quality_gate.acknowledged_count` / `decision`；确认不写入 `quality_findings.jsonl`，不进入 `check_fingerprint`，也不能解除 blocker。`quality-ack <manifest>` 不带选择参数时列出未确认报警摘要；`--finding <id>` 可重复，或 `--all` 确认全部 warning。重新 `check` 后，匹配不到新 finding 的旧确认自动失效。
 - `apply` 默认要求最近一次 `check` 对应当前 manifest/results，且 `writeback_gate.decision` 必须是 `allow`；未 check、results 变化、manifest item 变化、结构 `warn / block` 或质量规则被配置为 blocker 都会拒绝写回。
-- `--force` 只绕过“manifest 已经 apply 过”的重复写回保护，不会绕过 stale check、source snapshot 校验或 `block`。
+- `--force` 只绕过“manifest 已经 apply 过”的重复写回保护，不会绕过 stale check、source snapshot、adapter/version、plan/request/hash 校验或 `block`。
 - `apply` 写回前会再次校验当前源文本；如果 apply 阶段发现漂移，会拒绝写回并在包目录写入 `apply_failure_report.json` / `failures.jsonl`。
 - 当 `rag.enabled=true` 时，`split` 更接近“静态快照拆包”，不是动态波次式 RAG 工作流；后续包的回灌结果不会自动回流到已经 split 完的旧包。
 

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -4,6 +4,19 @@
 
 本文档说明 Batch / sync 可选上下文层：RAG history store、Batch source-only index、Structured Story Memory，以及 **Project Analysis（项目分析）** 的产物合同。
 
+## 共享组装与裁剪顺序
+
+Sync 与 Gemini Batch 初译由共享 ContextAssembler 按固定优先级组装：TARGET/结构信息、
+block-bounded 局部前后文、本地 Macro 与词法 glossary、检索上下文、分析上下文。预算不足
+时保留高优先级层，先裁剪/舍弃分析层，再处理检索层；每层的 rank、字符预算、实际使用、
+truncated 标记和舍弃原因进入 request diagnostics。必需层以及本地 Macro/glossary 不会被可选
+检索预算挤掉；若它们本身已超过总预算，诊断会明确报告 mandatory overflow。
+
+本地 `normalize_map`、`preserve_terms`、`non_translatable_exact` 与 Macro 不依赖 RAG 或
+Embedding。关闭 RAG/Embedding 只关闭检索层，不会移除这些项目层上下文，也不会为了词法
+匹配调用 embedding Provider。Source Index 与 Published Project Analysis 在 Sync 的生产接线
+仍属于 #341/#346 P5，本节不表示它们已经在普通 Sync 中启用。
+
 ## 如何选择上下文层
 
 - RAG history store：使用“已有原文 + 已有译文”保持术语、称呼和风格一致。

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -7,10 +7,11 @@
 ## 共享组装与裁剪顺序
 
 Sync 与 Gemini Batch 初译由共享 ContextAssembler 按固定优先级组装：TARGET/结构信息、
-block-bounded 局部前后文、本地 Macro 与词法 glossary、检索上下文、分析上下文。预算不足
-时保留高优先级层，先裁剪/舍弃分析层，再处理检索层；每层的 rank、字符预算、实际使用、
-truncated 标记和舍弃原因进入 request diagnostics。必需层以及本地 Macro/glossary 不会被可选
-检索预算挤掉；若它们本身已超过总预算，诊断会明确报告 mandatory overflow。
+block-bounded 局部前后文、本地 Macro 与词法 glossary、检索上下文、分析上下文。现行生产
+策略分别对检索层和分析层应用字符 backstop；每层的 rank、字符预算、实际使用、truncated
+标记和舍弃原因进入 request diagnostics。核心 ContextPolicy 另支持调用方提供总字符预算；
+启用时会保留必需/本地/项目层，再依优先级裁剪检索和分析层，并报告 mandatory overflow。
+普通 Sync/Batch 当前未从模型 profile 自动设置这项总字符预算。
 
 本地 `normalize_map`、`preserve_terms`、`non_translatable_exact` 与 Macro 不依赖 RAG 或
 Embedding。关闭 RAG/Embedding 只关闭检索层，不会移除这些项目层上下文，也不会为了词法

--- a/docs/plans/issue-346-implementation-plan.md
+++ b/docs/plans/issue-346-implementation-plan.md
@@ -1,11 +1,11 @@
 # #346 实施分步计划：Sync / Batch 共用 TranslationPlan、ContextAssembler 与请求合同
 
-状态：已定稿决策（D1–D7 已于 2026-08-22 冻结，见 [定稿评论](https://github.com/hu-border-collie/renpy-translation-lab/issues/346#issuecomment-5379565547)）· 基线 `main@fa69d14`（2026-08-21）· 本文是实施计划，不是已合并的设计
+状态：P0–P4 已实现并完成正式出口审计（2026-08-28）；P5 仍等待 #341 · D1–D7 已于 2026-08-22 冻结，见 [定稿评论](https://github.com/hu-border-collie/renpy-translation-lab/issues/346#issuecomment-5379565547) · 历史基线 `main@fa69d14`（2026-08-21）
 关联 issue：<https://github.com/hu-border-collie/renpy-translation-lab/issues/346>
 
 ## 0. 结论
 
-#346 尚无实施代码，建议按五阶段落地。P0–P4 不依赖 #341；P5 与 #341 联动收口。
+#346 的 P0–P3 已由 #378/#380/#390/#394 合入；P4 在 #397 合并后的主干上重新审计并补齐普通 Sync/Batch freshness、规范化请求 diff、diagnostics/legacy/GUI/文档与回归测试。P5 与 #341 联动，仍不在本阶段范围内。
 
 | 阶段 | 内容 | 是否依赖 #341 |
 |---|---|---|

--- a/docs/sync_workflow.md
+++ b/docs/sync_workflow.md
@@ -24,7 +24,7 @@
 
 60/18000 是 #346 D4 冻结的兼容取舍：它保留 Batch 分组，但会让未显式配置的旧 Sync 用户比此前的 40/12000 生成更大的请求。若所选 ModelProfile 声明了较小的 `context_budget_tokens`，Sync 会先以相同固定 chunk、canonical prompt、本地上下文和字符上界估算做不调用 embedding/provider 的 preflight；明显超限时会在任何检索和模型调用前拒绝。真实检索上下文物化后还会做一次精确检查，以覆盖接近预算边界的组合。错误会给出 request、估算预算、模型预算、检查阶段及当前 `chunk_size` / `max_source_chars`。若 profile 未声明预算，运行日志会明确警告无法预检 provider 的 context/output 上限。可在 `translator_config.json` 中调小 `sync.chunk_size` 和/或 `sync.max_source_chars`（旧配置中的较小显式值继续生效），或改用上下文预算更大的模型；preflight 不会静默裁剪或重分原始 plan chunk。
 
-启用 Sync RAG 或 Story Memory 时，构建不可变 TranslationPlan 会在第一次模型调用前，按固定 chunk 顺序完成本次 plan 的全部检索并冻结模型可见上下文。运行日志会先提示这一阶段，并在结束时输出 `retrieval_chunks`、RAG 命中总数与 Story Memory 生效 chunk 数；大项目可能因此出现可见的启动等待，并把 query embedding 额度集中在启动阶段。若启动阶段持续失败，可暂时关闭相应上下文源或缩小 chunk 范围后重试。P3 不引入惰性检索，因为模型调用后再改变 provider 内容会破坏 initial plan 的 prompt fingerprint 与 Sync/Batch 共享语义；分阶段物化/性能优化留给 #346 P4 的 diagnostics 收口或后续独立性能项。
+启用 Sync RAG 或 Story Memory 时，构建不可变 TranslationPlan 会在第一次模型调用前，按固定 chunk 顺序完成本次 plan 的全部检索并冻结模型可见上下文。运行日志会先提示这一阶段，并在结束时输出 `retrieval_chunks`、RAG 命中总数与 Story Memory 生效 chunk 数；大项目可能因此出现可见的启动等待，并把 query embedding 额度集中在启动阶段。若启动阶段持续失败，可暂时关闭相应上下文源或缩小 chunk 范围后重试。普通 Sync 在第一次 Provider 调用前还会重扫 source/adapter identity 并校验 plan/root request fingerprint；不匹配时直接拒绝。P3 不引入惰性检索，因为模型调用后再改变 provider 内容会破坏 initial plan 的 prompt fingerprint 与 Sync/Batch 共享语义。
 
 `timeout_seconds` 默认 120 秒，可设为 5–600 秒。它是每一次模型请求的等待上限，不是整次任务的总时限；普通同步翻译、项目分析、同步关键词、同步订正、同步修补和翻译 A/B 对比均读取同一字段。Gemini backend 会把秒转换为 SDK 的毫秒级 `http_options.timeout`，LiteLLM backend 则按秒透传。手工配置超出范围时 runtime 会收敛到最近边界，避免异常值形成无界等待。
 
@@ -89,6 +89,7 @@ python scripts/run_provider_contract_smoke.py --provider deepseek
 - manifest 顶层 `prompt_context`：前后文设置、macro 文件与内容指纹、是否实际注入 macro、批次总数与截断批次数；
 - 每个文件的 `prompt_context.batches`：该文件各请求实际的前后文条目数/字符数、预算截断与 block 边界截断标记。
 - manifest 顶层 `translation_plan` / `plan_fingerprint` / `request_ids`：绑定本次初译的共享 plan、稳定请求身份和 prompt/request fingerprint；Gemini、LiteLLM 及自定义 OpenAI-compatible Provider 都接收同一 system/user 分离语义。
+- manifest 顶层 `translation_plan_diagnostics` 及各 request summary：记录规范化请求数、上下文层 rank/预算/裁剪/舍弃原因和 capability 估算；GUI「诊断与运行日志」显示非敏感摘要，完整 plan 留在本地 manifest。
 
 `prompt_context` 与文件级上下文诊断都纳入 manifest 指纹。源文件变化或预览制品被修改会直接使旧 manifest 无法通过写前校验；`--apply` 会把当前 macro 文件指纹与 manifest 记录的指纹比对，两者不一致（macro 文件新增、删除或内容变化）即拦截写回——不要强行复用旧预览，应基于当前文件重新生成并审查。未记录 `prompt_context` 的旧 manifest 保持可用。macro 路径限定在当前项目（`game_root`）内，配置指向项目外时会被忽略。
 
@@ -164,13 +165,13 @@ python gemini_translate.py --prepare
 python gemini_translate.py --apply logs/sync_runs/<run>/manifest.json
 ```
 
-`--apply` 不会重新调用模型。写回前会重新核对当前项目、TL 目录、TranslationPlan 指纹/request IDs、plan 的逐文件 source digest、每个源文件快照、预览制品哈希、质量 finding 报告哈希和 adapter 计划；项目切换、源文件变化、plan/预览制品被修改或质量规则/策略版本变化都会阻止写回。当前生产 Sync 路径只注册 Ren'Py adapter；公共 `WritebackPlan` 合同会稳定序列化 `engine` 与 `adapter_version`，apply 会逐文件、逐字段与 TranslationPlan source identity 对照，错误仅报告这些非敏感标识的 expected/actual。遇到阻断时不要强行复用旧 manifest，应基于当前文件重新生成并审查预览。没有 `translation_plan` 字段的旧 preview manifest 继续走 legacy 校验路径。
+`--apply` 不会重新调用模型。写回前会重新核对当前项目、TL 目录、TranslationPlan 指纹/request IDs、plan 的逐文件 source digest、每个源文件快照、预览制品哈希、质量 finding 报告哈希和 adapter 计划；项目切换、源文件变化、plan/预览制品被修改或质量规则/策略版本变化都会阻止写回。当前生产 Sync 路径只注册 Ren'Py adapter；公共 `WritebackPlan` 合同会稳定序列化 `engine` 与 `adapter_version`，apply 会逐文件、逐字段与 TranslationPlan source identity 对照，错误仅报告这些非敏感标识的 expected/actual。遇到阻断时不要强行复用旧 manifest，应基于当前文件重新生成并审查预览。没有 `translation_plan` 字段的旧 preview manifest 继续走 legacy 校验路径，并在 CLI/GUI 明确提示：旧 source/artifact/quality/adapter 校验仍生效，但缺少新的 plan/request freshness 绑定。
 
 `--prepare` 与 `--apply` 不能同时使用。旧的 `gemini_translate.py` 预览入口仍面向人类阅读；需要稳定机器合同或断点恢复时使用上面的耐久 `sync-*` 命令。
 
 ## Gemini 与 LiteLLM 数据边界
 
-- **Gemini 同步**：本工具从本机通过 Google `google-genai` SDK 直接调用 Gemini API。本项目没有自建中转服务，也不会上传整个 `api_keys.json` 文件；但 API 调用必然会把认证信息发送到 Google，并把待译文本、提示词以及启用的 glossary、macro、RAG、Source Index、Story Memory 或 Project Analysis 上下文发送给 Gemini。
+- **Gemini 同步**：本工具从本机通过 Google `google-genai` SDK 直接调用 Gemini API。本项目没有自建中转服务，也不会上传整个 `api_keys.json` 文件；但 API 调用必然会把认证信息发送到 Google，并把待译文本、提示词以及当前 Sync 已启用的 glossary、macro、RAG 或 Story Memory 上下文发送给 Gemini。Source Index / Published Project Analysis 的普通 Sync 生产接线属于 #341/#346 P5。
 - **LiteLLM 同步**：本工具从本机调用 LiteLLM Python SDK，再按所选 Provider / API Base 访问供应商。本项目不提供自建 LiteLLM 代理；待译文本、提示词和必要上下文会发送到所选供应商。凭据保存在操作系统凭据管理器或环境变量中，不写入 `translator_config.json`。
 - **本地产物**：manifest、diff、模型结果摘要、用量账本与日志保存在本机；它们可能包含私有游戏文本，不应提交到公开仓库或发给无权访问者。
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -7777,16 +7777,25 @@ def recover_submit_manifest(target=None, verify_remote=True):
 def validate_batch_translation_plan_before_dispatch(manifest, *, operation='submit'):
     """Validate a persisted Batch plan before any upload or model dispatch.
 
-    Legacy packages remain usable through their historical safeguards and
-    receive an explicit compatibility diagnostic.  Current packages must keep
-    their plan fingerprint, root request rows, source snapshot, and adapter
-    identity intact.
+    Legacy packages remain readable and may finish their historical
+    check/apply flow with an explicit compatibility diagnostic, but cannot
+    submit new provider work without the current plan/request protections.
+    Current packages must keep their plan fingerprint, root request rows,
+    source snapshot, and adapter identity intact.
     """
     diagnostic = translation_plan_compatibility_diagnostic(manifest)
     plan = manifest.get('translation_plan')
     if not isinstance(plan, dict) or not plan:
         manifest['translation_plan_diagnostics'] = diagnostic
         print(f"Warning: {diagnostic['message']}", file=sys.stderr)
+        if operation == 'submit':
+            raise cli_contract.MachineContractError(
+                'Batch submit refused: legacy package has no TranslationPlan '
+                'or request freshness protection.',
+                code_name='TRANSLATION_PLAN_LEGACY_SUBMIT_BLOCKED',
+                suggested_action='rebuild_batch_package',
+                details={'compatibility': diagnostic},
+            )
         return diagnostic
     try:
         translation_plan.validate_plan_fingerprint(plan)
@@ -7958,6 +7967,8 @@ def submit_manifest(
                 f'exceeds limit {float(max_cost):.4f} {currency}.'
             )
 
+    # Keep recovery/routing/cost errors deterministic, then enforce the plan
+    # gate before provider setup, upload reuse, or job creation.
     validate_batch_translation_plan_before_dispatch(manifest)
     save_manifest(manifest)
 

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2099,6 +2099,27 @@ def remember_latest_manifest(manifest_path):
     atomic_write_text(LATEST_MANIFEST_FILE, str(manifest_path))
 
 
+def translation_plan_compatibility_diagnostic(manifest):
+    """Describe whether a package has the current #346 plan protections."""
+    plan = manifest.get('translation_plan') if isinstance(manifest, dict) else None
+    if isinstance(plan, dict) and plan:
+        return {
+            'code': 'TRANSLATION_PLAN_CURRENT',
+            'mode': 'current',
+            'message': 'TranslationPlan and request bindings are available.',
+        }
+    return {
+        'code': 'TRANSLATION_PLAN_LEGACY_FALLBACK',
+        'mode': 'legacy',
+        'message': (
+            'Legacy package has no TranslationPlan; compatibility mode keeps '
+            'the existing check/apply source and adapter guards, but plan and '
+            'request freshness cannot be verified. Rebuild before submitting '
+            'new model work.'
+        ),
+    }
+
+
 def load_manifest(target=None):
     """Load and validate a JSON manifest or raise a structured contract error.
 
@@ -2151,6 +2172,9 @@ def load_manifest(target=None):
         )
     manifest['_manifest_path'] = manifest_path
     manifest['_package_dir'] = os.path.dirname(manifest_path)
+    manifest['_translation_plan_compatibility'] = (
+        translation_plan_compatibility_diagnostic(manifest)
+    )
     return manifest
 
 
@@ -2252,6 +2276,7 @@ def save_manifest(manifest, update_latest=True):
     data = dict(manifest)
     data.pop('_manifest_path', None)
     data.pop('_package_dir', None)
+    data.pop('_translation_plan_compatibility', None)
     atomic_write_json(manifest_path, data, ensure_ascii=False, indent=2)
     if update_latest:
         remember_latest_manifest(manifest_path)
@@ -2516,6 +2541,14 @@ def build_check_fingerprint(manifest):
     }
     if isinstance(manifest.get('durable_sync_source'), dict):
         payload['durable_sync_source'] = dict(manifest['durable_sync_source'])
+    plan = manifest.get('translation_plan')
+    if isinstance(plan, dict) and plan:
+        payload['translation_plan'] = {
+            'plan_fingerprint': str(plan.get('plan_fingerprint') or ''),
+            'requests': file_content_fingerprint(
+                str(manifest.get('input_jsonl_path') or '')
+            ),
+        }
     payload['fingerprint_sha256'] = stable_json_sha256(payload)
     return payload
 
@@ -3334,7 +3367,10 @@ def _batch_plan_context_policy():
         # policy. Batch can additionally inject Source Index reference text
         # (top_k * char_limit), so add that budget to the backstop;
         # section-level limits are already applied by the providers.
-        history_char_limit=RAG_HISTORY_CHAR_LIMIT + get_source_index_char_budget(),
+        history_char_limit=(
+            RAG_HISTORY_CHAR_LIMIT
+            + (get_source_index_char_budget() if SOURCE_INDEX_ENABLED else 0)
+        ),
         story_char_limit=STORY_MEMORY_MAX_CONTEXT_CHARS,
         # Project analysis injects both the global brief and local
         # label/route summaries; keep the backstop large enough for all
@@ -3343,6 +3379,8 @@ def _batch_plan_context_policy():
             PROJECT_ANALYSIS_MAX_BRIEF_CHARS
             + PROJECT_ANALYSIS_MAX_LABEL_SUMMARY_CHARS
             + PROJECT_ANALYSIS_MAX_ROUTE_SUMMARY_CHARS
+            if PROJECT_ANALYSIS_ENABLED
+            else translation_core.CANONICAL_ANALYSIS_CHAR_LIMIT
         ),
         include_source_text=True,
         include_translation_memory=True,
@@ -3927,6 +3965,27 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             translation_plan_manifest.plan.to_dict()
             if translation_plan_manifest is not None
             else {}
+        ),
+        'translation_plan_diagnostics': (
+            {
+                'code': 'TRANSLATION_PLAN_CURRENT',
+                'mode': 'current',
+                'request_count': len(translation_plan_manifest.requests),
+                'context_truncated_requests': sum(
+                    1
+                    for request in translation_plan_manifest.requests
+                    if any(
+                        bool((layer or {}).get('truncated'))
+                        for layer in (request.context_assembly or {}).get('layers') or []
+                    )
+                ),
+                'context_dropped_entries': sum(
+                    len((request.context_assembly or {}).get('dropped') or [])
+                    for request in translation_plan_manifest.requests
+                ),
+            }
+            if translation_plan_manifest is not None
+            else translation_plan_compatibility_diagnostic({})
         ),
         'settings': {
             'target_size': BATCH_TARGET_SIZE,
@@ -7694,6 +7753,104 @@ def recover_submit_manifest(target=None, verify_remote=True):
     return manifest['_manifest_path']
 
 
+def validate_batch_translation_plan_before_dispatch(manifest, *, operation='submit'):
+    """Validate a persisted Batch plan before any upload or model dispatch.
+
+    Legacy packages remain usable through their historical safeguards and
+    receive an explicit compatibility diagnostic.  Current packages must keep
+    their plan fingerprint, root request rows, source snapshot, and adapter
+    identity intact.
+    """
+    diagnostic = translation_plan_compatibility_diagnostic(manifest)
+    plan = manifest.get('translation_plan')
+    if not isinstance(plan, dict) or not plan:
+        manifest['translation_plan_diagnostics'] = diagnostic
+        print(f"Warning: {diagnostic['message']}", file=sys.stderr)
+        return diagnostic
+    if isinstance(manifest.get('durable_sync_source'), dict):
+        # #397's run-store integrity/freshness and bound-preview chain are the
+        # authority for durable Sync. Do not reinterpret its sync plan as a
+        # Gemini Batch request package here.
+        translation_plan.validate_plan_fingerprint(plan)
+        manifest['translation_plan_diagnostics'] = {
+            **diagnostic,
+            'delegated_guard': 'durable_sync_run_store',
+        }
+        return manifest['translation_plan_diagnostics']
+    try:
+        translation_plan.validate_plan_fingerprint(plan)
+    except ValueError as exc:
+        raise cli_contract.MachineContractError(
+            f'Batch {operation} refused: {exc}',
+            code_name='TRANSLATION_PLAN_STALE',
+            suggested_action='rebuild_batch_package',
+        ) from exc
+    if plan.get('execution_strategy') != translation_plan.STRATEGY_GEMINI_BATCH:
+        raise cli_contract.MachineContractError(
+            f'Batch {operation} refused: manifest TranslationPlan uses another execution strategy.',
+            code_name='TRANSLATION_PLAN_STRATEGY_MISMATCH',
+            suggested_action='rebuild_batch_package',
+        )
+
+    summaries = list(plan.get('request_summaries') or [])
+    chunks = list(manifest.get('chunks') or [])
+    rows = load_request_rows(manifest)
+    if not (len(summaries) == len(chunks) == len(rows)):
+        raise cli_contract.MachineContractError(
+            f'Batch {operation} refused: TranslationPlan, chunks, and requests.jsonl counts differ.',
+            code_name='TRANSLATION_PLAN_REQUEST_BINDING_MISMATCH',
+            suggested_action='rebuild_batch_package',
+        )
+    for index, (summary, chunk, row) in enumerate(zip(summaries, chunks, rows)):
+        expected_row = build_batch_request(
+            chunk,
+            model=str(manifest.get('batch_model') or ''),
+        )
+        bindings = (
+            str(summary.get('request_id') or '') == str(chunk.get('request_id') or ''),
+            str(summary.get('chunk_id') or '') == str(chunk.get('chunk_id') or ''),
+            str(summary.get('prompt_fingerprint') or '')
+            == str(chunk.get('prompt_fingerprint') or ''),
+            str(summary.get('request_fingerprint') or '')
+            == str(chunk.get('request_fingerprint') or ''),
+            stable_json_dumps(row) == stable_json_dumps(expected_row),
+        )
+        if not all(bindings):
+            raise cli_contract.MachineContractError(
+                f'Batch {operation} refused: request binding changed at index {index}.',
+                code_name='TRANSLATION_PLAN_REQUEST_BINDING_MISMATCH',
+                suggested_action='rebuild_batch_package',
+                details={'request_index': index, 'chunk_key': str(chunk.get('key') or '')},
+            )
+
+    current_jobs = collect_pending_file_jobs(
+        include_complete_files=True,
+        include_occurrences=False,
+        include_task_payloads=False,
+    )
+    current_identity = _batch_plan_source_identity(current_jobs).to_dict()
+    reasons = translation_plan.source_identity_differences(
+        plan.get('source_identity') or {},
+        current_identity,
+    )
+    if reasons:
+        raise cli_contract.MachineContractError(
+            f'Batch {operation} refused: source or adapter identity changed after build.',
+            code_name='TRANSLATION_PLAN_SOURCE_STALE',
+            suggested_action='rebuild_batch_package',
+            details={'reasons': reasons},
+        )
+    diagnostic = {
+        **diagnostic,
+        'source': 'fresh',
+        'adapter': 'fresh',
+        'plan': 'fresh',
+        'request_count': len(rows),
+    }
+    manifest['translation_plan_diagnostics'] = diagnostic
+    return diagnostic
+
+
 def submit_manifest(
     target=None,
     display_name_override='',
@@ -7771,6 +7928,9 @@ def submit_manifest(
                 f"estimated max {cost_estimate.get('estimated_cost_max', 0):.4f} {currency} "
                 f'exceeds limit {float(max_cost):.4f} {currency}.'
             )
+
+    validate_batch_translation_plan_before_dispatch(manifest)
+    save_manifest(manifest)
 
     resume_existing_upload = (
         resume_upload
@@ -12207,6 +12367,7 @@ def check_results(target=None):
     manifest = load_manifest(target)
     require_manifest_mode(manifest, MANIFEST_MODE_TRANSLATION, 'check')
     require_manifest_project_match(manifest, 'check')
+    validate_batch_translation_plan_before_dispatch(manifest, operation='check')
     replacements_by_file, _translated, failure_entries, summary = collect_result_actions(
         manifest,
         validate_sources=True,
@@ -12419,6 +12580,11 @@ def apply_results(target=None, force=False):
         )
         save_manifest(manifest, update_latest=manifest.get('execution') != 'sync')
         raise SystemExit(f'Apply refused because source revalidation is not safe. Report: {report_path}')
+
+    # Preserve the established check/recheck error contract above, then bind
+    # the persisted plan and request rows again at the final pre-write point.
+    # This remains unconditional: ``--force`` cannot bypass it.
+    validate_batch_translation_plan_before_dispatch(manifest, operation='apply')
 
     writeback_files = []
     if adapter_plan is not None and adapter_snapshot is not None:

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -2120,6 +2120,21 @@ def translation_plan_compatibility_diagnostic(manifest):
     }
 
 
+def merged_translation_plan_diagnostics(manifest, **freshness):
+    """Keep persisted context counters while adding current freshness facts."""
+    existing = manifest.get('translation_plan_diagnostics')
+    if not isinstance(existing, dict):
+        existing = {}
+    plan = manifest.get('translation_plan')
+    summaries = list((plan or {}).get('request_summaries') or []) if isinstance(plan, dict) else []
+    return {
+        **existing,
+        **translation_plan_compatibility_diagnostic(manifest),
+        **translation_plan.summarize_request_diagnostics(summaries),
+        **freshness,
+    }
+
+
 def load_manifest(target=None):
     """Load and validate a JSON manifest or raise a structured contract error.
 
@@ -2906,7 +2921,16 @@ def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
     if source_manifest.get('model_routing'):
         part_manifest['model_routing'] = copy.deepcopy(source_manifest.get('model_routing'))
     if source_manifest.get('translation_plan'):
-        part_manifest['translation_plan'] = copy.deepcopy(source_manifest.get('translation_plan'))
+        derivation_kind = 'retry' if part_manifest.get('retry_of_manifest') else 'split'
+        part_manifest['translation_plan'] = translation_plan.derive_translation_plan_payload(
+            source_manifest.get('translation_plan'),
+            part_chunks,
+            derivation_kind=derivation_kind,
+        )
+        part_manifest['translation_plan_diagnostics'] = merged_translation_plan_diagnostics(
+            part_manifest,
+            derivation_kind=derivation_kind,
+        )
     if source_manifest.get('keyword_settings'):
         part_manifest['keyword_settings'] = dict(source_manifest.get('keyword_settings') or {})
     if source_manifest.get('revision_settings'):
@@ -3597,6 +3621,13 @@ def _build_retry_subchunk_plan_request(parent_chunk, subchunk):
         transport_metadata=translation_plan.redact_sensitive(
             {
                 'batch_key': chunk_id,
+                'retry_parent_request_id': str(
+                    parent_chunk.get('request_id') or ''
+                ),
+                'retry_parent_chunk_id': str(
+                    parent_chunk.get('chunk_id') or parent_chunk.get('key') or ''
+                ),
+                'retry_lineage_kind': 'batch_retry',
                 'retry_parent_key': str(parent_chunk.get('key') or ''),
                 'retry_item_start': subchunk.get('retry_item_start'),
                 'retry_item_end': subchunk.get('retry_item_end'),
@@ -3970,18 +4001,8 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             {
                 'code': 'TRANSLATION_PLAN_CURRENT',
                 'mode': 'current',
-                'request_count': len(translation_plan_manifest.requests),
-                'context_truncated_requests': sum(
-                    1
-                    for request in translation_plan_manifest.requests
-                    if any(
-                        bool((layer or {}).get('truncated'))
-                        for layer in (request.context_assembly or {}).get('layers') or []
-                    )
-                ),
-                'context_dropped_entries': sum(
-                    len((request.context_assembly or {}).get('dropped') or [])
-                    for request in translation_plan_manifest.requests
+                **translation_plan.summarize_request_diagnostics(
+                    translation_plan_manifest.plan.request_summaries
                 ),
             }
             if translation_plan_manifest is not None
@@ -7767,16 +7788,6 @@ def validate_batch_translation_plan_before_dispatch(manifest, *, operation='subm
         manifest['translation_plan_diagnostics'] = diagnostic
         print(f"Warning: {diagnostic['message']}", file=sys.stderr)
         return diagnostic
-    if isinstance(manifest.get('durable_sync_source'), dict):
-        # #397's run-store integrity/freshness and bound-preview chain are the
-        # authority for durable Sync. Do not reinterpret its sync plan as a
-        # Gemini Batch request package here.
-        translation_plan.validate_plan_fingerprint(plan)
-        manifest['translation_plan_diagnostics'] = {
-            **diagnostic,
-            'delegated_guard': 'durable_sync_run_store',
-        }
-        return manifest['translation_plan_diagnostics']
     try:
         translation_plan.validate_plan_fingerprint(plan)
     except ValueError as exc:
@@ -7785,6 +7796,15 @@ def validate_batch_translation_plan_before_dispatch(manifest, *, operation='subm
             code_name='TRANSLATION_PLAN_STALE',
             suggested_action='rebuild_batch_package',
         ) from exc
+    if isinstance(manifest.get('durable_sync_source'), dict):
+        # #397's run-store integrity/freshness and bound-preview chain are the
+        # authority for durable Sync. Do not reinterpret its sync plan as a
+        # Gemini Batch request package here.
+        manifest['translation_plan_diagnostics'] = merged_translation_plan_diagnostics(
+            manifest,
+            delegated_guard='durable_sync_run_store',
+        )
+        return manifest['translation_plan_diagnostics']
     if plan.get('execution_strategy') != translation_plan.STRATEGY_GEMINI_BATCH:
         raise cli_contract.MachineContractError(
             f'Batch {operation} refused: manifest TranslationPlan uses another execution strategy.',
@@ -7802,6 +7822,10 @@ def validate_batch_translation_plan_before_dispatch(manifest, *, operation='subm
             suggested_action='rebuild_batch_package',
         )
     for index, (summary, chunk, row) in enumerate(zip(summaries, chunks, rows)):
+        request = translation_plan.TranslationRequest.from_dict(chunk)
+        semantic_fingerprint, audit_fingerprint = (
+            translation_plan.recompute_request_fingerprints(request)
+        )
         expected_row = build_batch_request(
             chunk,
             model=str(manifest.get('batch_model') or ''),
@@ -7813,6 +7837,11 @@ def validate_batch_translation_plan_before_dispatch(manifest, *, operation='subm
             == str(chunk.get('prompt_fingerprint') or ''),
             str(summary.get('request_fingerprint') or '')
             == str(chunk.get('request_fingerprint') or ''),
+            str(plan.get('plan_id') or '') == request.plan_id,
+            str(summary.get('prompt_fingerprint') or '') == semantic_fingerprint,
+            str(chunk.get('prompt_fingerprint') or '') == semantic_fingerprint,
+            str(summary.get('request_fingerprint') or '') == audit_fingerprint,
+            str(chunk.get('request_fingerprint') or '') == audit_fingerprint,
             stable_json_dumps(row) == stable_json_dumps(expected_row),
         )
         if not all(bindings):
@@ -7840,13 +7869,13 @@ def validate_batch_translation_plan_before_dispatch(manifest, *, operation='subm
             suggested_action='rebuild_batch_package',
             details={'reasons': reasons},
         )
-    diagnostic = {
-        **diagnostic,
-        'source': 'fresh',
-        'adapter': 'fresh',
-        'plan': 'fresh',
-        'request_count': len(rows),
-    }
+    diagnostic = merged_translation_plan_diagnostics(
+        manifest,
+        source='fresh',
+        adapter='fresh',
+        plan='fresh',
+        request_count=len(rows),
+    )
     manifest['translation_plan_diagnostics'] = diagnostic
     return diagnostic
 

--- a/gui_qt/app.py
+++ b/gui_qt/app.py
@@ -7267,9 +7267,25 @@ class MainWindow(QMainWindow):
             usage_ledger_path or None
         )
         if spec.mode == WorkMode.SYNC_TRANSLATION:
+            sync_preview_path = self.sync_translation_page.preview_manifest_path()
+            sync_preview_mtime = self._diagnostics_manifest_mtime_ns(
+                sync_preview_path or None
+            )
+            sync_preview_manifest = None
+            if sync_preview_path:
+                try:
+                    loaded_preview = json.loads(
+                        Path(sync_preview_path).read_text(encoding="utf-8-sig")
+                    )
+                    if isinstance(loaded_preview, dict):
+                        sync_preview_manifest = loaded_preview
+                except (OSError, UnicodeError, json.JSONDecodeError):
+                    sync_preview_manifest = None
             input_key = (
                 "sync",
                 str(self.state.get_sync_script_path()),
+                sync_preview_path,
+                sync_preview_mtime,
                 sys.executable,
                 str(game_root or ""),
                 usage_ledger_mtime,
@@ -7282,6 +7298,8 @@ class MainWindow(QMainWindow):
                 batch_script_path=str(self.state.get_batch_script_path()),
                 game_root=str(game_root or ""),
                 python_exe=sys.executable,
+                preview_manifest_path=sync_preview_path,
+                preview_manifest=sync_preview_manifest,
             )
             self._set_diagnostics_context(context)
             self._diagnostics_refresh_input_key = input_key

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -9,6 +9,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
 import model_usage_ledger
+import translation_plan
 from keyword_glossary_merge import build_merge_keywords_cli_command
 
 from .batch_workflow_support import (
@@ -1039,12 +1040,23 @@ def format_translation_plan_facts(manifest: dict[str, object]) -> list[str]:
     diagnostics = manifest.get("translation_plan_diagnostics")
     if not isinstance(diagnostics, dict):
         diagnostics = {}
+    derived_diagnostics = translation_plan.summarize_request_diagnostics(summaries)
     facts.append(
         f'{TRANSLATION_PLAN_COPY["requests"]}：'
-        f'{int(diagnostics.get("request_count") or len(summaries))}'
+        f'{int(diagnostics.get("request_count", derived_diagnostics["request_count"]))}'
     )
-    truncated = int(diagnostics.get("context_truncated_requests") or 0)
-    dropped = int(diagnostics.get("context_dropped_entries") or 0)
+    truncated = int(
+        diagnostics.get(
+            "context_truncated_requests",
+            derived_diagnostics["context_truncated_requests"],
+        )
+    )
+    dropped = int(
+        diagnostics.get(
+            "context_dropped_entries",
+            derived_diagnostics["context_dropped_entries"],
+        )
+    )
     if truncated:
         facts.append(f'{TRANSLATION_PLAN_COPY["context_truncated"]}：{truncated}')
     if dropped:

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -21,6 +21,7 @@ from .batch_workflow_support import (
 )
 from .user_copy import (
     DURABLE_SYNC_COPY,
+    TRANSLATION_PLAN_COPY,
     USAGE_LEDGER_COPY,
     VERSION_ASSET_COPY,
     format_notice_fact,
@@ -135,6 +136,18 @@ def manifest_for_preview(manifest: dict[str, object]) -> dict[str, object]:
         if key in {"chunks", "files"}:
             continue
         preview[key] = value
+
+    plan = manifest.get("translation_plan")
+    if isinstance(plan, dict):
+        preview["translation_plan"] = {
+            "schema_version": plan.get("schema_version"),
+            "plan_id": plan.get("plan_id"),
+            "execution_strategy": plan.get("execution_strategy"),
+            "plan_fingerprint": plan.get("plan_fingerprint"),
+            "source_identity": plan.get("source_identity"),
+            "request_count": len(plan.get("request_summaries") or []),
+            "diagnostics": manifest.get("translation_plan_diagnostics") or {},
+        }
 
     files = manifest.get("files")
     chunks = manifest.get("chunks")
@@ -1008,6 +1021,34 @@ def build_manifest_facts(manifest: dict[str, object], manifest_path: str) -> lis
     if isinstance(mode, str) and mode.strip():
         facts.append(f"任务类型：{manifest_mode_label(mode.strip())}")
 
+    facts.extend(format_translation_plan_facts(manifest))
+
+    return facts
+
+
+def format_translation_plan_facts(manifest: dict[str, object]) -> list[str]:
+    """Render a compact, credential-free plan/request diagnostics summary."""
+    plan = manifest.get("translation_plan")
+    if not isinstance(plan, dict) or not plan:
+        return [TRANSLATION_PLAN_COPY["legacy"]]
+    facts = [TRANSLATION_PLAN_COPY["current"]]
+    fingerprint = str(plan.get("plan_fingerprint") or "")
+    if fingerprint:
+        facts.append(f'{TRANSLATION_PLAN_COPY["fingerprint"]}：{fingerprint}')
+    summaries = list(plan.get("request_summaries") or [])
+    diagnostics = manifest.get("translation_plan_diagnostics")
+    if not isinstance(diagnostics, dict):
+        diagnostics = {}
+    facts.append(
+        f'{TRANSLATION_PLAN_COPY["requests"]}：'
+        f'{int(diagnostics.get("request_count") or len(summaries))}'
+    )
+    truncated = int(diagnostics.get("context_truncated_requests") or 0)
+    dropped = int(diagnostics.get("context_dropped_entries") or 0)
+    if truncated:
+        facts.append(f'{TRANSLATION_PLAN_COPY["context_truncated"]}：{truncated}')
+    if dropped:
+        facts.append(f'{TRANSLATION_PLAN_COPY["context_dropped"]}：{dropped}')
     return facts
 
 
@@ -1059,18 +1100,41 @@ def sync_diagnostics_context(
     batch_script_path: str = "",
     game_root: str | None = None,
     python_exe: str = "python",
+    preview_manifest_path: str = "",
+    preview_manifest: dict[str, object] | None = None,
+    path_exists: Callable[[str], bool] | None = None,
 ) -> DiagnosticsContext:
     command = format_cli_command(python_exe, sync_script_path, [])
     commands = [DiagnosticsCommand(label="同步翻译", command=command)]
     commands.extend(_usage_report_command(batch_script_path, python_exe))
+    facts = _project_usage_facts(game_root)
+    paths = []
+    preview = ""
+    status = "ready"
+    message = "同步模式会先生成差异预览；以下为可手动运行的同步命令。"
+    if preview_manifest is not None:
+        facts.extend(format_translation_plan_facts(preview_manifest))
+        package_dir = resolve_package_dir(preview_manifest_path, preview_manifest)
+        exists = path_exists or _default_path_exists
+        if preview_manifest_path and exists(preview_manifest_path):
+            paths.append(DiagnosticsPathEntry("同步预览任务记录", preview_manifest_path))
+        report_path = str(preview_manifest.get("report_path") or "")
+        if report_path and package_dir:
+            report_path = join_directory_file(package_dir, report_path)
+            if exists(report_path):
+                paths.append(DiagnosticsPathEntry("同步翻译差异预览", report_path))
+        preview = format_manifest_json_preview(preview_manifest)
+        if not isinstance(preview_manifest.get("translation_plan"), dict):
+            status = "warning"
+            message = TRANSLATION_PLAN_COPY["legacy"]
     return DiagnosticsContext(
-        status="ready",
+        status=status,
         heading="同步翻译上下文",
-        message="同步模式不生成批量任务记录；以下为可手动运行的同步命令。",
-        facts=_project_usage_facts(game_root),
-        paths=[],
+        message=message,
+        facts=facts,
+        paths=paths,
         commands=commands,
-        manifest_json_preview="",
+        manifest_json_preview=preview,
     )
 
 

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -93,6 +93,18 @@ DURABLE_SYNC_COPY = {
     "apply": "耐久同步翻译·写回已检查预览",
 }
 
+TRANSLATION_PLAN_COPY = {
+    "current": "翻译计划：已绑定共享 TranslationPlan",
+    "legacy": (
+        "翻译计划：旧版兼容模式；仍执行原有 source/check/adapter 安全校验，"
+        "但没有 plan/request 级 freshness 绑定。建议重新生成任务。"
+    ),
+    "fingerprint": "翻译计划指纹",
+    "requests": "规范化请求数",
+    "context_truncated": "上下文裁剪请求数",
+    "context_dropped": "上下文舍弃记录数",
+}
+
 CONTEXT_LIBRARY_COPY = {
     "empty_title": "尚未启用上下文库",
     "empty_body": (

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -459,27 +459,11 @@ def create_sync_preview(
             translation_plan_payload.get("plan_fingerprint") or ""
         )
         manifest["request_ids"] = [str(item) for item in request_ids]
-        request_summaries = list(
-            translation_plan_payload.get("request_summaries") or []
-        )
         manifest["translation_plan_diagnostics"] = {
             "code": "TRANSLATION_PLAN_CURRENT",
             "mode": "current",
-            "request_count": len(request_summaries),
-            "context_truncated_requests": sum(
-                1
-                for summary in request_summaries
-                if any(
-                    bool((layer or {}).get("truncated"))
-                    for layer in (
-                        (summary.get("context_diagnostics") or {}).get("layers")
-                        or []
-                    )
-                )
-            ),
-            "context_dropped_entries": sum(
-                len((summary.get("context_diagnostics") or {}).get("dropped") or [])
-                for summary in request_summaries
+            **translation_plan.summarize_request_diagnostics(
+                translation_plan_payload.get("request_summaries") or []
             ),
         }
         _validate_translation_plan_binding(manifest)

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -167,7 +167,12 @@ def _fingerprint_payload(manifest: dict[str, Any]) -> dict[str, Any]:
         payload["failures"] = manifest.get("failures")
     if "model_contract" in manifest:
         payload["model_contract"] = manifest.get("model_contract")
-    for key in ("translation_plan", "plan_fingerprint", "request_ids"):
+    for key in (
+        "translation_plan",
+        "translation_plan_diagnostics",
+        "plan_fingerprint",
+        "request_ids",
+    ):
         if key in manifest:
             payload[key] = manifest.get(key)
     return payload
@@ -454,6 +459,29 @@ def create_sync_preview(
             translation_plan_payload.get("plan_fingerprint") or ""
         )
         manifest["request_ids"] = [str(item) for item in request_ids]
+        request_summaries = list(
+            translation_plan_payload.get("request_summaries") or []
+        )
+        manifest["translation_plan_diagnostics"] = {
+            "code": "TRANSLATION_PLAN_CURRENT",
+            "mode": "current",
+            "request_count": len(request_summaries),
+            "context_truncated_requests": sum(
+                1
+                for summary in request_summaries
+                if any(
+                    bool((layer or {}).get("truncated"))
+                    for layer in (
+                        (summary.get("context_diagnostics") or {}).get("layers")
+                        or []
+                    )
+                )
+            ),
+            "context_dropped_entries": sum(
+                len((summary.get("context_diagnostics") or {}).get("dropped") or [])
+                for summary in request_summaries
+            ),
+        }
         _validate_translation_plan_binding(manifest)
     if durable_check_binding is not None:
         manifest['durable_check_binding'] = dict(durable_check_binding)
@@ -477,6 +505,22 @@ def load_sync_preview(manifest_path: str | os.PathLike[str]) -> dict[str, Any]:
         raise ValueError("Sync preview manifest files must be a list.")
     if manifest.get("preview_fingerprint") != _fingerprint(manifest):
         raise ValueError("Sync preview manifest changed after preview generation.")
+    if isinstance(manifest.get("translation_plan"), dict):
+        manifest["_translation_plan_compatibility"] = {
+            "code": "TRANSLATION_PLAN_CURRENT",
+            "mode": "current",
+            "message": "TranslationPlan and request bindings are available.",
+        }
+    else:
+        manifest["_translation_plan_compatibility"] = {
+            "code": "TRANSLATION_PLAN_LEGACY_FALLBACK",
+            "mode": "legacy",
+            "message": (
+                "Legacy Sync preview has no TranslationPlan/request binding; "
+                "the historical source, artifact, quality, and adapter checks "
+                "still apply. Regenerate for current plan diagnostics."
+            ),
+        }
     manifest["_manifest_path"] = str(path)
     return manifest
 

--- a/tests/fixtures/translation_plan_minimal/expected/plan.gemini_batch.json
+++ b/tests/fixtures/translation_plan_minimal/expected/plan.gemini_batch.json
@@ -99,7 +99,8 @@
     "local_context_after": 10,
     "local_context_before": 30,
     "story_block_suffix": "\n\n",
-    "story_char_limit": 1200
+    "story_char_limit": 1200,
+    "total_char_limit": 0
   },
   "execution_strategy": "gemini_batch",
   "model_profile_snapshot": {
@@ -124,26 +125,270 @@
     },
     "provider": "openai_compatible"
   },
-  "plan_fingerprint": "36d2ede9501212f1",
-  "plan_id": "c24ba960433436e9",
+  "plan_fingerprint": "8b677ab3816175fb",
+  "plan_id": "299f778e5dc44f5d",
   "request_summaries": [
     {
+      "capability_requirements": {
+        "context_budget_tokens": 2038,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "004851531f-00001",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 486,
+            "diagnostics": {
+              "file_rel_path": "chapter01/dialogue.rpy",
+              "speakers": [
+                "g",
+                "p"
+              ],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 108,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": true,
+              "block_bounded_before": false,
+              "context_after_chars": 55,
+              "context_after_items": 1,
+              "context_after_limit": 10,
+              "context_before_chars": 0,
+              "context_before_items": 0,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 186,
+            "diagnostics": {
+              "lexical_glossary_hits": 3,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 915
+      },
       "prompt_fingerprint": "e14597acfc6111bf",
       "request_fingerprint": "f4480a0ef639a161",
-      "request_id": "a7c2c56c7f4895b8"
+      "request_id": "62566ff3eedd2d50"
     },
     {
+      "capability_requirements": {
+        "context_budget_tokens": 2145,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "004851531f-00002",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 484,
+            "diagnostics": {
+              "file_rel_path": "chapter01/dialogue.rpy",
+              "speakers": [
+                "g",
+                "m",
+                "p"
+              ],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 238,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": false,
+              "block_bounded_before": false,
+              "context_after_chars": 0,
+              "context_after_items": 0,
+              "context_after_limit": 10,
+              "context_before_chars": 161,
+              "context_before_items": 3,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 165,
+            "diagnostics": {
+              "lexical_glossary_hits": 2,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 1022
+      },
       "prompt_fingerprint": "926854780f0e1ea7",
       "request_fingerprint": "436c542dfa3c5b0c",
-      "request_id": "3f25ef73cef53e3d"
+      "request_id": "a4a7a95c9c956b92"
     },
     {
+      "capability_requirements": {
+        "context_budget_tokens": 1648,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "029e98ba77-00001",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 218,
+            "diagnostics": {
+              "file_rel_path": "chapter02/strings.rpy",
+              "speakers": [],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 45,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": false,
+              "block_bounded_before": false,
+              "context_after_chars": 0,
+              "context_after_items": 0,
+              "context_after_limit": 10,
+              "context_before_chars": 0,
+              "context_before_items": 0,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 127,
+            "diagnostics": {
+              "lexical_glossary_hits": 1,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 525
+      },
       "prompt_fingerprint": "00756b8992768dfe",
       "request_fingerprint": "61a3213074a32c59",
-      "request_id": "cb535eddb76a5755"
+      "request_id": "01417c3411de278f"
     }
   ],
   "run_id": "fixture-run",

--- a/tests/fixtures/translation_plan_minimal/expected/plan.sync.json
+++ b/tests/fixtures/translation_plan_minimal/expected/plan.sync.json
@@ -99,7 +99,8 @@
     "local_context_after": 10,
     "local_context_before": 30,
     "story_block_suffix": "\n\n",
-    "story_char_limit": 1200
+    "story_char_limit": 1200,
+    "total_char_limit": 0
   },
   "execution_strategy": "sync",
   "model_profile_snapshot": {
@@ -124,26 +125,270 @@
     },
     "provider": "openai_compatible"
   },
-  "plan_fingerprint": "b2b6ed61ce8e4b6d",
-  "plan_id": "b718a000d7b28fc8",
+  "plan_fingerprint": "687aed7c3e455711",
+  "plan_id": "ba66db4f04767530",
   "request_summaries": [
     {
+      "capability_requirements": {
+        "context_budget_tokens": 2038,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "004851531f-00001",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 486,
+            "diagnostics": {
+              "file_rel_path": "chapter01/dialogue.rpy",
+              "speakers": [
+                "g",
+                "p"
+              ],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 108,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": true,
+              "block_bounded_before": false,
+              "context_after_chars": 55,
+              "context_after_items": 1,
+              "context_after_limit": 10,
+              "context_before_chars": 0,
+              "context_before_items": 0,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 186,
+            "diagnostics": {
+              "lexical_glossary_hits": 3,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 915
+      },
       "prompt_fingerprint": "e14597acfc6111bf",
       "request_fingerprint": "834db6c7a8fd6618",
-      "request_id": "0ad090eade0fba5d"
+      "request_id": "aa3179d72c278013"
     },
     {
+      "capability_requirements": {
+        "context_budget_tokens": 2145,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "004851531f-00002",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 484,
+            "diagnostics": {
+              "file_rel_path": "chapter01/dialogue.rpy",
+              "speakers": [
+                "g",
+                "m",
+                "p"
+              ],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 238,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": false,
+              "block_bounded_before": false,
+              "context_after_chars": 0,
+              "context_after_items": 0,
+              "context_after_limit": 10,
+              "context_before_chars": 161,
+              "context_before_items": 3,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 165,
+            "diagnostics": {
+              "lexical_glossary_hits": 2,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 1022
+      },
       "prompt_fingerprint": "926854780f0e1ea7",
       "request_fingerprint": "f04d56049df22ea0",
-      "request_id": "6e7dcbcfed5d4edb"
+      "request_id": "8b4e4e3c3a533587"
     },
     {
+      "capability_requirements": {
+        "context_budget_tokens": 1648,
+        "estimate_method": "char_upper_bound",
+        "structured_output": true
+      },
       "chunk_id": "029e98ba77-00001",
+      "context_diagnostics": {
+        "dropped": [],
+        "layers": [
+          {
+            "char_limit": 0,
+            "char_used": 218,
+            "diagnostics": {
+              "file_rel_path": "chapter02/strings.rpy",
+              "speakers": [],
+              "unit_count": 3
+            },
+            "layer": "required",
+            "rank": 1,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 45,
+            "diagnostics": {
+              "algorithm": "block_bounded_window",
+              "block_bounded_after": false,
+              "block_bounded_before": false,
+              "context_after_chars": 0,
+              "context_after_items": 0,
+              "context_after_limit": 10,
+              "context_before_chars": 0,
+              "context_before_items": 0,
+              "context_before_limit": 30,
+              "context_truncated": false
+            },
+            "layer": "local",
+            "rank": 2,
+            "truncated": false
+          },
+          {
+            "char_limit": 0,
+            "char_used": 127,
+            "diagnostics": {
+              "lexical_glossary_hits": 1,
+              "macro_injected": true,
+              "rag_independent": true
+            },
+            "layer": "project",
+            "rank": 3,
+            "truncated": false
+          },
+          {
+            "char_limit": 1420,
+            "char_used": 85,
+            "diagnostics": {
+              "budget_mode": "d5_combined_backstop",
+              "history_char_limit": 220,
+              "include_source_text": true,
+              "story_char_limit": 1200
+            },
+            "layer": "retrieval",
+            "rank": 4,
+            "truncated": false
+          },
+          {
+            "char_limit": 4000,
+            "char_used": 50,
+            "diagnostics": {
+              "analysis_char_limit": 4000,
+              "budget_mode": "d5_backstop",
+              "source": "published_project_analysis"
+            },
+            "layer": "analysis",
+            "rank": 5,
+            "truncated": false
+          }
+        ],
+        "total_char_used": 525
+      },
       "prompt_fingerprint": "00756b8992768dfe",
       "request_fingerprint": "74043d88587073ed",
-      "request_id": "8080ab948435b217"
+      "request_id": "cf24b48f29760be5"
     }
   ],
   "run_id": "fixture-run",

--- a/tests/test_batch_repair.py
+++ b/tests/test_batch_repair.py
@@ -244,6 +244,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
             with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
                  mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key']), \
                  mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'validate_batch_translation_plan_before_dispatch'), \
                  mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()), \
                  mock.patch('sys.stdout', stdout):
                 with self.assertRaises(QuotaError):
@@ -320,6 +321,7 @@ class BatchRepairRegressionTests(unittest.TestCase):
             with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
                  mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key-a', 'key-b']), \
                  mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'validate_batch_translation_plan_before_dispatch'), \
                  mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()), \
                  mock.patch.object(batch_mod.legacy, 'rotate_api_key', return_value=True):
                 result = batch_mod.submit_manifest(str(manifest_path))

--- a/tests/test_batch_submit_recovery.py
+++ b/tests/test_batch_submit_recovery.py
@@ -230,6 +230,7 @@ class BatchSubmitRecoveryFlowTests(unittest.TestCase):
             with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
                  mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key']), \
                  mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'validate_batch_translation_plan_before_dispatch'), \
                  mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()), \
                  mock.patch('sys.stdout', stdout):
                 result = batch_mod.submit_manifest(str(manifest_path), resume_upload=True)
@@ -266,6 +267,7 @@ class BatchSubmitRecoveryFlowTests(unittest.TestCase):
             with mock.patch.object(batch_mod, 'LATEST_MANIFEST_FILE', str(latest_path)), \
                  mock.patch.object(batch_mod.legacy, 'API_KEYS', ['key']), \
                  mock.patch.object(batch_mod, 'genai_types', fake_types), \
+                 mock.patch.object(batch_mod, 'validate_batch_translation_plan_before_dispatch'), \
                  mock.patch.object(batch_mod, 'create_batch_client', return_value=FakeClient()):
                 batch_mod.submit_manifest(str(manifest_path))
 

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -91,6 +91,25 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         legacy = format_translation_plan_facts({})
         self.assertTrue(any("旧版兼容模式" in fact for fact in legacy))
 
+    def test_translation_plan_facts_derive_missing_context_summary(self):
+        facts = format_translation_plan_facts({
+            "translation_plan": {
+                "plan_fingerprint": "fp-1",
+                "request_summaries": [{
+                    "request_id": "r1",
+                    "context_diagnostics": {
+                        "layers": [{"truncated": True}],
+                        "dropped": [
+                            {"reason": "duplicate_text", "char_used": 0},
+                            {"reason": "aggregate_budget_exceeded", "char_used": 4},
+                        ],
+                    },
+                }],
+            },
+        })
+        self.assertTrue(any("上下文裁剪请求数：1" in fact for fact in facts))
+        self.assertTrue(any("上下文舍弃记录数：1" in fact for fact in facts))
+
     def test_collect_existing_report_paths_only_returns_existing_files(self):
         package_dir = r"C:\logs\batch_jobs\job1"
         paths = {

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -10,6 +10,7 @@ from gui_qt.diagnostics_context import (
     build_diagnostics_context,
     collect_existing_report_paths,
     format_cli_command,
+    format_translation_plan_facts,
     idle_diagnostics_context,
     join_directory_file,
     manifest_for_preview,
@@ -53,6 +54,42 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertNotIn("files", preview)
         self.assertNotIn("chunks", preview)
         self.assertIn("_preview_note", preview)
+
+    def test_manifest_preview_compacts_nested_translation_plan(self):
+        preview = manifest_for_preview({
+            "translation_plan": {
+                "schema_version": 1,
+                "plan_id": "plan-1",
+                "plan_fingerprint": "fp-1",
+                "execution_strategy": "gemini_batch",
+                "source_identity": {"engine": "renpy", "adapter_version": "1"},
+                "chunks": [{"large": "x" * 1000}],
+                "request_summaries": [{"request_id": "request-1"}],
+            },
+            "translation_plan_diagnostics": {"request_count": 1},
+        })
+        plan = preview["translation_plan"]
+        self.assertEqual(plan["request_count"], 1)
+        self.assertNotIn("chunks", plan)
+        self.assertNotIn("request_summaries", plan)
+
+    def test_translation_plan_facts_show_current_and_legacy_modes(self):
+        current = format_translation_plan_facts({
+            "translation_plan": {
+                "plan_fingerprint": "fp-1",
+                "request_summaries": [{"request_id": "r1"}],
+            },
+            "translation_plan_diagnostics": {
+                "request_count": 1,
+                "context_truncated_requests": 1,
+                "context_dropped_entries": 2,
+            },
+        })
+        self.assertTrue(any("fp-1" in fact for fact in current))
+        self.assertTrue(any("规范化请求数：1" in fact for fact in current))
+        self.assertTrue(any("上下文裁剪请求数：1" in fact for fact in current))
+        legacy = format_translation_plan_facts({})
+        self.assertTrue(any("旧版兼容模式" in fact for fact in legacy))
 
     def test_collect_existing_report_paths_only_returns_existing_files(self):
         package_dir = r"C:\logs\batch_jobs\job1"
@@ -409,6 +446,37 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertEqual(len(context.commands), 1)
         self.assertIn("gemini_translate.py", context.commands[0].command)
         self.assertEqual(context.manifest_json_preview, "")
+
+    def test_sync_diagnostics_context_shows_preview_plan_and_paths(self):
+        manifest_path = r"C:\logs\sync_runs\run1\manifest.json"
+        report_path = r"C:\logs\sync_runs\run1\preview.diff"
+        context = sync_diagnostics_context(
+            sync_script_path=r"C:\tools\gemini_translate.py",
+            preview_manifest_path=manifest_path,
+            preview_manifest={
+                "translation_plan": {
+                    "plan_fingerprint": "sync-fp",
+                    "request_summaries": [{"request_id": "r1"}],
+                },
+                "translation_plan_diagnostics": {"request_count": 1},
+                "report_path": "preview.diff",
+            },
+            path_exists=lambda path: path in {manifest_path, report_path},
+        )
+        self.assertEqual(context.status, "ready")
+        self.assertTrue(any("sync-fp" in fact for fact in context.facts))
+        self.assertEqual(len(context.paths), 2)
+        self.assertIn("translation_plan", context.manifest_json_preview)
+
+    def test_sync_diagnostics_context_warns_for_legacy_preview(self):
+        context = sync_diagnostics_context(
+            sync_script_path="gemini_translate.py",
+            preview_manifest_path="manifest.json",
+            preview_manifest={"report_path": "preview.diff"},
+            path_exists=lambda _path: False,
+        )
+        self.assertEqual(context.status, "warning")
+        self.assertIn("旧版兼容模式", context.message)
 
     def test_build_diagnostics_context_ready_with_manifest(self):
         manifest_path = r"C:\logs\batch_jobs\job1\manifest.json"

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -813,6 +813,8 @@ class RoutingPreflightIntegrationTests(unittest.TestCase):
                     batch_mod, "create_batch_client",
                     side_effect=RuntimeError("do not upload"),
                 ), mock.patch.object(
+                    batch_mod, "validate_batch_translation_plan_before_dispatch",
+                ), mock.patch.object(
                     batch_mod, "_runtime_keyring_has_credential",
                     return_value=True,
                 ):

--- a/tests/test_translation_plan.py
+++ b/tests/test_translation_plan.py
@@ -646,6 +646,37 @@ class ContextAssemblyTests(unittest.TestCase):
         self.assertTrue(retrieval.truncated)
         self.assertEqual(retrieval.char_used, retrieval.char_limit)
 
+    def test_aggregate_budget_preserves_priority_and_explains_trimming(self):
+        chunk_input = translation_plan.ChunkContextInput(
+            target_units=[],
+            macro_setting='Keep names stable.',
+            retrieval_blocks_text='R' * 40,
+            analysis_blocks_text='A' * 40,
+        )
+        baseline = translation_plan.assemble_context_layers(chunk_input)
+        mandatory_used = sum(
+            layer.char_used
+            for layer in baseline.layers
+            if layer.layer in {'required', 'local', 'project'}
+        )
+        assembly = translation_plan.assemble_context_layers(
+            chunk_input,
+            translation_plan.ContextPolicy(total_char_limit=mandatory_used + 20),
+        )
+        by_layer = {layer.layer: layer for layer in assembly.layers}
+        self.assertEqual(by_layer['retrieval'].char_used, 20)
+        self.assertEqual(by_layer['analysis'].char_used, 0)
+        self.assertTrue(by_layer['retrieval'].truncated)
+        self.assertTrue(by_layer['analysis'].truncated)
+        self.assertEqual(
+            [item['layer'] for item in assembly.dropped],
+            ['retrieval', 'analysis'],
+        )
+        self.assertTrue(all(
+            item['reason'] == 'aggregate_budget_exceeded'
+            for item in assembly.dropped
+        ))
+
     def test_duplicate_layer_texts_are_dropped_with_reason(self):
         chunk_input = translation_plan.ChunkContextInput(
             target_units=[],
@@ -832,6 +863,36 @@ class DerivedRequestTests(unittest.TestCase):
 
 
 class GoldenPlanTests(unittest.TestCase):
+    def test_normalized_sync_and_batch_requests_have_empty_readable_diff(self):
+        sync = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        batch = build_fixture_plan(translation_plan.STRATEGY_GEMINI_BATCH)
+        report = translation_plan.plan_diff(sync.requests, batch.requests)
+        self.assertTrue(report['equivalent'], translation_plan.format_plan_diff(report))
+        self.assertEqual(
+            translation_plan.format_plan_diff(report),
+            'TranslationPlan semantic requests are equivalent (3 requests).',
+        )
+        for sync_request, batch_request in zip(sync.requests, batch.requests):
+            self.assertEqual(
+                translation_plan.canonical_semantic_request(sync_request),
+                translation_plan.canonical_semantic_request(batch_request),
+            )
+            self.assertEqual(
+                sync_request.prompt_fingerprint,
+                batch_request.prompt_fingerprint,
+            )
+
+    def test_plan_diff_names_chunk_and_changed_semantic_field(self):
+        sync = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        batch = build_fixture_plan(translation_plan.STRATEGY_GEMINI_BATCH)
+        batch.requests[0].user_prompt += '\nchanged'
+        report = translation_plan.plan_diff(sync.requests, batch.requests)
+        rendered = translation_plan.format_plan_diff(report)
+        self.assertFalse(report['equivalent'])
+        self.assertIn(sync.requests[0].chunk_id, rendered)
+        self.assertIn('user_prompt', rendered)
+        self.assertIn('+  "user_prompt"', rendered)
+
     def test_sync_plan_matches_frozen_golden(self):
         build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
         _assert_golden('plan.sync.json', build.plan.to_dict())

--- a/tests/test_translation_plan.py
+++ b/tests/test_translation_plan.py
@@ -893,6 +893,25 @@ class GoldenPlanTests(unittest.TestCase):
         self.assertIn('user_prompt', rendered)
         self.assertIn('+  "user_prompt"', rendered)
 
+    def test_plan_diff_reports_missing_request_without_json_error(self):
+        sync = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        report = translation_plan.plan_diff(sync.requests, sync.requests[:-1])
+        rendered = translation_plan.format_plan_diff(report)
+        self.assertFalse(report['equivalent'])
+        self.assertIn('<missing>', rendered)
+        self.assertIn('missing_request', rendered)
+
+    def test_empty_optional_duplicate_is_not_a_material_drop(self):
+        build = build_fixture_plan(
+            translation_plan.STRATEGY_SYNC,
+            retrieval_blocks_provider='',
+            analysis_blocks_provider='',
+        )
+        diagnostics = translation_plan.summarize_request_diagnostics(
+            build.plan.request_summaries
+        )
+        self.assertEqual(diagnostics['context_dropped_entries'], 0)
+
     def test_sync_plan_matches_frozen_golden(self):
         build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
         _assert_golden('plan.sync.json', build.plan.to_dict())

--- a/tests/test_translation_plan_p4.py
+++ b/tests/test_translation_plan_p4.py
@@ -356,9 +356,47 @@ class DispatchFreshnessTests(unittest.TestCase):
 
 class CompatibilityDiagnosticsTests(unittest.TestCase):
     def test_legacy_batch_package_is_explicitly_downgraded(self):
-        diagnostic = batch.validate_batch_translation_plan_before_dispatch({})
-        self.assertEqual(diagnostic['mode'], 'legacy')
-        self.assertEqual(diagnostic['code'], 'TRANSLATION_PLAN_LEGACY_FALLBACK')
+        for operation in ('check', 'apply'):
+            with self.subTest(operation=operation):
+                diagnostic = batch.validate_batch_translation_plan_before_dispatch(
+                    {},
+                    operation=operation,
+                )
+                self.assertEqual(diagnostic['mode'], 'legacy')
+                self.assertEqual(
+                    diagnostic['code'],
+                    'TRANSLATION_PLAN_LEGACY_FALLBACK',
+                )
+
+    def test_legacy_batch_submit_is_blocked_before_provider_setup(self):
+        manifest = {'job_name': '', 'submit_disabled': False}
+        with (
+            mock.patch.object(batch, 'load_manifest', return_value=manifest),
+            mock.patch.object(batch, '_manifest_package_dir', return_value='package'),
+            mock.patch.object(
+                batch.batch_submit_recovery,
+                'get_uncertain_submit_state',
+                return_value=None,
+            ),
+            mock.patch.object(batch, 'resolve_manifest_routing_plan'),
+            mock.patch.object(batch, 'require_valid_routing_plan'),
+            mock.patch.object(batch, 'create_batch_client') as create_client,
+        ):
+            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                batch.submit_manifest('legacy-manifest.json')
+        self.assertEqual(
+            raised.exception.code_name,
+            'TRANSLATION_PLAN_LEGACY_SUBMIT_BLOCKED',
+        )
+        self.assertEqual(
+            raised.exception.suggested_action,
+            'rebuild_batch_package',
+        )
+        self.assertEqual(
+            raised.exception.details['compatibility']['code'],
+            'TRANSLATION_PLAN_LEGACY_FALLBACK',
+        )
+        create_client.assert_not_called()
 
     def test_legacy_sync_preview_loads_with_runtime_only_diagnostic(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_translation_plan_p4.py
+++ b/tests/test_translation_plan_p4.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""P4 exit tests for plan diffs, dispatch freshness, and legacy diagnostics."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gemini_translate_batch as batch
+import sync_translation_preview
+import translation_plan
+import translator_runtime as runtime
+from tests.test_translation_plan import build_fixture_plan
+
+
+def _batch_manifest(tmp_dir):
+    build = build_fixture_plan(translation_plan.STRATEGY_GEMINI_BATCH)
+    jobs = json.loads(
+        (
+            Path(__file__).parent
+            / 'fixtures'
+            / 'translation_plan_minimal'
+            / 'inputs'
+            / 'file_jobs.json'
+        ).read_text(encoding='utf-8')
+    )
+    items_by_file = {job['file_rel_path']: job['tasks'] for job in jobs}
+    chunks = []
+    offsets = {}
+    for plan_chunk, request in zip(build.plan.chunks, build.requests):
+        start = offsets.get(plan_chunk.file_rel_path, 0)
+        end = start + len(request.expected_ids)
+        offsets[plan_chunk.file_rel_path] = end
+        chunks.append({
+            'key': request.chunk_id,
+            'file_rel_path': plan_chunk.file_rel_path,
+            'items': items_by_file[plan_chunk.file_rel_path][start:end],
+            **request.to_dict(),
+        })
+    requests_path = Path(tmp_dir) / 'requests.jsonl'
+    rows = [batch.build_batch_request(chunk, model='fixture-model') for chunk in chunks]
+    requests_path.write_text(
+        ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+        encoding='utf-8',
+    )
+    return {
+        'batch_model': 'fixture-model',
+        'input_jsonl_path': str(requests_path),
+        'translation_plan': build.plan.to_dict(),
+        'chunks': chunks,
+    }, build
+
+
+class DispatchFreshnessTests(unittest.TestCase):
+    def test_sync_source_or_adapter_stale_refuses_before_dispatch(self):
+        build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        current = dict(build.plan.source_identity)
+        current['adapter_version'] = 'changed-adapter'
+        with mock.patch.object(runtime, 'current_sync_source_identity', return_value=current):
+            with self.assertRaisesRegex(RuntimeError, 'adapter_version_changed'):
+                runtime.validate_sync_translation_plan_before_dispatch(build)
+
+    def test_sync_request_tamper_refuses_before_dispatch(self):
+        build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        build.requests[0].user_prompt += '\ntampered'
+        with mock.patch.object(
+            runtime,
+            'current_sync_source_identity',
+            return_value=dict(build.plan.source_identity),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'request binding is stale'):
+                runtime.validate_sync_translation_plan_before_dispatch(build)
+
+    def test_sync_generation_tamper_refuses_before_dispatch(self):
+        build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
+        build.requests[0].generation_config['temperature'] = 0.9
+        with mock.patch.object(
+            runtime,
+            'current_sync_source_identity',
+            return_value=dict(build.plan.source_identity),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'request binding is stale'):
+                runtime.validate_sync_translation_plan_before_dispatch(build)
+
+    def test_batch_source_or_adapter_stale_refuses_before_upload(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            stale = dict(build.plan.source_identity)
+            stale['source_snapshot_fingerprint'] = 'changed-source'
+            with (
+                mock.patch.object(batch, 'collect_pending_file_jobs', return_value=[]),
+                mock.patch.object(
+                    batch,
+                    '_batch_plan_source_identity',
+                    return_value=translation_plan.SourceIdentity.from_dict(stale),
+                ),
+            ):
+                with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                    batch.validate_batch_translation_plan_before_dispatch(manifest)
+            self.assertEqual(raised.exception.code_name, 'TRANSLATION_PLAN_SOURCE_STALE')
+
+    def test_batch_request_tamper_refuses_before_upload(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, _build = _batch_manifest(tmp_dir)
+            path = Path(manifest['input_jsonl_path'])
+            rows = [json.loads(line) for line in path.read_text(encoding='utf-8').splitlines()]
+            rows[0]['request']['contents'][0]['parts'][0]['text'] += '\ntampered'
+            path.write_text(
+                ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+                encoding='utf-8',
+            )
+            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                batch.validate_batch_translation_plan_before_dispatch(manifest)
+            self.assertEqual(
+                raised.exception.code_name,
+                'TRANSLATION_PLAN_REQUEST_BINDING_MISMATCH',
+            )
+
+
+class CompatibilityDiagnosticsTests(unittest.TestCase):
+    def test_legacy_batch_package_is_explicitly_downgraded(self):
+        diagnostic = batch.validate_batch_translation_plan_before_dispatch({})
+        self.assertEqual(diagnostic['mode'], 'legacy')
+        self.assertEqual(diagnostic['code'], 'TRANSLATION_PLAN_LEGACY_FALLBACK')
+
+    def test_legacy_sync_preview_loads_with_runtime_only_diagnostic(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / 'manifest.json'
+            manifest = {
+                'schema': sync_translation_preview.SCHEMA,
+                'version': sync_translation_preview.VERSION,
+                'created_at': '2026-01-01T00:00:00+00:00',
+                'project_root': tmp_dir,
+                'tl_dir': tmp_dir,
+                'report_path': 'preview.diff',
+                'report_sha256': '',
+                'summary': {},
+                'files': [],
+            }
+            manifest['preview_fingerprint'] = sync_translation_preview._fingerprint(manifest)
+            path.write_text(json.dumps(manifest), encoding='utf-8')
+            loaded = sync_translation_preview.load_sync_preview(path)
+            self.assertEqual(
+                loaded['_translation_plan_compatibility']['code'],
+                'TRANSLATION_PLAN_LEGACY_FALLBACK',
+            )
+            self.assertNotIn('_translation_plan_compatibility', json.loads(path.read_text()))
+
+
+class RagIndependentContextTests(unittest.TestCase):
+    def test_no_retrieval_keeps_macro_and_all_local_glossary_kinds(self):
+        build = build_fixture_plan(
+            translation_plan.STRATEGY_SYNC,
+            retrieval_blocks_provider='',
+            analysis_blocks_provider='',
+        )
+        prompt = '\n'.join(request.user_prompt for request in build.requests)
+        system = '\n'.join(request.system_instruction for request in build.requests)
+        self.assertIn('A college a cappella story', system)
+        self.assertIn('Existing mapping: setlist -> 曲目单', prompt)
+        self.assertIn('Preserve: Dawn Chorus', prompt)
+        self.assertIn('Non-translatable: B-side', prompt)
+        for request in build.requests:
+            project = next(
+                layer
+                for layer in request.context_assembly['layers']
+                if layer['layer'] == translation_plan.CONTEXT_LAYER_PROJECT
+            )
+            self.assertTrue(project['diagnostics']['rag_independent'])
+
+
+class PersistedDiagnosticsSafetyTests(unittest.TestCase):
+    def test_plan_requests_and_diff_artifacts_do_not_persist_credentials(self):
+        secret = 'credential-value-must-not-leak'
+        build = build_fixture_plan(
+            translation_plan.STRATEGY_SYNC,
+            model_profile_snapshot={
+                'id': 'fixture',
+                'extra_headers': {'Authorization': f'Bearer {secret}'},
+            },
+            generation_config={'temperature': 0.2, 'api_key': secret},
+            transport_metadata={'auth_token': secret},
+        )
+        peer = build_fixture_plan(
+            translation_plan.STRATEGY_SYNC,
+            model_profile_snapshot={
+                'id': 'fixture',
+                'extra_headers': {'Authorization': f'Bearer {secret}'},
+            },
+            generation_config={'temperature': 0.2, 'api_key': secret},
+            transport_metadata={'auth_token': secret},
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / 'manifest.json').write_text(
+                json.dumps(build.plan.to_dict(), ensure_ascii=False),
+                encoding='utf-8',
+            )
+            (root / 'requests.jsonl').write_text(
+                ''.join(
+                    json.dumps(request.to_dict(), ensure_ascii=False) + '\n'
+                    for request in build.requests
+                ),
+                encoding='utf-8',
+            )
+            (root / 'plan_diff.txt').write_text(
+                translation_plan.format_plan_diff(
+                    translation_plan.plan_diff(build.requests, peer.requests)
+                ),
+                encoding='utf-8',
+            )
+            persisted = '\n'.join(
+                path.read_text(encoding='utf-8') for path in root.iterdir()
+            )
+        self.assertNotIn(secret, persisted)
+        self.assertNotIn('Bearer ', persisted)
+        self.assertIn(translation_plan.REDACTED_VALUE, persisted)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_translation_plan_p4.py
+++ b/tests/test_translation_plan_p4.py
@@ -35,6 +35,7 @@ def _batch_manifest(tmp_dir):
         chunks.append({
             'key': request.chunk_id,
             'file_rel_path': plan_chunk.file_rel_path,
+            'file_path': plan_chunk.file_path,
             'items': items_by_file[plan_chunk.file_rel_path][start:end],
             **request.to_dict(),
         })
@@ -53,6 +54,22 @@ def _batch_manifest(tmp_dir):
 
 
 class DispatchFreshnessTests(unittest.TestCase):
+    def _validate_current_batch(self, manifest, build, *, operation='submit'):
+        with (
+            mock.patch.object(batch, 'collect_pending_file_jobs', return_value=[]),
+            mock.patch.object(
+                batch,
+                '_batch_plan_source_identity',
+                return_value=translation_plan.SourceIdentity.from_dict(
+                    build.plan.source_identity
+                ),
+            ),
+        ):
+            return batch.validate_batch_translation_plan_before_dispatch(
+                manifest,
+                operation=operation,
+            )
+
     def test_sync_source_or_adapter_stale_refuses_before_dispatch(self):
         build = build_fixture_plan(translation_plan.STRATEGY_SYNC)
         current = dict(build.plan.source_identity)
@@ -115,6 +132,225 @@ class DispatchFreshnessTests(unittest.TestCase):
             self.assertEqual(
                 raised.exception.code_name,
                 'TRANSLATION_PLAN_REQUEST_BINDING_MISMATCH',
+            )
+
+    def test_batch_coordinated_chunk_and_jsonl_tamper_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            manifest['chunks'][0]['user_prompt'] += '\ntampered together'
+            path = Path(manifest['input_jsonl_path'])
+            rows = [
+                batch.build_batch_request(chunk, model=manifest['batch_model'])
+                for chunk in manifest['chunks']
+            ]
+            path.write_text(
+                ''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in rows),
+                encoding='utf-8',
+            )
+            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                self._validate_current_batch(manifest, build)
+            self.assertEqual(
+                raised.exception.code_name,
+                'TRANSLATION_PLAN_REQUEST_BINDING_MISMATCH',
+            )
+
+    def test_batch_adapter_version_stale_is_explicit(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            stale = dict(build.plan.source_identity)
+            stale['adapter_version'] = 'changed-adapter'
+            with (
+                mock.patch.object(batch, 'collect_pending_file_jobs', return_value=[]),
+                mock.patch.object(
+                    batch,
+                    '_batch_plan_source_identity',
+                    return_value=translation_plan.SourceIdentity.from_dict(stale),
+                ),
+            ):
+                with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                    batch.validate_batch_translation_plan_before_dispatch(manifest)
+            self.assertEqual(raised.exception.code_name, 'TRANSLATION_PLAN_SOURCE_STALE')
+            self.assertIn('adapter_version_changed', raised.exception.details['reasons'])
+
+    def test_split_child_plan_is_sliced_signed_and_valid(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            child_chunks = manifest['chunks'][:1]
+            child = {
+                'batch_model': manifest['batch_model'],
+                'chunks': child_chunks,
+                'split_from_manifest': 'parent.json',
+                'input_jsonl_path': str(Path(tmp_dir) / 'split.requests.jsonl'),
+            }
+            batch.copy_split_context_metadata(manifest, child, child_chunks)
+            Path(child['input_jsonl_path']).write_text(
+                json.dumps(
+                    batch.build_batch_request(
+                        child_chunks[0], model=child['batch_model']
+                    ),
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            diagnostics = [
+                self._validate_current_batch(child, build, operation=operation)
+                for operation in ('submit', 'check', 'apply')
+            ]
+            self.assertEqual(len(child['translation_plan']['request_summaries']), 1)
+            self.assertEqual(
+                child['translation_plan']['artifacts']['derivation']['kind'],
+                'split',
+            )
+            self.assertTrue(all(item['plan'] == 'fresh' for item in diagnostics))
+
+    def test_split_manifest_current_plan_children_pass_all_plan_gates(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            manifest.update({
+                'version': 2,
+                'display_name': 'fixture',
+                'settings': {},
+            })
+            manifest_path = Path(tmp_dir) / 'manifest.json'
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False),
+                encoding='utf-8',
+            )
+            with mock.patch.object(
+                batch,
+                'LATEST_MANIFEST_FILE',
+                str(Path(tmp_dir) / 'latest.txt'),
+            ):
+                children = batch.split_manifest(
+                    str(manifest_path),
+                    max_chunks=1,
+                )
+            self.assertGreater(len(children), 1)
+            for child_path in children:
+                child = batch.load_manifest(child_path)
+                for operation in ('submit', 'check', 'apply'):
+                    diagnostic = self._validate_current_batch(
+                        child,
+                        build,
+                        operation=operation,
+                    )
+                    self.assertEqual(diagnostic['plan'], 'fresh')
+
+    def test_split_child_cannot_resign_tampered_parent_request(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, _build = _batch_manifest(tmp_dir)
+            chunk = manifest['chunks'][0]
+            chunk['user_prompt'] += '\ncoordinated parent tamper'
+            prompt_fingerprint, request_fingerprint = (
+                translation_plan.recompute_request_fingerprints(chunk)
+            )
+            chunk['prompt_fingerprint'] = prompt_fingerprint
+            chunk['request_fingerprint'] = request_fingerprint
+            child = {
+                'chunks': [chunk],
+                'split_from_manifest': 'parent.json',
+            }
+            with self.assertRaisesRegex(ValueError, 'not bound'):
+                batch.copy_split_context_metadata(manifest, child, [chunk])
+
+    def test_retry_child_plan_binds_derived_request_and_is_valid(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            retry_chunk = batch.build_retry_subchunk(
+                manifest['chunks'][0], 0, 1, 1
+            )
+            child = {
+                'batch_model': manifest['batch_model'],
+                'chunks': [retry_chunk],
+                'retry_of_manifest': 'parent.json',
+                'input_jsonl_path': str(Path(tmp_dir) / 'retry.requests.jsonl'),
+            }
+            batch.copy_split_context_metadata(manifest, child, [retry_chunk])
+            Path(child['input_jsonl_path']).write_text(
+                json.dumps(
+                    batch.build_batch_request(
+                        retry_chunk, model=child['batch_model']
+                    ),
+                    ensure_ascii=False,
+                ) + '\n',
+                encoding='utf-8',
+            )
+            diagnostics = [
+                self._validate_current_batch(child, build, operation=operation)
+                for operation in ('submit', 'check', 'apply')
+            ]
+            summary = child['translation_plan']['request_summaries'][0]
+            self.assertEqual(summary['request_id'], retry_chunk['request_id'])
+            self.assertEqual(
+                child['translation_plan']['artifacts']['derivation']['kind'],
+                'retry',
+            )
+            self.assertTrue(all(item['request_count'] == 1 for item in diagnostics))
+
+    def test_apply_force_cannot_bypass_stale_plan_fingerprint(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, _build = _batch_manifest(tmp_dir)
+            manifest.update({
+                '_manifest_path': str(Path(tmp_dir) / 'manifest.json'),
+                '_package_dir': tmp_dir,
+                'applied_at': '2026-08-28T00:00:00',
+                'files': {},
+            })
+            manifest['translation_plan']['artifacts']['tampered'] = True
+
+            def allow_contract(_manifest, summary):
+                summary['writeback_gate'] = {'decision': batch.translation_quality.GATE_ALLOW}
+                return summary
+
+            with (
+                mock.patch.object(batch, 'load_manifest', return_value=manifest),
+                mock.patch.object(batch, 'require_manifest_mode'),
+                mock.patch.object(batch, 'require_manifest_project_match'),
+                mock.patch.object(batch, 'recover_atomic_write_transaction'),
+                mock.patch.object(batch, 'require_safe_check_for_apply'),
+                mock.patch.object(
+                    batch,
+                    'collect_result_actions',
+                    return_value=({}, {}, [], {}),
+                ),
+                mock.patch.object(batch, 'attach_check_contract', side_effect=allow_contract),
+                mock.patch.object(
+                    batch,
+                    '_validate_adapter_writeback_plan',
+                    return_value=(None, None),
+                ),
+            ):
+                with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                    batch.apply_results('manifest.json', force=True)
+            self.assertEqual(raised.exception.code_name, 'TRANSLATION_PLAN_STALE')
+
+    def test_durable_invalid_plan_uses_structured_contract_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, _build = _batch_manifest(tmp_dir)
+            manifest['durable_sync_source'] = {'run_id': 'run-1'}
+            manifest['translation_plan']['artifacts']['tampered'] = True
+            with self.assertRaises(batch.cli_contract.MachineContractError) as raised:
+                batch.validate_batch_translation_plan_before_dispatch(manifest)
+            self.assertEqual(raised.exception.code_name, 'TRANSLATION_PLAN_STALE')
+
+    def test_validation_preserves_context_diagnostic_counts(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest, build = _batch_manifest(tmp_dir)
+            expected = translation_plan.summarize_request_diagnostics(
+                manifest['translation_plan']['request_summaries']
+            )
+            manifest['translation_plan_diagnostics'] = {
+                'code': 'TRANSLATION_PLAN_CURRENT',
+                **expected,
+            }
+            diagnostic = self._validate_current_batch(manifest, build)
+            self.assertEqual(
+                diagnostic['context_truncated_requests'],
+                expected['context_truncated_requests'],
+            )
+            self.assertEqual(
+                diagnostic['context_dropped_entries'],
+                expected['context_dropped_entries'],
             )
 
 

--- a/tests/test_translator_runtime.py
+++ b/tests/test_translator_runtime.py
@@ -585,16 +585,23 @@ class TranslatorRuntimeRegressionTests(unittest.TestCase):
         self.assertEqual(sync_request.user_prompt, batch_request.user_prompt)
         self.assertEqual(sync_request.response_schema, batch_request.response_schema)
         self.assertEqual(sync_request.expected_ids, batch_request.expected_ids)
-        self.assertEqual(
-            [
-                (layer['layer'], layer['char_used'], layer['truncated'])
-                for layer in sync_request.context_assembly['layers']
-            ],
-            [
-                (layer['layer'], layer['char_used'], layer['truncated'])
-                for layer in batch_request.context_assembly['layers']
-            ],
+        report = translation_plan.plan_diff(
+            sync_build.requests,
+            batch_build.requests,
         )
+        self.assertTrue(report['equivalent'], translation_plan.format_plan_diff(report))
+        self.assertEqual(
+            translation_plan.canonical_semantic_request(sync_request),
+            translation_plan.canonical_semantic_request(batch_request),
+        )
+        self.assertEqual(
+            sync_request.prompt_fingerprint,
+            batch_request.prompt_fingerprint,
+        )
+        self.assertEqual(sync_request.context_assembly, batch_request.context_assembly)
+        self.assertIn('Use a warm stage tone.', sync_request.system_instruction)
+        self.assertIn('Existing mapping: Encore -> 返场', sync_request.user_prompt)
+        self.assertIn('Preserve: [Gil_name!t]', sync_request.user_prompt)
         self.assertEqual(
             sync_request.transport_metadata['sync_stage'],
             'initial_translation',

--- a/translation_plan.py
+++ b/translation_plan.py
@@ -167,6 +167,19 @@ def canonical_semantic_request(request):
     return canonical_json(payload)
 
 
+def recompute_request_fingerprints(request):
+    """Recompute semantic and audit fingerprints without trusting stored fields."""
+    if not isinstance(request, TranslationRequest):
+        request = TranslationRequest.from_dict(request)
+    prompt_fingerprint = short_fingerprint(canonical_semantic_request(request))
+    request_fingerprint = short_fingerprint(canonical_json({
+        'prompt_fingerprint': prompt_fingerprint,
+        'generation_config': dict(request.generation_config or {}),
+        'transport_metadata': dict(request.transport_metadata or {}),
+    }))
+    return prompt_fingerprint, request_fingerprint
+
+
 def plan_diff(left_requests, right_requests, *, left_label='sync', right_label='gemini_batch'):
     """Compare normalized model-visible requests and return a readable report.
 
@@ -181,10 +194,14 @@ def plan_diff(left_requests, right_requests, *, left_label='sync', right_label='
         left_request = left[index] if index < len(left) else None
         right_request = right[index] if index < len(right) else None
         left_text = (
-            canonical_semantic_request(left_request) if left_request is not None else ''
+            canonical_semantic_request(left_request)
+            if left_request is not None
+            else canonical_json({'missing_request': True})
         )
         right_text = (
-            canonical_semantic_request(right_request) if right_request is not None else ''
+            canonical_semantic_request(right_request)
+            if right_request is not None
+            else canonical_json({'missing_request': True})
         )
         if left_text == right_text:
             continue
@@ -260,6 +277,147 @@ def validate_plan_fingerprint(payload):
     if not recorded or recorded != expected:
         raise ValueError('TranslationPlan fingerprint is invalid or stale.')
     return recorded
+
+
+def refresh_plan_fingerprint(payload):
+    """Return a deep-copied plan payload with a freshly computed fingerprint."""
+    refreshed = json.loads(canonical_json(dict(payload or {})))
+    fingerprint_payload = dict(refreshed)
+    fingerprint_payload.pop('plan_fingerprint', None)
+    fingerprint_payload.pop('run_id', None)
+    refreshed['plan_fingerprint'] = short_fingerprint(
+        canonical_json(fingerprint_payload)
+    )
+    return refreshed
+
+
+def is_material_context_drop(entry):
+    """Return whether a drop record represents model-visible context loss."""
+    entry = dict(entry or {})
+    if (
+        entry.get('reason') == 'duplicate_text'
+        and int(entry.get('char_used') or 0) <= 0
+    ):
+        return False
+    return True
+
+
+def summarize_request_diagnostics(request_summaries):
+    """Aggregate stable trim/drop counters from persisted request summaries."""
+    summaries = list(request_summaries or [])
+    return {
+        'request_count': len(summaries),
+        'context_truncated_requests': sum(
+            1
+            for summary in summaries
+            if any(
+                bool((layer or {}).get('truncated'))
+                for layer in (
+                    (summary.get('context_diagnostics') or {}).get('layers') or []
+                )
+            )
+        ),
+        'context_dropped_entries': sum(
+            1
+            for summary in summaries
+            for entry in (
+                (summary.get('context_diagnostics') or {}).get('dropped') or []
+            )
+            if is_material_context_drop(entry)
+        ),
+    }
+
+
+def derive_translation_plan_payload(parent_payload, request_payloads, *, derivation_kind):
+    """Create a signed child-plan view for split or D7-derived requests.
+
+    The parent plan remains immutable.  The child keeps its semantic ``plan_id``
+    and full-project source identity, but binds only the requests that the child
+    package can dispatch. Retry request lineage remains in each request's
+    transport metadata and is also recorded in the plan artifacts.
+    """
+    validate_plan_fingerprint(parent_payload)
+    parent = json.loads(canonical_json(dict(parent_payload or {})))
+    parent_chunks = {
+        str((chunk or {}).get('chunk_id') or ''): dict(chunk or {})
+        for chunk in parent.get('chunks') or []
+    }
+    parent_summaries_by_chunk = {
+        str((summary or {}).get('chunk_id') or ''): dict(summary or {})
+        for summary in parent.get('request_summaries') or []
+    }
+    parent_request_ids = {
+        str((summary or {}).get('request_id') or '')
+        for summary in parent.get('request_summaries') or []
+    }
+    summaries = []
+    chunks = []
+    for index, payload in enumerate(request_payloads or [], start=1):
+        raw = (
+            payload.to_dict()
+            if isinstance(payload, TranslationRequest)
+            else dict(payload or {})
+        )
+        request = TranslationRequest.from_dict(raw)
+        prompt_fingerprint, request_fingerprint = recompute_request_fingerprints(
+            request
+        )
+        if (
+            request.plan_id != str(parent.get('plan_id') or '')
+            or request.prompt_fingerprint != prompt_fingerprint
+            or request.request_fingerprint != request_fingerprint
+        ):
+            raise ValueError('Child TranslationPlan request fingerprint is stale.')
+        parent_summary = parent_summaries_by_chunk.get(request.chunk_id)
+        exact_parent_request = bool(
+            parent_summary
+            and str(parent_summary.get('request_id') or '') == request.request_id
+            and str(parent_summary.get('prompt_fingerprint') or '')
+            == prompt_fingerprint
+            and str(parent_summary.get('request_fingerprint') or '')
+            == request_fingerprint
+        )
+        retry_parent_request_id = str(
+            (request.transport_metadata or {}).get('retry_parent_request_id') or ''
+        )
+        if not exact_parent_request and (
+            str(derivation_kind or '') != 'retry'
+            or retry_parent_request_id not in parent_request_ids
+        ):
+            raise ValueError(
+                'Child TranslationPlan request is not bound to its parent plan.'
+            )
+        summaries.append(request.summary())
+        existing = parent_chunks.get(request.chunk_id)
+        if existing is not None:
+            chunks.append(existing)
+            continue
+        items = list(raw.get('items') or [])
+        chunks.append({
+            'chunk_id': request.chunk_id or str(raw.get('key') or ''),
+            'chunk_index': int(raw.get('chunk_index') or index),
+            'file_rel_path': str(raw.get('file_rel_path') or ''),
+            'file_path': str(raw.get('file_path') or ''),
+            'line_numbers': list(raw.get('line_numbers') or [
+                item.get('line') for item in items if item.get('line') is not None
+            ]),
+            'unit_ids': list(request.expected_ids),
+            'source_char_count': int(raw.get('source_char_count') or sum(
+                len(str(item.get('source', item.get('text', '')) or ''))
+                for item in items
+            )),
+            'context_window_spec': dict(raw.get('context_window_spec') or {}),
+        })
+    artifacts = dict(parent.get('artifacts') or {})
+    artifacts['derivation'] = {
+        'kind': str(derivation_kind or 'child'),
+        'parent_plan_id': str(parent.get('plan_id') or ''),
+        'parent_plan_fingerprint': str(parent.get('plan_fingerprint') or ''),
+    }
+    parent['chunks'] = chunks
+    parent['request_summaries'] = summaries
+    parent['artifacts'] = artifacts
+    return refresh_plan_fingerprint(parent)
 
 
 def source_identity_differences(expected, actual):

--- a/translation_plan.py
+++ b/translation_plan.py
@@ -27,6 +27,7 @@ Hard constraints (enforced by tests):
 """
 
 from dataclasses import dataclass, field
+import difflib
 import hashlib
 import json
 import re
@@ -149,6 +150,137 @@ def short_fingerprint(text):
     return sha256_hex(text)[:16]
 
 
+def canonical_semantic_request(request):
+    """Return the canonical bytes used to compare executor-neutral requests."""
+    if isinstance(request, TranslationRequest):
+        payload = request.semantic_payload()
+    elif isinstance(request, Mapping):
+        payload = {
+            'system_instruction': str(request.get('system_instruction') or ''),
+            'user_prompt': str(request.get('user_prompt') or ''),
+            'response_schema': dict(request.get('response_schema') or {}),
+            'expected_ids': list(request.get('expected_ids') or []),
+            'context_assembly': dict(request.get('context_assembly') or {}),
+        }
+    else:
+        raise TypeError('request must be a TranslationRequest or mapping')
+    return canonical_json(payload)
+
+
+def plan_diff(left_requests, right_requests, *, left_label='sync', right_label='gemini_batch'):
+    """Compare normalized model-visible requests and return a readable report.
+
+    Transport and generation metadata are intentionally excluded.  Request
+    pairs are matched by position because stable request ids include the
+    execution strategy through ``plan_id`` while chunk order is shared.
+    """
+    left = list(left_requests or [])
+    right = list(right_requests or [])
+    entries = []
+    for index in range(max(len(left), len(right))):
+        left_request = left[index] if index < len(left) else None
+        right_request = right[index] if index < len(right) else None
+        left_text = (
+            canonical_semantic_request(left_request) if left_request is not None else ''
+        )
+        right_text = (
+            canonical_semantic_request(right_request) if right_request is not None else ''
+        )
+        if left_text == right_text:
+            continue
+        left_chunk = str(
+            getattr(left_request, 'chunk_id', '')
+            or ((left_request or {}).get('chunk_id') if isinstance(left_request, Mapping) else '')
+            or '<missing>'
+        )
+        right_chunk = str(
+            getattr(right_request, 'chunk_id', '')
+            or ((right_request or {}).get('chunk_id') if isinstance(right_request, Mapping) else '')
+            or '<missing>'
+        )
+        unified = '\n'.join(difflib.unified_diff(
+            json.dumps(json.loads(left_text), ensure_ascii=False, indent=2, sort_keys=True).splitlines(),
+            json.dumps(json.loads(right_text), ensure_ascii=False, indent=2, sort_keys=True).splitlines(),
+            fromfile=f'{left_label}:{left_chunk}',
+            tofile=f'{right_label}:{right_chunk}',
+            lineterm='',
+        ))
+        entries.append({
+            'index': index,
+            'left_chunk_id': left_chunk,
+            'right_chunk_id': right_chunk,
+            'unified_diff': unified,
+        })
+    return {
+        'equivalent': not entries,
+        'left_label': str(left_label),
+        'right_label': str(right_label),
+        'left_request_count': len(left),
+        'right_request_count': len(right),
+        'differences': entries,
+    }
+
+
+def format_plan_diff(report):
+    """Format :func:`plan_diff` output for logs, tests, and review artifacts."""
+    payload = dict(report or {})
+    if payload.get('equivalent'):
+        return (
+            'TranslationPlan semantic requests are equivalent '
+            f"({int(payload.get('left_request_count') or 0)} requests)."
+        )
+    lines = [
+        'TranslationPlan semantic request mismatch: '
+        f"{payload.get('left_label') or 'left'}="
+        f"{int(payload.get('left_request_count') or 0)}, "
+        f"{payload.get('right_label') or 'right'}="
+        f"{int(payload.get('right_request_count') or 0)}."
+    ]
+    for entry in payload.get('differences') or []:
+        lines.append(
+            f"request[{int(entry.get('index') or 0)}] "
+            f"{entry.get('left_chunk_id') or '<missing>'} <> "
+            f"{entry.get('right_chunk_id') or '<missing>'}"
+        )
+        if entry.get('unified_diff'):
+            lines.append(str(entry['unified_diff']))
+    return '\n'.join(lines)
+
+
+def validate_plan_fingerprint(payload):
+    """Validate a persisted plan fingerprint without rebuilding its prompts."""
+    if not isinstance(payload, Mapping):
+        raise ValueError('TranslationPlan must be an object.')
+    if int(payload.get('schema_version') or 0) != PLAN_SCHEMA_VERSION:
+        raise ValueError('Unsupported TranslationPlan schema version.')
+    fingerprint_payload = dict(payload)
+    recorded = str(fingerprint_payload.pop('plan_fingerprint', '') or '')
+    fingerprint_payload.pop('run_id', None)
+    expected = short_fingerprint(canonical_json(fingerprint_payload))
+    if not recorded or recorded != expected:
+        raise ValueError('TranslationPlan fingerprint is invalid or stale.')
+    return recorded
+
+
+def source_identity_differences(expected, actual):
+    """Return stable, non-sensitive source/adapter identity mismatch codes."""
+    expected = dict(expected or {})
+    actual = dict(actual or {})
+    differences = []
+    for field, code in (
+        ('engine', 'engine_changed'),
+        ('adapter_version', 'adapter_version_changed'),
+        ('project_identity_digest', 'project_identity_changed'),
+        ('source_snapshot_fingerprint', 'source_snapshot_changed'),
+        ('file_digests', 'source_file_digests_changed'),
+    ):
+        if canonical_json(expected.get(field) or ({} if field == 'file_digests' else '')) != canonical_json(
+            actual.get(field) or ({} if field == 'file_digests' else '')
+        ):
+            differences.append(code)
+    return differences
+
+
 def _canonical_term_sequence(terms):
     """Deterministic sequence for term iterables of any collection type.
 
@@ -201,6 +333,7 @@ class ContextPolicy:
     include_source_text: bool = translation_core.CANONICAL_INCLUDE_SOURCE_TEXT
     include_translation_memory: bool = True
     story_block_suffix: str = translation_core.CANONICAL_STORY_BLOCK_SUFFIX
+    total_char_limit: int = 0
 
     def to_dict(self):
         return {
@@ -212,6 +345,7 @@ class ContextPolicy:
             'include_source_text': bool(self.include_source_text),
             'include_translation_memory': bool(self.include_translation_memory),
             'story_block_suffix': self.story_block_suffix,
+            'total_char_limit': int(self.total_char_limit),
         }
 
 
@@ -570,6 +704,51 @@ def assemble_context_layers(chunk_input, context_policy=None):
             continue
         seen_texts.add(result.text)
         layers.append(result)
+    total_limit = max(0, int(policy.total_char_limit or 0))
+    if total_limit:
+        mandatory_used = sum(
+            layer.char_used
+            for layer in layers
+            if layer.layer in {
+                CONTEXT_LAYER_REQUIRED,
+                CONTEXT_LAYER_LOCAL,
+                CONTEXT_LAYER_PROJECT,
+            }
+        )
+        remaining = max(0, total_limit - mandatory_used)
+        for layer in layers:
+            if layer.layer not in {
+                CONTEXT_LAYER_RETRIEVAL,
+                CONTEXT_LAYER_ANALYSIS,
+            }:
+                continue
+            original_used = layer.char_used
+            if original_used <= remaining:
+                remaining -= original_used
+                continue
+            layer.text = layer.text[:remaining]
+            layer.char_used = len(layer.text)
+            layer.truncated = True
+            layer.diagnostics = {
+                **dict(layer.diagnostics or {}),
+                'aggregate_budget_reason': 'lower_priority_trimmed',
+                'aggregate_char_limit': total_limit,
+                'char_discarded': original_used - layer.char_used,
+            }
+            dropped.append({
+                'layer': layer.layer,
+                'rank': layer.rank,
+                'reason': 'aggregate_budget_exceeded',
+                'char_used': original_used - layer.char_used,
+            })
+            remaining = 0
+        if mandatory_used > total_limit:
+            dropped.append({
+                'layer': 'budget',
+                'rank': 0,
+                'reason': 'mandatory_layers_exceed_budget',
+                'char_used': mandatory_used - total_limit,
+            })
     return ContextAssembly(
         layers=layers,
         total_char_used=sum(layer.char_used for layer in layers),
@@ -723,6 +902,27 @@ class TranslationRequest:
             'chunk_id': self.chunk_id,
             'prompt_fingerprint': self.prompt_fingerprint,
             'request_fingerprint': self.request_fingerprint,
+            'capability_requirements': dict(self.capability_requirements or {}),
+            'context_diagnostics': {
+                'total_char_used': int(
+                    (self.context_assembly or {}).get('total_char_used') or 0
+                ),
+                'layers': [
+                    {
+                        'layer': str((layer or {}).get('layer') or ''),
+                        'rank': int((layer or {}).get('rank') or 0),
+                        'char_used': int((layer or {}).get('char_used') or 0),
+                        'char_limit': int((layer or {}).get('char_limit') or 0),
+                        'truncated': bool((layer or {}).get('truncated')),
+                        'diagnostics': dict((layer or {}).get('diagnostics') or {}),
+                    }
+                    for layer in (self.context_assembly or {}).get('layers') or []
+                ],
+                'dropped': [
+                    dict(item)
+                    for item in (self.context_assembly or {}).get('dropped') or []
+                ],
+            },
         }
 
 

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -4513,6 +4513,56 @@ def current_sync_source_identity():
     return _sync_plan_source_identity(snapshot).to_dict()
 
 
+def validate_sync_translation_plan_before_dispatch(plan_build):
+    """Reject ordinary Sync source/adapter/plan drift before provider use."""
+    if plan_build is None or plan_build.plan is None:
+        raise RuntimeError('Sync TranslationPlan is missing before model dispatch.')
+    plan_payload = plan_build.plan.to_dict()
+    translation_plan.validate_plan_fingerprint(plan_payload)
+    reasons = translation_plan.source_identity_differences(
+        plan_payload.get('source_identity') or {},
+        current_sync_source_identity(),
+    )
+    if reasons:
+        raise RuntimeError(
+            'Sync TranslationPlan is stale before model dispatch: '
+            + ', '.join(reasons)
+            + '. Regenerate the preview from the current project.'
+        )
+    summaries = list(plan_payload.get('request_summaries') or [])
+    requests = list(plan_build.requests or [])
+    if len(summaries) != len(requests):
+        raise RuntimeError(
+            'Sync TranslationPlan request summaries no longer match root requests.'
+        )
+    for index, (summary, request) in enumerate(zip(summaries, requests)):
+        semantic_fingerprint = translation_plan.short_fingerprint(
+            translation_plan.canonical_semantic_request(request)
+        )
+        request_fingerprint = translation_plan.short_fingerprint(
+            translation_plan.canonical_json(request.audit_payload())
+        )
+        if (
+            str(summary.get('request_id') or '') != request.request_id
+            or str(summary.get('prompt_fingerprint') or '')
+            != semantic_fingerprint
+            or request.prompt_fingerprint != semantic_fingerprint
+            or str(summary.get('request_fingerprint') or '')
+            != request_fingerprint
+            or request.request_fingerprint != request_fingerprint
+        ):
+            raise RuntimeError(
+                'Sync TranslationPlan request binding is stale before model '
+                f'dispatch: index={index}.'
+            )
+    return {
+        'source': 'fresh',
+        'adapter': 'fresh',
+        'plan': 'fresh',
+        'request_count': len(requests),
+    }
+
+
 def _render_sync_retrieval_reference_text(history_hits, story_hits):
     """Render the shared retrieval layer without the lexical glossary block."""
     blocks = []
@@ -6429,6 +6479,9 @@ def apply_sync_translation_preview(manifest_path, *, allow_durable=False):
         manifest = sync_translation_preview.load_sync_preview(manifest_path)
     except ValueError as exc:
         raise SystemExit(f"Sync apply blocked: {exc}") from exc
+    compatibility = manifest.get('_translation_plan_compatibility') or {}
+    if compatibility.get('mode') == 'legacy':
+        print(f"Warning: {compatibility.get('message')}", file=sys.stderr)
     if manifest.get('durable_check_binding') is not None and not allow_durable:
         raise SystemExit(
             'Sync apply blocked: Durable Sync previews must be applied with '
@@ -6616,6 +6669,15 @@ def run_translation(*, prepare=False):
             f'id={sync_plan_build.plan.plan_id}, '
             f'fingerprint={sync_plan_build.plan.plan_fingerprint}, '
             f'requests={len(sync_plan_build.requests)}'
+        )
+        sync_plan_dispatch_diagnostics = (
+            validate_sync_translation_plan_before_dispatch(sync_plan_build)
+        )
+        print(
+            'Sync TranslationPlan freshness: '
+            f"source={sync_plan_dispatch_diagnostics['source']}, "
+            f"adapter={sync_plan_dispatch_diagnostics['adapter']}, "
+            f"plan={sync_plan_dispatch_diagnostics['plan']}"
         )
         for document in source_documents:
             file_path = document.file_path

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -4536,11 +4536,8 @@ def validate_sync_translation_plan_before_dispatch(plan_build):
             'Sync TranslationPlan request summaries no longer match root requests.'
         )
     for index, (summary, request) in enumerate(zip(summaries, requests)):
-        semantic_fingerprint = translation_plan.short_fingerprint(
-            translation_plan.canonical_semantic_request(request)
-        )
-        request_fingerprint = translation_plan.short_fingerprint(
-            translation_plan.canonical_json(request.audit_payload())
+        semantic_fingerprint, request_fingerprint = (
+            translation_plan.recompute_request_fingerprints(request)
         )
         if (
             str(summary.get('request_id') or '') != request.request_id


### PR DESCRIPTION
## 摘要

- 为 Sync 与 Gemini Batch 增加规范化语义请求 golden 等价和可读 plan diff
- 落盘 TranslationPlan/request/context diagnostics，并同步 GUI 诊断文案与现行文档
- 在普通 Sync 模型调用前、Batch 提交/check/最终写回前校验 source、adapter、plan、request 与 hash freshness
- 保留旧 Batch 包和旧 Sync preview 的兼容路径，并提供明确 legacy 降级诊断
- 固化上下文裁剪优先级，验证关闭 RAG/Embedding 时本地 glossary 与 Macro 不丢失，诊断产物不包含凭据

## 安全合同

- 保留既有 check -> preview/apply 合同
- --force 不能绕过 stale check、source snapshot、adapter/version、plan/request/hash 或结构阻断
- 复用 PR #397 已合并的 durable Sync run-store 与 freshness/writeback 门禁

## 范围

本 PR 仅完成 issue #346 P4 正式收口；不实现 P5，不处理 #341、#348 或 #318，不新增用户配置表面。issue #346 仍保留 P5，因此本 PR 不使用自动关闭关键字。

## 验证

- 针对性核心回归：496 项通过；最终增量回归：64 项通过
- CLI：1672 项通过，1 项按预期跳过
- GUI：1175 项通过
- python scripts/run_quality_gates.py all
- git diff --check

Refs #346