### PR TITLE
fix: honor frozen sync route in translation A/B

### DIFF
--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -489,6 +489,8 @@ python gemini_translate_batch.py merge-keywords-to-glossary logs/batch_jobs/<pac
 
 新 manifest 默认复用其中冻结的 `ab_experiment` 路由（通常为 `primary` 同步模型），不会把 `batch_model` 当作 A/B 模型。只有显式传入 `--model` 时才覆盖该同步路由；LiteLLM 路由可使用带 Provider 前缀的模型名。报告中的 Model / Provider 以实际执行路由为准。
 
+兼容旧包或不完整 manifest 时，如果其中没有可用的同步 `ab_experiment` 路由（路由缺失或被冻结为非同步策略），`compare-variants` 不会执行那条非同步路由，而会按 `--model`、manifest 记录的 Batch 模型、当前 Batch 默认值的顺序重建一次同步 A/B 回退路由。该兼容回退与直接调用内部同步覆盖函数不同；后者会拒绝非同步冻结路由。
+
 图形界面入口见 [GUI 工作台 · 翻译 A/B 对比](gui_workbench.md#翻译-ab-对比)：在「诊断与运行日志」页工具栏打开，通过对话框选择 baseline 与 Story Memory / RAG / 原文索引的强制开/关变体，无需手写 `variants.json`。
 
 ```bash

--- a/docs/batch_workflows.md
+++ b/docs/batch_workflows.md
@@ -487,6 +487,8 @@ python gemini_translate_batch.py merge-keywords-to-glossary logs/batch_jobs/<pac
 
 `compare-variants` 用同一批 manifest chunk 在**同步模式**下跑多个配置变体，生成并排 Markdown 报告，**不会写回** `.rpy` 或 `glossary.json`。适合比较 Story Memory、RAG、macro setting 等上下文层对译文的影响。
 
+新 manifest 默认复用其中冻结的 `ab_experiment` 路由（通常为 `primary` 同步模型），不会把 `batch_model` 当作 A/B 模型。只有显式传入 `--model` 时才覆盖该同步路由；LiteLLM 路由可使用带 Provider 前缀的模型名。报告中的 Model / Provider 以实际执行路由为准。
+
 图形界面入口见 [GUI 工作台 · 翻译 A/B 对比](gui_workbench.md#翻译-ab-对比)：在「诊断与运行日志」页工具栏打开，通过对话框选择 baseline 与 Story Memory / RAG / 原文索引的强制开/关变体，无需手写 `variants.json`。
 
 ```bash

--- a/docs/gui_workbench.md
+++ b/docs/gui_workbench.md
@@ -213,7 +213,7 @@ GUI 不要求手写 JSON 变体文件。对话框以 **baseline + 可选覆盖�
   - **原文索引**
 - 「强制开启 / 强制关闭」会在 baseline 之外追加一个仅覆盖该开关的变体。
 
-至少需为某一维度选择「强制开启」或「强制关闭」，否则会提示对比项不足。高级用户仍可在命令参考区复制 `compare-variants --variants-file <variants.json>` 模板，自行编写更复杂的变体（例如 macro setting、模型覆盖）；GUI 对话框暂不覆盖这些维度。
+至少需为某一维度选择「强制开启」或「强制关闭」，否则会提示对比项不足。高级用户仍可在命令参考区复制 `compare-variants --variants-file <variants.json>` 模板，自行编写更复杂的上下文变体（例如 macro setting）；GUI 对话框暂不覆盖这些维度。模型是单次实验的共享执行路由，如需切换模型请使用运行级 `--model`，`variants.json` 中的 `model` / `provider` 不会形成逐变体路由。
 
 ### 高级选项
 

--- a/model_profile.py
+++ b/model_profile.py
@@ -1334,6 +1334,11 @@ def override_sync_stage(
     base_route = plan.routes.get(stage)
     if base_route is None:
         raise ValueError(f"Routing plan has no route for stage: {stage}")
+    if base_route.strategy is not ExecutionStrategy.SYNC:
+        raise ValueError(
+            f"Routing plan stage {stage} is not synchronous and cannot accept "
+            "a sync model override."
+        )
     base_profile = profile_for_route(plan, base_route)
     sync_backend = (
         SYNC_BACKEND_LITELLM

--- a/model_profile.py
+++ b/model_profile.py
@@ -1323,7 +1323,9 @@ def override_sync_stage(
 
     The replacement keeps the frozen stage's adapter family: a LiteLLM route
     may switch to another provider-prefixed model, while a direct Gemini route
-    remains Gemini-only and is rejected later if given a provider prefix.
+    remains Gemini-only. Adapter-incompatible model ids are rejected here so
+    callers do not receive advice that changing the live backend could alter a
+    frozen route.
     Other stages, profiles, and config origins remain unchanged.
     """
     cleaned = _clean_str(model)
@@ -1340,6 +1342,24 @@ def override_sync_stage(
             "a sync model override."
         )
     base_profile = profile_for_route(plan, base_route)
+    if (
+        base_profile.adapter == ADAPTER_LITELLM
+        and not provider_from_model(cleaned)
+    ):
+        raise ValueError(
+            f"Frozen LiteLLM stage {stage} requires a provider-prefixed model "
+            "id '<provider>/<model>'."
+        )
+    if base_profile.adapter == ADAPTER_GEMINI and "/" in cleaned:
+        raise ValueError(
+            f"Frozen direct Gemini stage {stage} cannot accept provider-prefixed "
+            f"model {cleaned}; rebuild the manifest with a LiteLLM sync route."
+        )
+    if base_profile.adapter not in {ADAPTER_GEMINI, ADAPTER_LITELLM}:
+        raise ValueError(
+            f"Frozen stage {stage} uses unsupported sync adapter "
+            f"{base_profile.adapter}."
+        )
     sync_backend = (
         SYNC_BACKEND_LITELLM
         if base_profile.adapter == ADAPTER_LITELLM

--- a/model_profile.py
+++ b/model_profile.py
@@ -1312,6 +1312,63 @@ def override_gemini_batch_stage(
     )
 
 
+def override_sync_stage(
+    plan: ModelRoutingPlan,
+    stage: str,
+    model: str,
+    *,
+    custom_providers: Mapping[str, CustomLiteLLMProvider] | None = None,
+) -> ModelRoutingPlan:
+    """Replace one synchronous stage on a frozen routing plan.
+
+    The replacement keeps the frozen stage's adapter family: a LiteLLM route
+    may switch to another provider-prefixed model, while a direct Gemini route
+    remains Gemini-only and is rejected later if given a provider prefix.
+    Other stages, profiles, and config origins remain unchanged.
+    """
+    cleaned = _clean_str(model)
+    if not cleaned:
+        raise ValueError("Sync stage override requires a model id.")
+    if stage not in KNOWN_STAGES:
+        raise ValueError(f"Unknown task stage in routing plan: {stage}")
+    base_route = plan.routes.get(stage)
+    if base_route is None:
+        raise ValueError(f"Routing plan has no route for stage: {stage}")
+    base_profile = profile_for_route(plan, base_route)
+    sync_backend = (
+        SYNC_BACKEND_LITELLM
+        if base_profile.adapter == ADAPTER_LITELLM
+        else SYNC_BACKEND_GEMINI
+    )
+    profile_id = f"{stage}_override"
+    profile = _sync_profile(
+        profile_id,
+        cleaned,
+        sync_backend,
+        custom_providers,
+        label=f"{stage} explicit model",
+    )
+    profiles = dict(plan.profiles)
+    profiles[profile_id] = profile
+    capabilities = dict(plan.capabilities)
+    capabilities[profile_id] = resolve_capabilities(
+        profile, custom_providers=custom_providers,
+    )
+    routes = dict(plan.routes)
+    routes[stage] = TaskRoute(
+        stage=stage,
+        profile_id=profile_id,
+        strategy=ExecutionStrategy.SYNC,
+        source=ROUTE_SOURCE_EXPLICIT,
+    )
+    return replace(
+        plan,
+        profiles=profiles,
+        routes=routes,
+        capabilities=capabilities,
+    )
+
+
 def resolve_routing_plan_from_runtime(
     *,
     sync_backend: str,

--- a/model_profile.py
+++ b/model_profile.py
@@ -604,6 +604,16 @@ def _clean_str(value: Any) -> str:
     return str(value).strip() if isinstance(value, str) else ""
 
 
+def is_provider_prefixed_model_id(model: str) -> bool:
+    """Return whether ``model`` is a LiteLLM-style provider/model id.
+
+    Google APIs also accept Gemini resource names such as
+    ``models/gemini-2.5-flash``; ``models`` is not a LiteLLM provider.
+    """
+    cleaned = _clean_str(model)
+    return "/" in cleaned and not cleaned.lower().startswith("models/")
+
+
 def _gemini_capabilities(overrides: Mapping[str, Any]) -> ModelCapabilities:
     """Adapter defaults for the direct google-genai client."""
     caps = ModelCapabilities(
@@ -778,7 +788,7 @@ def _batch_profile(
     transport.
     """
     provider = provider_from_model(model)
-    if provider:
+    if is_provider_prefixed_model_id(model):
         return ModelProfile(
             id=profile_id,
             label=label or provider_display_label(provider, custom_providers) or model,
@@ -1173,14 +1183,20 @@ def validate_routing_plan(
                 profile_id=profile_id,
             ))
             continue
-        if profile.adapter == ADAPTER_LITELLM and not profile.provider:
+        if (
+            profile.adapter == ADAPTER_LITELLM
+            and not is_provider_prefixed_model_id(profile.model)
+        ):
             issues.append(RoutingValidationIssue(
                 MODEL_PROFILE_INVALID,
                 f"Profile {profile_id} has a model without a provider prefix; "
                 "LiteLLM needs '<provider>/<model>'.",
                 profile_id=profile_id,
             ))
-        if profile.adapter == ADAPTER_GEMINI and "/" in profile.model:
+        if (
+            profile.adapter == ADAPTER_GEMINI
+            and is_provider_prefixed_model_id(profile.model)
+        ):
             issues.append(RoutingValidationIssue(
                 MODEL_PROFILE_INVALID,
                 f"Profile {profile_id} uses provider-prefixed model "
@@ -1344,13 +1360,16 @@ def override_sync_stage(
     base_profile = profile_for_route(plan, base_route)
     if (
         base_profile.adapter == ADAPTER_LITELLM
-        and not provider_from_model(cleaned)
+        and not is_provider_prefixed_model_id(cleaned)
     ):
         raise ValueError(
             f"Frozen LiteLLM stage {stage} requires a provider-prefixed model "
             "id '<provider>/<model>'."
         )
-    if base_profile.adapter == ADAPTER_GEMINI and "/" in cleaned:
+    if (
+        base_profile.adapter == ADAPTER_GEMINI
+        and is_provider_prefixed_model_id(cleaned)
+    ):
         raise ValueError(
             f"Frozen direct Gemini stage {stage} cannot accept provider-prefixed "
             f"model {cleaned}; rebuild the manifest with a LiteLLM sync route."

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -312,6 +312,84 @@ class ResolveRoutingPlanTests(unittest.TestCase):
             "gemini-2.0-flash",
         )
 
+    def test_override_sync_stage_keeps_litellm_family_and_other_profiles(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {
+                "sync": {
+                    "backend": "litellm",
+                    "model": "openai/gpt-4o-mini",
+                },
+                "batch": {
+                    "model": "gemini-2.0-flash",
+                    "project_analysis": {"model": "openai/pa-frozen"},
+                },
+            },
+            execution=mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+        patched = mp.override_sync_stage(
+            plan,
+            mp.STAGE_AB_EXPERIMENT,
+            "openrouter/deepseek/deepseek-v4-flash-0731",
+        )
+        ab_profile = patched.profiles[
+            patched.routes[mp.STAGE_AB_EXPERIMENT].profile_id
+        ]
+        self.assertEqual(ab_profile.adapter, mp.ADAPTER_LITELLM)
+        self.assertEqual(ab_profile.provider, "openrouter")
+        self.assertEqual(
+            ab_profile.model, "openrouter/deepseek/deepseek-v4-flash-0731",
+        )
+        self.assertEqual(
+            patched.profiles[patched.routes[mp.STAGE_PROJECT_ANALYSIS].profile_id].model,
+            "openai/pa-frozen",
+        )
+        self.assertEqual(plan.profiles["primary"].model, "openai/gpt-4o-mini")
+
+    def test_override_sync_stage_keeps_gemini_family(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "gemini", "model": "gemini-2.0-flash"}},
+        )
+        patched = mp.override_sync_stage(
+            plan, mp.STAGE_AB_EXPERIMENT, "gemini-2.5-flash",
+        )
+        profile = patched.profiles[
+            patched.routes[mp.STAGE_AB_EXPERIMENT].profile_id
+        ]
+        self.assertEqual(profile.adapter, mp.ADAPTER_GEMINI)
+        self.assertEqual(profile.model, "gemini-2.5-flash")
+
+    def test_override_sync_stage_rejects_non_sync_route(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {}, execution=mp.ExecutionStrategy.GEMINI_BATCH,
+        )
+        with self.assertRaisesRegex(ValueError, "not synchronous"):
+            mp.override_sync_stage(
+                plan, mp.STAGE_TRANSLATION, "gemini-2.5-flash",
+            )
+
+    def test_override_sync_stage_rejects_prefixed_model_for_gemini(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "gemini", "model": "gemini-2.0-flash"}},
+        )
+        with self.assertRaisesRegex(ValueError, "direct Gemini"):
+            mp.override_sync_stage(
+                plan, mp.STAGE_AB_EXPERIMENT, "openrouter/example/model",
+            )
+
+    def test_override_sync_stage_requires_provider_prefix_for_litellm(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {
+                "sync": {
+                    "backend": "litellm",
+                    "model": "openai/gpt-4o-mini",
+                },
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "provider-prefixed"):
+            mp.override_sync_stage(
+                plan, mp.STAGE_AB_EXPERIMENT, "gpt-4o-mini",
+            )
+
     def test_unknown_sync_backend_refused(self) -> None:
         with self.assertRaises(ValueError):
             mp.resolve_routing_plan({"sync": {"backend": "openai"}})

--- a/tests/test_model_profile.py
+++ b/tests/test_model_profile.py
@@ -280,6 +280,17 @@ class ResolveRoutingPlanTests(unittest.TestCase):
             plan.routes["translation"].strategy, mp.ExecutionStrategy.GEMINI_BATCH,
         )
 
+    def test_gemini_resource_name_uses_batch_adapter(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {},
+            execution=mp.ExecutionStrategy.GEMINI_BATCH,
+            stage_overrides={"translation": "models/gemini-2.5-flash"},
+        )
+        profile = plan.profiles["translation_override"]
+        self.assertEqual(profile.adapter, mp.ADAPTER_GEMINI)
+        self.assertEqual(profile.provider, "gemini")
+        self.assertEqual(profile.model, "models/gemini-2.5-flash")
+
     def test_override_gemini_batch_stage_keeps_other_profiles(self) -> None:
         plan = mp.resolve_routing_plan(
             {
@@ -358,6 +369,19 @@ class ResolveRoutingPlanTests(unittest.TestCase):
         self.assertEqual(profile.adapter, mp.ADAPTER_GEMINI)
         self.assertEqual(profile.model, "gemini-2.5-flash")
 
+    def test_override_sync_stage_accepts_gemini_resource_name(self) -> None:
+        plan = mp.resolve_routing_plan(
+            {"sync": {"backend": "gemini", "model": "gemini-2.0-flash"}},
+        )
+        patched = mp.override_sync_stage(
+            plan, mp.STAGE_AB_EXPERIMENT, "models/gemini-2.5-flash",
+        )
+        profile = patched.profiles[
+            patched.routes[mp.STAGE_AB_EXPERIMENT].profile_id
+        ]
+        self.assertEqual(profile.adapter, mp.ADAPTER_GEMINI)
+        self.assertEqual(profile.model, "models/gemini-2.5-flash")
+
     def test_override_sync_stage_rejects_non_sync_route(self) -> None:
         plan = mp.resolve_routing_plan(
             {}, execution=mp.ExecutionStrategy.GEMINI_BATCH,
@@ -388,6 +412,10 @@ class ResolveRoutingPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "provider-prefixed"):
             mp.override_sync_stage(
                 plan, mp.STAGE_AB_EXPERIMENT, "gpt-4o-mini",
+            )
+        with self.assertRaisesRegex(ValueError, "provider-prefixed"):
+            mp.override_sync_stage(
+                plan, mp.STAGE_AB_EXPERIMENT, "models/gemini-2.5-flash",
             )
 
     def test_unknown_sync_backend_refused(self) -> None:

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -401,7 +401,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
             with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
                 manifest = json.load(source)
             manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
-            manifest['batch_model'] = 'gemini-fallback'
+            manifest['batch_model'] = 'models/gemini-2.5-flash'
             plan = batch_mod.model_profile.resolve_routing_plan(
                 {
                     'sync': {'backend': 'litellm', 'model': 'openrouter/original'},
@@ -436,7 +436,10 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 sync_runner=fake_sync_runner,
             )
 
-            self.assertEqual(captured, [('gemini', 'gemini-fallback')] * 2)
+            self.assertEqual(
+                captured,
+                [('gemini', 'models/gemini-2.5-flash')] * 2,
+            )
 
     def test_non_sync_frozen_ab_route_uses_explicit_model_fallback(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -154,6 +154,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
                     ab_mod.VariantRunResult(
                         variant_name='baseline',
                         settings={
+                            'provider': 'openrouter',
                             'model': 'test-model',
                             'story_memory_enabled': False,
                             'rag_enabled': False,
@@ -165,6 +166,7 @@ class TranslationAbExperimentTests(unittest.TestCase):
                     ab_mod.VariantRunResult(
                         variant_name='story_memory',
                         settings={
+                            'provider': 'openrouter',
                             'model': 'test-model',
                             'story_memory_enabled': True,
                             'rag_enabled': False,
@@ -185,6 +187,8 @@ class TranslationAbExperimentTests(unittest.TestCase):
         )
         self.assertIn('baseline', report)
         self.assertIn('story_memory', report)
+        self.assertIn('| Variant | Provider | Model |', report)
+        self.assertIn('| baseline | openrouter | test-model |', report)
         self.assertIn('| line-1 | Hello | 你好 | 你好啊 |', report)
 
     def test_run_translation_ab_experiment_dry_run_writes_outputs(self):
@@ -215,6 +219,9 @@ class TranslationAbExperimentTests(unittest.TestCase):
             self.assertEqual(len(rows), 1)
             self.assertEqual(len(rows[0]['variants']), 2)
             self.assertTrue(all(variant['dry_run'] for variant in rows[0]['variants']))
+            with open(summary['settings_path'], 'r', encoding='utf-8') as handle:
+                settings = json.load(handle)
+            self.assertTrue(settings['provider'])
 
     def test_run_translation_ab_experiment_calls_sync_runner_per_variant(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -322,6 +329,13 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 {variant['settings']['model'] for variant in row['variants']},
                 {'openrouter/deepseek/deepseek-v4-flash-0731'},
             )
+            self.assertEqual(
+                {variant['settings']['provider'] for variant in row['variants']},
+                {'openrouter'},
+            )
+            with open(summary['settings_path'], 'r', encoding='utf-8') as handle:
+                settings = json.load(handle)
+            self.assertEqual(settings['provider'], 'openrouter')
 
     def test_manifest_routing_explicit_model_override_stays_on_sync_adapter(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -259,6 +259,128 @@ class TranslationAbExperimentTests(unittest.TestCase):
             self.assertEqual(translations['baseline'][SAMPLE_ITEM_ID], '你好')
             self.assertEqual(translations['story_memory'][SAMPLE_ITEM_ID], '你好')
 
+    def test_manifest_routing_keeps_ab_experiment_on_primary_sync_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            plan = batch_mod.model_profile.resolve_routing_plan(
+                {
+                    'sync': {
+                        'backend': 'litellm',
+                        'model': 'openrouter/deepseek/deepseek-v4-flash-0731',
+                    },
+                    'batch': {'model': 'gemini-batch-should-not-run'},
+                },
+                execution=batch_mod.model_profile.ExecutionStrategy.GEMINI_BATCH,
+            )
+            manifest['model_routing'] = plan.to_manifest_dict()
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            captured = []
+
+            def fake_sync_runner(request_payload, route, plan=None, api_key_index=None):
+                profile = batch_mod.model_profile.profile_for_route(plan, route)
+                captured.append((profile.adapter, profile.provider, profile.model))
+                return {
+                    'response_text': _full_chunk_translations(),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {'total_tokens': 3},
+                    'request_metadata': {'provider': profile.provider},
+                }
+
+            summary = ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                output_dir=os.path.join(tmp, 'experiment'),
+                sync_runner=fake_sync_runner,
+            )
+
+            self.assertEqual(
+                captured,
+                [
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                ],
+            )
+            with open(summary['results_path'], 'r', encoding='utf-8') as handle:
+                row = json.loads(handle.readline())
+            self.assertEqual(
+                {variant['settings']['model'] for variant in row['variants']},
+                {'openrouter/deepseek/deepseek-v4-flash-0731'},
+            )
+
+    def test_manifest_routing_explicit_model_override_stays_on_sync_adapter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            plan = batch_mod.model_profile.resolve_routing_plan(
+                {
+                    'sync': {
+                        'backend': 'litellm',
+                        'model': 'openrouter/original',
+                    },
+                    'batch': {'model': 'gemini-batch-should-not-run'},
+                },
+                execution=batch_mod.model_profile.ExecutionStrategy.GEMINI_BATCH,
+            )
+            manifest['model_routing'] = plan.to_manifest_dict()
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            captured = []
+
+            def fake_sync_runner(request_payload, route, plan=None, api_key_index=None):
+                profile = batch_mod.model_profile.profile_for_route(plan, route)
+                captured.append((profile.adapter, profile.provider, profile.model))
+                return {
+                    'response_text': _full_chunk_translations(),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {},
+                }
+
+            ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                output_dir=os.path.join(tmp, 'experiment'),
+                model_override='openrouter/deepseek/deepseek-v4-flash-0731',
+                sync_runner=fake_sync_runner,
+            )
+
+            self.assertEqual(
+                captured,
+                [
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                ],
+            )
+
     def test_run_translation_ab_experiment_usage_ledger_error_does_not_fail_variant(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest_path = os.path.join(tmp, 'manifest.json')

--- a/tests/test_translation_ab_experiment.py
+++ b/tests/test_translation_ab_experiment.py
@@ -381,6 +381,111 @@ class TranslationAbExperimentTests(unittest.TestCase):
                 ],
             )
 
+    def test_partial_manifest_without_ab_route_uses_legacy_model_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            manifest['batch_model'] = 'gemini-fallback'
+            plan = batch_mod.model_profile.resolve_routing_plan(
+                {
+                    'sync': {'backend': 'litellm', 'model': 'openrouter/original'},
+                    'batch': {'model': 'gemini-fallback'},
+                },
+                execution=batch_mod.model_profile.ExecutionStrategy.GEMINI_BATCH,
+            )
+            frozen = plan.to_manifest_dict()
+            del frozen['routes'][batch_mod.model_profile.STAGE_AB_EXPERIMENT]
+            manifest['model_routing'] = frozen
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            captured = []
+
+            def fake_sync_runner(request_payload, route, plan=None, api_key_index=None):
+                profile = batch_mod.model_profile.profile_for_route(plan, route)
+                captured.append((profile.adapter, profile.model))
+                return {
+                    'response_text': _full_chunk_translations(),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {},
+                }
+
+            ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                output_dir=os.path.join(tmp, 'experiment'),
+                sync_runner=fake_sync_runner,
+            )
+
+            self.assertEqual(captured, [('gemini', 'gemini-fallback')] * 2)
+
+    def test_non_sync_frozen_ab_route_uses_explicit_model_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = os.path.join(tmp, 'manifest.json')
+            with open(FIXTURE_MANIFEST, 'r', encoding='utf-8') as source:
+                manifest = json.load(source)
+            manifest['mode'] = batch_mod.MANIFEST_MODE_TRANSLATION
+            plan = batch_mod.model_profile.resolve_routing_plan(
+                {
+                    'sync': {'backend': 'litellm', 'model': 'openrouter/original'},
+                    'batch': {'model': 'gemini-batch'},
+                },
+                execution=batch_mod.model_profile.ExecutionStrategy.GEMINI_BATCH,
+            )
+            frozen = plan.to_manifest_dict()
+            frozen['routes'][batch_mod.model_profile.STAGE_AB_EXPERIMENT] = {
+                'stage': batch_mod.model_profile.STAGE_AB_EXPERIMENT,
+                'profile_id': 'batch',
+                'strategy': 'gemini_batch',
+                'source': 'stage_config',
+            }
+            manifest['model_routing'] = frozen
+            with open(manifest_path, 'w', encoding='utf-8') as handle:
+                json.dump(manifest, handle, ensure_ascii=False, indent=2)
+
+            loaded = batch_mod.load_manifest(manifest_path)
+            variants = ab_mod.load_variants_file(str(FIXTURE_VARIANTS))
+            captured = []
+
+            def fake_sync_runner(request_payload, route, plan=None, api_key_index=None):
+                profile = batch_mod.model_profile.profile_for_route(plan, route)
+                captured.append((profile.adapter, profile.provider, profile.model))
+                return {
+                    'response_text': _full_chunk_translations(),
+                    'finish_reason': 'STOP',
+                    'usage_metadata': {},
+                }
+
+            ab_mod.run_translation_ab_experiment(
+                loaded,
+                variants,
+                limit=1,
+                output_dir=os.path.join(tmp, 'experiment'),
+                model_override='openrouter/deepseek/deepseek-v4-flash-0731',
+                sync_runner=fake_sync_runner,
+            )
+
+            self.assertEqual(
+                captured,
+                [
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                    (
+                        'litellm',
+                        'openrouter',
+                        'openrouter/deepseek/deepseek-v4-flash-0731',
+                    ),
+                ],
+            )
+
     def test_run_translation_ab_experiment_usage_ledger_error_does_not_fail_variant(self):
         with tempfile.TemporaryDirectory() as tmp:
             manifest_path = os.path.join(tmp, 'manifest.json')

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -591,6 +591,32 @@ def _invoke_ab_sync_runner(
     )
 
 
+def _legacy_ab_routing_plan(model_name: str):
+    """Resolve old manifests without leaking the live sync backend into them."""
+    batch_mod = _batch()
+    model = str(model_name or '').strip()
+    sync_backend = (
+        batch_mod.model_profile.SYNC_BACKEND_LITELLM
+        if '/' in model
+        else batch_mod.model_profile.SYNC_BACKEND_GEMINI
+    )
+    plan = batch_mod.model_profile.resolve_routing_plan_from_runtime(
+        sync_backend=sync_backend,
+        sync_model=model,
+        batch_model=str(batch_mod.BATCH_MODEL or model),
+        custom_providers=batch_mod._runtime_custom_providers(),
+        execution=batch_mod.model_profile.ExecutionStrategy.SYNC,
+        stage_overrides={
+            batch_mod.model_profile.STAGE_AB_EXPERIMENT: model,
+        } if model else None,
+    )
+    batch_mod.require_valid_routing_plan(
+        plan,
+        {batch_mod.model_profile.STAGE_AB_EXPERIMENT},
+    )
+    return plan
+
+
 def run_variant_for_chunk(
     chunk: dict,
     *,
@@ -606,18 +632,12 @@ def run_variant_for_chunk(
 ) -> VariantRunResult:
     batch_mod = _batch()
     if plan is None or route is None:
-        overrides = {}
         explicit = (
             model_override.strip()
             or str(settings.get('model') or '').strip()
             or str(batch_mod.BATCH_MODEL or '').strip()
         )
-        if explicit:
-            overrides[batch_mod.model_profile.STAGE_AB_EXPERIMENT] = explicit
-        plan = batch_mod.freeze_runtime_routing_plan(
-            stage_overrides=overrides or None,
-            required_stages={batch_mod.model_profile.STAGE_AB_EXPERIMENT},
-        )
+        plan = _legacy_ab_routing_plan(explicit)
         route = plan.routes[batch_mod.model_profile.STAGE_AB_EXPERIMENT]
     model_name = batch_mod.route_model(plan, route)
     try:
@@ -725,16 +745,32 @@ def run_translation_ab_experiment(
     batch_mod = _batch()
     batch_mod.require_manifest_mode(manifest, batch_mod.MANIFEST_MODE_TRANSLATION, 'compare-variants')
     chunks = select_manifest_chunks(manifest, limit=limit, offset=offset)
-    default_model = model_override.strip() or manifest.get('batch_model') or batch_mod.BATCH_MODEL
-    ab_overrides = {}
-    if str(default_model or '').strip():
-        ab_overrides[batch_mod.model_profile.STAGE_AB_EXPERIMENT] = str(default_model).strip()
-    routing_plan = batch_mod.freeze_runtime_routing_plan(
-        stage_overrides=ab_overrides or None,
-        required_stages={batch_mod.model_profile.STAGE_AB_EXPERIMENT},
-    )
+    explicit_model = model_override.strip()
+    routing_plan = batch_mod.routing_plan_from_manifest(manifest)
+    if routing_plan is None:
+        # Legacy manifests did not freeze routing. Preserve their historical
+        # fallback to the recorded Batch model, then the loaded Batch default.
+        fallback_model = (
+            explicit_model
+            or str(manifest.get('batch_model') or '').strip()
+            or str(batch_mod.BATCH_MODEL or '').strip()
+        )
+        routing_plan = _legacy_ab_routing_plan(fallback_model)
+    else:
+        if explicit_model:
+            routing_plan = batch_mod.model_profile.override_sync_stage(
+                routing_plan,
+                batch_mod.model_profile.STAGE_AB_EXPERIMENT,
+                explicit_model,
+                custom_providers=batch_mod._runtime_custom_providers(),
+            )
+        batch_mod.require_valid_routing_plan(
+            routing_plan,
+            {batch_mod.model_profile.STAGE_AB_EXPERIMENT},
+        )
     ab_route = routing_plan.routes[batch_mod.model_profile.STAGE_AB_EXPERIMENT]
     default_model = batch_mod.route_model(routing_plan, ab_route)
+    ab_profile = batch_mod.model_profile.profile_for_route(routing_plan, ab_route)
 
     if not output_dir:
         slug = batch_mod.guess_project_slug()
@@ -764,6 +800,11 @@ def run_translation_ab_experiment(
     try:
         for variant in variants:
             with variant_batch_settings(variant.get('overrides') or {}) as settings:
+                settings = {
+                    **settings,
+                    'model': default_model,
+                    'provider': ab_profile.provider,
+                }
                 for chunk_index, chunk in enumerate(chunks):
                     chunk_results[chunk_index].variant_results.append(
                         run_variant_for_chunk(

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -617,6 +617,18 @@ def _legacy_ab_routing_plan(model_name: str):
     return plan
 
 
+def _has_frozen_sync_ab_route(plan) -> bool:
+    """Return whether a manifest plan froze a usable synchronous A/B route."""
+    if plan is None:
+        return False
+    batch_mod = _batch()
+    route = plan.routes.get(batch_mod.model_profile.STAGE_AB_EXPERIMENT)
+    return bool(
+        route is not None
+        and route.strategy is batch_mod.model_profile.ExecutionStrategy.SYNC
+    )
+
+
 def run_variant_for_chunk(
     chunk: dict,
     *,
@@ -747,9 +759,10 @@ def run_translation_ab_experiment(
     chunks = select_manifest_chunks(manifest, limit=limit, offset=offset)
     explicit_model = model_override.strip()
     routing_plan = batch_mod.routing_plan_from_manifest(manifest)
-    if routing_plan is None:
-        # Legacy manifests did not freeze routing. Preserve their historical
-        # fallback to the recorded Batch model, then the loaded Batch default.
+    if not _has_frozen_sync_ab_route(routing_plan):
+        # Legacy or partial manifests did not freeze a synchronous A/B route.
+        # Preserve their historical fallback to the recorded Batch model,
+        # then the loaded Batch default.
         fallback_model = (
             explicit_model
             or str(manifest.get('batch_model') or '').strip()

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -413,14 +413,15 @@ def render_markdown_report(
         '',
         '## Variant Settings',
         '',
-        '| Variant | Model | Story Memory | RAG | Source Index | Macro (preview) |',
-        '| --- | --- | --- | --- | --- | --- |',
+        '| Variant | Provider | Model | Story Memory | RAG | Source Index | Macro (preview) |',
+        '| --- | --- | --- | --- | --- | --- | --- |',
     ]
     for name in variant_names:
         settings = settings_by_variant.get(name, {})
         lines.append(
-            '| {name} | {model} | {story} | {rag} | {source_index} | {macro} |'.format(
+            '| {name} | {provider} | {model} | {story} | {rag} | {source_index} | {macro} |'.format(
                 name=_escape_table_cell(name),
+                provider=_escape_table_cell(settings.get('provider', '')),
                 model=_escape_table_cell(settings.get('model', '')),
                 story='yes' if settings.get('story_memory_enabled') else 'no',
                 rag='yes' if settings.get('rag_enabled') else 'no',
@@ -838,6 +839,7 @@ def run_translation_ab_experiment(
     finally:
         experiment_settings = {
             'manifest_path': manifest.get('_manifest_path', ''),
+            'provider': ab_profile.provider,
             'model': default_model,
             'limit': limit,
             'offset': offset,

--- a/translation_ab_experiment.py
+++ b/translation_ab_experiment.py
@@ -598,7 +598,7 @@ def _legacy_ab_routing_plan(model_name: str):
     model = str(model_name or '').strip()
     sync_backend = (
         batch_mod.model_profile.SYNC_BACKEND_LITELLM
-        if '/' in model
+        if batch_mod.model_profile.is_provider_prefixed_model_id(model)
         else batch_mod.model_profile.SYNC_BACKEND_GEMINI
     )
     plan = batch_mod.model_profile.resolve_routing_plan_from_runtime(


### PR DESCRIPTION
## Summary

- make `compare-variants` use the manifest's frozen `ab_experiment` sync route instead of the Batch model
- keep explicit `--model` overrides on the frozen sync adapter family
- preserve deterministic legacy/partial/non-sync-manifest fallback and report the actual provider/model
- reject adapter-incompatible direct sync overrides with frozen-route-specific errors
- preserve official Gemini resource model ids such as `models/gemini-2.5-flash`
- add routing regressions and document run-level model/provider behavior

## Validation

- `python -m unittest tests.test_translation_ab_experiment tests.test_model_profile -q` (87 passed)
- `python -m unittest tests.test_gui_ab_experiment_report tests.test_gui_diagnostics_context -q` (52 passed)
- `python -B tests/run_cli_tests.py -q` (1746 passed, 1 skipped)
- `python -B tests/run_gui_tests.py -q` (1177 passed)
- `python scripts/run_quality_gates.py all` (passed)
- real-project-copy A/B smoke test: OpenRouter + `deepseek/deepseek-v4-flash-0731`, 5/5 responses for both baseline and Source Index variants; no writeback

Related to #341.
