### PR TITLE
test: complete #346 P5 provider parity

### DIFF
--- a/advanced_context.py
+++ b/advanced_context.py
@@ -17,6 +17,9 @@ import prompt_context
 from rag_memory import truncate_text
 import story_memory
 
+# Independent aggregate Source Index partition budget.
+DEFAULT_SOURCE_INDEX_CHAR_BUDGET = 880
+
 
 def compact_text(text: object) -> str:
     if not isinstance(text, str):
@@ -40,14 +43,7 @@ def compact_item_texts(items: Sequence[object] | None) -> list[str]:
 
 
 def embedding_provider_diagnostics(settings: object) -> dict[str, Any]:
-    """Return the credential-free identity of the active embedding provider.
-
-    Sync and Gemini Batch construct their runtime settings in different
-    modules, but the provider contract must be observable in the same shape.
-    Keeping this small adapter here prevents either executor from serializing
-    endpoints, API-key names, or other transport-only details into plan
-    diagnostics.
-    """
+    """Return credential-free identity facts for the active embedding provider."""
 
     public_dict = getattr(settings, 'public_dict', None)
     if not callable(public_dict):
@@ -328,11 +324,10 @@ def analysis_skip_diagnostics(project_context: Mapping[str, Any] | None) -> dict
 
     payload = dict(project_context or {})
     status = payload.get('status') if isinstance(payload.get('status'), Mapping) else {}
+    explicit_brief_status = payload.get('brief_status') or status.get('brief_status')
     brief_status = str(
-        payload.get('brief_status')
-        or status.get('brief_status')
+        explicit_brief_status
         or ('published' if payload.get('injectable') else '')
-        or 'missing'
     )
     reason = str(payload.get('reason') or '')
     if not payload.get('injectable') and not reason:
@@ -344,11 +339,19 @@ def analysis_skip_diagnostics(project_context: Mapping[str, Any] | None) -> dict
         if isinstance(brief_entry, Mapping):
             lineage = dict(brief_entry.get('lineage') or {})
     fingerprint = str(lineage.get('source_fingerprint') or payload.get('source_fingerprint') or '')
+    raw_injected_chars = payload.get('injected_chars')
+    if raw_injected_chars is None:
+        injected_chars = len(str(payload.get('text') or ''))
+    else:
+        try:
+            injected_chars = max(0, int(raw_injected_chars))
+        except (TypeError, ValueError):
+            injected_chars = len(str(payload.get('text') or ''))
     return {
         'injectable': bool(payload.get('injectable')),
         'reason': reason,
         'brief_status': brief_status,
         'source_fingerprint': fingerprint,
         'diagnostics': str(payload.get('diagnostics') or ''),
-        'injected_chars': len(str(payload.get('text') or '')),
+        'injected_chars': injected_chars,
     }

--- a/advanced_context.py
+++ b/advanced_context.py
@@ -39,6 +39,26 @@ def compact_item_texts(items: Sequence[object] | None) -> list[str]:
     return compacted
 
 
+def embedding_provider_diagnostics(settings: object) -> dict[str, Any]:
+    """Return the credential-free identity of the active embedding provider.
+
+    Sync and Gemini Batch construct their runtime settings in different
+    modules, but the provider contract must be observable in the same shape.
+    Keeping this small adapter here prevents either executor from serializing
+    endpoints, API-key names, or other transport-only details into plan
+    diagnostics.
+    """
+
+    public_dict = getattr(settings, 'public_dict', None)
+    if not callable(public_dict):
+        return {}
+    try:
+        payload = public_dict()
+    except Exception:
+        return {}
+    return dict(payload) if isinstance(payload, Mapping) else {}
+
+
 def build_source_only_query_text(target_items: Sequence[object] | None) -> str:
     """Build a TARGET-only query for Source Index retrieval."""
 
@@ -92,17 +112,43 @@ def shape_history_hits(matches: Sequence[Mapping[str, Any]] | None, char_limit: 
 def shape_source_hits(
     matches: Sequence[Mapping[str, Any]] | None,
     char_limit: int,
+    char_budget: int = 0,
 ) -> tuple[list[dict[str, Any]], int, int]:
+    """Shape source hits under both per-hit and aggregate text budgets.
+
+    ``char_limit`` protects each excerpt while ``char_budget`` protects the
+    complete Source Index partition for one request. A zero aggregate budget
+    preserves the historical per-hit-only behavior; positive budgets consume
+    ranked hits in order and truncate the final excerpt when necessary.
+    """
+
     hits = []
     truncated_count = 0
     source_context_chars = 0
-    for match in matches or []:
+    try:
+        remaining_budget = max(0, int(char_budget or 0))
+    except (TypeError, ValueError):
+        remaining_budget = 0
+    bounded = remaining_budget > 0
+    try:
+        per_hit_limit = int(char_limit or 0)
+    except (TypeError, ValueError):
+        per_hit_limit = 0
+    match_list = list(matches or [])
+    for match in match_list:
+        if bounded and remaining_budget <= 0:
+            break
         source_text = match.get('source_text', '')
-        truncated_source_text = truncate_text(source_text, char_limit)
+        effective_limit = per_hit_limit
+        if bounded:
+            effective_limit = min(effective_limit, remaining_budget) if effective_limit > 0 else remaining_budget
+        truncated_source_text = truncate_text(source_text, effective_limit)
         was_truncated = isinstance(source_text, str) and truncated_source_text != source_text
         if was_truncated:
             truncated_count += 1
         source_context_chars += len(truncated_source_text)
+        if bounded:
+            remaining_budget = max(0, remaining_budget - len(truncated_source_text))
         hits.append(
             {
                 'source_id': match.get('source_id', ''),
@@ -184,7 +230,7 @@ def retrieve_source_hits_compatible(
         'hit_count': 0,
         'truncated_count': 0,
         'source_context_chars': 0,
-        'source_context_char_budget': char_budget,
+        'source_context_char_budget': 0,
         'store_dir': getattr(store, 'store_dir', ''),
         'store_schema_version': (getattr(store, 'metadata', {}) or {}).get('schema_version'),
         'embedding_compatibility': compatibility,
@@ -194,14 +240,30 @@ def retrieve_source_hits_compatible(
             if key != 'embedding_compatibility'
         },
     }
+    try:
+        normalized_budget = max(0, int(char_budget or 0))
+    except (TypeError, ValueError):
+        normalized_budget = 0
+    stats['source_context_char_budget'] = normalized_budget
     if not compatibility.get('compatible'):
         stats['reason'] = 'rebuild_store'
         stats['action'] = compatibility.get('action') or 'rebuild_store'
         return [], stats
-    hits, truncated_count, source_context_chars = shape_source_hits(matches, char_limit)
+    hits, truncated_count, source_context_chars = shape_source_hits(
+        matches,
+        char_limit,
+        char_budget=char_budget,
+    )
     stats['hit_count'] = len(hits)
     stats['truncated_count'] = truncated_count
     stats['source_context_chars'] = source_context_chars
+    stats['source_context_budget_dropped_count'] = max(
+        0,
+        len(matches or []) - len(hits),
+    ) if normalized_budget else 0
+    stats['source_context_budget_exhausted'] = bool(
+        normalized_budget and source_context_chars >= normalized_budget
+    )
     stats['matched_count'] = diagnostics.get('matched_before_top_k', len(matches))
     stats['filtered_count'] = diagnostics.get('metadata_filtered_count', 0)
     stats['stale_hits_skipped'] = diagnostics.get('metadata_filtered_count', 0)
@@ -273,6 +335,8 @@ def analysis_skip_diagnostics(project_context: Mapping[str, Any] | None) -> dict
         or 'missing'
     )
     reason = str(payload.get('reason') or '')
+    if not payload.get('injectable') and not reason:
+        reason = 'injection_disabled'
     lineage = {}
     artifacts = status.get('artifacts') if isinstance(status, Mapping) else {}
     if isinstance(artifacts, Mapping):

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -325,6 +325,14 @@ Prompt 中 source index 命中会进入独立的 `RELATED PROJECT CONTEXT` 分�
 
 普通 Sync 使用同一 Source Index Store，不复制第二套索引格式。项目级开关 `sync_source_index_enabled`（配置键 `sync.source_index.enabled`）默认关闭；开启后为 TARGET 构建 source-only query，只注入与当前 embedding identity 完全兼容的命中，并使用独立的 top-k、相似度阈值、单条截断和总字符预算。没有 store、没有命中、检索失败或 identity 不兼容时降级为空命中，并在 prompt/manifest/doctor 中报告原因。
 
+P5 的 provider 诊断在 Sync preview 和 Batch manifest 中保持同一口径：每个 retrieval / analysis layer
+可带脱敏的 provider identity 与状态；plan 摘要汇总 `context_provider_downgrade_count`、
+`context_provider_status_counts` 和 `context_provider_downgrade_reasons`。Source Index 的总预算裁剪会
+额外记录 `source_context_budget_dropped_count` / `source_context_budget_exhausted`；Batch 的
+`source_index_summary` 和 `project_analysis_summary`、Sync 每个文件的 `prompt_context_batches`
+都会保留这些摘要，便于区分 disabled、missing、incompatible/rebuild、draft 和 stale，而不把凭据
+写入 plan 或 manifest。
+
 ## 结构化剧情记忆
 
 Structured Story Memory 是 glossary / translation-memory RAG 之外的可选上下文层。它不会调用额外 LLM 自动抽取图谱，也不依赖 Neo4j；启用后只读取本地 JSON，并把命中的结构化信息插入到 prompt 的 `STORY MEMORY` 分区。

--- a/docs/context_systems.md
+++ b/docs/context_systems.md
@@ -291,7 +291,7 @@ source_segments.jsonl
 3. 输出同步前统计信息。
 4. 默认自动 prune stale 记录；如需保留，可传入 `--no-prune`。
 
-Batch 构建时是否检索 source index 由 `batch.source_index.enabled` 控制。当前 source index 复用 `batch.rag` 中的 embedding 模型、query/document task type、output dimensionality 和 `segment_lines`；`batch.source_index` 自身控制检索开关、命中数、相似度阈值、单条原文截断预算和独立存储目录：
+Batch 构建时是否检索 source index 由 `batch.source_index.enabled` 控制。当前 source index 复用 `batch.rag` 中的 embedding 模型、query/document task type、output dimensionality 和 `segment_lines`；`batch.source_index` 自身控制检索开关、命中数、相似度阈值、单条原文截断预算和独立存储目录。总字符预算是独立的每 chunk 分区预算（默认 880，写入 manifest 的 `char_budget_per_chunk`），不由 `top_k × char_limit` 推导。
 
 ```json
 {

--- a/docs/plans/issue-346-implementation-plan.md
+++ b/docs/plans/issue-346-implementation-plan.md
@@ -1,11 +1,11 @@
 # #346 实施分步计划：Sync / Batch 共用 TranslationPlan、ContextAssembler 与请求合同
 
-状态：P0–P4 已实现并完成正式出口审计（2026-08-28）；P5 仍等待 #341 · D1–D7 已于 2026-08-22 冻结，见 [定稿评论](https://github.com/hu-border-collie/renpy-translation-lab/issues/346#issuecomment-5379565547) · 历史基线 `main@fa69d14`（2026-08-21）
+状态：P0–P5 已实现并完成正式出口审计（2026-08-30）；D1–D7 已于 2026-08-22 冻结，见 [定稿评论](https://github.com/hu-border-collie/renpy-translation-lab/issues/346#issuecomment-5379565547) · 历史基线 `main@fa69d14`（2026-08-21）
 关联 issue：<https://github.com/hu-border-collie/renpy-translation-lab/issues/346>
 
 ## 0. 结论
 
-#346 的 P0–P3 已由 #378/#380/#390/#394 合入；P4 在 #397 合并后的主干上重新审计并补齐普通 Sync/Batch freshness、规范化请求 diff、diagnostics/legacy/GUI/文档与回归测试。P5 与 #341 联动，仍不在本阶段范围内。
+#346 的 P0–P3 已由 #378/#380/#390/#394 合入；P4 在 #397 合并后的主干上重新审计并补齐普通 Sync/Batch freshness、规范化请求 diff、diagnostics/legacy/GUI/文档与回归测试；P5 在 #401 合入 #341 provider 后补齐了两条执行路径的等价请求、预算裁剪与降级诊断。
 
 | 阶段 | 内容 | 是否依赖 #341 |
 |---|---|---|
@@ -14,7 +14,7 @@
 | P2 | Gemini Batch 改为消费 TranslationPlan | 否 |
 | P3 | Sync 初译改为消费同一 TranslationPlan | 否 |
 | P4 | 诊断、黄金等价测试与 source snapshot 安全收口 | 否 |
-| P5 | Source Index / Published Project Analysis / Embedding provider 接入 | 是 |
+| P5 | Source Index / Published Project Analysis / Embedding provider 的等价合同、预算与降级诊断 | 是 |
 
 ## 1. 基线事实（main@`fa69d14`）
 
@@ -199,15 +199,15 @@ ContextLayer / ContextAssembly
 
 ## 8. P5：#341 联动
 
-#341 在 P1 冻结 provider 接口后即可并行开发，P4 完成后合并最终集成：
+#341 在 P1 冻结 provider 接口后并行完成生产接线，#346 P5 负责最终合同收口：
 
 1. #341 实现 `source_index` provider（复用现有 Source Index Store，不复制索引格式）；
 2. #341 实现 `published_project_analysis` provider（只注入 fresh/published brief，记录 identity）；
 3. #341 实现 provider-neutral Embedding 边界（model/task type/dimension 与 store 一致，否则拒绝混用）；
-4. #346 侧补充两条路径对这些 provider 的等价 golden case 与预算/降级诊断；
+4. #346 侧已补充两条路径对这些 provider 的等价 golden case，以及预算裁剪、disabled/missing/incompatible/rebuild/draft/stale 降级诊断；
 5. 用 #139 或真实项目 A/B 验证收益后再决定是否默认开启。
 
-#346 的最终验收项中涉及 Source Index / PA 的部分在此阶段关闭。
+#346 的最终验收项中涉及 Source Index / PA / Embedding 的部分已在 P5 关闭。
 
 ## 9. 阶段与 issue checkbox 映射
 
@@ -222,7 +222,8 @@ ContextLayer / ContextAssembly
 | Gemini Batch 构建器改为消费 TranslationPlan | P2 |
 | 同步初译入口改为消费同一 TranslationPlan | P3 |
 | plan 和每个 request 输出规范化 fingerprint/diagnostics | P1 / P4 |
-| golden tests：Sync 与 Batch 交给模型前规范化请求相同 | P4 |
+| golden tests：Sync 与 Batch 交给模型前规范化请求相同 | P4 / P5 |
+| Source Index / Published Project Analysis / Embedding provider 的预算与降级诊断 | P5 |
 | 与 #265 source snapshot/引擎适配标识对齐 | P2–P4 |
 
 ## 10. 门禁命令

--- a/embedding_runtime.py
+++ b/embedding_runtime.py
@@ -149,6 +149,8 @@ class EmbeddingRuntimeSettings:
             'adapter_backend': self.adapter_backend,
             'provider': identity.provider,
             'model': self.model,
+            'query_task_type': self.native_query_task_type,
+            'document_task_type': self.native_document_task_type,
             'output_dimension': self.output_dimension,
             'timeout_seconds': self.timeout_seconds,
             'fingerprint': identity.fingerprint,

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -862,6 +862,7 @@ def load_injectable_project_context_for_prompts(file_rel_path='', line_numbers=N
     base_dir = legacy.BASE_DIR or None
     current_fp = compute_current_project_analysis_fingerprint(base_dir, store_dir=store_dir)
     if not current_fp:
+        empty['reason'] = 'source_fingerprint_unavailable'
         return empty
     normalized_lines = []
     for raw_value in line_numbers or []:
@@ -910,6 +911,13 @@ def load_injectable_project_context_for_prompts(file_rel_path='', line_numbers=N
                 'local_diagnostics': '',
                 'injectable': bool(payload.get('injectable')),
                 'reason': str(payload.get('reason') or ''),
+                # Preserve the published artifact identity/status for the
+                # shared P5 diagnostics seam. The renderer ignores these
+                # fields; analysis_skip_diagnostics uses them to explain
+                # draft/stale/missing decisions exactly like Sync.
+                'status': dict(payload.get('status') or {}),
+                'brief_status': str(payload.get('brief_status') or ''),
+                'source_fingerprint': str(payload.get('source_fingerprint') or ''),
             },
             'label_records': label_records,
             'route_records': route_records,
@@ -2022,12 +2030,15 @@ def retrieve_source_hits(target_items, context_past):
     if not SOURCE_INDEX_ENABLED:
         return [], {'enabled': False}
 
-    query_text = build_rag_query_text(target_items, context_past)
+    settings = current_batch_embedding_settings()
+    embedding_provider = advanced_context.embedding_provider_diagnostics(settings)
+    query_text = advanced_context.build_source_only_query_text(target_items)
     if not query_text:
         return [], {
             'enabled': True,
             'reason': 'empty_query',
             'source_context_char_budget': get_source_index_char_budget(),
+            'embedding_provider': embedding_provider,
         }
 
     try:
@@ -2039,8 +2050,9 @@ def retrieve_source_hits(target_items, context_past):
                 'source_context_char_budget': get_source_index_char_budget(),
                 'store_dir': getattr(store, 'store_dir', SOURCE_INDEX_STORE_DIR or ''),
                 'store_schema_version': (getattr(store, 'metadata', {}) or {}).get('schema_version') if store else None,
+                'embedding_provider': embedding_provider,
             }
-        query_identity = current_batch_embedding_settings().query_identity()
+        query_identity = settings.query_identity()
         compatibility = embedding_runtime.store_compatibility_report(store, query_identity)
         if not compatibility.compatible:
             return [], {
@@ -2050,9 +2062,15 @@ def retrieve_source_hits(target_items, context_past):
                 'embedding_compatibility': compatibility.to_dict(),
                 'source_context_char_budget': get_source_index_char_budget(),
                 'store_dir': getattr(store, 'store_dir', SOURCE_INDEX_STORE_DIR or ''),
+                'store_schema_version': (
+                    (getattr(store, 'metadata', {}) or {}).get('schema_version')
+                    if store is not None
+                    else None
+                ),
+                'embedding_provider': embedding_provider,
             }
         query_vector = embed_query_text(query_text)
-        return advanced_context.retrieve_source_hits_compatible(
+        hits, stats = advanced_context.retrieve_source_hits_compatible(
             store,
             query_vector,
             query_identity,
@@ -2065,6 +2083,8 @@ def retrieve_source_hits(target_items, context_past):
             embedding_dim=RAG_OUTPUT_DIMENSIONALITY,
             char_budget=get_source_index_char_budget(),
         )
+        stats['embedding_provider'] = embedding_provider
+        return hits, stats
     except Exception as exc:
         diagnostics = embedding_runtime.public_error_diagnostics(exc)
         print(
@@ -2074,6 +2094,7 @@ def retrieve_source_hits(target_items, context_past):
         return [], {
             'enabled': True,
             'source_context_char_budget': get_source_index_char_budget(),
+            'embedding_provider': embedding_provider,
             **diagnostics,
         }
 
@@ -3020,6 +3041,18 @@ def copy_split_context_metadata(source_manifest, part_manifest, part_chunks):
     if source_manifest.get('source_index_enabled'):
         part_manifest['source_index_summary'] = summarize_batch_source_index(part_chunks)
 
+    for key in (
+        'project_analysis_enabled',
+        'project_analysis_inject_published_brief',
+        'project_analysis_settings',
+    ):
+        if key in source_manifest:
+            part_manifest[key] = source_manifest[key]
+    if source_manifest.get('project_analysis_enabled'):
+        part_manifest['project_analysis_summary'] = summarize_batch_project_analysis(
+            part_chunks
+        )
+
 
 def split_chunks_and_lines(chunks, request_lines, max_chunks=0, max_items=0):
     groups = []
@@ -3556,15 +3589,15 @@ def _build_retry_subchunk_plan_request(parent_chunk, subchunk):
     lexical_hits = retrieve_glossary_hits(target_items)
     context_past = list(subchunk.get('context_past') or [])
     context_future = list(subchunk.get('context_future') or [])
-    history_hits, _rag_stats = (
+    history_hits, rag_stats = (
         retrieve_history_hits(target_items, context_past)
         if RAG_ENABLED
         else ([], {'enabled': False})
     )
-    source_hits, _source_index_stats = (
+    source_hits, source_index_stats = (
         retrieve_source_hits(target_items, context_past)
         if SOURCE_INDEX_ENABLED
-        else ([], {})
+        else ([], {'enabled': False})
     )
     story_hits = (
         retrieve_batch_story_hits(
@@ -3582,6 +3615,15 @@ def _build_retry_subchunk_plan_request(parent_chunk, subchunk):
         [unit.display_line_number for unit in target_units],
     )
     analysis_text = _render_batch_analysis_reference_text(project_context)
+    retrieval_diagnostics = {
+        'source_index': dict(source_index_stats or {}),
+    }
+    if SOURCE_INDEX_ENABLED or RAG_ENABLED:
+        retrieval_diagnostics['embedding_provider'] = (
+            advanced_context.embedding_provider_diagnostics(
+                current_batch_embedding_settings()
+            )
+        )
     chunk_input = translation_plan.ChunkContextInput(
         file_rel_path=file_rel_path,
         target_items=target_items,
@@ -3595,6 +3637,12 @@ def _build_retry_subchunk_plan_request(parent_chunk, subchunk):
         lexical_glossary_hits=lexical_hits,
         retrieval_blocks_text=retrieval_text,
         analysis_blocks_text=analysis_text,
+        retrieval_diagnostics=retrieval_diagnostics,
+        analysis_diagnostics={
+            'published_project_analysis': advanced_context.analysis_skip_diagnostics(
+                project_context
+            ),
+        },
     )
     assembly = translation_plan.assemble_context_layers(chunk_input, _batch_plan_context_policy())
     reference_blocks_text = '\n\n'.join(
@@ -3700,7 +3748,9 @@ def _build_batch_translation_plan(file_jobs, routing_plan=None):
             )
             sys.stdout.flush()
         source_hits, source_index_stats = (
-            retrieve_source_hits(target_items, before) if SOURCE_INDEX_ENABLED else ([], {})
+            retrieve_source_hits(target_items, before)
+            if SOURCE_INDEX_ENABLED
+            else ([], {'enabled': False})
         )
         story_hits = (
             retrieve_batch_story_hits(
@@ -3733,20 +3783,54 @@ def _build_batch_translation_plan(file_jobs, routing_plan=None):
                 'project_analysis': advanced_context.analysis_skip_diagnostics(project_context),
             }
         )
-        return _render_batch_retrieval_reference_text(history_hits, story_hits, source_hits)
+        return {
+            'text': _render_batch_retrieval_reference_text(
+                history_hits,
+                story_hits,
+                source_hits,
+            ),
+            'diagnostics': {
+                'source_index': dict(source_index_stats or {}),
+                **(
+                    {
+                        'embedding_provider': advanced_context.embedding_provider_diagnostics(
+                            current_batch_embedding_settings()
+                        )
+                    }
+                    if (SOURCE_INDEX_ENABLED or RAG_ENABLED)
+                    else {}
+                ),
+            },
+        }
 
     def analysis_provider(chunk_input):
         for capture in captures:
             if capture.get('file_rel_path') == str(chunk_input.file_rel_path or '') and list(
                 capture.get('target_units') or []
             ) == list(chunk_input.target_units or []):
-                return _render_batch_analysis_reference_text(capture.get('project_context'))
+                return {
+                    'text': _render_batch_analysis_reference_text(
+                        capture.get('project_context')
+                    ),
+                    'diagnostics': {
+                        'published_project_analysis': advanced_context.analysis_skip_diagnostics(
+                            capture.get('project_context')
+                        ),
+                    },
+                }
         target_units = chunk_input.target_units
         project_context = load_injectable_project_context_for_prompts(
             str(chunk_input.file_rel_path or ''),
             [unit.display_line_number for unit in target_units],
         )
-        return _render_batch_analysis_reference_text(project_context)
+        return {
+            'text': _render_batch_analysis_reference_text(project_context),
+            'diagnostics': {
+                'published_project_analysis': advanced_context.analysis_skip_diagnostics(
+                    project_context
+                ),
+            },
+        }
 
     if routing_plan is None:
         model_profile_snapshot = None
@@ -3802,6 +3886,7 @@ def _build_batch_translation_plan(file_jobs, routing_plan=None):
             'rag_stats': capture.get('rag_stats', {}),
             'source_hits': capture.get('source_hits', []),
             'source_index_stats': capture.get('source_index_stats', {}),
+            'project_analysis': capture.get('project_analysis', {}),
             'items': [
                 translation_core.legacy_item_from_unit(unit, translation_core.MODE_TRANSLATION)
                 for unit in capture.get('target_units', [])
@@ -3887,9 +3972,44 @@ def summarize_batch_source_index(chunks):
         'source_context_truncation_count': sum(int(stats.get('truncated_count') or 0) for stats in stats_list),
         'source_context_char_count': sum(int(stats.get('source_context_chars') or 0) for stats in stats_list),
         'source_context_char_budget': sum(int(stats.get('source_context_char_budget') or 0) for stats in stats_list),
+        'source_context_budget_dropped_count': sum(
+            int(stats.get('source_context_budget_dropped_count') or 0)
+            for stats in stats_list
+        ),
+        'source_context_budget_exhausted_count': sum(
+            1 for stats in stats_list if stats.get('source_context_budget_exhausted')
+        ),
         'source_filtered_count': sum(int(stats.get('filtered_count') or 0) for stats in stats_list),
         'stale_hits_skipped': sum(int(stats.get('stale_hits_skipped') or 0) for stats in stats_list),
         'below_similarity_count': sum(int(stats.get('below_similarity_count') or 0) for stats in stats_list),
+    }
+
+
+def summarize_batch_project_analysis(chunks):
+    """Aggregate Published Project Analysis injection/skip diagnostics."""
+
+    chunk_count = len(chunks)
+    payloads = [chunk.get('project_analysis') or {} for chunk in chunks]
+    injectable_count = sum(1 for payload in payloads if payload.get('injectable'))
+    reasons = {}
+    brief_statuses = {}
+    for payload in payloads:
+        reason = str(payload.get('reason') or '')
+        if reason:
+            reasons[reason] = reasons.get(reason, 0) + 1
+        status = str(payload.get('brief_status') or '')
+        if status:
+            brief_statuses[status] = brief_statuses.get(status, 0) + 1
+    return {
+        'enabled': bool(PROJECT_ANALYSIS_ENABLED),
+        'inject_published_brief': bool(PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF),
+        'chunks': chunk_count,
+        'injectable_chunks': injectable_count,
+        'injected_char_count': sum(
+            int(payload.get('injected_chars') or 0) for payload in payloads
+        ),
+        'skip_reasons': reasons,
+        'brief_statuses': brief_statuses,
     }
 
 
@@ -4075,6 +4195,18 @@ def create_batch_package(display_name_override='', skip_prepare=False):
             'char_budget_per_chunk': get_source_index_char_budget(),
         } if SOURCE_INDEX_ENABLED else {},
         'source_index_summary': summarize_batch_source_index(chunks) if SOURCE_INDEX_ENABLED else {},
+        'project_analysis_enabled': PROJECT_ANALYSIS_ENABLED,
+        'project_analysis_inject_published_brief': PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF,
+        'project_analysis_settings': {
+            'max_brief_chars': PROJECT_ANALYSIS_MAX_BRIEF_CHARS,
+            'max_label_summary_chars': PROJECT_ANALYSIS_MAX_LABEL_SUMMARY_CHARS,
+            'max_route_summary_chars': PROJECT_ANALYSIS_MAX_ROUTE_SUMMARY_CHARS,
+        } if PROJECT_ANALYSIS_ENABLED else {},
+        'project_analysis_summary': (
+            summarize_batch_project_analysis(chunks)
+            if PROJECT_ANALYSIS_ENABLED
+            else {}
+        ),
         'story_memory_enabled': STORY_MEMORY_ENABLED,
         'story_memory_graph_file': STORY_MEMORY_GRAPH_FILE if STORY_MEMORY_ENABLED else '',
         'story_memory_settings': {

--- a/gemini_translate_batch.py
+++ b/gemini_translate_batch.py
@@ -335,6 +335,7 @@ SOURCE_INDEX_SCHEMA_VERSION = 1
 SOURCE_INDEX_TOP_K = 4
 SOURCE_INDEX_MIN_SIMILARITY = 0.72
 SOURCE_INDEX_CHAR_LIMIT = 220
+SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
 
 STORY_MEMORY_ENABLED = False
 STORY_MEMORY_GRAPH_FILE = ''
@@ -496,6 +497,7 @@ def load_batch_settings(*, tolerate_routing_errors=False):
     global RAG_BOOTSTRAP_ON_BUILD, RAG_HISTORY_CHAR_LIMIT, _RAG_STORE
     global SOURCE_INDEX_ENABLED, SOURCE_INDEX_STORE_DIR, _SOURCE_INDEX_STORE
     global SOURCE_INDEX_TOP_K, SOURCE_INDEX_MIN_SIMILARITY, SOURCE_INDEX_CHAR_LIMIT
+    global SOURCE_INDEX_CHAR_BUDGET
     global STORY_MEMORY_ENABLED, STORY_MEMORY_GRAPH_FILE, STORY_MEMORY_MAX_CONTEXT_CHARS
     global STORY_MEMORY_TOP_K_RELATIONS, STORY_MEMORY_TOP_K_TERMS
     global STORY_MEMORY_INCLUDE_SCENE_SUMMARY, _STORY_GRAPH, _STORY_GRAPH_PATH
@@ -710,6 +712,7 @@ def load_batch_settings(*, tolerate_routing_errors=False):
     SOURCE_INDEX_TOP_K = coerce_positive_int(source_index_config.get('top_k'), SOURCE_INDEX_TOP_K)
     SOURCE_INDEX_MIN_SIMILARITY = coerce_float(source_index_config.get('min_similarity'), SOURCE_INDEX_MIN_SIMILARITY)
     SOURCE_INDEX_CHAR_LIMIT = coerce_positive_int(source_index_config.get('char_limit'), SOURCE_INDEX_CHAR_LIMIT)
+    SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
     source_index_store_dir = source_index_config.get('store_dir')
     if source_index_store_dir:
         SOURCE_INDEX_STORE_DIR = legacy._resolve_path(legacy.BASE_DIR, source_index_store_dir)
@@ -911,10 +914,7 @@ def load_injectable_project_context_for_prompts(file_rel_path='', line_numbers=N
                 'local_diagnostics': '',
                 'injectable': bool(payload.get('injectable')),
                 'reason': str(payload.get('reason') or ''),
-                # Preserve the published artifact identity/status for the
-                # shared P5 diagnostics seam. The renderer ignores these
-                # fields; analysis_skip_diagnostics uses them to explain
-                # draft/stale/missing decisions exactly like Sync.
+                # Keep status and lineage for diagnostics without rendering them.
                 'status': dict(payload.get('status') or {}),
                 'brief_status': str(payload.get('brief_status') or ''),
                 'source_fingerprint': str(payload.get('source_fingerprint') or ''),
@@ -1113,7 +1113,7 @@ def get_default_source_index_store_dir():
 
 
 def get_source_index_char_budget():
-    return max(0, int(SOURCE_INDEX_TOP_K or 0)) * max(0, int(SOURCE_INDEX_CHAR_LIMIT or 0))
+    return max(0, int(SOURCE_INDEX_CHAR_BUDGET or 0))
 
 
 def current_batch_embedding_settings():
@@ -3948,6 +3948,9 @@ def summarize_batch_source_index(chunks):
     failure_reasons = {}
     for stats in stats_list:
         reason = stats.get('failure_reason') or stats.get('reason')
+        compatibility = stats.get('embedding_compatibility')
+        if isinstance(compatibility, dict) and compatibility.get('compatible') is False:
+            reason = 'incompatible'
         if reason:
             failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
     store_schema_versions = sorted(
@@ -3989,7 +3992,14 @@ def summarize_batch_project_analysis(chunks):
     """Aggregate Published Project Analysis injection/skip diagnostics."""
 
     chunk_count = len(chunks)
-    payloads = [chunk.get('project_analysis') or {} for chunk in chunks]
+    payloads = []
+    for chunk in chunks:
+        payload = chunk.get('project_analysis') or {}
+        payloads.append(
+            advanced_context.analysis_skip_diagnostics(payload)
+            if payload
+            else {}
+        )
     injectable_count = sum(1 for payload in payloads if payload.get('injectable'))
     reasons = {}
     brief_statuses = {}

--- a/gui_qt/diagnostics_context.py
+++ b/gui_qt/diagnostics_context.py
@@ -1061,6 +1061,17 @@ def format_translation_plan_facts(manifest: dict[str, object]) -> list[str]:
         facts.append(f'{TRANSLATION_PLAN_COPY["context_truncated"]}：{truncated}')
     if dropped:
         facts.append(f'{TRANSLATION_PLAN_COPY["context_dropped"]}：{dropped}')
+    provider_downgrades = int(
+        diagnostics.get(
+            "context_provider_downgrade_count",
+            derived_diagnostics["context_provider_downgrade_count"],
+        )
+    )
+    if provider_downgrades:
+        facts.append(
+            f'{TRANSLATION_PLAN_COPY["context_provider_downgrade"]}：'
+            f'{provider_downgrades}'
+        )
     return facts
 
 

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -103,7 +103,7 @@ TRANSLATION_PLAN_COPY = {
     "requests": "规范化请求数",
     "context_truncated": "上下文裁剪请求数",
     "context_dropped": "上下文舍弃记录数",
-    "context_provider_downgrade": "上下文 provider 降级数",
+    "context_provider_downgrade": "上下文供给降级数",
 }
 
 CONTEXT_LIBRARY_COPY = {

--- a/gui_qt/user_copy.py
+++ b/gui_qt/user_copy.py
@@ -103,6 +103,7 @@ TRANSLATION_PLAN_COPY = {
     "requests": "规范化请求数",
     "context_truncated": "上下文裁剪请求数",
     "context_dropped": "上下文舍弃记录数",
+    "context_provider_downgrade": "上下文 provider 降级数",
 }
 
 CONTEXT_LIBRARY_COPY = {

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -83,11 +83,13 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
                 "request_count": 1,
                 "context_truncated_requests": 1,
                 "context_dropped_entries": 2,
+                "context_provider_downgrade_count": 1,
             },
         })
         self.assertTrue(any("fp-1" in fact for fact in current))
         self.assertTrue(any("规范化请求数：1" in fact for fact in current))
         self.assertTrue(any("上下文裁剪请求数：1" in fact for fact in current))
+        self.assertTrue(any("上下文 provider 降级数：1" in fact for fact in current))
         legacy = format_translation_plan_facts({})
         self.assertTrue(any("旧版兼容模式" in fact for fact in legacy))
 

--- a/tests/test_gui_diagnostics_context.py
+++ b/tests/test_gui_diagnostics_context.py
@@ -89,7 +89,7 @@ class GuiDiagnosticsContextTests(unittest.TestCase):
         self.assertTrue(any("fp-1" in fact for fact in current))
         self.assertTrue(any("规范化请求数：1" in fact for fact in current))
         self.assertTrue(any("上下文裁剪请求数：1" in fact for fact in current))
-        self.assertTrue(any("上下文 provider 降级数：1" in fact for fact in current))
+        self.assertTrue(any("上下文供给降级数：1" in fact for fact in current))
         legacy = format_translation_plan_facts({})
         self.assertTrue(any("旧版兼容模式" in fact for fact in legacy))
 

--- a/tests/test_issue_346_p5.py
+++ b/tests/test_issue_346_p5.py
@@ -1,0 +1,500 @@
+# -*- coding: utf-8 -*-
+"""Issue #346 P5 golden contracts for #341 context providers."""
+
+import hashlib
+import types
+import unittest
+from contextlib import ExitStack
+from unittest import mock
+
+import advanced_context
+import gemini_translate_batch as batch_mod
+import model_profile
+import translation_plan
+import translator_runtime as runtime
+from embedding_runtime import parse_embedding_runtime_settings
+from engine_adapters.contracts import SourceDocument
+
+
+def _fixture_jobs():
+    content = b'label start:\n    e "Hello tonight."\n    "Keep [Name!t]."\n'
+    document = SourceDocument(
+        file_rel_path='script.rpy',
+        file_path='C:/fixture/script.rpy',
+        size=len(content),
+        sha256=hashlib.sha256(content).hexdigest(),
+        content=content,
+    )
+    project = types.SimpleNamespace(
+        engine='renpy',
+        adapter_version='fixture-adapter',
+        project_snapshot_fingerprint='fixture-project',
+        source_documents=(document,),
+    )
+    snapshot = types.SimpleNamespace(project=project)
+    jobs = [{
+        'file_rel_path': 'script.rpy',
+        'file_path': document.file_path,
+        'tasks': [
+            {
+                'id': 'script:1:4',
+                'text': 'Hello tonight.',
+                'line': 1,
+                'speaker_id': 'e',
+                'speaker_name': 'Eileen',
+                'block_name': 'start',
+            },
+            {
+                'id': 'script:2:4',
+                'text': 'Keep [Name!t].',
+                'line': 2,
+                'block_name': 'start',
+            },
+        ],
+    }]
+    return jobs, snapshot, document
+
+
+def _published_context():
+    return {
+        'text': 'Published project brief for the current story.',
+        'injectable': True,
+        'reason': '',
+        'brief_status': 'published',
+        'source_fingerprint': 'fixture-source-fingerprint',
+        'diagnostics': 'status=published fingerprint=fixture-source-fingerprint',
+        'labels': [{'label_id': 'tone', 'summary': 'Keep the dialogue warm.'}],
+        'routes': [{'route_id': 'start', 'summary': 'Opening scene route.'}],
+        'local_diagnostics': 'selected=1',
+    }
+
+
+class P5ProductionGoldenTests(unittest.TestCase):
+    def test_sync_and_batch_source_pa_embedding_requests_are_equivalent(self):
+        jobs, snapshot, _document = _fixture_jobs()
+        batch_jobs = batch_mod.TranslationFileJobs(
+            jobs,
+            adapter_snapshot=snapshot,
+        )
+        routing = model_profile.resolve_routing_plan_from_runtime(
+            sync_backend='gemini',
+            sync_model='gemini-2.5-flash',
+            sync_models=('gemini-2.5-flash',),
+        )
+        source_hits = [{
+            'source_id': 'source-1',
+            'file_rel_path': 'other/script.rpy',
+            'line_start': 10,
+            'line_end': 11,
+            'source_text': 'A related source excerpt.',
+            'score': 0.93,
+        }]
+        source_stats = {
+            'enabled': True,
+            'hit_count': 1,
+            'matched_count': 1,
+            'filtered_count': 0,
+            'stale_hits_skipped': 0,
+            'below_similarity_count': 0,
+            'truncated_count': 0,
+            'source_context_chars': len(source_hits[0]['source_text']),
+            'source_context_char_budget': 80,
+        }
+        project_context = _published_context()
+        glossary = {'Hello': '你好'}
+        preserve = ['[Name!t]']
+        non_translatable = {'Eileen'}
+
+        patches = (
+            mock.patch.object(runtime, 'MAX_ITEMS', 60),
+            mock.patch.object(runtime, 'MAX_CHARS', 18000),
+            mock.patch.object(runtime, 'SYNC_CONTEXT_BEFORE', 30),
+            mock.patch.object(runtime, 'SYNC_CONTEXT_AFTER', 10),
+            mock.patch.object(runtime, 'SYNC_RAG_ENABLED', False),
+            mock.patch.object(runtime, 'SYNC_RAG_HISTORY_CHAR_LIMIT', 220),
+            mock.patch.object(runtime, 'SYNC_STORY_MEMORY_ENABLED', False),
+            mock.patch.object(runtime, 'SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS', 1200),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_TOP_K', 2),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_MIN_SIMILARITY', 0.7),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_LIMIT', 40),
+            mock.patch.object(runtime, 'SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF', True),
+            mock.patch.object(runtime, 'SYNC_MACRO_SETTING', 'Use a warm stage tone.'),
+            mock.patch.object(runtime, 'NORMALIZE_TRANSLATION_MAP', glossary),
+            mock.patch.object(runtime, 'PRESERVE_TERMS', preserve),
+            mock.patch.object(runtime, 'NON_TRANSLATABLE_EXACT', non_translatable),
+            mock.patch.object(batch_mod, 'BATCH_TARGET_SIZE', 60),
+            mock.patch.object(batch_mod, 'BATCH_TARGET_CHARS', 18000),
+            mock.patch.object(batch_mod, 'BATCH_CONTEXT_BEFORE', 30),
+            mock.patch.object(batch_mod, 'BATCH_CONTEXT_AFTER', 10),
+            mock.patch.object(batch_mod, 'RAG_ENABLED', False),
+            mock.patch.object(batch_mod, 'RAG_HISTORY_CHAR_LIMIT', 220),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_TOP_K', 2),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_MIN_SIMILARITY', 0.7),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_LIMIT', 40),
+            mock.patch.object(batch_mod, 'STORY_MEMORY_ENABLED', False),
+            mock.patch.object(batch_mod, 'STORY_MEMORY_MAX_CONTEXT_CHARS', 1200),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_ENABLED', True),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF', True),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_MAX_BRIEF_CHARS', 4000),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_MAX_LABEL_SUMMARY_CHARS', 800),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_MAX_ROUTE_SUMMARY_CHARS', 1200),
+            mock.patch.object(batch_mod, 'BATCH_MACRO_SETTING', 'Use a warm stage tone.'),
+            mock.patch.object(batch_mod.legacy, 'NORMALIZE_TRANSLATION_MAP', glossary),
+            mock.patch.object(batch_mod.legacy, 'PRESERVE_TERMS', preserve),
+            mock.patch.object(batch_mod.legacy, 'NON_TRANSLATABLE_EXACT', non_translatable),
+            mock.patch.object(runtime, 'retrieve_sync_source_hits', return_value=(source_hits, source_stats)),
+            mock.patch.object(runtime, 'load_sync_injectable_project_context', return_value=project_context),
+            mock.patch.object(batch_mod, 'retrieve_source_hits', return_value=(source_hits, source_stats)),
+            mock.patch.object(batch_mod, 'load_injectable_project_context_for_prompts', return_value=project_context),
+        )
+        with ExitStack() as stack:
+            for patcher in patches:
+                stack.enter_context(patcher)
+            sync_build, _sync_captures = runtime.build_sync_translation_plan(
+                jobs,
+                snapshot,
+                routing,
+                run_id='p5-sync',
+            )
+            batch_build = batch_mod._build_batch_translation_plan(
+                batch_jobs,
+                routing_plan=routing,
+            )['plan_build']
+
+        self.assertTrue(
+            translation_plan.plan_diff(
+                sync_build.requests,
+                batch_build.requests,
+            )['equivalent']
+        )
+        sync_request = sync_build.requests[0]
+        batch_request = batch_build.requests[0]
+        self.assertEqual(
+            translation_plan.canonical_semantic_request(sync_request),
+            translation_plan.canonical_semantic_request(batch_request),
+        )
+        self.assertEqual(sync_request.prompt_fingerprint, batch_request.prompt_fingerprint)
+        self.assertEqual(sync_request.context_assembly, batch_request.context_assembly)
+        self.assertIn('RELATED PROJECT CONTEXT:', sync_request.user_prompt)
+        self.assertIn('PROJECT BRIEF:', sync_request.user_prompt)
+        self.assertIn('Published project brief', sync_request.user_prompt)
+        diagnostics = translation_plan.summarize_request_diagnostics(
+            sync_build.plan.request_summaries
+        )
+        self.assertEqual(diagnostics['context_provider_diagnostic_requests'], 1)
+        self.assertEqual(diagnostics['context_provider_downgrade_count'], 0)
+        self.assertIn('source_index:available', diagnostics['context_provider_status_counts'])
+        self.assertIn(
+            'published_project_analysis:available',
+            diagnostics['context_provider_status_counts'],
+        )
+        self.assertIn(
+            'query_task_type',
+            runtime.current_sync_embedding_settings().public_dict(),
+        )
+
+
+class P5ProviderDiagnosticGoldenTests(unittest.TestCase):
+    def _build(self, strategy, source_diagnostic, analysis_diagnostic):
+        jobs, _snapshot, _document = _fixture_jobs()
+        settings = parse_embedding_runtime_settings({
+            'embedding_model': 'gemini-embedding-001',
+            'output_dimensionality': 768,
+        })
+        source_text = (
+            'RELATED PROJECT CONTEXT:\n- related source'
+            if source_diagnostic.get('enabled') is not False
+            and not source_diagnostic.get('reason')
+            else ''
+        )
+        analysis_text = (
+            'PROJECT BRIEF:\nPublished brief'
+            if analysis_diagnostic.get('injectable')
+            else ''
+        )
+        return translation_plan.build_translation_plan(
+            jobs,
+            execution_strategy=strategy,
+            source_identity=translation_plan.SourceIdentity(
+                engine='renpy',
+                adapter_version='fixture',
+                project_identity_digest='project',
+                source_snapshot_fingerprint='source',
+            ),
+            config_snapshot={'fixture': True},
+            model_profile_snapshot={'model': 'fixture'},
+            chunk_policy=translation_plan.ChunkPolicy(60, 18000),
+            context_policy=translation_plan.ContextPolicy(
+                local_context_before=30,
+                local_context_after=10,
+                history_char_limit=220,
+                story_char_limit=1200,
+                source_index_char_limit=80,
+                analysis_char_limit=6000,
+            ),
+            preserve_terms=['[Name!t]'],
+            normalize_map={'Hello': '你好'},
+            non_translatable_exact={'Eileen'},
+            macro_setting='Use a warm stage tone.',
+            retrieval_blocks_provider=lambda _chunk: {
+                'text': source_text,
+                'diagnostics': {
+                    'source_index': source_diagnostic,
+                    'embedding_provider': settings.public_dict(),
+                },
+            },
+            analysis_blocks_provider=lambda _chunk: {
+                'text': analysis_text,
+                'diagnostics': {
+                    'published_project_analysis': analysis_diagnostic,
+                },
+            },
+        )
+
+    def test_all_disabled_missing_incompatible_rebuild_draft_stale_cases_match(self):
+        source_cases = (
+            ('disabled', {'enabled': False}),
+            ('missing', {'enabled': True, 'reason': 'empty_source_store'}),
+            ('incompatible', {
+                'enabled': True,
+                'reason': 'rebuild_store',
+                'action': 'rebuild_store',
+                'embedding_compatibility': {
+                    'compatible': False,
+                    'action': 'rebuild_store',
+                    'codes': ['model_mismatch'],
+                },
+            }),
+            ('rebuild', {
+                'enabled': True,
+                'reason': 'rebuild_store',
+                'action': 'rebuild_store',
+            }),
+        )
+        analysis_cases = (
+            ('disabled', {'injectable': False, 'reason': 'injection_disabled'}),
+            ('missing', {
+                'injectable': False,
+                'reason': 'brief_not_published:missing',
+                'brief_status': 'missing',
+            }),
+            ('draft', {
+                'injectable': False,
+                'reason': 'brief_not_published:draft',
+                'brief_status': 'draft',
+            }),
+            ('stale', {
+                'injectable': False,
+                'reason': 'brief_not_fresh:stale',
+                'brief_status': 'stale',
+            }),
+        )
+        for source_name, source_diagnostic in source_cases:
+            for analysis_name, analysis_diagnostic in analysis_cases:
+                with self.subTest(source=source_name, analysis=analysis_name):
+                    sync = self._build(
+                        model_profile.ExecutionStrategy.SYNC.value,
+                        source_diagnostic,
+                        analysis_diagnostic,
+                    )
+                    batch = self._build(
+                        model_profile.ExecutionStrategy.GEMINI_BATCH.value,
+                        source_diagnostic,
+                        analysis_diagnostic,
+                    )
+                    report = translation_plan.plan_diff(sync.requests, batch.requests)
+                    self.assertTrue(report['equivalent'], translation_plan.format_plan_diff(report))
+                    self.assertEqual(
+                        sync.requests[0].context_assembly,
+                        batch.requests[0].context_assembly,
+                    )
+                    summary = translation_plan.summarize_request_diagnostics(
+                        sync.plan.request_summaries
+                    )
+                    self.assertGreaterEqual(summary['context_provider_downgrade_count'], 2)
+                    self.assertIn(
+                        f'source_index:{source_diagnostic.get("reason", "disabled") if source_diagnostic.get("enabled") is not False else "disabled"}',
+                        summary['context_provider_downgrade_reasons'],
+                    )
+                    self.assertIn(
+                        f'published_project_analysis:{analysis_diagnostic["reason"]}',
+                        summary['context_provider_downgrade_reasons'],
+                    )
+
+    def test_batch_project_analysis_keeps_published_identity_for_diagnostics(self):
+        payload = {
+            'text': '',
+            'injectable': False,
+            'reason': 'brief_not_fresh:stale',
+            'status': {
+                'brief_status': 'stale',
+                'artifacts': {
+                    'project_brief': {
+                        'lineage': {'source_fingerprint': 'old-source-fingerprint'},
+                    },
+                },
+            },
+            'diagnostics': '',
+        }
+        with (
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_ENABLED', True),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF', True),
+            mock.patch.object(batch_mod, '_PROJECT_BRIEF_CACHE', None),
+            mock.patch.object(batch_mod, '_PROJECT_BRIEF_CACHE_KEY', None),
+            mock.patch.object(
+                batch_mod,
+                'compute_current_project_analysis_fingerprint',
+                return_value='current-source-fingerprint',
+            ),
+            mock.patch(
+                'project_analysis.load_injectable_project_context',
+                return_value=payload,
+            ),
+        ):
+            result = batch_mod.load_injectable_project_context_for_prompts(
+                'script.rpy', [2]
+            )
+
+        diagnostics = advanced_context.analysis_skip_diagnostics(result)
+        self.assertEqual(diagnostics['brief_status'], 'stale')
+        self.assertEqual(diagnostics['source_fingerprint'], 'old-source-fingerprint')
+        self.assertEqual(diagnostics['reason'], 'brief_not_fresh:stale')
+
+
+class P5BudgetAndEmbeddingTests(unittest.TestCase):
+    def test_source_index_aggregate_budget_crops_ranked_hits(self):
+        matches = [
+            {'source_id': 'one', 'source_text': 'abcdefghij', 'score': 0.9},
+            {'source_id': 'two', 'source_text': 'klmnopqrst', 'score': 0.8},
+            {'source_id': 'three', 'source_text': 'uvwxyz', 'score': 0.7},
+        ]
+        hits, truncated_count, source_chars = advanced_context.shape_source_hits(
+            matches,
+            char_limit=8,
+            char_budget=10,
+        )
+        self.assertEqual([hit['source_text'] for hit in hits], ['abcde...', 'kl'])
+        self.assertEqual(source_chars, 10)
+        self.assertEqual(truncated_count, 2)
+
+        class Store:
+            store_dir = 'fixture-source-index'
+            metadata = {'schema_version': 1}
+
+            def count_segments(self):
+                return len(matches)
+
+            def search_segments_compatible(self, *_args, **_kwargs):
+                return matches, {
+                    'embedding_compatibility': {'compatible': True},
+                    'matched_before_top_k': len(matches),
+                }
+
+        shaped, stats = advanced_context.retrieve_source_hits_compatible(
+            Store(),
+            [1.0],
+            object(),
+            top_k=3,
+            min_similarity=0.0,
+            char_limit=8,
+            char_budget=10,
+            query_text='Target:\n- query',
+        )
+        self.assertEqual(len(shaped), 2)
+        self.assertEqual(stats['source_context_chars'], 10)
+        self.assertEqual(stats['source_context_budget_dropped_count'], 1)
+        self.assertTrue(stats['source_context_budget_exhausted'])
+
+    def test_sync_and_batch_source_queries_use_same_embedding_contract(self):
+        settings = parse_embedding_runtime_settings({
+            'embedding_model': 'gemini-embedding-001',
+            'output_dimensionality': 2,
+        })
+        calls = {'sync': [], 'batch': []}
+        matches = [{
+            'source_id': 'source-1',
+            'file_rel_path': 'script.rpy',
+            'line_start': 1,
+            'line_end': 1,
+            'source_text': 'Related excerpt',
+            'score': 0.95,
+        }]
+
+        class Compatibility:
+            compatible = True
+            action = ''
+
+            def to_dict(self):
+                return {'compatible': True, 'action': '', 'codes': []}
+
+        class Store:
+            store_dir = 'fixture-source-index'
+            metadata = {'schema_version': 1}
+
+            def count_segments(self):
+                return 1
+
+            def embedding_compatibility(self, _identity):
+                return Compatibility()
+
+            def search_segments_compatible(self, *_args, **_kwargs):
+                return matches, {
+                    'embedding_compatibility': {'compatible': True},
+                    'matched_before_top_k': 1,
+                    'returned_count': 1,
+                }
+
+        store = Store()
+        patches = (
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_TOP_K', 1),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_LIMIT', 80),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_MIN_SIMILARITY', 0.0),
+            mock.patch.object(runtime, 'SYNC_RAG_OUTPUT_DIMENSIONALITY', 2),
+            mock.patch.object(runtime, 'SYNC_RAG_EMBEDDING_MODEL', settings.model),
+            mock.patch.object(runtime, 'SYNC_RAG_DOCUMENT_TASK_TYPE', settings.native_document_task_type),
+            mock.patch.object(runtime, 'current_sync_embedding_settings', return_value=settings),
+            mock.patch.object(runtime, 'get_sync_source_index_store', return_value=store),
+            mock.patch.object(
+                runtime,
+                'embed_sync_query_text',
+                side_effect=lambda text: calls['sync'].append(text) or [1.0, 0.0],
+            ),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_TOP_K', 1),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_LIMIT', 80),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_MIN_SIMILARITY', 0.0),
+            mock.patch.object(batch_mod, 'RAG_OUTPUT_DIMENSIONALITY', 2),
+            mock.patch.object(batch_mod, 'RAG_EMBEDDING_MODEL', settings.model),
+            mock.patch.object(batch_mod, 'RAG_DOCUMENT_TASK_TYPE', settings.native_document_task_type),
+            mock.patch.object(batch_mod, 'current_batch_embedding_settings', return_value=settings),
+            mock.patch.object(batch_mod, 'get_source_index_store', return_value=store),
+            mock.patch.object(
+                batch_mod,
+                'embed_query_text',
+                side_effect=lambda text: calls['batch'].append(text) or [1.0, 0.0],
+            ),
+        )
+        with ExitStack() as stack:
+            for patcher in patches:
+                stack.enter_context(patcher)
+            sync_hits, sync_stats = runtime.retrieve_sync_source_hits(
+                [{'text': 'Hello world'}]
+            )
+            batch_hits, batch_stats = batch_mod.retrieve_source_hits(
+                [{'text': 'Hello world'}],
+                [{'text': 'Previous line must not enter Source Index query'}],
+            )
+
+        self.assertEqual(calls['sync'], ['Target:\n- Hello world'])
+        self.assertEqual(calls['batch'], calls['sync'])
+        self.assertEqual(sync_hits, batch_hits)
+        self.assertEqual(sync_stats['embedding_provider'], batch_stats['embedding_provider'])
+        self.assertEqual(sync_stats['source_context_chars'], batch_stats['source_context_chars'])
+        self.assertEqual(sync_stats['source_context_char_budget'], 80)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_issue_346_p5.py
+++ b/tests/test_issue_346_p5.py
@@ -186,6 +186,7 @@ class P5ProductionGoldenTests(unittest.TestCase):
         self.assertEqual(diagnostics['context_provider_diagnostic_requests'], 1)
         self.assertEqual(diagnostics['context_provider_downgrade_count'], 0)
         self.assertIn('source_index:available', diagnostics['context_provider_status_counts'])
+        self.assertNotIn('embedding_provider:available', diagnostics['context_provider_status_counts'])
         self.assertIn(
             'published_project_analysis:available',
             diagnostics['context_provider_status_counts'],
@@ -481,6 +482,25 @@ class P5ProviderDiagnosticGoldenTests(unittest.TestCase):
             },
         )
         self.assertEqual(diagnostics['context_provider_downgrade_reasons'], {})
+
+        identity_only = translation_plan.summarize_request_diagnostics([
+            {
+                'context_diagnostics': {
+                    'layers': [{
+                        'diagnostics': {
+                            'provider': {
+                                'embedding_provider': {
+                                    'backend': 'gemini',
+                                    'model': 'gemini-embedding-001',
+                                }
+                            }
+                        }
+                    }]
+                }
+            }
+        ])
+        self.assertEqual(identity_only['context_provider_diagnostic_requests'], 0)
+        self.assertEqual(identity_only['context_provider_status_counts'], {})
 
 
 class P5BudgetAndEmbeddingTests(unittest.TestCase):

--- a/tests/test_issue_346_p5.py
+++ b/tests/test_issue_346_p5.py
@@ -313,15 +313,75 @@ class P5ProviderDiagnosticGoldenTests(unittest.TestCase):
                     summary = translation_plan.summarize_request_diagnostics(
                         sync.plan.request_summaries
                     )
-                    self.assertGreaterEqual(summary['context_provider_downgrade_count'], 2)
-                    self.assertIn(
-                        f'source_index:{source_diagnostic.get("reason", "disabled") if source_diagnostic.get("enabled") is not False else "disabled"}',
-                        summary['context_provider_downgrade_reasons'],
+                    expected_source_status = (
+                        'disabled'
+                        if source_diagnostic.get('enabled') is False
+                        else (
+                            'incompatible'
+                            if (source_diagnostic.get('embedding_compatibility') or {}).get('compatible') is False
+                            else source_diagnostic.get('reason', 'available')
+                        )
+                    )
+                    expected_analysis_status = (
+                        'disabled'
+                        if analysis_diagnostic.get('reason') == 'injection_disabled'
+                        else analysis_diagnostic['reason']
+                    )
+                    expected_downgrades = sum(
+                        status not in {
+                            'available',
+                            'disabled',
+                            'empty_query',
+                            'excerpt_cropped',
+                            'stale_hits_skipped',
+                        }
+                        for status in (expected_source_status, expected_analysis_status)
+                    )
+                    self.assertEqual(
+                        summary['context_provider_downgrade_count'],
+                        expected_downgrades,
                     )
                     self.assertIn(
-                        f'published_project_analysis:{analysis_diagnostic["reason"]}',
-                        summary['context_provider_downgrade_reasons'],
+                        f'source_index:{expected_source_status}',
+                        summary['context_provider_status_counts'],
                     )
+                    self.assertIn(
+                        f'published_project_analysis:{expected_analysis_status}',
+                        summary['context_provider_status_counts'],
+                    )
+                    source_summary = batch_mod.summarize_batch_source_index([
+                        {'source_index_stats': source_diagnostic}
+                    ])
+                    expected_source_failure = (
+                        'incompatible'
+                        if expected_source_status == 'incompatible'
+                        else source_diagnostic.get('reason')
+                    )
+                    if expected_source_failure:
+                        self.assertEqual(
+                            source_summary['source_retrieval_failure_reasons'],
+                            {expected_source_failure: 1},
+                        )
+                    else:
+                        self.assertEqual(
+                            source_summary['source_retrieval_failure_reasons'],
+                            {},
+                        )
+                    for provider_name, status in (
+                        ('source_index', expected_source_status),
+                        ('published_project_analysis', expected_analysis_status),
+                    ):
+                        key = f'{provider_name}:{status}'
+                        if status in {
+                            'available',
+                            'disabled',
+                            'empty_query',
+                            'excerpt_cropped',
+                            'stale_hits_skipped',
+                        }:
+                            self.assertNotIn(key, summary['context_provider_downgrade_reasons'])
+                        else:
+                            self.assertIn(key, summary['context_provider_downgrade_reasons'])
 
     def test_batch_project_analysis_keeps_published_identity_for_diagnostics(self):
         payload = {
@@ -361,6 +421,66 @@ class P5ProviderDiagnosticGoldenTests(unittest.TestCase):
         self.assertEqual(diagnostics['brief_status'], 'stale')
         self.assertEqual(diagnostics['source_fingerprint'], 'old-source-fingerprint')
         self.assertEqual(diagnostics['reason'], 'brief_not_fresh:stale')
+
+    def test_disabled_injection_does_not_report_missing_brief(self):
+        with (
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_ENABLED', True),
+            mock.patch.object(batch_mod, 'PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF', False),
+            mock.patch.object(batch_mod, 'compute_current_project_analysis_fingerprint') as fingerprint,
+        ):
+            result = batch_mod.load_injectable_project_context_for_prompts(
+                'script.rpy', [2]
+            )
+
+        fingerprint.assert_not_called()
+        summary = batch_mod.summarize_batch_project_analysis([
+            {'project_analysis': result}
+        ])
+        self.assertEqual(summary['skip_reasons'], {'injection_disabled': 1})
+        self.assertEqual(summary['brief_statuses'], {})
+        self.assertEqual(summary['injected_char_count'], 0)
+
+    def test_project_analysis_summary_counts_injected_chars(self):
+        payload = _published_context()
+        summary = batch_mod.summarize_batch_project_analysis([
+            {'project_analysis': payload}
+        ])
+        self.assertEqual(
+            summary['injected_char_count'],
+            len(payload['text']),
+        )
+        self.assertEqual(summary['brief_statuses'], {'published': 1})
+
+    def test_routine_filtering_and_excerpt_crop_are_not_provider_downgrades(self):
+        diagnostics = translation_plan.summarize_request_diagnostics([
+            {
+                'context_diagnostics': {
+                    'layers': [{
+                        'diagnostics': {
+                            'provider': {
+                                'source_index': {
+                                    'enabled': True,
+                                    'stale_hits_skipped': 1,
+                                },
+                                'published_project_analysis': {
+                                    'injectable': True,
+                                    'truncated_count': 1,
+                                },
+                            }
+                        }
+                    }]
+                }
+            }
+        ])
+        self.assertEqual(diagnostics['context_provider_downgrade_count'], 0)
+        self.assertEqual(
+            diagnostics['context_provider_status_counts'],
+            {
+                'source_index:stale_hits_skipped': 1,
+                'published_project_analysis:excerpt_cropped': 1,
+            },
+        )
+        self.assertEqual(diagnostics['context_provider_downgrade_reasons'], {})
 
 
 class P5BudgetAndEmbeddingTests(unittest.TestCase):
@@ -451,6 +571,7 @@ class P5BudgetAndEmbeddingTests(unittest.TestCase):
             mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_ENABLED', True),
             mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_TOP_K', 1),
             mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_LIMIT', 80),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_BUDGET', 80),
             mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_MIN_SIMILARITY', 0.0),
             mock.patch.object(runtime, 'SYNC_RAG_OUTPUT_DIMENSIONALITY', 2),
             mock.patch.object(runtime, 'SYNC_RAG_EMBEDDING_MODEL', settings.model),
@@ -465,6 +586,7 @@ class P5BudgetAndEmbeddingTests(unittest.TestCase):
             mock.patch.object(batch_mod, 'SOURCE_INDEX_ENABLED', True),
             mock.patch.object(batch_mod, 'SOURCE_INDEX_TOP_K', 1),
             mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_LIMIT', 80),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_BUDGET', 80),
             mock.patch.object(batch_mod, 'SOURCE_INDEX_MIN_SIMILARITY', 0.0),
             mock.patch.object(batch_mod, 'RAG_OUTPUT_DIMENSIONALITY', 2),
             mock.patch.object(batch_mod, 'RAG_EMBEDDING_MODEL', settings.model),
@@ -494,6 +616,82 @@ class P5BudgetAndEmbeddingTests(unittest.TestCase):
         self.assertEqual(sync_stats['embedding_provider'], batch_stats['embedding_provider'])
         self.assertEqual(sync_stats['source_context_chars'], batch_stats['source_context_chars'])
         self.assertEqual(sync_stats['source_context_char_budget'], 80)
+
+    def test_production_source_index_uses_independent_partition_budget(self):
+        settings = parse_embedding_runtime_settings({
+            'embedding_model': 'gemini-embedding-001',
+            'output_dimensionality': 2,
+        })
+        matches = [
+            {'source_id': 'one', 'source_text': 'abcdefghij', 'score': 0.9},
+            {'source_id': 'two', 'source_text': 'klmnopqrst', 'score': 0.8},
+            {'source_id': 'three', 'source_text': 'uvwxyz', 'score': 0.7},
+        ]
+
+        class Compatibility:
+            compatible = True
+            action = ''
+
+            def to_dict(self):
+                return {'compatible': True, 'action': '', 'codes': []}
+
+        class Store:
+            store_dir = 'fixture-source-index'
+            metadata = {'schema_version': 1}
+
+            def count_segments(self):
+                return len(matches)
+
+            def embedding_compatibility(self, _identity):
+                return Compatibility()
+
+            def search_segments_compatible(self, *_args, **_kwargs):
+                return matches, {
+                    'embedding_compatibility': {'compatible': True},
+                    'matched_before_top_k': len(matches),
+                }
+
+        store = Store()
+        patches = (
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_TOP_K', 3),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_LIMIT', 8),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_CHAR_BUDGET', 10),
+            mock.patch.object(runtime, 'SYNC_SOURCE_INDEX_MIN_SIMILARITY', 0.0),
+            mock.patch.object(runtime, 'SYNC_RAG_OUTPUT_DIMENSIONALITY', 2),
+            mock.patch.object(runtime, 'SYNC_RAG_EMBEDDING_MODEL', settings.model),
+            mock.patch.object(runtime, 'SYNC_RAG_DOCUMENT_TASK_TYPE', settings.native_document_task_type),
+            mock.patch.object(runtime, 'current_sync_embedding_settings', return_value=settings),
+            mock.patch.object(runtime, 'get_sync_source_index_store', return_value=store),
+            mock.patch.object(runtime, 'embed_sync_query_text', return_value=[1.0, 0.0]),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_ENABLED', True),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_TOP_K', 3),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_LIMIT', 8),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_CHAR_BUDGET', 10),
+            mock.patch.object(batch_mod, 'SOURCE_INDEX_MIN_SIMILARITY', 0.0),
+            mock.patch.object(batch_mod, 'RAG_OUTPUT_DIMENSIONALITY', 2),
+            mock.patch.object(batch_mod, 'RAG_EMBEDDING_MODEL', settings.model),
+            mock.patch.object(batch_mod, 'RAG_DOCUMENT_TASK_TYPE', settings.native_document_task_type),
+            mock.patch.object(batch_mod, 'current_batch_embedding_settings', return_value=settings),
+            mock.patch.object(batch_mod, 'get_source_index_store', return_value=store),
+            mock.patch.object(batch_mod, 'embed_query_text', return_value=[1.0, 0.0]),
+        )
+        with ExitStack() as stack:
+            for patcher in patches:
+                stack.enter_context(patcher)
+            sync_hits, sync_stats = runtime.retrieve_sync_source_hits(
+                [{'text': 'Hello world'}]
+            )
+            batch_hits, batch_stats = batch_mod.retrieve_source_hits(
+                [{'text': 'Hello world'}], []
+            )
+
+        self.assertEqual(sync_hits, batch_hits)
+        for stats in (sync_stats, batch_stats):
+            self.assertEqual(stats['source_context_char_budget'], 10)
+            self.assertEqual(stats['source_context_chars'], 10)
+            self.assertEqual(stats['source_context_budget_dropped_count'], 1)
+            self.assertTrue(stats['source_context_budget_exhausted'])
 
 
 if __name__ == '__main__':

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -456,7 +456,7 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertEqual(stats['filtered_count'], 0)
             self.assertEqual(stats['truncated_count'], 0)
             self.assertEqual(stats['source_context_chars'], len('Good morning everyone'))
-            self.assertEqual(stats['source_context_char_budget'], 100)
+            self.assertEqual(stats['source_context_char_budget'], batch_mod.get_source_index_char_budget())
             self.assertEqual(stats['search_diagnostics']['segments_seen'], 2)
 
     def test_retrieve_source_hits_filters_stale_embedding_metadata(self):
@@ -521,7 +521,7 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertTrue(hits[0]['source_text_truncated'])
             self.assertEqual(stats['truncated_count'], 1)
             self.assertEqual(stats['source_context_chars'], 12)
-            self.assertEqual(stats['source_context_char_budget'], 12)
+            self.assertEqual(stats['source_context_char_budget'], batch_mod.get_source_index_char_budget())
 
     def test_retrieve_source_hits_reports_failure_reason(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -548,7 +548,7 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertEqual(stats.get('error_category'), 'provider_error')
             self.assertEqual(
                 stats['source_context_char_budget'],
-                batch_mod.SOURCE_INDEX_TOP_K * batch_mod.SOURCE_INDEX_CHAR_LIMIT,
+                batch_mod.get_source_index_char_budget(),
             )
 
     def test_retrieve_source_hits_degrades_when_source_store_is_locked(self):
@@ -578,7 +578,7 @@ class SourceIndexIntegrationTests(unittest.TestCase):
             self.assertEqual(hits, [])
             self.assertTrue(stats['enabled'])
             self.assertEqual(stats['reason'], 'empty_source_store')
-            self.assertEqual(stats['source_context_char_budget'], 5 * batch_mod.SOURCE_INDEX_CHAR_LIMIT)
+            self.assertEqual(stats['source_context_char_budget'], batch_mod.get_source_index_char_budget())
 
     def test_retrieve_source_hits_skips_incompatible_store_without_mixing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -733,18 +733,27 @@ class SourceIndexIntegrationTests(unittest.TestCase):
                 self.assertEqual(manifest_data['source_index_store_path'], str(source_store_dir))
                 self.assertEqual(manifest_data['source_index_settings']['top_k'], batch_mod.SOURCE_INDEX_TOP_K)
                 self.assertEqual(manifest_data['source_index_settings']['schema_version'], batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
-                self.assertEqual(manifest_data['source_index_settings']['char_budget_per_chunk'], 40)
+                self.assertEqual(
+                    manifest_data['source_index_settings']['char_budget_per_chunk'],
+                    batch_mod.get_source_index_char_budget(),
+                )
                 self.assertIn('source_index_summary', manifest_data)
 
                 summary = manifest_data['source_index_summary']
                 self.assertEqual(summary['schema_version'], batch_mod.SOURCE_INDEX_SCHEMA_VERSION)
                 self.assertEqual(summary['store_schema_versions'], [batch_mod.SOURCE_INDEX_SCHEMA_VERSION])
-                self.assertEqual(summary['per_chunk_char_budget'], 40)
+                self.assertEqual(
+                    summary['per_chunk_char_budget'],
+                    batch_mod.get_source_index_char_budget(),
+                )
                 self.assertEqual(summary['chunks_with_source_hits'], 1)
                 self.assertEqual(summary['source_hit_count'], 1)
                 self.assertEqual(summary['source_context_truncation_count'], 0)
                 self.assertEqual(summary['source_context_char_count'], len('Hello world'))
-                self.assertEqual(summary['source_context_char_budget'], 40)
+                self.assertEqual(
+                    summary['source_context_char_budget'],
+                    batch_mod.get_source_index_char_budget(),
+                )
                 self.assertEqual(summary['source_filtered_count'], 1)
                 self.assertEqual(summary['stale_hits_skipped'], 1)
                 self.assertEqual(summary['below_similarity_count'], 0)

--- a/translation_plan.py
+++ b/translation_plan.py
@@ -344,6 +344,8 @@ def summarize_request_diagnostics(request_summaries):
             if not isinstance(provider, Mapping):
                 continue
             for provider_name, payload in provider.items():
+                if provider_name == 'embedding_provider':
+                    continue
                 request_has_provider_diagnostic = True
                 status = provider_status(provider_name, payload)
                 key = f'{provider_name}:{status}'

--- a/translation_plan.py
+++ b/translation_plan.py
@@ -303,8 +303,55 @@ def is_material_context_drop(entry):
 
 
 def summarize_request_diagnostics(request_summaries):
-    """Aggregate stable trim/drop counters from persisted request summaries."""
+    """Aggregate stable trim/drop/provider counters from request summaries.
+
+    Provider payloads are intentionally summarized by status and reason only;
+    the detailed, credential-free payload remains attached to each context
+    layer for diagnostics and golden comparisons.
+    """
     summaries = list(request_summaries or [])
+    provider_status_counts = {}
+    provider_downgrade_reasons = {}
+    provider_diagnostic_requests = 0
+    provider_downgrade_count = 0
+
+    def provider_status(provider_name, payload):
+        if not isinstance(payload, Mapping):
+            return 'invalid'
+        if payload.get('enabled') is False:
+            return 'disabled'
+        if payload.get('injectable') is False:
+            return str(payload.get('reason') or 'not_injectable')
+        reason = payload.get('failure_reason') or payload.get('reason')
+        if reason:
+            return str(reason)
+        if int(payload.get('source_context_budget_dropped_count') or 0) > 0:
+            return 'budget_cropped'
+        if int(payload.get('stale_hits_skipped') or 0) > 0:
+            return 'stale_hits_skipped'
+        if int(payload.get('truncated_count') or 0) > 0:
+            return 'excerpt_cropped'
+        return 'available'
+
+    for summary in summaries:
+        request_has_provider_diagnostic = False
+        for layer in ((summary.get('context_diagnostics') or {}).get('layers') or []):
+            provider = ((layer or {}).get('diagnostics') or {}).get('provider')
+            if not isinstance(provider, Mapping):
+                continue
+            for provider_name, payload in provider.items():
+                request_has_provider_diagnostic = True
+                status = provider_status(provider_name, payload)
+                key = f'{provider_name}:{status}'
+                provider_status_counts[key] = provider_status_counts.get(key, 0) + 1
+                if status != 'available':
+                    provider_downgrade_count += 1
+                    provider_downgrade_reasons[key] = (
+                        provider_downgrade_reasons.get(key, 0) + 1
+                    )
+        if request_has_provider_diagnostic:
+            provider_diagnostic_requests += 1
+
     return {
         'request_count': len(summaries),
         'context_truncated_requests': sum(
@@ -325,6 +372,10 @@ def summarize_request_diagnostics(request_summaries):
             )
             if is_material_context_drop(entry)
         ),
+        'context_provider_diagnostic_requests': provider_diagnostic_requests,
+        'context_provider_downgrade_count': provider_downgrade_count,
+        'context_provider_status_counts': provider_status_counts,
+        'context_provider_downgrade_reasons': provider_downgrade_reasons,
     }
 
 
@@ -664,6 +715,8 @@ class ChunkContextInput:
     lexical_glossary_hits: list = field(default_factory=list)
     retrieval_blocks_text: str = ''
     analysis_blocks_text: str = ''
+    retrieval_diagnostics: dict = field(default_factory=dict)
+    analysis_diagnostics: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -798,6 +851,12 @@ def _retrieval_layer(chunk_input, policy):
         'source_index_char_limit': policy.source_index_char_limit,
         'include_source_text': policy.include_source_text,
     }
+    if chunk_input.retrieval_diagnostics:
+        diagnostics['provider'] = redact_sensitive(
+            dict(chunk_input.retrieval_diagnostics)
+        )
+    if truncated:
+        diagnostics['char_discarded'] = max(0, len(chunk_input.retrieval_blocks_text or '') - len(text))
     return ContextLayerResult(
         layer=CONTEXT_LAYER_RETRIEVAL,
         rank=CONTEXT_LAYER_RANKS[CONTEXT_LAYER_RETRIEVAL],
@@ -825,6 +884,17 @@ def _analysis_layer(chunk_input, policy):
         text = text[:limit]
         truncated = True
     text = text.rstrip('\n')
+    diagnostics = {
+        'source': 'published_project_analysis',
+        'budget_mode': 'd5_backstop',
+        'analysis_char_limit': limit,
+    }
+    if chunk_input.analysis_diagnostics:
+        diagnostics['provider'] = redact_sensitive(
+            dict(chunk_input.analysis_diagnostics)
+        )
+    if truncated:
+        diagnostics['char_discarded'] = max(0, len(chunk_input.analysis_blocks_text or '') - len(text))
     return ContextLayerResult(
         layer=CONTEXT_LAYER_ANALYSIS,
         rank=CONTEXT_LAYER_RANKS[CONTEXT_LAYER_ANALYSIS],
@@ -832,11 +902,7 @@ def _analysis_layer(chunk_input, policy):
         char_used=len(text),
         char_limit=limit,
         truncated=truncated,
-        diagnostics={
-            'source': 'published_project_analysis',
-            'budget_mode': 'd5_backstop',
-            'analysis_char_limit': limit,
-        },
+        diagnostics=diagnostics,
     )
 
 
@@ -860,14 +926,24 @@ def assemble_context_layers(chunk_input, context_policy=None):
     dropped = []
     seen_texts = set()
     for result in sorted(results, key=lambda item: item.rank):
-        if result.text in seen_texts:
+        # Empty provider partitions still carry the reason why no text was
+        # injected (disabled, missing, stale, or incompatible). Keep those
+        # diagnostic-only layers so a safe degradation is explainable even
+        # when it contributes zero model-visible characters.
+        diagnostic_only_provider_layer = bool(
+            not result.text
+            and result.layer in {CONTEXT_LAYER_RETRIEVAL, CONTEXT_LAYER_ANALYSIS}
+            and result.diagnostics.get('provider')
+        )
+        if result.text in seen_texts and not diagnostic_only_provider_layer:
             dropped.append({
                 'layer': result.layer,
                 'reason': 'duplicate_text',
                 'char_used': result.char_used,
             })
             continue
-        seen_texts.add(result.text)
+        if not diagnostic_only_provider_layer:
+            seen_texts.add(result.text)
         layers.append(result)
     total_limit = max(0, int(policy.total_char_limit or 0))
     if total_limit:
@@ -1178,7 +1254,7 @@ def normalize_context_provider_text(value):
     return str(value or '').replace('\r\n', '\n')
 
 
-def _resolve_text_source(value, chunk_input, label):
+def _resolve_provider_source(value, chunk_input, label):
     """Accept a constant string or a per-chunk callable, LF-normalized.
 
     Provider text is normalized to LF line endings on entry so a CRLF
@@ -1186,14 +1262,35 @@ def _resolve_text_source(value, chunk_input, label):
     text is byte-stable by contract, not by caller discipline.
     """
     if value is None:
-        return ''
+        return '', {}
     if callable(value):
-        resolved = str(value(chunk_input) or '')
+        resolved = value(chunk_input)
     elif isinstance(value, str):
         resolved = value
     else:
-        raise TypeError(f'{label} must be a string or a callable(chunk_input) -> str')
-    return normalize_context_provider_text(resolved)
+        raise TypeError(
+            f'{label} must be a string or a callable(chunk_input) -> str or mapping'
+        )
+    diagnostics = {}
+    if isinstance(resolved, Mapping):
+        if 'text' not in resolved and 'diagnostics' not in resolved:
+            raise TypeError(
+                f'{label} mapping result must contain text and/or diagnostics'
+            )
+        text_value = resolved.get('text', '')
+        raw_diagnostics = resolved.get('diagnostics') or {}
+        if not isinstance(raw_diagnostics, Mapping):
+            raise TypeError(f'{label}.diagnostics must be a mapping')
+        diagnostics = redact_sensitive(dict(raw_diagnostics))
+    else:
+        text_value = resolved
+    return normalize_context_provider_text(text_value), diagnostics
+
+
+def _resolve_text_source(value, chunk_input, label):
+    """Compatibility wrapper returning only provider text."""
+
+    return _resolve_provider_source(value, chunk_input, label)[0]
 
 
 def _unit_semantic_entry(unit):
@@ -1252,12 +1349,15 @@ def build_translation_plan(
     ``file_jobs`` mirrors the legacy batch shape: a list of
     ``{'file_rel_path', 'file_path', 'tasks': [...]}`` mappings. Retrieved
     context enters through ``retrieval_blocks_provider`` /
-    ``analysis_blocks_provider`` — each a ``callable(chunk_input) -> str`` of
-    pre-rendered reference text (P2/P3 adapt their stores to this seam; #341
-    attaches providers here). ``plan_id`` covers source identity, redacted
-    config/profile snapshots, strategy, policies, and unit content — never
-    retrieved content or ``run_id``; retrieved content is captured by each
-    request's ``prompt_fingerprint`` instead.
+    ``analysis_blocks_provider`` — each may be a string, a
+    ``callable(chunk_input) -> str``, or a callable returning
+    ``{'text': str, 'diagnostics': mapping}`` of pre-rendered reference text
+    and credential-free provider facts (P2/P3 adapt their stores to this
+    seam; #341 attaches providers here). ``plan_id`` covers source identity,
+    redacted config/profile snapshots, strategy, policies, and unit content —
+    never retrieved content or ``run_id``; retrieved content and provider
+    diagnostics are captured by each request's ``prompt_fingerprint`` and
+    context diagnostics instead.
     """
     strategy = _resolve_strategy(execution_strategy)
     chunk_policy = chunk_policy or ChunkPolicy()
@@ -1352,10 +1452,20 @@ def build_translation_plan(
             macro_setting=str(macro_setting or ''),
             lexical_glossary_hits=lexical_hits,
         )
-        retrieval_text = _resolve_text_source(retrieval_blocks_provider, chunk_input, 'retrieval_blocks_provider')
-        analysis_text = _resolve_text_source(analysis_blocks_provider, chunk_input, 'analysis_blocks_provider')
+        retrieval_text, retrieval_diagnostics = _resolve_provider_source(
+            retrieval_blocks_provider,
+            chunk_input,
+            'retrieval_blocks_provider',
+        )
+        analysis_text, analysis_diagnostics = _resolve_provider_source(
+            analysis_blocks_provider,
+            chunk_input,
+            'analysis_blocks_provider',
+        )
         chunk_input.retrieval_blocks_text = retrieval_text
         chunk_input.analysis_blocks_text = analysis_text
+        chunk_input.retrieval_diagnostics = retrieval_diagnostics
+        chunk_input.analysis_diagnostics = analysis_diagnostics
 
         assembly = assemble_context_layers(chunk_input, context_policy)
         system_instruction = translation_core.build_canonical_translation_system_instruction(
@@ -1467,6 +1577,8 @@ def derive_translation_request(
     macro_setting='',
     retrieval_blocks_text='',
     analysis_blocks_text='',
+    retrieval_diagnostics=None,
+    analysis_diagnostics=None,
     lineage_kind='',
 ):
     """Create a deterministic retry request without changing its parent plan.
@@ -1498,6 +1610,24 @@ def derive_translation_request(
         preserve_terms=preserve_terms,
         non_translatable_exact=non_translatable_exact,
     )
+
+    def inherited_provider_diagnostics(layer_name):
+        for layer in (parent_request.context_assembly or {}).get('layers') or []:
+            if (layer or {}).get('layer') != layer_name:
+                continue
+            diagnostics = (layer or {}).get('diagnostics') or {}
+            provider = diagnostics.get('provider')
+            return dict(provider) if isinstance(provider, Mapping) else {}
+        return {}
+
+    if retrieval_diagnostics is None:
+        retrieval_diagnostics = inherited_provider_diagnostics(
+            CONTEXT_LAYER_RETRIEVAL
+        )
+    if analysis_diagnostics is None:
+        analysis_diagnostics = inherited_provider_diagnostics(
+            CONTEXT_LAYER_ANALYSIS
+        )
     chunk_input = ChunkContextInput(
         file_rel_path=str(file_rel_path or ''),
         target_items=items,
@@ -1512,6 +1642,8 @@ def derive_translation_request(
         analysis_blocks_text=normalize_context_provider_text(
             analysis_blocks_text
         ),
+        retrieval_diagnostics=dict(retrieval_diagnostics or {}),
+        analysis_diagnostics=dict(analysis_diagnostics or {}),
     )
     assembly = assemble_context_layers(chunk_input, policy)
     reference_blocks_text = '\n\n'.join(

--- a/translation_plan.py
+++ b/translation_plan.py
@@ -321,7 +321,11 @@ def summarize_request_diagnostics(request_summaries):
         if payload.get('enabled') is False:
             return 'disabled'
         if payload.get('injectable') is False:
-            return str(payload.get('reason') or 'not_injectable')
+            reason = str(payload.get('reason') or 'not_injectable')
+            return 'disabled' if reason == 'injection_disabled' else reason
+        compatibility = payload.get('embedding_compatibility')
+        if isinstance(compatibility, Mapping) and compatibility.get('compatible') is False:
+            return 'incompatible'
         reason = payload.get('failure_reason') or payload.get('reason')
         if reason:
             return str(reason)
@@ -344,7 +348,13 @@ def summarize_request_diagnostics(request_summaries):
                 status = provider_status(provider_name, payload)
                 key = f'{provider_name}:{status}'
                 provider_status_counts[key] = provider_status_counts.get(key, 0) + 1
-                if status != 'available':
+                if status not in {
+                    'available',
+                    'disabled',
+                    'empty_query',
+                    'excerpt_cropped',
+                    'stale_hits_skipped',
+                }:
                     provider_downgrade_count += 1
                     provider_downgrade_reasons[key] = (
                         provider_downgrade_reasons.get(key, 0) + 1
@@ -926,10 +936,7 @@ def assemble_context_layers(chunk_input, context_policy=None):
     dropped = []
     seen_texts = set()
     for result in sorted(results, key=lambda item: item.rank):
-        # Empty provider partitions still carry the reason why no text was
-        # injected (disabled, missing, stale, or incompatible). Keep those
-        # diagnostic-only layers so a safe degradation is explainable even
-        # when it contributes zero model-visible characters.
+        # Retain diagnostic-only provider partitions so safe skips remain explainable.
         diagnostic_only_provider_layer = bool(
             not result.text
             and result.layer in {CONTEXT_LAYER_RETRIEVAL, CONTEXT_LAYER_ANALYSIS}

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -3627,11 +3627,14 @@ def retrieve_sync_source_hits(target_items):
         return [], {"enabled": False}
     query_text = advanced_context.build_source_only_query_text(target_items)
     char_budget = get_sync_source_index_char_budget()
+    settings = current_sync_embedding_settings()
+    embedding_provider = advanced_context.embedding_provider_diagnostics(settings)
     if not query_text:
         return [], {
             "enabled": True,
             "reason": "empty_query",
             "source_context_char_budget": char_budget,
+            "embedding_provider": embedding_provider,
         }
     try:
         store = get_sync_source_index_store()
@@ -3641,8 +3644,13 @@ def retrieve_sync_source_hits(target_items):
                 "reason": "empty_source_store",
                 "source_context_char_budget": char_budget,
                 "store_dir": getattr(store, "store_dir", SYNC_SOURCE_INDEX_STORE_DIR or ""),
+                "store_schema_version": (
+                    (getattr(store, "metadata", {}) or {}).get("schema_version")
+                    if store is not None
+                    else None
+                ),
+                "embedding_provider": embedding_provider,
             }
-        settings = current_sync_embedding_settings()
         compatibility = embedding_runtime.store_compatibility_report(
             store,
             settings.query_identity(),
@@ -3654,9 +3662,16 @@ def retrieve_sync_source_hits(target_items):
                 "action": compatibility.action,
                 "embedding_compatibility": compatibility.to_dict(),
                 "source_context_char_budget": char_budget,
+                "store_dir": getattr(store, "store_dir", SYNC_SOURCE_INDEX_STORE_DIR or ""),
+                "store_schema_version": (
+                    (getattr(store, "metadata", {}) or {}).get("schema_version")
+                    if store is not None
+                    else None
+                ),
+                "embedding_provider": embedding_provider,
             }
         query_vector = embed_sync_query_text(query_text)
-        return advanced_context.retrieve_source_hits_compatible(
+        hits, stats = advanced_context.retrieve_source_hits_compatible(
             store,
             query_vector,
             settings.query_identity(),
@@ -3669,6 +3684,8 @@ def retrieve_sync_source_hits(target_items):
             embedding_dim=SYNC_RAG_OUTPUT_DIMENSIONALITY,
             char_budget=char_budget,
         )
+        stats["embedding_provider"] = embedding_provider
+        return hits, stats
     except Exception as exc:
         diagnostics = embedding_runtime.public_error_diagnostics(exc)
         print(
@@ -3678,6 +3695,7 @@ def retrieve_sync_source_hits(target_items):
         return [], {
             "enabled": True,
             "source_context_char_budget": char_budget,
+            "embedding_provider": embedding_provider,
             **diagnostics,
         }
 
@@ -5157,7 +5175,21 @@ def build_sync_translation_plan(file_jobs, adapter_snapshot, routing_plan, *, ru
             'non_translatable_exact': non_translatable_exact,
             'macro_setting': macro_setting,
         })
-        return text
+        return {
+            'text': text,
+            'diagnostics': {
+                'source_index': dict(source_index_stats or {}),
+                **(
+                    {
+                        'embedding_provider': advanced_context.embedding_provider_diagnostics(
+                            current_sync_embedding_settings()
+                        )
+                    }
+                    if (SYNC_SOURCE_INDEX_ENABLED or SYNC_RAG_ENABLED)
+                    else {}
+                ),
+            },
+        }
 
     def analysis_provider(chunk_input):
         for capture in captures:
@@ -5166,14 +5198,28 @@ def build_sync_translation_plan(file_jobs, adapter_snapshot, routing_plan, *, ru
                 and list(capture.get('expected_ids') or [])
                 == [unit.id for unit in chunk_input.target_units]
             ):
-                return capture.get('analysis_blocks_text') or ''
+                return {
+                    'text': capture.get('analysis_blocks_text') or '',
+                    'diagnostics': {
+                        'published_project_analysis': dict(
+                            capture.get('project_analysis') or {}
+                        ),
+                    },
+                }
         project_context = load_sync_injectable_project_context(
             chunk_input.file_rel_path,
             [unit.display_line_number for unit in chunk_input.target_units],
         )
-        return translation_plan.normalize_context_provider_text(
-            advanced_context.render_analysis_reference_text(project_context)
-        )
+        return {
+            'text': translation_plan.normalize_context_provider_text(
+                advanced_context.render_analysis_reference_text(project_context)
+            ),
+            'diagnostics': {
+                'published_project_analysis': advanced_context.analysis_skip_diagnostics(
+                    project_context
+                ),
+            },
+        }
 
     plan_build = build_plan(retrieval_provider, analysis_provider)
     if len(captures) != len(plan_build.requests):
@@ -6070,6 +6116,8 @@ def derive_sync_retry_request(parent_request, batch, request_context, suffix, ki
         macro_setting=context.get('macro_setting', SYNC_MACRO_SETTING),
         retrieval_blocks_text=context.get('retrieval_blocks_text', ''),
         analysis_blocks_text=context.get('analysis_blocks_text', ''),
+        retrieval_diagnostics=context.get('retrieval_diagnostics'),
+        analysis_diagnostics=context.get('analysis_diagnostics'),
         lineage_kind=kind,
     )
 
@@ -7196,6 +7244,12 @@ def run_translation(*, prepare=False):
                         translation_request.context_assembly or {}
                     ),
                     'rag_stats': dict(request_context.get('rag_stats') or {}),
+                    'source_index_stats': dict(
+                        request_context.get('source_index_stats') or {}
+                    ),
+                    'project_analysis': dict(
+                        request_context.get('project_analysis') or {}
+                    ),
                 })
                 file_context_batches.append(context_stats)
                 successful_entries.extend(process_batch_with_retry(

--- a/translator_runtime.py
+++ b/translator_runtime.py
@@ -237,6 +237,7 @@ SYNC_SOURCE_INDEX_STORE_DIR = ""
 SYNC_SOURCE_INDEX_TOP_K = DEFAULT_SYNC_SOURCE_INDEX_TOP_K
 SYNC_SOURCE_INDEX_MIN_SIMILARITY = DEFAULT_SYNC_SOURCE_INDEX_MIN_SIMILARITY
 SYNC_SOURCE_INDEX_CHAR_LIMIT = DEFAULT_SYNC_SOURCE_INDEX_CHAR_LIMIT
+SYNC_SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
 _SYNC_SOURCE_INDEX_STORE = None
 SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF = False
 
@@ -1009,7 +1010,8 @@ def load_sync_rag_settings(config):
 def load_sync_source_index_settings(config):
     global SYNC_SOURCE_INDEX_ENABLED, SYNC_SOURCE_INDEX_STORE_DIR
     global SYNC_SOURCE_INDEX_TOP_K, SYNC_SOURCE_INDEX_MIN_SIMILARITY
-    global SYNC_SOURCE_INDEX_CHAR_LIMIT, _SYNC_SOURCE_INDEX_STORE
+    global SYNC_SOURCE_INDEX_CHAR_LIMIT, SYNC_SOURCE_INDEX_CHAR_BUDGET
+    global _SYNC_SOURCE_INDEX_STORE
 
     sync = config.get("sync")
     if not isinstance(sync, dict):
@@ -1030,6 +1032,7 @@ def load_sync_source_index_settings(config):
         source_index.get("char_limit"),
         DEFAULT_SYNC_SOURCE_INDEX_CHAR_LIMIT,
     )
+    SYNC_SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
     store_dir = source_index.get("store_dir")
     if store_dir:
         SYNC_SOURCE_INDEX_STORE_DIR = _resolve_path(BASE_DIR, store_dir)
@@ -1608,7 +1611,8 @@ def apply_runtime_config(config: RuntimeConfig) -> RuntimeConfig:
     global SYNC_RAG_UPDATE_ON_SUCCESS, _SYNC_RAG_STORE
     global SYNC_SOURCE_INDEX_ENABLED, SYNC_SOURCE_INDEX_STORE_DIR
     global SYNC_SOURCE_INDEX_TOP_K, SYNC_SOURCE_INDEX_MIN_SIMILARITY
-    global SYNC_SOURCE_INDEX_CHAR_LIMIT, _SYNC_SOURCE_INDEX_STORE
+    global SYNC_SOURCE_INDEX_CHAR_LIMIT, SYNC_SOURCE_INDEX_CHAR_BUDGET
+    global _SYNC_SOURCE_INDEX_STORE
     global SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF
     global SYNC_STORY_MEMORY_ENABLED, SYNC_STORY_MEMORY_GRAPH_FILE
     global SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS, SYNC_STORY_MEMORY_TOP_K_RELATIONS
@@ -1694,6 +1698,7 @@ def apply_runtime_config(config: RuntimeConfig) -> RuntimeConfig:
         SYNC_SOURCE_INDEX_TOP_K = applied.sync_source_index_top_k
         SYNC_SOURCE_INDEX_MIN_SIMILARITY = applied.sync_source_index_min_similarity
         SYNC_SOURCE_INDEX_CHAR_LIMIT = applied.sync_source_index_char_limit
+        SYNC_SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
         _SYNC_SOURCE_INDEX_STORE = None
         SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF = (
             applied.sync_project_analysis_inject_published_brief
@@ -1840,7 +1845,8 @@ def _reset_project_settings_to_defaults():
     global SYNC_RAG_UPDATE_ON_SUCCESS, _SYNC_RAG_STORE
     global SYNC_SOURCE_INDEX_ENABLED, SYNC_SOURCE_INDEX_STORE_DIR
     global SYNC_SOURCE_INDEX_TOP_K, SYNC_SOURCE_INDEX_MIN_SIMILARITY
-    global SYNC_SOURCE_INDEX_CHAR_LIMIT, _SYNC_SOURCE_INDEX_STORE
+    global SYNC_SOURCE_INDEX_CHAR_LIMIT, SYNC_SOURCE_INDEX_CHAR_BUDGET
+    global _SYNC_SOURCE_INDEX_STORE
     global SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF
     global SYNC_STORY_MEMORY_ENABLED, SYNC_STORY_MEMORY_GRAPH_FILE
     global SYNC_STORY_MEMORY_MAX_CONTEXT_CHARS, SYNC_STORY_MEMORY_TOP_K_RELATIONS
@@ -1898,6 +1904,7 @@ def _reset_project_settings_to_defaults():
     SYNC_SOURCE_INDEX_TOP_K = DEFAULT_SYNC_SOURCE_INDEX_TOP_K
     SYNC_SOURCE_INDEX_MIN_SIMILARITY = DEFAULT_SYNC_SOURCE_INDEX_MIN_SIMILARITY
     SYNC_SOURCE_INDEX_CHAR_LIMIT = DEFAULT_SYNC_SOURCE_INDEX_CHAR_LIMIT
+    SYNC_SOURCE_INDEX_CHAR_BUDGET = advanced_context.DEFAULT_SOURCE_INDEX_CHAR_BUDGET
     _SYNC_SOURCE_INDEX_STORE = None
     SYNC_PROJECT_ANALYSIS_INJECT_PUBLISHED_BRIEF = False
 
@@ -3393,9 +3400,7 @@ def build_live_embedding_adapter(settings=None):
 
 
 def get_sync_source_index_char_budget():
-    return max(0, int(SYNC_SOURCE_INDEX_TOP_K or 0)) * max(
-        0, int(SYNC_SOURCE_INDEX_CHAR_LIMIT or 0)
-    )
+    return max(0, int(SYNC_SOURCE_INDEX_CHAR_BUDGET or 0))
 
 
 def _attach_store_document_identity(store, settings=None, *, rebuild=False):


### PR DESCRIPTION
Closes #346\n\nSummary:\n- Add shared structured provider diagnostics and credential-safe embedding identity fields.\n- Make Sync and Gemini Batch Source Index target-only queries, aggregate budget cropping, Published Project Analysis lifecycle identity, and manifest/preview summaries equivalent.\n- Add production-path golden tests for Source Index, Published Project Analysis, Embedding provider, budget cropping, and disabled/missing/incompatible/rebuild/draft/stale degradation.\n- Update GUI diagnostics and context-system documentation.\n- Scope intentionally excludes reimplementation of #341 and changes to #265/#399.\n\nValidation:\n- Targeted P5/provider tests: passed\n- CLI full suite: 1740 passed, 1 skipped\n- GUI full suite: 1177 passed\n- scripts/run_quality_gates.py all: passed\n- git diff --check: passed