### PR TITLE
feat(engine): add Tyrano native catalog writeback planning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@
 | 手动使用完整 CLI 工作流 | 根目录 `README.md` → [安装与本地配置](setup.md) → [Batch 工作流与安全检查](batch_workflows.md) 或 [同步翻译工作流](sync_workflow.md) |
 | 多游戏工作区总表 | [工作区项目总表](games_registry.md) |
 | 理解环境检查建议 | [环境检查智能建议机制](doctor_recommendations.md) · [状态矩阵](doctor_states_matrix.md) |
-| 理解 Ren'Py 扫描边界与 coverage 产物 | [Ren'Py Engine Adapter 与覆盖审计](engine_adapter.md) |
+| 理解引擎扫描边界、coverage 与安全写回 | [Engine Adapter、覆盖审计与安全写回](engine_adapter.md) |
 | 启用 RAG / 原文索引 / 剧情记忆 | [上下文系统](context_systems.md) · [setup.md](setup.md) 中的项目级开关 |
 | 角色关系 / 语义分析 | [关系与语义分析](relation_analysis.md) · [`relation_analyzer/README.md`](../relation_analyzer/README.md) |
 | 项目边界与安全 | [项目说明](project_notes.md) |
@@ -44,7 +44,7 @@
 
 - [Batch 工作流与安全检查](batch_workflows.md)：`build → apply`、订正、最终审校 campaign、关键词、identity v2、A/B、golden corpus。
 - [同步翻译工作流](sync_workflow.md)：同步 CLI 的 preview → 人工审查 → 显式 apply、配置、供应商与安全边界。
-- [Ren'Py Engine Adapter 与覆盖审计](engine_adapter.md)：P1 扫描边界、candidate / occurrence、coverage/review 产物、P3/P4 快照与复用，以及脱敏后的真实项目门禁实测。
+- [Engine Adapter、覆盖审计与安全写回](engine_adapter.md)：Ren'Py P1–P4 扫描、coverage、版本快照与复用，以及 TyranoScript P5 原生 catalog 写回边界。
 - [实际模型用量账本](model_usage_ledger.md)：按当前项目、任务、阶段、provider 与模型归集 Batch / 同步实际调用，并说明离线补录、成本和未知值语义。
 - [上下文系统](context_systems.md)：RAG、原文索引、Story Memory、store 路径与 benchmark。
 - [环境检查智能建议机制](doctor_recommendations.md)：建议等级、必需/可选并列、workflow_state。

--- a/docs/engine_adapter.md
+++ b/docs/engine_adapter.md
@@ -1,4 +1,4 @@
-# Ren'Py Engine Adapter 与覆盖审计
+# Engine Adapter、覆盖审计与安全写回
 
 文档地图：[docs/README.md](README.md)
 
@@ -12,8 +12,9 @@ workflow 执行 check→apply、路径约束、事务恢复和 atomic write。P3
 `check` → `apply`。
 
 已在两部私有 Ren'Py 项目的副本上完成 P1–P4 门禁实测；摘要见
-[真实项目门禁实测](#真实项目门禁实测)。P5 TyranoScript
-V600+ 验证 adapter 与 P6 产品化仍未交付。
+[真实项目门禁实测](#真实项目门禁实测)。P5 TyranoScript V600+ 已交付只读发现、
+inventory、coverage、occurrence extraction，以及原生语言 JSON 的声明式语义写回
+核心；relocation、完整性/语言切换收口和 P6 产品化仍未交付。
 
 ## 当前边界
 
@@ -21,8 +22,9 @@ V600+ 验证 adapter 与 P6 产品化仍未交付。
 |---|---|
 | `engine_adapters/contracts.py` | engine-neutral protocol、capability、candidate、occurrence、validation / writeback 的版本化信封 |
 | `engine_adapters/renpy.py` | Ren'Py 项目发现、`.rpy` inventory、分类、source marker、speaker、translate block / occurrence / ordinal、只读 occurrence 提取 |
+| `engine_adapters/tyrano.py` | TyranoScript V600+ `.ks` inventory、原生语言 JSON 对账、occurrence extraction、译文校验与 `json_catalog_set` plan |
 | `engine_adapters/coverage.py` | 独立校验 inventory invariant、生成稳定 digest、导出 coverage/review package、导入并校验人工或 Agent review |
-| `engine_adapters/writeback.py` | 公共 plan schema、source snapshot、相对路径、文件 hash、span、重叠和 plan digest 校验；只在内存中渲染，不持有 writer |
+| `engine_adapters/writeback.py` | 公共 plan schema、source snapshot、相对路径、文件 hash、span / JSON path、冲突和 plan digest 校验；只在内存中渲染，不持有 writer |
 | `engine_adapters/versioning.py` | P3 `GameVersion` / `ProjectSnapshot` / source-only `UnitOccurrenceRecord`、JSON/JSONL 导入导出、只读 reconciliation 与 freshness 校验 |
 | `translation_core.py` | 唯一的 `TranslationUnit` / `ModelResult` 核心模型；adapter 不创建第二套翻译单元 |
 | sync / Batch / revision workflow | 模型调用、prompt、progress、manifest、preview/check/apply、RAG / Source Index 回灌；atomic writer 仍在 workflow/common 层 |
@@ -31,11 +33,12 @@ P2 的 `relocate_occurrences()` 先按 identity v2，再在同一 localization �
 source/context evidence 做唯一重定位；content evidence 还需达到最低结构分
 （`CONTENT_EVIDENCE_MIN_SCORE`，默认 140，排除仅“同文件+同原文”的 125 分弱匹配），
 同分并列时仍返回 `common.locator.unresolved`。`validate_translation()`
-输出版本化 `ValidationResult`，`build_writeback_plan()` 只产生
-`text_span_replace` 操作。公共消费者会在 check 和 apply 的二次源重读后再次校验
-source snapshot、文件 hash、半开 span、非重叠、相对路径和 plan digest；adapter 没有
-文件写入权限。keyword、Project Analysis 与 Final Review 的独立扫描入口不在本阶段
-扩大范围。
+输出版本化 `ValidationResult`。Ren'Py 的 `build_writeback_plan()` 产生
+`text_span_replace`；TyranoScript 只对既有原生 catalog row 产生
+`json_catalog_set`，不会直接改写 `.ks`。公共消费者会在 check 和 apply 的二次源重读
+后再次校验 source snapshot、文件 hash、半开 span或 JSON path、目标当前值、相对路径和
+plan digest；adapter 没有文件写入权限。keyword、Project Analysis 与 Final Review 的
+独立扫描入口不在本阶段扩大范围。
 
 ## 扫描与等价性
 
@@ -256,10 +259,20 @@ P4 不新增 GUI 界面；GUI 只在诊断命令参考提供模板（完整交�
   `writeback_gate.decision=allow` 后 apply 成功完成最小写回。
 - 对同一清单改源后再 `apply`，以及 `apply --force`，均被拒绝。
 
-### 对 P5 的含义
+### P5 TyranoScript 当前状态
 
-P1–P4 的真实项目门禁已满足，可以按「一阶段一个子 issue / PR」开 P5。下列问题
-不阻挡 TyranoScript adapter，应另开 follow-up，而不是扩写 P5：
+TyranoScript adapter 使用 `hybrid` 模式：`.ks` 负责完整候选清单，
+`data/others/lang/<lang>.json` 是唯一译文写回目标。catalog 自身纳入 source snapshot；
+计划生成后只要场景、`Config.tjs` 或 catalog 任一文件变化，旧计划即失效。
+
+当前声明式 `json_catalog_set` 仅更新已存在且当前值匹配的 string row；缺 scenario、
+缺 row、非 string row、同一 row 的冲突译文、空译文、控制字符和被修改的 catalog 都会
+fail closed。重复对白或角色 occurrence 映射到同一 catalog row 时合并为一个操作。
+公共 renderer 只返回内存中的 catalog 文件内容，`.ks` 不会成为渲染目标。
+
+P5 尚需继续完成 relocation、`lang_set` / 多 catalog / 语言代码完整性、完整 coverage
+review 门禁接线与最终 Ren'Py 非回归。下列既有 Ren'Py 问题不阻挡 P5，应另开
+follow-up，而不是扩写 P5：
 
 1. speaker-label 在对白已是目标语言时仍标 translatable；
 2. 大型项目上 unknown / unsupported / parse_error 导致 coverage `block`。

--- a/docs/plans/engine_adapter_contract.md
+++ b/docs/plans/engine_adapter_contract.md
@@ -445,18 +445,22 @@ fragment。adapter 负责按 Ren'Py renderer 语义生成它；common 层只做 
 validation 校验并拼接，不得再次调用 `render_replacement_lines()`、`quote_with()` 或
 其他 engine renderer 二次渲染。
 
-v1 只允许 common 层实现并注册的 operation kinds。Ren'Py 首个 kind 为
-`text_span_replace`。plan：
+v1 只允许 common 层实现并注册的 operation kinds。Ren'Py 使用
+`text_span_replace`；TyranoScript 原生语言 JSON 使用 `json_catalog_set`，并增加
+`target_json_path` 字符串数组。后者的 `line/start_col/end_col` 固定为 `-1`，
+`expected_fragment_sha256` 绑定目标 path 的当前字符串值；目标 path 或 row 缺失时
+不得自动创建。plan：
 
 - 不含绝对目标路径；
 - 不含删除目录、重命名、shell、Python 表达式或 callback；
 - 每个 operation 绑定 live file hash、span、expected fragment 和 validation；
 - operation 按 `target_rel_path/line/start_col` canonical sort 后计算 plan digest；
-- common 层拒绝重叠 span、重复 operation、未知 root/kind 和路径逃逸；
+- common 层拒绝重叠 span、重复 JSON target、未知 root/kind 和路径逃逸；
 - common 层在第一笔写入前再次读取全部文件并复核；
 - 全部通过后才生成 rendered files 并交给 `atomic_write_many_lines()`。
 
-- `expected_fragment_sha256` 是 common consumer 对 live raw span 的校验；
+- `expected_fragment_sha256` 是 common consumer 对 live raw span 或 JSON row 当前值的
+  校验；
 - `expected_text_digest` 绑定 adapter 已解码的源文本与 operation/plan payload，
   但 common 层保持 engine-neutral，不重新解析 Ren'Py 字符串 literal；adapter
   构建 plan 时必须从同一已验证 occurrence 生成该 digest。

--- a/engine_adapters/contracts.py
+++ b/engine_adapters/contracts.py
@@ -309,7 +309,10 @@ class ValidatedTranslation:
 class WritebackOperation:
     """Declarative replacement emitted by an engine adapter.
 
-    ``expected_fragment_sha256`` is the common consumer's live raw-span guard.
+    ``expected_fragment_sha256`` is the common consumer's live value guard. For
+    ``text_span_replace`` it covers the raw source span; for
+    ``json_catalog_set`` it covers the current string value at
+    ``target_json_path``.
     ``expected_text_digest`` binds the adapter-decoded source text into the
     operation and plan digests; the engine-neutral consumer deliberately does
     not decode engine-specific literals a second time.
@@ -327,9 +330,10 @@ class WritebackOperation:
     expected_text_digest: str
     replacement_fragment: str
     validation_digest: str
+    target_json_path: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "operation_id": self.operation_id,
             "kind": self.kind,
             "occurrence_id": self.occurrence_id,
@@ -344,6 +348,11 @@ class WritebackOperation:
             "replacement_fragment": self.replacement_fragment,
             "validation_digest": self.validation_digest,
         }
+        # Keep schema-v1 text-span payloads byte-for-byte compatible with
+        # persisted plans created before semantic catalog operations existed.
+        if self.target_json_path:
+            payload["target_json_path"] = list(self.target_json_path)
+        return payload
 
 
 @dataclass(frozen=True)

--- a/engine_adapters/tyrano.py
+++ b/engine_adapters/tyrano.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Read-only TyranoScript V600+ adapter for project discovery, inventory,
-coverage audit, and occurrence extraction (#265 P5 / #399).
+"""TyranoScript V600+ hybrid adapter (#265 P5 / #399).
 
-This module intentionally implements only the read side of the common
-``EngineAdapter`` contract for now.  Writeback for Tyrano native
-localization catalogs needs a new common operation kind and will be added in
-a later PR; the adapter therefore fails closed for relocation, validation,
-and writeback planning unless/until those operations are supported.
+The adapter inventories source ``.ks`` files but emits semantic writeback
+operations only for existing rows in Tyrano's native language JSON. Direct
+source-script mutation remains unsupported.
 """
 
 from __future__ import annotations
@@ -18,6 +15,7 @@ import os
 from pathlib import Path
 import re
 from typing import Any, Mapping, Sequence
+import unicodedata
 
 import translation_core
 
@@ -25,6 +23,8 @@ from .contracts import (
     CANDIDATE_SCHEMA_VERSION,
     CONTENT_FINGERPRINT_SCHEMA_VERSION,
     ENGINE_ADAPTER_PROTOCOL_VERSION,
+    VALIDATION_SCHEMA_VERSION,
+    WRITEBACK_PLAN_SCHEMA_VERSION,
     Candidate,
     CandidateInventory,
     CoverageReportDraft,
@@ -39,15 +39,17 @@ from .contracts import (
     SourceDocument,
     ValidatedTranslation,
     ValidationResult,
+    WritebackOperation,
     WritebackPlan,
 )
 from .coverage import (
     REVIEW_POLICIES,
     digest_json,
 )
+from .writeback import WritebackPlanError, source_snapshot_fingerprint
 
 
-ADAPTER_VERSION = "0.1.0"
+ADAPTER_VERSION = "0.2.0"
 LOCATOR_SCHEMA_VERSION = 1
 DEFAULT_TAG_REGISTRY = {"glink": ("text",), "ptext": ("text",)}
 SCENARIO_DIR = "data/scenario"
@@ -624,7 +626,7 @@ def _merged_tag_registry(catalog_data: Mapping[str, Any]) -> Mapping[str, tuple[
 
 
 class TyranoAdapter:
-    """Read-only TyranoScript V600+ adapter.
+    """TyranoScript V600+ hybrid source/catalog adapter.
 
     Source inventory is a strict superset of the official parser: the same
     dialogue / tag / character candidates are produced, and malformed tags are
@@ -654,7 +656,7 @@ class TyranoAdapter:
             source_inventory=True,
             native_catalog=True,
             relocation=False,
-            declarative_writeback=(),
+            declarative_writeback=("json_catalog_set",),
             native_catalog_required_for_writeback=True,
         )
 
@@ -665,9 +667,10 @@ class TyranoAdapter:
                 "engine": self.engine,
                 "adapter_version": self.adapter_version,
                 "locator_schema_version": self.locator_schema_version,
-                "read_only": True,
+                "read_only": False,
                 "source_inventory": True,
                 "native_catalog": True,
+                "json_catalog_writeback": True,
                 "candidate_schema_version": CANDIDATE_SCHEMA_VERSION,
                 "content_fingerprint_schema_version": CONTENT_FINGERPRINT_SCHEMA_VERSION,
             }
@@ -754,6 +757,19 @@ class TyranoAdapter:
                     content=config_content,
                 )
             )
+        catalog_path = self._catalog_path(project_root_path, target_language)
+        catalog_state = self._read_catalog_state(project_root_path, target_language)
+        catalog_content = catalog_state.get("content")
+        if isinstance(catalog_content, bytes):
+            documents.append(
+                SourceDocument(
+                    file_rel_path=f"{CATALOG_DIR}/{target_language}.json",
+                    file_path=str(catalog_path),
+                    size=len(catalog_content),
+                    sha256=str(catalog_state.get("sha256") or ""),
+                    content=catalog_content,
+                )
+            )
         documents.sort(key=lambda item: item.file_rel_path)
 
         source_payload = [document.manifest_entry() for document in documents]
@@ -767,8 +783,6 @@ class TyranoAdapter:
             }
         )
 
-        catalog_path = self._catalog_path(project_root_path, target_language)
-        catalog_state = self._read_catalog_state(project_root_path, target_language)
         catalog_provenance = {
             "format": "tyrano_lang_json",
             "target_language": target_language,
@@ -1653,7 +1667,7 @@ class TyranoAdapter:
         return tuple(occurrences)
 
     # ------------------------------------------------------------------
-    # Unsupported write-side operations fail closed
+    # Validation and native catalog writeback
     # ------------------------------------------------------------------
 
     def relocate_occurrences(
@@ -1672,9 +1686,114 @@ class TyranoAdapter:
         occurrence: Occurrence,
         translated_text: str,
     ) -> ValidationResult:
-        raise NotImplementedError(
-            "TyranoAdapter validation is not implemented yet."
+        if occurrence.engine != self.engine or occurrence.locator.engine != self.engine:
+            raise ValueError(
+                f"TyranoAdapter cannot validate engine={occurrence.engine!r}."
+            )
+        source_constraints_digest = digest_json(
+            {
+                "engine": self.engine,
+                "content_fingerprint": occurrence.content_fingerprint,
+                "locator": occurrence.locator.to_dict(),
+                "source_text": occurrence.unit.text,
+            }
         )
+        reason_codes: list[str] = []
+        diagnostics: list[Mapping[str, Any]] = []
+        if not isinstance(translated_text, str) or translated_text == "":
+            reason_codes.append("tyrano.translation.empty")
+        elif any(unicodedata.category(character) == "Cc" for character in translated_text):
+            reason_codes.append("tyrano.translation.control_character")
+            diagnostics.append(
+                {
+                    "reason_code": "tyrano.translation.control_character",
+                    "positions": [
+                        index
+                        for index, character in enumerate(translated_text)
+                        if unicodedata.category(character) == "Cc"
+                    ],
+                }
+            )
+        translation_digest = digest_json(
+            {
+                "validation_schema_version": VALIDATION_SCHEMA_VERSION,
+                "translation": translated_text,
+            }
+        )
+        return ValidationResult(
+            occurrence_id=occurrence.occurrence_id,
+            engine=self.engine,
+            status="block" if reason_codes else "pass",
+            reason_codes=tuple(reason_codes),
+            diagnostics=tuple(diagnostics),
+            source_constraints_digest=source_constraints_digest,
+            translation_digest=translation_digest,
+        )
+
+    @staticmethod
+    def _catalog_json_path(occurrence: Occurrence) -> tuple[str, ...]:
+        locator = occurrence.locator.locator
+        source_value = str(locator.get("parser_value") or "")
+        file_rel_path = _normalize_rel_path(str(locator.get("file_rel_path") or ""))
+        scenario = str(locator.get("scenario") or "")
+        if not source_value or source_value != occurrence.unit.text:
+            raise WritebackPlanError(
+                "tyrano.writeback.locator_invalid",
+                f"Tyrano occurrence source does not match its locator: {occurrence.occurrence_id}",
+            )
+        if scenario != _scenario_key(file_rel_path):
+            raise WritebackPlanError(
+                "tyrano.writeback.locator_invalid",
+                f"Tyrano occurrence scenario does not match its source path: {occurrence.occurrence_id}",
+            )
+        kind = str(locator.get("kind") or "")
+        if kind == "text":
+            return ("scenes", scenario, "scenario", source_value)
+        if kind == "chara_ptext":
+            return ("charas", source_value)
+        if kind == "tag":
+            tag_name = str(locator.get("tag_name") or "")
+            param_name = str(locator.get("param_name") or "")
+            if tag_name and param_name:
+                return (
+                    "scenes",
+                    scenario,
+                    "tag",
+                    tag_name,
+                    param_name,
+                    source_value,
+                )
+        raise WritebackPlanError(
+            "tyrano.writeback.locator_unsupported",
+            f"Tyrano occurrence has no writable catalog locator: {occurrence.occurrence_id}",
+        )
+
+    @staticmethod
+    def _catalog_value_at_path(
+        catalog_data: Mapping[str, Any],
+        json_path: tuple[str, ...],
+    ) -> str:
+        current: Any = catalog_data
+        for part in json_path[:-1]:
+            if not isinstance(current, dict) or part not in current:
+                raise WritebackPlanError(
+                    "tyrano.writeback.catalog_path_missing",
+                    "Tyrano catalog path is missing: " + "/".join(json_path),
+                )
+            current = current[part]
+        leaf = json_path[-1]
+        if not isinstance(current, dict) or leaf not in current:
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_row_missing",
+                "Tyrano catalog row is missing: " + "/".join(json_path),
+            )
+        value = current[leaf]
+        if not isinstance(value, str):
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_value_invalid",
+                "Tyrano catalog row is not a string: " + "/".join(json_path),
+            )
+        return value
 
     def build_writeback_plan(
         self,
@@ -1682,8 +1801,173 @@ class TyranoAdapter:
         validated: Sequence[ValidatedTranslation],
         live_sources: Sequence[SourceDocument],
     ) -> WritebackPlan:
-        raise NotImplementedError(
-            "TyranoAdapter writeback planning is not implemented yet."
+        if project.engine != self.engine:
+            raise ValueError(
+                f"TyranoAdapter cannot build a plan for engine={project.engine!r}."
+            )
+        expected_documents = project.document_by_path()
+        live_documents = {
+            _normalize_rel_path(document.file_rel_path): document
+            for document in live_sources
+        }
+        if len(live_documents) != len(live_sources):
+            raise WritebackPlanError(
+                "tyrano.writeback.source_snapshot_mismatch",
+                "Tyrano writeback received duplicate live source paths.",
+            )
+        if set(live_documents) != set(expected_documents):
+            raise WritebackPlanError(
+                "tyrano.writeback.source_snapshot_mismatch",
+                "Tyrano writeback requires the complete discovered source and catalog snapshot.",
+            )
+        for rel_path, expected in expected_documents.items():
+            live = live_documents[rel_path]
+            if live.sha256 != expected.sha256 or live.size != expected.size:
+                raise WritebackPlanError(
+                    "tyrano.writeback.source_snapshot_mismatch",
+                    f"Tyrano writeback source changed after discovery: {rel_path}",
+                )
+        live_source_fingerprint = source_snapshot_fingerprint(tuple(live_documents.values()))
+        if live_source_fingerprint != project.source_fingerprint:
+            raise WritebackPlanError(
+                "tyrano.writeback.source_snapshot_mismatch",
+                "Tyrano writeback snapshot fingerprint changed after discovery.",
+            )
+
+        catalog_rel_path = _normalize_rel_path(
+            str(project.catalog_provenance.get("catalog_rel_path") or "")
+        )
+        catalog_document = live_documents.get(catalog_rel_path)
+        if catalog_document is None:
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_missing",
+                f"Tyrano catalog is missing from the live snapshot: {catalog_rel_path}",
+            )
+        if catalog_document.sha256 != str(
+            project.catalog_provenance.get("catalog_sha256") or ""
+        ):
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_snapshot_mismatch",
+                f"Tyrano catalog changed after discovery: {catalog_rel_path}",
+            )
+        try:
+            catalog_data = json.loads(catalog_document.text())
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_invalid_json",
+                f"Tyrano catalog is not valid JSON: {type(exc).__name__}",
+            ) from exc
+        if not isinstance(catalog_data, dict):
+            raise WritebackPlanError(
+                "tyrano.writeback.catalog_invalid_json",
+                "Tyrano catalog root must be an object.",
+            )
+
+        rows: dict[tuple[str, ...], tuple[ValidatedTranslation, str]] = {}
+        for item in validated:
+            occurrence = item.occurrence
+            if occurrence.project_snapshot_fingerprint != project.project_snapshot_fingerprint:
+                raise WritebackPlanError(
+                    "tyrano.writeback.occurrence_snapshot_mismatch",
+                    f"Tyrano occurrence is stale: {occurrence.occurrence_id}",
+                )
+            expected_content_fingerprint = digest_json(
+                {
+                    "engine": self.engine,
+                    "locator": occurrence.locator.to_dict(),
+                    "source_value": occurrence.unit.text,
+                }
+            )
+            if occurrence.content_fingerprint != expected_content_fingerprint:
+                raise WritebackPlanError(
+                    "tyrano.writeback.occurrence_digest_mismatch",
+                    f"Tyrano occurrence digest is invalid: {occurrence.occurrence_id}",
+                )
+            expected_validation = self.validate_translation(
+                occurrence,
+                item.translated_text,
+            )
+            if item.validation != expected_validation or expected_validation.status != "pass":
+                raise WritebackPlanError(
+                    "tyrano.writeback.validation_mismatch",
+                    f"Tyrano validation is missing, stale, or blocking: {occurrence.occurrence_id}",
+                )
+            json_path = self._catalog_json_path(occurrence)
+            current_value = self._catalog_value_at_path(catalog_data, json_path)
+            previous = rows.get(json_path)
+            if previous is not None and previous[0].translated_text != item.translated_text:
+                raise WritebackPlanError(
+                    "tyrano.writeback.catalog_translation_conflict",
+                    "Tyrano occurrences mapped to one catalog row have conflicting translations: "
+                    + "/".join(json_path),
+                )
+            if previous is None or occurrence.occurrence_id < previous[0].occurrence.occurrence_id:
+                rows[json_path] = (item, current_value)
+
+        operations: list[WritebackOperation] = []
+        for json_path in sorted(rows):
+            item, current_value = rows[json_path]
+            operation_payload = {
+                "kind": "json_catalog_set",
+                "occurrence_id": item.occurrence.occurrence_id,
+                "target_root": "localization_catalog",
+                "target_rel_path": catalog_rel_path,
+                "expected_file_sha256": catalog_document.sha256,
+                "line": -1,
+                "start_col": -1,
+                "end_col": -1,
+                "expected_fragment_sha256": _sha256_bytes(current_value.encode("utf-8")),
+                "expected_text_digest": _sha256_bytes(
+                    item.occurrence.unit.text.encode("utf-8")
+                ),
+                "replacement_fragment": item.translated_text,
+                "validation_digest": digest_json(item.validation.to_dict()),
+                "target_json_path": json_path,
+            }
+            operations.append(
+                WritebackOperation(
+                    operation_id="op1:" + digest_json(operation_payload),
+                    **operation_payload,
+                )
+            )
+
+        project_identity_digest = digest_json(
+            {
+                "engine": project.engine,
+                "target_language": project.target_language,
+                "localization_mode": project.localization_mode.value,
+                "localization_root": os.path.realpath(project.localization_root),
+            }
+        )
+        coverage_digest = str(
+            project.coverage_digest
+            or project.catalog_provenance.get("coverage_digest")
+            or ""
+        )
+        coverage_review_digest = str(
+            project.coverage_review_digest
+            or project.catalog_provenance.get("coverage_review_digest")
+            or ""
+        )
+        plan_payload = {
+            "writeback_plan_schema_version": WRITEBACK_PLAN_SCHEMA_VERSION,
+            "engine": self.engine,
+            "adapter_version": self.adapter_version,
+            "project_identity_digest": project_identity_digest,
+            "source_snapshot_fingerprint": live_source_fingerprint,
+            "coverage_digest": coverage_digest,
+            "coverage_review_digest": coverage_review_digest,
+            "operations": [operation.to_dict() for operation in operations],
+        }
+        return WritebackPlan(
+            engine=self.engine,
+            adapter_version=self.adapter_version,
+            project_identity_digest=project_identity_digest,
+            source_snapshot_fingerprint=live_source_fingerprint,
+            coverage_digest=coverage_digest,
+            coverage_review_digest=coverage_review_digest,
+            operations=tuple(operations),
+            plan_digest=digest_json(plan_payload),
         )
 
     # ------------------------------------------------------------------
@@ -1709,10 +1993,6 @@ class TyranoAdapter:
             expired = self._catalog_cache_order.pop(0)
             self._catalog_cache.pop(expired, None)
 
-    @staticmethod
-    def _catalog_path(project_root: Path, target_language: str) -> Path:
-        return project_root / CATALOG_DIR / f"{target_language}.json"
-
     def _read_catalog_state(
         self,
         project_root: Path,
@@ -1720,7 +2000,7 @@ class TyranoAdapter:
     ) -> Mapping[str, Any]:
         path = self._catalog_path(project_root, target_language)
         if not path.is_file():
-            return {"data": {}, "status": "missing", "sha256": ""}
+            return {"data": {}, "status": "missing", "sha256": "", "content": None}
         try:
             catalog_bytes = path.read_bytes()
         except OSError as exc:
@@ -1728,6 +2008,7 @@ class TyranoAdapter:
                 "data": {},
                 "status": "missing",
                 "sha256": "",
+                "content": None,
                 "detail": type(exc).__name__,
             }
         sha256 = _sha256_bytes(catalog_bytes)
@@ -1738,6 +2019,7 @@ class TyranoAdapter:
                 "data": {},
                 "status": "invalid_json",
                 "sha256": sha256,
+                "content": catalog_bytes,
                 "detail": type(exc).__name__,
             }
         if not isinstance(data, dict):
@@ -1745,9 +2027,15 @@ class TyranoAdapter:
                 "data": {},
                 "status": "invalid_json",
                 "sha256": sha256,
+                "content": catalog_bytes,
                 "detail": type(data).__name__,
             }
-        return {"data": data, "status": "ok", "sha256": sha256}
+        return {
+            "data": data,
+            "status": "ok",
+            "sha256": sha256,
+            "content": catalog_bytes,
+        }
 
     def _load_catalog_state(
         self,

--- a/engine_adapters/writeback.py
+++ b/engine_adapters/writeback.py
@@ -364,6 +364,8 @@ def render_writeback_plan(
         source_text = document.text()
         newline = "\r\n" if "\r\n" in source_text else "\n"
         serialized = json.dumps(data, ensure_ascii=False, indent=2)
+        if newline != "\n":
+            serialized = serialized.replace("\n", newline)
         if document.content.startswith(b"\xef\xbb\xbf"):
             serialized = "\ufeff" + serialized
         if source_text.endswith(("\n", "\r")):

--- a/engine_adapters/writeback.py
+++ b/engine_adapters/writeback.py
@@ -1,14 +1,16 @@
 """Common validation and rendering for declarative adapter writeback plans.
 
-Adapters describe safe text-span operations.  This module re-checks the plan
-against the live source snapshot and renders changed lines in memory.  It has
-no filesystem write authority; workflow code remains responsible for path
-resolution, transaction journaling, and atomic writes.
+Adapters describe safe text-span or semantic JSON catalog operations. This
+module re-checks the plan against the live source snapshot and renders changed
+files in memory. It has no filesystem write authority; workflow code remains
+responsible for path resolution, transaction journaling, and atomic writes.
 """
 
 from __future__ import annotations
 
+import copy
 import hashlib
+import json
 import ntpath
 from typing import Mapping, NoReturn, Sequence
 
@@ -81,8 +83,11 @@ def _validate_operation(
     operation: WritebackOperation,
     documents: Mapping[str, SourceDocument],
     spans: list[tuple[str, int, int, int]],
+    json_targets: set[tuple[str, tuple[str, ...]]],
+    target_kinds: dict[str, str],
+    json_documents: dict[str, object],
 ) -> tuple[str, SourceDocument, list[str]]:
-    if operation.kind != "text_span_replace":
+    if operation.kind not in {"text_span_replace", "json_catalog_set"}:
         _fail(
             "common.writeback.operation_unsupported",
             f"Unsupported writeback operation kind: {operation.kind!r}",
@@ -133,6 +138,81 @@ def _validate_operation(
         _fail(
             "common.writeback.source_snapshot_mismatch",
             f"Writeback target file changed: {rel_path}",
+        )
+
+    existing_kind = target_kinds.setdefault(rel_path, operation.kind)
+    if existing_kind != operation.kind:
+        _fail(
+            "common.writeback.plan_invalid",
+            f"Writeback target mixes incompatible operation kinds: {rel_path}",
+        )
+
+    if operation.kind == "json_catalog_set":
+        if (operation.line, operation.start_col, operation.end_col) != (-1, -1, -1):
+            _fail(
+                "common.writeback.plan_invalid",
+                f"JSON catalog operation has unexpected span coordinates: {rel_path}",
+            )
+        json_path = tuple(operation.target_json_path)
+        if not json_path or any(
+            not isinstance(part, str) or not part for part in json_path
+        ):
+            _fail(
+                "common.writeback.plan_invalid",
+                f"JSON catalog operation has an invalid target path: {rel_path}",
+            )
+        json_target = (rel_path, json_path)
+        if json_target in json_targets:
+            _fail(
+                "common.writeback.target_duplicate",
+                f"Duplicate JSON catalog target: {rel_path}:{'/'.join(json_path)}",
+            )
+        json_targets.add(json_target)
+        if rel_path not in json_documents:
+            try:
+                json_documents[rel_path] = json.loads(document.text())
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                _fail(
+                    "common.writeback.catalog_invalid_json",
+                    f"Writeback catalog is not valid JSON: {rel_path} ({type(exc).__name__})",
+                )
+        data = json_documents[rel_path]
+        current = data
+        for part in json_path[:-1]:
+            if not isinstance(current, dict) or part not in current:
+                _fail(
+                    "common.writeback.catalog_path_missing",
+                    f"Writeback catalog path is missing: {rel_path}:{'/'.join(json_path)}",
+                )
+            current = current[part]
+        leaf = json_path[-1]
+        if not isinstance(current, dict) or leaf not in current:
+            _fail(
+                "common.writeback.catalog_path_missing",
+                f"Writeback catalog row is missing: {rel_path}:{'/'.join(json_path)}",
+            )
+        current_value = current[leaf]
+        if not isinstance(current_value, str):
+            _fail(
+                "common.writeback.catalog_value_invalid",
+                f"Writeback catalog row is not a string: {rel_path}:{'/'.join(json_path)}",
+            )
+        if _sha256_text(current_value) != operation.expected_fragment_sha256:
+            _fail(
+                "common.writeback.catalog_value_mismatch",
+                f"Writeback catalog row no longer matches the plan: {rel_path}:{'/'.join(json_path)}",
+            )
+        if operation.replacement_fragment == "":
+            _fail(
+                "common.writeback.replacement_invalid",
+                f"JSON catalog replacement must not be empty: {rel_path}:{'/'.join(json_path)}",
+            )
+        return rel_path, document, list(document.lines())
+
+    if operation.target_json_path:
+        _fail(
+            "common.writeback.plan_invalid",
+            f"Text-span operation has an unexpected JSON target path: {rel_path}",
         )
     lines = document.lines()
     if operation.line < 0 or operation.line >= len(lines):
@@ -223,9 +303,19 @@ def validate_writeback_plan(
             )
         documents[rel_path] = document
     spans: list[tuple[str, int, int, int]] = []
+    json_targets: set[tuple[str, tuple[str, ...]]] = set()
+    target_kinds: dict[str, str] = {}
+    json_documents: dict[str, object] = {}
     validated: list[tuple[str, WritebackOperation, SourceDocument]] = []
     for operation in plan.operations:
-        rel_path, document, _lines = _validate_operation(operation, documents, spans)
+        rel_path, document, _lines = _validate_operation(
+            operation,
+            documents,
+            spans,
+            json_targets,
+            target_kinds,
+            json_documents,
+        )
         validated.append((rel_path, operation, document))
     return tuple(validated)
 
@@ -249,11 +339,34 @@ def render_writeback_plan(
         )
     )
     rendered: dict[str, list[str]] = {}
+    json_documents: dict[str, object] = {}
+    json_source_documents: dict[str, SourceDocument] = {}
     for rel_path, operation, document in validated:
+        if operation.kind == "json_catalog_set":
+            data = json_documents.setdefault(
+                rel_path,
+                copy.deepcopy(json.loads(document.text())),
+            )
+            json_source_documents[rel_path] = document
+            current = data
+            for part in operation.target_json_path[:-1]:
+                current = current[part]
+            current[operation.target_json_path[-1]] = operation.replacement_fragment
+            continue
         lines = rendered.setdefault(rel_path, list(document.lines()))
         lines[operation.line] = (
             lines[operation.line][: operation.start_col]
             + operation.replacement_fragment
             + lines[operation.line][operation.end_col :]
         )
+    for rel_path, data in json_documents.items():
+        document = json_source_documents[rel_path]
+        source_text = document.text()
+        newline = "\r\n" if "\r\n" in source_text else "\n"
+        serialized = json.dumps(data, ensure_ascii=False, indent=2)
+        if document.content.startswith(b"\xef\xbb\xbf"):
+            serialized = "\ufeff" + serialized
+        if source_text.endswith(("\n", "\r")):
+            serialized += newline
+        rendered[rel_path] = serialized.splitlines(keepends=True)
     return rendered

--- a/sync_translation_preview.py
+++ b/sync_translation_preview.py
@@ -228,6 +228,12 @@ def _deserialize_writeback_plan(payload: Any):
             values["line"] = int(values["line"])
             values["start_col"] = int(values["start_col"])
             values["end_col"] = int(values["end_col"])
+            raw_json_path = raw_operation.get("target_json_path", [])
+            if not isinstance(raw_json_path, list) or any(
+                not isinstance(part, str) for part in raw_json_path
+            ):
+                raise ValueError("Sync preview writeback target_json_path must be a string list.")
+            values["target_json_path"] = tuple(raw_json_path)
             operations.append(WritebackOperation(**values))
         return WritebackPlan(
             engine=str(payload["engine"]),

--- a/tests/test_engine_adapter_p5_tyrano.py
+++ b/tests/test_engine_adapter_p5_tyrano.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
-"""Read-only TyranoScript V600+ adapter tests (#265 P5 / #399)."""
+"""TyranoScript V600+ hybrid adapter tests (#265 P5 / #399)."""
 
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import replace
 import json
-import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
-from engine_adapters.coverage import build_coverage_report
-from engine_adapters.contracts import InventoryPolicy, ProjectDiscoveryRequest
+from engine_adapters.coverage import build_coverage_report, digest_json
+from engine_adapters.contracts import (
+    InventoryPolicy,
+    ProjectDiscoveryRequest,
+    ValidatedTranslation,
+)
 from engine_adapters.tyrano import (
     ADAPTER_VERSION,
     TyranoAdapter,
@@ -20,6 +24,7 @@ from engine_adapters.tyrano import (
     build_translation_snapshot,
     parse_tyrano_scenario,
 )
+from engine_adapters.writeback import WritebackPlanError, render_writeback_plan
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "tyranoscript_v600"
 
@@ -37,14 +42,14 @@ class TyranoAdapterFixtureTests(unittest.TestCase):
             ),
         )
 
-    def test_capabilities_are_read_only_hybrid(self):
+    def test_capabilities_are_hybrid_with_catalog_writeback(self):
         capabilities = self.adapter.capabilities()
         self.assertEqual(capabilities.engine, "tyrano")
         self.assertEqual(capabilities.adapter_version, ADAPTER_VERSION)
         self.assertTrue(capabilities.source_inventory)
         self.assertTrue(capabilities.native_catalog)
         self.assertTrue(capabilities.native_catalog_required_for_writeback)
-        self.assertEqual(capabilities.declarative_writeback, ())
+        self.assertEqual(capabilities.declarative_writeback, ("json_catalog_set",))
         self.assertEqual(capabilities.relocation, False)
 
     def test_discovery_scans_ks_and_fingerprint_behavior_config(self):
@@ -57,6 +62,7 @@ class TyranoAdapterFixtureTests(unittest.TestCase):
                 "data/scenario/choices.ks",
                 "data/scenario/broken.ks",
                 "data/system/Config.tjs",
+                "data/others/lang/ch.json",
             },
         )
         self.assertTrue(project.source_fingerprint)
@@ -263,16 +269,247 @@ class TyranoAdapterFixtureTests(unittest.TestCase):
                 [approved[0], approved[0]],
             )
 
-    def test_write_side_operations_fail_closed(self):
+    def test_relocation_remains_fail_closed(self):
         with self.assertRaises(NotImplementedError):
             self.adapter.relocate_occurrences(self.snapshot.project, (), ())
-        with self.assertRaises(NotImplementedError):
-            self.adapter.validate_translation(self.snapshot.occurrences[0], "译文")
-        with self.assertRaises(NotImplementedError):
-            self.adapter.build_writeback_plan(self.snapshot.project, (), ())
+
+    def test_validation_rejects_empty_and_control_characters(self):
+        occurrence = self.snapshot.occurrences[0]
+        empty = self.adapter.validate_translation(occurrence, "")
+        self.assertEqual(empty.status, "block")
+        self.assertEqual(empty.reason_codes, ("tyrano.translation.empty",))
+
+        control = self.adapter.validate_translation(occurrence, "译文\n下一行")
+        self.assertEqual(control.status, "block")
+        self.assertEqual(
+            control.reason_codes,
+            ("tyrano.translation.control_character",),
+        )
+
+        valid = self.adapter.validate_translation(occurrence, "有效译文")
+        self.assertEqual(valid.status, "pass")
+        self.assertTrue(valid.source_constraints_digest)
+        self.assertTrue(valid.translation_digest)
+
+    def _validated(self, occurrence, translated_text):
+        return ValidatedTranslation(
+            occurrence=occurrence,
+            translated_text=translated_text,
+            validation=self.adapter.validate_translation(occurrence, translated_text),
+        )
+
+    def test_catalog_plan_is_semantic_and_does_not_render_ks_files(self):
+        occurrence = next(
+            item for item in self.snapshot.occurrences if item.unit.text == "Hello, world!"
+        )
+        plan = self.adapter.build_writeback_plan(
+            self.snapshot.project,
+            (self._validated(occurrence, "新的问候"),),
+            self.snapshot.project.source_documents,
+        )
+        self.assertEqual(len(plan.operations), 1)
+        operation = plan.operations[0]
+        self.assertEqual(operation.kind, "json_catalog_set")
+        self.assertEqual(operation.target_rel_path, "data/others/lang/ch.json")
+        self.assertEqual(
+            operation.target_json_path,
+            ("scenes", "scene1.ks", "scenario", "Hello, world!"),
+        )
+        self.assertEqual((operation.line, operation.start_col, operation.end_col), (-1, -1, -1))
+
+        rendered = render_writeback_plan(
+            plan,
+            self.snapshot.project.source_documents,
+        )
+        self.assertEqual(set(rendered), {"data/others/lang/ch.json"})
+        catalog = json.loads("".join(rendered["data/others/lang/ch.json"]))
+        self.assertEqual(
+            catalog["scenes"]["scene1.ks"]["scenario"]["Hello, world!"],
+            "新的问候",
+        )
+
+    def test_duplicate_occurrences_share_one_catalog_operation(self):
+        occurrences = [
+            item for item in self.snapshot.occurrences if item.unit.text == "akane"
+        ]
+        self.assertEqual(len(occurrences), 2)
+        plan = self.adapter.build_writeback_plan(
+            self.snapshot.project,
+            tuple(self._validated(item, "朱音") for item in occurrences),
+            self.snapshot.project.source_documents,
+        )
+        self.assertEqual(len(plan.operations), 1)
+        self.assertEqual(plan.operations[0].target_json_path, ("charas", "akane"))
+
+        conflicting = (
+            self._validated(occurrences[0], "朱音"),
+            self._validated(occurrences[1], "茜"),
+        )
+        with self.assertRaises(WritebackPlanError) as captured:
+            self.adapter.build_writeback_plan(
+                self.snapshot.project,
+                conflicting,
+                self.snapshot.project.source_documents,
+            )
+        self.assertEqual(
+            captured.exception.reason_code,
+            "tyrano.writeback.catalog_translation_conflict",
+        )
+
+    def test_missing_catalog_row_and_incomplete_snapshot_block_planning(self):
+        missing_row = next(
+            item
+            for item in self.snapshot.occurrences
+            if item.unit.text == " text before a "
+        )
+        with self.assertRaises(WritebackPlanError) as captured:
+            self.adapter.build_writeback_plan(
+                self.snapshot.project,
+                (self._validated(missing_row, " 标签前的文本 "),),
+                self.snapshot.project.source_documents,
+            )
+        self.assertEqual(
+            captured.exception.reason_code,
+            "tyrano.writeback.catalog_row_missing",
+        )
+
+        catalog_rel_path = "data/others/lang/ch.json"
+        without_catalog = tuple(
+            document
+            for document in self.snapshot.project.source_documents
+            if document.file_rel_path != catalog_rel_path
+        )
+        existing = next(
+            item for item in self.snapshot.occurrences if item.unit.text == "Hello, world!"
+        )
+        with self.assertRaises(WritebackPlanError) as captured:
+            self.adapter.build_writeback_plan(
+                self.snapshot.project,
+                (self._validated(existing, "新的问候"),),
+                without_catalog,
+            )
+        self.assertEqual(
+            captured.exception.reason_code,
+            "tyrano.writeback.source_snapshot_mismatch",
+        )
+
+    def test_changed_catalog_snapshot_blocks_render(self):
+        occurrence = next(
+            item for item in self.snapshot.occurrences if item.unit.text == "Hello, world!"
+        )
+        plan = self.adapter.build_writeback_plan(
+            self.snapshot.project,
+            (self._validated(occurrence, "新的问候"),),
+            self.snapshot.project.source_documents,
+        )
+        changed_documents = tuple(
+            replace(document, sha256="0" * 64)
+            if document.file_rel_path == "data/others/lang/ch.json"
+            else document
+            for document in self.snapshot.project.source_documents
+        )
+        with self.assertRaises(WritebackPlanError) as captured:
+            render_writeback_plan(plan, changed_documents)
+        self.assertEqual(
+            captured.exception.reason_code,
+            "common.writeback.source_snapshot_mismatch",
+        )
+
+    def test_common_renderer_rejects_missing_signed_catalog_path(self):
+        occurrence = next(
+            item for item in self.snapshot.occurrences if item.unit.text == "Hello, world!"
+        )
+        plan = self.adapter.build_writeback_plan(
+            self.snapshot.project,
+            (self._validated(occurrence, "新的问候"),),
+            self.snapshot.project.source_documents,
+        )
+        changed_operation = replace(
+            plan.operations[0],
+            operation_id="",
+            target_json_path=("scenes", "scene1.ks", "scenario", "missing"),
+        )
+        operation_payload = changed_operation.to_dict()
+        operation_payload.pop("operation_id")
+        changed_operation = replace(
+            changed_operation,
+            operation_id="op1:" + digest_json(operation_payload),
+        )
+        changed_plan = replace(plan, operations=(changed_operation,), plan_digest="")
+        plan_payload = changed_plan.to_dict()
+        plan_payload.pop("plan_digest")
+        changed_plan = replace(changed_plan, plan_digest=digest_json(plan_payload))
+
+        with self.assertRaises(WritebackPlanError) as captured:
+            render_writeback_plan(
+                changed_plan,
+                self.snapshot.project.source_documents,
+            )
+        self.assertEqual(
+            captured.exception.reason_code,
+            "common.writeback.catalog_path_missing",
+        )
 
 
 class TyranoAdapterNegativeFixtureTests(unittest.TestCase):
+    def test_catalog_writeback_preserves_utf8_bom_and_crlf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_project(
+                root,
+                "*start|Start\nHello, world!\n",
+                catalog={
+                    "scenes": {
+                        "sample.ks": {
+                            "scenario": {"Hello, world!": "你好"},
+                            "tag": {},
+                        }
+                    }
+                },
+            )
+            catalog_path = root / "data" / "others" / "lang" / "ch.json"
+            payload = json.dumps(
+                {
+                    "scenes": {
+                        "sample.ks": {
+                            "scenario": {"Hello, world!": "你好"},
+                            "tag": {},
+                        }
+                    }
+                },
+                ensure_ascii=False,
+                indent=2,
+            ).replace("\n", "\r\n") + "\r\n"
+            catalog_path.write_bytes(b"\xef\xbb\xbf" + payload.encode("utf-8"))
+
+            adapter = TyranoAdapter()
+            snapshot = build_translation_snapshot(
+                adapter,
+                ProjectDiscoveryRequest(
+                    project_root=str(root),
+                    localization_root=str(catalog_path.parent),
+                    target_language="ch",
+                ),
+            )
+            occurrence = snapshot.occurrences[0]
+            translated = ValidatedTranslation(
+                occurrence=occurrence,
+                translated_text="新的问候",
+                validation=adapter.validate_translation(occurrence, "新的问候"),
+            )
+            plan = adapter.build_writeback_plan(
+                snapshot.project,
+                (translated,),
+                snapshot.project.source_documents,
+            )
+            rendered = "".join(
+                render_writeback_plan(plan, snapshot.project.source_documents)[
+                    "data/others/lang/ch.json"
+                ]
+            )
+            self.assertTrue(rendered.startswith("\ufeff"))
+            self.assertIn("\r\n", rendered)
+
     def test_missing_catalog_blocks_coverage(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_engine_adapter_p5_tyrano.py
+++ b/tests/test_engine_adapter_p5_tyrano.py
@@ -455,28 +455,24 @@ class TyranoAdapterNegativeFixtureTests(unittest.TestCase):
     def test_catalog_writeback_preserves_utf8_bom_and_crlf(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            original_catalog = {
+                "format": "tyrano_lang_json",
+                "scenes": {
+                    "sample.ks": {
+                        "scenario": {"Hello, world!": "你好"},
+                        "tag": {},
+                    }
+                },
+                "target_language": "ch",
+            }
             self._make_project(
                 root,
                 "*start|Start\nHello, world!\n",
-                catalog={
-                    "scenes": {
-                        "sample.ks": {
-                            "scenario": {"Hello, world!": "你好"},
-                            "tag": {},
-                        }
-                    }
-                },
+                catalog=original_catalog,
             )
             catalog_path = root / "data" / "others" / "lang" / "ch.json"
             payload = json.dumps(
-                {
-                    "scenes": {
-                        "sample.ks": {
-                            "scenario": {"Hello, world!": "你好"},
-                            "tag": {},
-                        }
-                    }
-                },
+                original_catalog,
                 ensure_ascii=False,
                 indent=2,
             ).replace("\n", "\r\n") + "\r\n"
@@ -509,6 +505,20 @@ class TyranoAdapterNegativeFixtureTests(unittest.TestCase):
             )
             self.assertTrue(rendered.startswith("\ufeff"))
             self.assertIn("\r\n", rendered)
+            self.assertNotIn("\n", rendered.replace("\r\n", ""))
+
+            rendered_catalog = json.loads(rendered.removeprefix("\ufeff"))
+            self.assertEqual(list(rendered_catalog), list(original_catalog))
+            self.assertEqual(
+                list(rendered_catalog["scenes"]["sample.ks"]),
+                list(original_catalog["scenes"]["sample.ks"]),
+            )
+            self.assertEqual(
+                rendered_catalog["scenes"]["sample.ks"]["scenario"][
+                    "Hello, world!"
+                ],
+                "新的问候",
+            )
 
     def test_missing_catalog_blocks_coverage(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_sync_translation_preview.py
+++ b/tests/test_sync_translation_preview.py
@@ -13,6 +13,48 @@ from atomic_io import file_sha256
 
 
 class SyncTranslationPreviewTests(unittest.TestCase):
+    def test_deserialize_writeback_plan_preserves_json_catalog_path(self):
+        payload = {
+            "writeback_plan_schema_version": 1,
+            "engine": "tyrano",
+            "adapter_version": "0.2.0",
+            "project_identity_digest": "project",
+            "source_snapshot_fingerprint": "source",
+            "coverage_digest": "coverage",
+            "coverage_review_digest": "review",
+            "operations": [
+                {
+                    "operation_id": "op1:digest",
+                    "kind": "json_catalog_set",
+                    "occurrence_id": "occ1:digest",
+                    "target_root": "localization_catalog",
+                    "target_rel_path": "data/others/lang/ch.json",
+                    "expected_file_sha256": "file",
+                    "line": -1,
+                    "start_col": -1,
+                    "end_col": -1,
+                    "expected_fragment_sha256": "value",
+                    "expected_text_digest": "source-value",
+                    "replacement_fragment": "译文",
+                    "validation_digest": "validation",
+                    "target_json_path": [
+                        "scenes",
+                        "sample.ks",
+                        "scenario",
+                        "Hello",
+                    ],
+                }
+            ],
+            "plan_digest": "plan",
+        }
+
+        plan = preview._deserialize_writeback_plan(payload)
+
+        self.assertEqual(
+            plan.operations[0].target_json_path,
+            ("scenes", "sample.ks", "scenario", "Hello"),
+        )
+
     def _refresh_binding_plan_fingerprint(self, manifest):
         plan_payload = manifest["translation_plan"]
         fingerprint_payload = dict(plan_payload)


### PR DESCRIPTION
## 摘要

- 为公共写回合同新增 `json_catalog_set` 语义化 JSON catalog 操作，同时保持既有 `text_span_replace` 计划兼容
- 为 TyranoScript V600+ adapter 实现译文验证、原生 lang JSON 写回计划、重复 row 合并与冲突拒绝
- 将 catalog 纳入 source snapshot，并对缺 row、快照变化、空译文、控制字符和非法 JSON fail closed
- 保留 UTF-8 BOM、CRLF 与 JSON 键顺序；写回渲染不会修改 `.ks`
- 同步持久化反序列化、现行文档与回归测试

## 验证

- `python -m unittest tests.test_engine_adapter_p5_tyrano tests.test_engine_adapter_p2 tests.test_sync_translation_preview -q`（72 tests）
- `python -m unittest tests.test_tyranoscript_p5_fixtures -q`（17 tests）
- `python scripts/run_quality_gates.py all`
- `git diff --check`

本地全量 CLI runner 共执行 1806 tests，出现 2 个既有 ModelProfile 顺序相关错误；两个失败用例分别单独复跑均通过。工作区的未跟踪 `tests/test_issue_341_acceptance.py` 未包含在本 PR。

Refs #399
Refs #265